### PR TITLE
[RFC] Composed Dtabs

### DIFF
--- a/namerd/core/src/main/scala/io/buoyant/namerd/InterpreterInterfaceConfig.scala
+++ b/namerd/core/src/main/scala/io/buoyant/namerd/InterpreterInterfaceConfig.scala
@@ -8,7 +8,7 @@ import io.buoyant.config.ConfigInitializer
 trait InterpreterInterfaceConfig extends InterfaceConfig {
   @JsonIgnore
   final def mk(store: DtabStore, namers: Seq[(Path, Namer)]): Servable =
-    mk(ns => ConfiguredDtabNamer(store.observe(ns).map(extractDtab), namers))
+    mk(ns => ConfiguredDtabNamer(store.observeComposed(ns).map(extractDtab), namers))
 
   @JsonIgnore
   protected def mk(namers: Ns => NameInterpreter): Servable

--- a/namerd/storage/in-memory/src/test/scala/io/buoyant/namerd/storage/InMemoryDtabStoreTest.scala
+++ b/namerd/storage/in-memory/src/test/scala/io/buoyant/namerd/storage/InMemoryDtabStoreTest.scala
@@ -86,4 +86,14 @@ class InMemoryDtabStoreTest extends FunSuite {
       extractDtab(store.observe("test")) == Dtab.read("/hello => /world")
     )
   }
+
+  test("observe composed") {
+    val store = mkStore
+    val obs = store.observeComposed("test/child")
+    assert(obs.sample.isEmpty)
+    Await.result(store.create("test/child", Dtab.read("/nice => /to/meet/you")))
+    assert(obs.sample.get.dtab == Dtab.read("/foo => /bar; /nice => /to/meet/you"))
+    Await.result(store.put("test", Dtab.read("/foo => /bas")))
+    assert(obs.sample.get.dtab == Dtab.read("/foo => /bas; /nice => /to/meet/you"))
+  }
 }


### PR DESCRIPTION
We introduce the notion that slash delimited namespaces are hierarchical paths and that dtabs have a "composed" view where they are composed with each of their ancestors.  

For example, if the namespace `alex` contains the dtab `/foo => /bar` and the namespace `alex/leong` contains the dtab `/foo => /bas` then the composed view of `alex/leong` would be `/foo => /bar; /foo => /baz`.  

This allows a sort of dtab inheritance where base dentries are set up in a parent and inherited by a child.  Child dtabs must come after ancestor dtabs in the composed view so that they may "override" dentries from the ancestor.
