### PR TITLE
Resolving #709 Linkerd does not try the fallback Namer

### DIFF
--- a/namer/consul/src/main/scala/io/buoyant/namer/consul/LookupCache.scala
+++ b/namer/consul/src/main/scala/io/buoyant/namer/consul/LookupCache.scala
@@ -35,8 +35,14 @@ private[consul] class LookupCache(
           NameTree.Neg
 
         case Some(addr) =>
-          log.debug("consul ns %s service %s found + %s", dc, key, residual.show)
-          NameTree.Leaf(Name.Bound(addr, id, residual))
+          addr.sample() match {
+            case Addr.Neg =>
+              log.debug("consul dc %s service %s missing", dc, key)
+              NameTree.Neg
+            case _ =>
+              log.debug("consul ns %s service %s found + %s", dc, key, residual.show)
+              NameTree.Leaf(Name.Bound(addr, id, residual))
+          }
       }
     }
   }

--- a/namer/consul/src/test/scala/io/buoyant/namer/consul/ConsulNamerTest.scala
+++ b/namer/consul/src/test/scala/io/buoyant/namer/consul/ConsulNamerTest.scala
@@ -201,7 +201,10 @@ class ConsulNamerTest extends FunSuite with Awaits {
       Seq("dc", "opens") -> 1,
       Seq("dc", "updates") -> 2,
       Seq("dc", "adds") -> 4,
-      Seq("lookups") -> 1
+      Seq("lookups") -> 1,
+      Seq("service", "opens") -> 1,
+      Seq("service", "updates") -> 1,
+      Seq("service", "closes") -> 1
     ))
   }
 
@@ -253,9 +256,9 @@ class ConsulNamerTest extends FunSuite with Awaits {
       Seq("dc", "opens") -> 1,
       Seq("dc", "updates") -> 1,
       Seq("dc", "adds") -> 4,
-      Seq("service", "opens") -> 1,
-      Seq("service", "updates") -> 1,
-      Seq("service", "closes") -> 1,
+      Seq("service", "opens") -> 2,
+      Seq("service", "updates") -> 2,
+      Seq("service", "closes") -> 2,
       Seq("lookups") -> 1
     ))
   }
@@ -316,9 +319,9 @@ class ConsulNamerTest extends FunSuite with Awaits {
       Seq("dc", "opens") -> 1,
       Seq("dc", "updates") -> 1,
       Seq("dc", "adds") -> 4,
-      Seq("service", "opens") -> 2,
-      Seq("service", "updates") -> 4,
-      Seq("service", "closes") -> 2,
+      Seq("service", "opens") -> 3,
+      Seq("service", "updates") -> 6,
+      Seq("service", "closes") -> 3,
       Seq("lookups") -> 1
     ))
   }
@@ -375,9 +378,9 @@ class ConsulNamerTest extends FunSuite with Awaits {
       Seq("dc", "opens") -> 1,
       Seq("dc", "updates") -> 1,
       Seq("dc", "adds") -> 4,
-      Seq("service", "opens") -> 1,
-      Seq("service", "updates") -> 1,
-      Seq("service", "closes") -> 1,
+      Seq("service", "opens") -> 2,
+      Seq("service", "updates") -> 2,
+      Seq("service", "closes") -> 2,
       Seq("lookups") -> 1
     ))
   }
@@ -429,9 +432,9 @@ class ConsulNamerTest extends FunSuite with Awaits {
       Seq("dc", "opens") -> 1,
       Seq("dc", "updates") -> 1,
       Seq("dc", "adds") -> 4,
-      Seq("service", "opens") -> 1,
-      Seq("service", "updates") -> 1,
-      Seq("service", "closes") -> 1,
+      Seq("service", "opens") -> 2,
+      Seq("service", "updates") -> 2,
+      Seq("service", "closes") -> 2,
       Seq("lookups") -> 1
     ))
   }
@@ -491,9 +494,9 @@ class ConsulNamerTest extends FunSuite with Awaits {
       Seq("dc", "opens") -> 1,
       Seq("dc", "updates") -> 1,
       Seq("dc", "adds") -> 4,
-      Seq("service", "opens") -> 1,
-      Seq("service", "updates") -> 1,
-      Seq("service", "closes") -> 1,
+      Seq("service", "opens") -> 2,
+      Seq("service", "updates") -> 2,
+      Seq("service", "closes") -> 2,
       Seq("lookups") -> 1
     ))
   }


### PR DESCRIPTION
Resolving #709 Linkerd does not try the fallback Namer, when Health API returns empty list.

The cache is updated to use NameTree.Neg, in case there are no addresses available in HealthApi response.
