### PR TITLE
Identifiers must return a Dst.Path

### DIFF
--- a/router/core/src/main/scala/io/buoyant/router/RoutingFactory.scala
+++ b/router/core/src/main/scala/io/buoyant/router/RoutingFactory.scala
@@ -63,10 +63,10 @@ object RoutingFactory {
    *                identifiers to effectively mutate requests that they
    *                identify.
    */
-  class IdentifiedRequest[Req](val dst: Dst, val request: Req) extends RequestIdentification[Req]
+  class IdentifiedRequest[Req](val dst: Dst.Path, val request: Req) extends RequestIdentification[Req]
 
   object IdentifiedRequest {
-    def unapply[Req](identified: IdentifiedRequest[Req]): Option[(Dst, Req)] =
+    def unapply[Req](identified: IdentifiedRequest[Req]): Option[(Dst.Path, Req)] =
       Some((identified.dst, identified.request))
   }
 

--- a/router/core/src/test/scala/com/twitter/finagle/buoyant/DstBindingFactoryTest.scala
+++ b/router/core/src/test/scala/com/twitter/finagle/buoyant/DstBindingFactoryTest.scala
@@ -63,7 +63,7 @@ class DstBindingFactoryTest extends FunSuite with Awaits with Exceptions {
     val closed = new AtomicBoolean(false)
     val factory = DstBindingFactory.refcount {
       new DstBindingFactory[String, String] {
-        def apply(dst: Dst, conn: ClientConnection): Future[Service[String, String]] = ???
+        def apply(dst: Dst.Path, conn: ClientConnection): Future[Service[String, String]] = ???
         def status = Status.Open
         def close(t: Time): Future[Unit] = {
           closed.set(true)

--- a/router/core/src/test/scala/io/buoyant/router/RoutingFactoryTest.scala
+++ b/router/core/src/test/scala/io/buoyant/router/RoutingFactoryTest.scala
@@ -35,7 +35,7 @@ class RoutingFactoryTest extends FunSuite {
     new DstBindingFactory[Request, Response] {
       def status = Status.Open
       def close(d: Time) = Future.Unit
-      def apply(dst: Dst, conn: ClientConnection) = client
+      def apply(dst: Dst.Path, conn: ClientConnection) = client
     }
 
   def mkService(


### PR DESCRIPTION
Prevent Identifiers from returning a Dst.Bound and skipping the path stack.

Fixes #724 