### PR TITLE
Change the internal Delegator API to accept a NameTree

### DIFF
--- a/namer/core/src/main/scala/io/buoyant/namer/ConfiguredDtabNamer.scala
+++ b/namer/core/src/main/scala/io/buoyant/namer/ConfiguredDtabNamer.scala
@@ -44,7 +44,7 @@ case class ConfiguredDtabNamer(
 
   override def delegate(
     dtab: Dtab,
-    tree: DelegateTree[Name.Path]
+    tree: NameTree[Name.Path]
   ): Activity[DelegateTree[Bound]] =
     configuredDtab.flatMap { confDtab =>
       namersInterpreter.delegate(confDtab ++ dtab, tree)

--- a/namer/core/src/main/scala/io/buoyant/namer/DefaultInterpreterInitializer.scala
+++ b/namer/core/src/main/scala/io/buoyant/namer/DefaultInterpreterInitializer.scala
@@ -77,8 +77,11 @@ case class ConfiguredNamersInterpreter(namers: Seq[(Path, Namer)])
 
   override def delegate(
     dtab: Dtab,
-    tree: DelegateTree[Name.Path]
-  ): Activity[DelegateTree[Bound]] = delegateBind(dtab, 0, tree).map(_.simplified)
+    tree: NameTree[Name.Path]
+  ): Activity[DelegateTree[Bound]] = {
+    val dtree = DelegateTree.fromNameTree(Path.empty, tree)
+    delegateBind(dtab, 0, dtree).map(_.simplified)
+  }
 
   val MaxDepth = 100
 

--- a/namer/core/src/main/scala/io/buoyant/namer/DefaultInterpreterInitializer.scala
+++ b/namer/core/src/main/scala/io/buoyant/namer/DefaultInterpreterInitializer.scala
@@ -79,7 +79,7 @@ case class ConfiguredNamersInterpreter(namers: Seq[(Path, Namer)])
     dtab: Dtab,
     tree: NameTree[Name.Path]
   ): Activity[DelegateTree[Bound]] = {
-    val dtree = DelegateTree.fromNameTree(Path.empty, tree)
+    val dtree = DelegateTree.fromNameTree(tree)
     delegateBind(dtab, 0, dtree).map(_.simplified)
   }
 

--- a/namer/core/src/main/scala/io/buoyant/namer/DelegateTree.scala
+++ b/namer/core/src/main/scala/io/buoyant/namer/DelegateTree.scala
@@ -130,20 +130,20 @@ object DelegateTree {
         DelegateTree.Union(path, dentry, delegates: _*)
     }
 
-  def fromNameTree[T](names: NameTree[T]): DelegateTree[T] =
+  def fromNameTree[T](path: Path, names: NameTree[T]): DelegateTree[T] =
     names match {
-      case NameTree.Empty => DelegateTree.Empty(null, Dentry.nop)
-      case NameTree.Fail => DelegateTree.Fail(null, Dentry.nop)
-      case NameTree.Neg => DelegateTree.Neg(null, Dentry.nop)
-      case NameTree.Leaf(v) => DelegateTree.Leaf(null, Dentry.nop, v)
+      case NameTree.Empty => DelegateTree.Empty(path, Dentry.nop)
+      case NameTree.Fail => DelegateTree.Fail(path, Dentry.nop)
+      case NameTree.Neg => DelegateTree.Neg(path, Dentry.nop)
+      case NameTree.Leaf(v) => DelegateTree.Leaf(path, Dentry.nop, v)
       case NameTree.Alt(names@_*) =>
-        val delegates = names.map(fromNameTree[T](null, Dentry.nop, _))
-        DelegateTree.Alt(null, Dentry.nop, delegates: _*)
+        val delegates = names.map(fromNameTree[T](path, Dentry.nop, _))
+        DelegateTree.Alt(path, Dentry.nop, delegates: _*)
       case NameTree.Union(names@_*) =>
         val delegates = names.map {
           case NameTree.Weighted(w, tree) =>
-            DelegateTree.Weighted(w, fromNameTree(null, Dentry.nop, tree))
+            DelegateTree.Weighted(w, fromNameTree(path, Dentry.nop, tree))
         }
-        DelegateTree.Union(null, Dentry.nop, delegates: _*)
+        DelegateTree.Union(path, Dentry.nop, delegates: _*)
     }
 }

--- a/namer/core/src/main/scala/io/buoyant/namer/DelegateTree.scala
+++ b/namer/core/src/main/scala/io/buoyant/namer/DelegateTree.scala
@@ -130,7 +130,7 @@ object DelegateTree {
         DelegateTree.Union(path, dentry, delegates: _*)
     }
 
-  def fromNameTree[T](path: Path, names: NameTree[T]): DelegateTree[T] =
+  def fromNameTree[T](names: NameTree[T], path: Path = Path.empty): DelegateTree[T] =
     names match {
       case NameTree.Empty => DelegateTree.Empty(path, Dentry.nop)
       case NameTree.Fail => DelegateTree.Fail(path, Dentry.nop)

--- a/namer/core/src/main/scala/io/buoyant/namer/Delegator.scala
+++ b/namer/core/src/main/scala/io/buoyant/namer/Delegator.scala
@@ -1,20 +1,20 @@
 package io.buoyant.namer
 
-import com.twitter.finagle._
+import com.twitter.finagle.{Dentry, Dtab, Name, NameTree, Path}
 import com.twitter.util.Activity
 
 trait Delegator {
 
   def delegate(
     dtab: Dtab,
-    tree: DelegateTree[Name.Path]
+    tree: NameTree[Name.Path]
   ): Activity[DelegateTree[Name.Bound]]
 
   final def delegate(
     dtab: Dtab,
     path: Path
   ): Activity[DelegateTree[Name.Bound]] =
-    delegate(dtab, DelegateTree.Leaf(path, Dentry.nop, Name.Path(path)))
+    delegate(dtab, NameTree.Leaf(Name.Path(path)))
 
   def dtab: Activity[Dtab]
 }

--- a/namer/core/src/main/scala/io/buoyant/namer/NameTreeTransformer.scala
+++ b/namer/core/src/main/scala/io/buoyant/namer/NameTreeTransformer.scala
@@ -61,8 +61,9 @@ trait DelegatingNameTreeTransformer extends NameTreeTransformer {
 
     override def delegate(
       dtab: Dtab,
-      tree: DelegateTree[Name.Path]
-    ): Activity[DelegateTree[Bound]] = underlying.delegate(dtab, tree).flatMap(transformDelegate)
+      tree: NameTree[Name.Path]
+    ): Activity[DelegateTree[Bound]] =
+      underlying.delegate(dtab, tree).flatMap(transformDelegate)
 
     override def dtab: Activity[Dtab] = underlying.dtab
   }

--- a/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/BindHandler.scala
+++ b/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/BindHandler.scala
@@ -41,6 +41,6 @@ class BindHandler(cache: NameInterpreterCache) extends Service[Request, Response
 object BindHandler {
   def renderNameTree(tree: NameTree[Name.Bound]): Future[Buf] =
     JsonDelegateTree.mk(
-      DelegateTree.fromNameTree(null, tree)
+      DelegateTree.fromNameTree(tree, path = null)
     ).map(DelegateApiHandler.Codec.writeBuf).map(_.concat(Buf.Utf8("\n")))
 }

--- a/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/BindHandler.scala
+++ b/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/BindHandler.scala
@@ -41,6 +41,6 @@ class BindHandler(cache: NameInterpreterCache) extends Service[Request, Response
 object BindHandler {
   def renderNameTree(tree: NameTree[Name.Bound]): Future[Buf] =
     JsonDelegateTree.mk(
-      DelegateTree.fromNameTree(tree)
+      DelegateTree.fromNameTree(null, tree)
     ).map(DelegateApiHandler.Codec.writeBuf).map(_.concat(Buf.Utf8("\n")))
 }

--- a/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/StreamingNamerClient.scala
+++ b/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/StreamingNamerClient.scala
@@ -30,10 +30,10 @@ class StreamingNamerClient(
 
   override def delegate(
     dtab: Dtab,
-    tree: DelegateTree[Name.Path]
+    tree: NameTree[Name.Path]
   ): Activity[DelegateTree[Name.Bound]] = {
     val path = tree match {
-      case DelegateTree.Leaf(_, _, p) => p.path
+      case NameTree.Leaf(Name.Path(p)) => p
       case _ => throw new IllegalArgumentException("Delegation too complex")
     }
     delegateCache.get((dtab, path))

--- a/namerd/iface/interpreter-thrift/src/main/scala/io/buoyant/namerd/iface/ThriftNamerClient.scala
+++ b/namerd/iface/interpreter-thrift/src/main/scala/io/buoyant/namerd/iface/ThriftNamerClient.scala
@@ -254,10 +254,14 @@ class ThriftNamerClient(
 
   override def delegate(
     dtab: Dtab,
-    tree: DelegateTree[Name.Path]
+    tree: NameTree[Name.Path]
   ): Activity[DelegateTree[Bound]] = {
     val tdtab = dtab.show
-    val (root, nodes, _) = ThriftNamerInterface.mkDelegateTree(tree)
+    val (root, nodes, _) = tree match {
+      case NameTree.Leaf(n@Name.Path(p)) =>
+        ThriftNamerInterface.mkDelegateTree(DelegateTree.Leaf(p, Dentry.nop, n))
+      case _ => throw new IllegalArgumentException("Delegation too complex")
+    }
     val ttree = thrift.DelegateTree(root, nodes)
 
     val states = Var.async[Activity.State[DelegateTree[Name.Bound]]](Activity.Pending) { states =>

--- a/namerd/iface/interpreter-thrift/src/test/scala/io/buoyant/namerd/iface/ThriftNamerInterfaceTest.scala
+++ b/namerd/iface/interpreter-thrift/src/test/scala/io/buoyant/namerd/iface/ThriftNamerInterfaceTest.scala
@@ -70,7 +70,7 @@ class ThriftNamerInterfaceTest extends FunSuite with Awaits {
   test("delegate") {
     val states = Var[Activity.State[DelegateTree[Name.Bound]]](Activity.Pending)
     def interpreter(ns: String) = new NameInterpreter with Delegator {
-      override def delegate(dtab: Dtab, tree: DelegateTree[Name.Path]) =
+      override def delegate(dtab: Dtab, tree: NameTree[Name.Path]) =
         Activity(states)
       override def bind(dtab: Dtab, path: Path) = ???
       override def dtab: Activity[Dtab] = ???
@@ -106,7 +106,7 @@ class ThriftNamerInterfaceTest extends FunSuite with Awaits {
   test("dtab") {
     val states = Var[Activity.State[Dtab]](Activity.Pending)
     def interpreter(ns: String) = new NameInterpreter with Delegator {
-      override def delegate(dtab: Dtab, tree: DelegateTree[Name.Path]) = ???
+      override def delegate(dtab: Dtab, tree: NameTree[Name.Path]) = ???
       override def bind(dtab: Dtab, path: Path) = ???
       override def dtab: Activity[Dtab] = Activity(states)
     }


### PR DESCRIPTION
Problem

The Delegator API accepts a `DelegatorTree[Name.Path]`, but this isn't really appropriate: nothing has been delegated yet! This is awkward when constructing an initial DelelgatorTree for requests.

Solution

To fix this, the Delegator API is modified to accept a `NameTree[Name.Path]`, as is this is actually the input we want.  The Thrift and HTTP APIs remain unchanged, though they only permit simple NameTree[Path] names now (which I think is actually all that was really supported before).

Note: NameTree[Path] is accepted so that users may evaluate expressions like `/s/foo | /s/bar`.