### PR TITLE
Configure namerd clients using the new TlsClientPrep scheme

### DIFF
--- a/interpreter/namerd/src/main/scala/io/buoyant/namerd/iface/NamerdHttpInterpreterInitializer.scala
+++ b/interpreter/namerd/src/main/scala/io/buoyant/namerd/iface/NamerdHttpInterpreterInitializer.scala
@@ -3,7 +3,6 @@ package io.buoyant.namerd.iface
 import com.twitter.conversions.time._
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.twitter.finagle._
-import com.twitter.finagle.buoyant.TlsClientPrep
 import com.twitter.finagle.naming.NameInterpreter
 import com.twitter.finagle.param.HighResTimer
 import com.twitter.finagle.service._
@@ -80,23 +79,13 @@ case class NamerdHttpInterpreterConfig(
         }
     }
 
-    val tlsTransformer = new Stack.Transformer {
-      override def apply[Req, Rep](stack: Stack[ServiceFactory[Req, Rep]]) = {
-        tls match {
-          case Some(tlsConfig) =>
-            TlsClientPrep.static[Req, Rep](tlsConfig.commonName, tlsConfig.caCert) +: stack
-          case None => stack
-        }
-      }
-    }
-
     val client = Http.client
       .withParams(Http.client.params ++ params)
       .withSessionQualifier.noFailFast
       .withSessionQualifier.noFailureAccrual
       .withStreaming(true)
       .transformed(retryTransformer)
-      .transformed(tlsTransformer)
+      .transformed(TlsTransformer(tls))
 
     new StreamingNamerClient(client.newService(name, label), namespace.getOrElse("default"))
   }

--- a/interpreter/namerd/src/main/scala/io/buoyant/namerd/iface/TlsTransformer.scala
+++ b/interpreter/namerd/src/main/scala/io/buoyant/namerd/iface/TlsTransformer.scala
@@ -1,0 +1,24 @@
+package io.buoyant.namerd.iface
+
+import com.twitter.finagle.{ServiceFactory, Stack}
+import com.twitter.finagle.stack.nilStack
+import com.twitter.finagle.buoyant.TlsClientPrep
+
+object TlsTransformer {
+  object Identity extends Stack.Transformer {
+    def apply[Req, Rep](stack: Stack[ServiceFactory[Req, Rep]]): Stack[ServiceFactory[Req, Rep]] = stack
+  }
+
+  def apply(config: Option[ClientTlsConfig]): Stack.Transformer = config match {
+    case None => Identity
+    case Some(tls) => new TlsTransformer(tls.commonName, tls.caCert)
+  }
+}
+
+class TlsTransformer(cn: String, cert: Option[String]) extends Stack.Transformer {
+  private[this] def prep[Req, Rep] = TlsClientPrep.static[Req, Rep](cn, cert)
+  private[this] def config[Req, Rep] = TlsClientPrep.configureFinagleTls[Req, Rep]
+
+  override def apply[Req, Rep](stack: Stack[ServiceFactory[Req, Rep]]) =
+    prep[Req, Rep] +: (stack ++ (config[Req, Rep] +: nilStack))
+}

--- a/interpreter/namerd/src/main/scala/io/buoyant/namerd/iface/TlsTransformer.scala
+++ b/interpreter/namerd/src/main/scala/io/buoyant/namerd/iface/TlsTransformer.scala
@@ -1,7 +1,6 @@
 package io.buoyant.namerd.iface
 
 import com.twitter.finagle.{ServiceFactory, Stack}
-import com.twitter.finagle.stack.nilStack
 import com.twitter.finagle.buoyant.TlsClientPrep
 
 object TlsTransformer {
@@ -19,6 +18,6 @@ class TlsTransformer(cn: String, cert: Option[String]) extends Stack.Transformer
   private[this] def prep[Req, Rep] = TlsClientPrep.static[Req, Rep](cn, cert)
   private[this] def config[Req, Rep] = TlsClientPrep.configureFinagleTls[Req, Rep]
 
-  override def apply[Req, Rep](stack: Stack[ServiceFactory[Req, Rep]]) =
-    prep[Req, Rep] +: (stack ++ (config[Req, Rep] +: nilStack))
+  override def apply[Req, Rep](underlyingg: Stack[ServiceFactory[Req, Rep]]) =
+    prep[Req, Rep] +: config[Req, Rep] +: underlying
 }

--- a/interpreter/namerd/src/main/scala/io/buoyant/namerd/iface/TlsTransformer.scala
+++ b/interpreter/namerd/src/main/scala/io/buoyant/namerd/iface/TlsTransformer.scala
@@ -18,6 +18,6 @@ class TlsTransformer(cn: String, cert: Option[String]) extends Stack.Transformer
   private[this] def prep[Req, Rep] = TlsClientPrep.static[Req, Rep](cn, cert)
   private[this] def config[Req, Rep] = TlsClientPrep.configureFinagleTls[Req, Rep]
 
-  override def apply[Req, Rep](underlyingg: Stack[ServiceFactory[Req, Rep]]) =
+  override def apply[Req, Rep](underlying: Stack[ServiceFactory[Req, Rep]]) =
     prep[Req, Rep] +: config[Req, Rep] +: underlying
 }


### PR DESCRIPTION
Problem

In 0.8.6, namerd client TLS broke because the new TlsClientPrep params
are used without injecting the needed configureFinagleTls module.

Solution

Extract TlsTransformer logic, and inject the tls configuration stack
module as well.

Fixes #955