### PR TITLE
grpc-interop server, grpc-finagle codegen bugfixes

### DIFF
--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/Error.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/Error.scala
@@ -18,11 +18,18 @@ sealed trait Reset extends Error
 object Reset {
   object Cancel extends Reset { override def toString = "Reset.Cancel" }
   object Closed extends Reset { override def toString = "Reset.Closed" }
+  object CompressionError extends Reset { override def toString = "Reset.CompressionError" }
+  object ConnectError extends Reset { override def toString = "Reset.ConnectError" }
   object EnhanceYourCalm extends Reset { override def toString = "Reset.EnhanceYourCalm" }
+  object FlowControlError extends Reset { override def toString = "Reset.FlowControlError" }
+  object InadequateSecurity extends Reset { override def toString = "Reset.InadequateSecurity" }
   object InternalError extends Reset { override def toString = "Reset.InternalError" }
   object ProtocolError extends Reset { override def toString = "Reset.ProtocolError" }
   object NoError extends Reset { override def toString = "Reset.NoError" }
   object Refused extends Reset { override def toString = "Reset.Refused" }
+  object DoesNotExist extends Reset { override def toString = "Reset.DoesNotExist" }
+  object SettingsTimeout extends Reset { override def toString = "Reset.SettingsTimeout" }
+  object StreamClosed extends Reset { override def toString = "Reset.StreamClosed" }
 }
 
 /**

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/Message.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/Message.scala
@@ -42,6 +42,7 @@ object Headers {
   val Path = ":path"
   val Scheme = ":scheme"
   val Status = ":status"
+  val ContentType = "content-type"
 
   def apply(pairs: Seq[(String, String)]): Headers =
     new Impl(pairs)

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4Message.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4Message.scala
@@ -121,7 +121,12 @@ private[h2] object Netty4Message {
       case Http2Error.NO_ERROR => h2.Reset.NoError
       case Http2Error.PROTOCOL_ERROR => h2.Reset.ProtocolError
       case Http2Error.REFUSED_STREAM => h2.Reset.Refused
-      case Http2Error.STREAM_CLOSED => h2.Reset.Closed
+      case Http2Error.COMPRESSION_ERROR => h2.Reset.CompressionError
+      case Http2Error.CONNECT_ERROR => h2.Reset.ConnectError
+      case Http2Error.FLOW_CONTROL_ERROR => h2.Reset.FlowControlError
+      case Http2Error.INADEQUATE_SECURITY => h2.Reset.InadequateSecurity
+      case Http2Error.SETTINGS_TIMEOUT => h2.Reset.SettingsTimeout
+      case Http2Error.STREAM_CLOSED => h2.Reset.StreamClosed
       case err => throw new IllegalArgumentException(s"invalid stream error: ${err}")
     }
 
@@ -133,6 +138,13 @@ private[h2] object Netty4Message {
       case h2.Reset.NoError => Http2Error.NO_ERROR
       case h2.Reset.ProtocolError => Http2Error.PROTOCOL_ERROR
       case h2.Reset.Refused => Http2Error.REFUSED_STREAM
+      case h2.Reset.DoesNotExist => Http2Error.REFUSED_STREAM
+      case h2.Reset.CompressionError => Http2Error.COMPRESSION_ERROR
+      case h2.Reset.ConnectError => Http2Error.CONNECT_ERROR
+      case h2.Reset.FlowControlError => Http2Error.FLOW_CONTROL_ERROR
+      case h2.Reset.InadequateSecurity => Http2Error.INADEQUATE_SECURITY
+      case h2.Reset.SettingsTimeout => Http2Error.SETTINGS_TIMEOUT
+      case h2.Reset.StreamClosed => Http2Error.STREAM_CLOSED
     }
   }
 

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4ServerDispatcher.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4ServerDispatcher.scala
@@ -97,9 +97,11 @@ class Netty4ServerDispatcher(
           case f@Failure(_) if f.isFlagged(Failure.Interrupted) =>
             log.info(f, "[%s S:%d] interrupted; resetting remote: CANCEL", prefix, st.streamId)
             Reset.Cancel
+          // TODO: disambiguate types of Refused. (need to have a way to map UNIMPLEMENTED)
           case f@Failure(_) if f.isFlagged(Failure.Rejected) =>
             log.info(f, "[%s S:%d] rejected; resetting remote: REFUSED", prefix, st.streamId)
             Reset.Refused
+
           case e =>
             log.info(e, "[%s S:%d] unexpected error; resetting remote: INTERNAL_ERROR", prefix, st.streamId)
             Reset.InternalError

--- a/grpc/eg/src/test/scala/io/buoyant/grpc/EgTest.scala
+++ b/grpc/eg/src/test/scala/io/buoyant/grpc/EgTest.scala
@@ -176,6 +176,10 @@ class EgTest extends FunSuite {
     } finally await(h2client.close().before(h2srv.close()))
   }
 
+  test("services not available should be routed as UNAVAILABLE") {
+    assert(false)
+  }
+
   def getAndRelease[T](f: Future[Stream.Releasable[T]]): T = {
     val Stream.Releasable(v, release) = await(f)
     await(release())

--- a/grpc/interop/src/main/protobuf/empty.proto
+++ b/grpc/interop/src/main/protobuf/empty.proto
@@ -1,0 +1,43 @@
+
+// Copyright 2015, Google Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+syntax = "proto3";
+
+package grpc.testing;
+
+// An empty message that you can re-use to avoid defining duplicated empty
+// messages in your project. A typical example is to use it as argument or the
+// return value of a service API. For instance:
+//
+//   service Foo {
+//     rpc Bar (grpc.testing.Empty) returns (grpc.testing.Empty) { };
+//   };
+//
+message Empty {}

--- a/grpc/interop/src/main/protobuf/messages.proto
+++ b/grpc/interop/src/main/protobuf/messages.proto
@@ -1,0 +1,184 @@
+
+// Copyright 2015-2016, Google Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// Message definitions to be used by integration test service definitions.
+
+syntax = "proto3";
+
+package grpc.testing;
+
+// TODO(dgq): Go back to using well-known types once
+// https://github.com/grpc/grpc/issues/6980 has been fixed.
+// import "google/protobuf/wrappers.proto";
+message BoolValue {
+  // The bool value.
+  bool value = 1;
+}
+
+// DEPRECATED, don't use. To be removed shortly.
+// The type of payload that should be returned.
+enum PayloadType {
+  // Compressable text format.
+  COMPRESSABLE = 0;
+}
+
+// A block of data, to simply increase gRPC message size.
+message Payload {
+  // DEPRECATED, don't use. To be removed shortly.
+  // The type of data in body.
+  PayloadType type = 1;
+  // Primary contents of payload.
+  bytes body = 2;
+}
+
+// A protobuf representation for grpc status. This is used by test
+// clients to specify a status that the server should attempt to return.
+message EchoStatus {
+  int32 code = 1;
+  string message = 2;
+}
+
+// Unary request.
+message SimpleRequest {
+  // DEPRECATED, don't use. To be removed shortly.
+  // Desired payload type in the response from the server.
+  // If response_type is RANDOM, server randomly chooses one from other formats.
+  PayloadType response_type = 1;
+
+  // Desired payload size in the response from the server.
+  int32 response_size = 2;
+
+  // Optional input payload sent along with the request.
+  Payload payload = 3;
+
+  // Whether SimpleResponse should include username.
+  bool fill_username = 4;
+
+  // Whether SimpleResponse should include OAuth scope.
+  bool fill_oauth_scope = 5;
+
+  // Whether to request the server to compress the response. This field is
+  // "nullable" in order to interoperate seamlessly with clients not able to
+  // implement the full compression tests by introspecting the call to verify
+  // the response's compression status.
+  BoolValue response_compressed = 6;
+
+  // Whether server should return a given status
+  EchoStatus response_status = 7;
+
+  // Whether the server should expect this request to be compressed.
+  BoolValue expect_compressed = 8;
+}
+
+// Unary response, as configured by the request.
+message SimpleResponse {
+  // Payload to increase message size.
+  Payload payload = 1;
+  // The user the request came from, for verifying authentication was
+  // successful when the client expected it.
+  string username = 2;
+  // OAuth scope.
+  string oauth_scope = 3;
+}
+
+// Client-streaming request.
+message StreamingInputCallRequest {
+  // Optional input payload sent along with the request.
+  Payload payload = 1;
+
+  // Whether the server should expect this request to be compressed. This field
+  // is "nullable" in order to interoperate seamlessly with servers not able to
+  // implement the full compression tests by introspecting the call to verify
+  // the request's compression status.
+  BoolValue expect_compressed = 2;
+
+  // Not expecting any payload from the response.
+}
+
+// Client-streaming response.
+message StreamingInputCallResponse {
+  // Aggregated size of payloads received from the client.
+  int32 aggregated_payload_size = 1;
+}
+
+// Configuration for a particular response.
+message ResponseParameters {
+  // Desired payload sizes in responses from the server.
+  int32 size = 1;
+
+  // Desired interval between consecutive responses in the response stream in
+  // microseconds.
+  int32 interval_us = 2;
+
+  // Whether to request the server to compress the response. This field is
+  // "nullable" in order to interoperate seamlessly with clients not able to
+  // implement the full compression tests by introspecting the call to verify
+  // the response's compression status.
+  BoolValue compressed = 3;
+}
+
+// Server-streaming request.
+message StreamingOutputCallRequest {
+  // DEPRECATED, don't use. To be removed shortly.
+  // Desired payload type in the response from the server.
+  // If response_type is RANDOM, the payload from each response in the stream
+  // might be of different types. This is to simulate a mixed type of payload
+  // stream.
+  PayloadType response_type = 1;
+
+  // Configuration for each expected response message.
+  repeated ResponseParameters response_parameters = 2;
+
+  // Optional input payload sent along with the request.
+  Payload payload = 3;
+
+  // Whether server should return a given status
+  EchoStatus response_status = 7;
+}
+
+// Server-streaming response, as configured by the request and parameters.
+message StreamingOutputCallResponse {
+  // Payload to increase response size.
+  Payload payload = 1;
+}
+
+// For reconnect interop test only.
+// Client tells server what reconnection parameters it used.
+message ReconnectParams {
+  int32 max_reconnect_backoff_ms = 1;
+}
+
+// For reconnect interop test only.
+// Server tells client whether its reconnects are following the spec and the
+// reconnect backoffs it saw.
+message ReconnectInfo {
+  bool passed = 1;
+  repeated int32 backoff_ms = 2;
+}

--- a/grpc/interop/src/main/protobuf/test.proto
+++ b/grpc/interop/src/main/protobuf/test.proto
@@ -1,0 +1,94 @@
+
+// Copyright 2015-2016, Google Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// An integration test service that covers all the method signature permutations
+// of unary/streaming requests/responses.
+
+syntax = "proto3";
+
+import "empty.proto";
+import "messages.proto";
+
+package grpc.testing;
+
+// A simple service to test the various types of RPCs and experiment with
+// performance with various types of payload.
+service TestService {
+  // One empty request followed by one empty response.
+  rpc EmptyCall(grpc.testing.Empty) returns (grpc.testing.Empty);
+
+  // One request followed by one response.
+  rpc UnaryCall(SimpleRequest) returns (SimpleResponse);
+
+  // One request followed by one response. Response has cache control
+  // headers set such that a caching HTTP proxy (such as GFE) can
+  // satisfy subsequent requests.
+  rpc CacheableUnaryCall(SimpleRequest) returns (SimpleResponse);
+
+  // One request followed by a sequence of responses (streamed download).
+  // The server returns the payload with client desired type and sizes.
+  rpc StreamingOutputCall(StreamingOutputCallRequest)
+      returns (stream StreamingOutputCallResponse);
+
+  // A sequence of requests followed by one response (streamed upload).
+  // The server returns the aggregated size of client payload as the result.
+  rpc StreamingInputCall(stream StreamingInputCallRequest)
+      returns (StreamingInputCallResponse);
+
+  // A sequence of requests with each request served by the server immediately.
+  // As one request could lead to multiple responses, this interface
+  // demonstrates the idea of full duplexing.
+  rpc FullDuplexCall(stream StreamingOutputCallRequest)
+      returns (stream StreamingOutputCallResponse);
+
+  // A sequence of requests followed by a sequence of responses.
+  // The server buffers all the client requests and then serves them in order. A
+  // stream of responses are returned to the client when the server starts with
+  // first request.
+  rpc HalfDuplexCall(stream StreamingOutputCallRequest)
+      returns (stream StreamingOutputCallResponse);
+
+  // The test server will not implement this method. It will be used
+  // to test the behavior when clients call unimplemented methods.
+  //rpc UnimplementedCall(grpc.testing.Empty) returns (grpc.testing.Empty);
+}
+
+// A simple service NOT implemented at servers so clients can test for
+// that case.
+service UnimplementedService {
+  // A call that no server should implement
+  rpc UnimplementedCall(grpc.testing.Empty) returns (grpc.testing.Empty);
+}
+
+// A service used to control reconnect server.
+service ReconnectService {
+  rpc Start(grpc.testing.ReconnectParams) returns (grpc.testing.Empty);
+  rpc Stop(grpc.testing.Empty) returns (grpc.testing.ReconnectInfo);
+}

--- a/grpc/interop/src/main/scala/grpc/testing/ServerMain.scala
+++ b/grpc/interop/src/main/scala/grpc/testing/ServerMain.scala
@@ -1,0 +1,82 @@
+package grpc.testing
+
+import com.google.protobuf.CodedOutputStream
+import com.twitter.conversions.time._
+import com.twitter.finagle.buoyant.H2
+import com.twitter.io.Buf
+import com.twitter.util.{Await, Future, Promise, Throw}
+import io.buoyant.grpc.runtime.{Stream, ServerDispatcher}
+import java.nio.ByteBuffer
+import java.util.Arrays
+
+/**
+ * The main object for running a gRPC interop server.
+ *
+ * The interop tests are described here:
+ *   https://github.com/grpc/grpc/blob/master/doc/interop-test-descriptions.md
+ */
+object ServerMain {
+  def main(args: Array[String]) {
+
+    val iface = new TestService {
+      def emptyCall(empty: Empty): Future[Empty] = {
+        Future.value(new Empty())
+      }
+
+      def unaryCall(req: SimpleRequest): Future[SimpleResponse] = {
+        Future.value(new SimpleResponse(None, None, None))
+      }
+
+      def cacheableUnaryCall(req: SimpleRequest): Future[SimpleResponse] = {
+        Future.value(new SimpleResponse(None, None, None))
+      }
+
+      def fullDuplexCall(req: Stream[StreamingOutputCallRequest]): Stream[StreamingOutputCallResponse] = {
+        val tx = Stream[StreamingOutputCallResponse]
+
+        req.recv().map { outputCallRequest =>
+          outputCallRequest.value.payload.map { payload =>
+            payload.body.map { body =>
+              val toSend = Buf.Utf8("".padTo(body.length, "\u0000").toString())
+              tx.send(StreamingOutputCallResponse(Some(Payload(None, Some(toSend)))))
+            }
+          }
+        }
+
+        return tx
+      }
+
+      def halfDuplexCall(req: Stream[StreamingOutputCallRequest]): Stream[StreamingOutputCallResponse] = {
+        val tx = Stream[StreamingOutputCallResponse]
+        tx.send(StreamingOutputCallResponse(None))
+        return tx
+      }
+
+      def streamingInputCall(req: Stream[StreamingInputCallRequest]): Future[StreamingInputCallResponse] = {
+        // expected: aggregated_payload_size: 74922
+        // For each item in req, add the payload.body.length to the aggregated_payload_size
+        var size = 0
+        val stream = req.recv()
+        // TODO: ask oliver if this is how he intended for this API to work.
+        stream.map { inputCallRequest =>
+          inputCallRequest.value.payload.map { _.body.map { body => size += body.length } }
+        }
+        Future.value(StreamingInputCallResponse(Some(size)))
+      }
+
+      def streamingOutputCall(req: StreamingOutputCallRequest): Stream[StreamingOutputCallResponse] = {
+        val tx = Stream[StreamingOutputCallResponse]()
+        tx.send(StreamingOutputCallResponse(None))
+        return tx
+      }
+
+      // This method should not be implemented on the Server.
+      // Note: making it unimplemented with ??? is still an implementation.
+      //def unimplementedCall(req: Empty): Future[grpc.testing.Empty] = ???
+    }
+
+    val service = new ServerDispatcher(Seq(new TestService.Server(iface)))
+    val server = H2.serve(":60001", service)
+    val _ = Await.ready(server)
+  }
+}

--- a/grpc/runtime/src/main/scala/io/buoyant/grpc/Error.scala
+++ b/grpc/runtime/src/main/scala/io/buoyant/grpc/Error.scala
@@ -1,0 +1,132 @@
+package io.buoyant.grpc
+
+import scala.util.control.NoStackTrace
+import com.twitter.finagle.buoyant.h2
+
+sealed trait Error
+  extends Throwable
+  with NoStackTrace {
+  def errorCode: Int
+}
+
+sealed trait GrpcError extends Error
+
+object GrpcError {
+  // These error codes came from grpc-go/codes/codes.go
+  object NoError extends GrpcError {
+    override def toString = "OK"
+    override def errorCode = 0
+  }
+
+  object Cancelled extends GrpcError {
+    override def toString = "CANCELLED"
+    override def errorCode = 1
+  }
+
+  object Unknown extends GrpcError {
+    override def toString = "UNKNOWN"
+    override def errorCode = 2
+  }
+
+  object InvalidArgument extends GrpcError {
+    override def toString = "INVALID_ARGUMENT"
+    override def errorCode = 3
+  }
+
+  object DeadlineExceeded extends GrpcError {
+    override def toString = "DEADLINE_EXCEEDED"
+    override def errorCode = 4
+  }
+
+  object NotFound extends GrpcError {
+    override def toString = "NOT_FOUND"
+    override def errorCode = 5
+  }
+
+  object AlreadyExists extends GrpcError {
+    override def toString = "ALREADY_EXISTS"
+    override def errorCode = 6
+  }
+
+  object PermissionDenied extends GrpcError {
+    override def toString = "PERMISSION_DENIED"
+    override def errorCode = 7
+  }
+
+  object ResourceExhaused extends GrpcError {
+    override def toString = "RESOURCE_EXHAUSED"
+    override def errorCode = 8
+  }
+
+  object FailedPrecondition extends GrpcError {
+    override def toString = "FAILED_PRECONDITION"
+    override def errorCode = 9
+  }
+
+  object Aborted extends GrpcError {
+    override def toString = "ABORTED"
+    override def errorCode = 10
+  }
+
+  object OutOfRange extends GrpcError {
+    override def toString = "OUT_OF_RANGE"
+    override def errorCode = 11
+  }
+
+  object Unimplemented extends GrpcError {
+    override def toString = "UNIMPLEMENTED"
+    override def errorCode = 12
+  }
+
+  object Internal extends GrpcError {
+    override def toString = "INTERNAL"
+    override def errorCode = 13
+  }
+
+  object Unavailable extends GrpcError {
+    override def toString = "UNAVAILABLE"
+    override def errorCode = 14
+  }
+
+  object DataLoss extends GrpcError {
+    override def toString = "DATA_LOSS"
+    override def errorCode = 15
+  }
+
+  object Unauthenticated extends GrpcError {
+    override def toString = "UNAUTHENTICATED"
+    override def errorCode = 16
+  }
+
+  /**
+   * Maps an HTTP/2 reset response to a gRPC transport error.
+   */
+  def fromRst(rst: h2.Reset): GrpcError = {
+    rst match {
+      case h2.Reset.NoError => GrpcError.NoError
+      case h2.Reset.ProtocolError => GrpcError.Internal
+      case h2.Reset.InternalError => GrpcError.Internal
+      case h2.Reset.FlowControlError => GrpcError.Internal
+      case h2.Reset.Cancel => GrpcError.Internal
+      // TODO: Reset.Closed can also be a FRAME_SIZE_ERROR
+      case h2.Reset.Closed => GrpcError.Internal
+      case h2.Reset.Refused => GrpcError.Unavailable
+      case h2.Reset.DoesNotExist => GrpcError.Unimplemented
+      case h2.Reset.EnhanceYourCalm => GrpcError.ResourceExhaused
+      case h2.Reset.CompressionError => GrpcError.Internal
+      case _ => GrpcError.Internal
+    }
+  }
+
+  /**
+   * Maps a gRPC error to an HTTP/2 Reset.
+   */
+  def toRst(grpcError: GrpcError): h2.Reset = {
+    grpcError match {
+      case GrpcError.NoError => h2.Reset.NoError
+      case GrpcError.Unavailable => h2.Reset.Refused
+      case GrpcError.ResourceExhaused => h2.Reset.EnhanceYourCalm
+      case _ => h2.Reset.InternalError
+    }
+  }
+}

--- a/grpc/runtime/src/main/scala/io/buoyant/grpc/runtime/Stream.scala
+++ b/grpc/runtime/src/main/scala/io/buoyant/grpc/runtime/Stream.scala
@@ -4,24 +4,44 @@ import com.twitter.concurrent.AsyncQueue
 import com.twitter.finagle.buoyant.h2
 import com.twitter.io.Buf
 import com.twitter.util.{Future, Promise, Return, Throw}
+import io.buoyant.grpc.GrpcError
 
+/**
+ *
+ */
 trait Stream[+T] {
+  /**
+   *
+   */
   def recv(): Future[Stream.Releasable[T]]
+
+  /**
+   * Question: Pinning this and Tx.reset together works but should we split this up into a Reader/Writer pair?
+   */
+  def reset(reason: GrpcError): Future[Unit]
 }
 
 object Stream {
 
-  case class Releasable[+T](value: T, release: () => Future[Unit])
+  case class Releasable[+T](value: T, onRelease: () => Future[Unit])
+  case class Errored(reason: GrpcError)
 
   trait Tx[-T] {
     def send(t: T): Future[Unit]
 
     def close(): Future[Unit]
 
-    // TODO support grpc error types
-    // def reset(err: Grpc.Error): Unit
+    /**
+     * Fuses this stream shut with a {{reason}}.
+     *
+     * Once this method is called, no more entries can be written and all unread messages are dropped.
+     */
+    def reset(reason: GrpcError): Future[Unit]
   }
 
+  /**
+   * Constructs a new Stream
+   */
   def apply[T](): Stream[T] with Tx[T] = new Stream[T] with Tx[T] {
     // TODO bound queue? not strictly necessary if send() future observed...
     private[this] val q = new AsyncQueue[Releasable[T]]
@@ -30,11 +50,11 @@ object Stream {
 
     override def send(msg: T): Future[Unit] = {
       val p = new Promise[Unit]
-      val release: () => Future[Unit] = { () =>
+      val onRelease: () => Future[Unit] = { () =>
         p.setDone()
         Future.Unit
       }
-      if (q.offer(Releasable(msg, release))) p
+      if (q.offer(Releasable(msg, onRelease))) p
       else Future.exception(Rejected)
     }
 
@@ -42,8 +62,14 @@ object Stream {
       q.fail(Closed, discard = false)
       Future.Unit
     }
+
+    override def reset(err: GrpcError): Future[Unit] = {
+      q.fail(RejectedWithReason(err), discard = true)
+      Future.Unit
+    }
   }
 
   object Closed extends Throwable
   object Rejected extends Throwable
+  case class RejectedWithReason(reason: GrpcError) extends Throwable
 }

--- a/grpc/runtime/src/test/scala/io/buoyant/grpc/runtime/StreamTest.scala
+++ b/grpc/runtime/src/test/scala/io/buoyant/grpc/runtime/StreamTest.scala
@@ -1,0 +1,72 @@
+package io.buoyant.grpc.runtime
+
+import com.twitter.concurrent.AsyncQueue
+import com.twitter.finagle.Failure
+import com.twitter.finagle.netty4.BufAsByteBuf
+import com.twitter.finagle.stats.InMemoryStatsReceiver
+import com.twitter.io.Buf
+import com.twitter.util._
+import io.buoyant.test.FunSuite
+import io.netty.buffer.ByteBuf
+import io.netty.handler.codec.http2._
+import io.buoyant.grpc.GrpcError
+import java.net.SocketAddress
+import java.util.concurrent.atomic.AtomicBoolean
+import scala.collection.immutable.Queue
+
+class StreamTest extends FunSuite {
+  setLogLevel(com.twitter.logging.Level.OFF)
+
+  case class Foo(body: String)
+
+  test("A sent message can be read once.") {
+    val stream = Stream[Foo]()
+    val sent = stream.send(Foo("hello"))
+
+    await(stream.recv().transform {
+      case Return(Stream.Releasable(Foo(s), release)) => {
+        assert(s == "hello")
+        Future.Unit
+      }
+      case f => fail(s"unexpected Foo: $f")
+    })
+  }
+
+  test("Closing a stream allows its remaining messages to be read'") {
+    val stream = Stream[Foo]()
+    val sent = stream.send(Foo("hello"))
+    val closed = stream.close()
+
+    await(stream.recv().transform {
+      case Return(Stream.Releasable(Foo(s), release)) => {
+        assert(s == "hello")
+        Future.Unit
+      }
+      case f => fail(s"unexpected Foo: $f")
+    })
+  }
+
+  test("Resetting a stream fuses it shut") {
+    val stream = Stream[Foo]()
+    val sent = stream.send(Foo("hello"))
+    val resetting = stream.reset(GrpcError.Internal)
+
+    // Even though a message has been sent, we can't read it as the reader has fused the stream shut.
+    await(stream.recv().transform {
+      case Throw(Stream.RejectedWithReason(reason)) => {
+        assert(reason == GrpcError.Internal)
+        Future.Unit
+      }
+      case f => fail(s"unexpected return: $f")
+    })
+
+    // A reset Stream will only return the reason upon future calls to recv()
+    await(stream.recv().transform {
+      case Throw(Stream.RejectedWithReason(reason)) => {
+        assert(reason == GrpcError.Internal)
+        Future.Unit
+      }
+      case f => fail(s"unexpected return: $f")
+    })
+  }
+}

--- a/project/Grpc.scala
+++ b/project/Grpc.scala
@@ -28,6 +28,7 @@ object Grpc extends Base {
 
   val runtime = projectDir("grpc/runtime")
     .dependsOn(Finagle.h2)
+    .withTests()
     .withLibs(Deps.protobuf)
 
   /*
@@ -108,6 +109,14 @@ object Grpc extends Base {
       publishArtifact := true
     )
 
-  val all = aggregateDir("grpc", usage, eg, gen, runtime)
+  /** Interop */
+  val interop = projectDir("grpc/interop")
+    .withGrpc
+    .withTests()
+    .settings(
+      publishArtifact := false
+    )
+
+  val all = aggregateDir("grpc", eg, interop, usage, gen, runtime)
 
 }


### PR DESCRIPTION
* Adds an implementation of the official interop service for testing.
* Adds Stream.reset method.
* Fixes grpc-finagle codegen bug when reserved keywords are in protos.