### PR TITLE
Update kind param fields in documentation

### DIFF
--- a/linkerd/docs/announcer.md
+++ b/linkerd/docs/announcer.md
@@ -12,7 +12,7 @@ These parameters are available to the announcer regardless of kind. Announcers m
 
 Key | Default Value | Description
 --- | ------------- | -----------
-kind | _required_ | Only `io.l5d.serversets` is available at this time.
+kind | _required_ | Only [`io.l5d.serversets`](#serversets) is available at this time.
 prefix | kind-specific | Announces names beginning with `/#/<prefix>`.
 
 ## Serversets

--- a/linkerd/docs/interpreter.md
+++ b/linkerd/docs/interpreter.md
@@ -10,7 +10,7 @@ routers:
     dst: /$/inet/1.2.3.4/4180
 ```
 
-An interpreter determines how names are resolved.  
+An interpreter determines how names are resolved.
 
 <aside class="notice">
 These parameters are available to the identifier regardless of kind. Identifiers may also have kind-specific parameters.
@@ -18,7 +18,7 @@ These parameters are available to the identifier regardless of kind. Identifiers
 
 Key | Default Value | Description
 --- | ------------- | -----------
-kind | `default` | Either `default`, `io.l5d.namerd`, or `io.l5d.fs`.
+kind | `default` | Either [`default`](#default), [`io.l5d.namerd`](#namerd), or [`io.l5d.fs`](#file-system).
 transformers | No transformers | A list of [transformers](#transformer) to apply to the resolved addresses.
 
 ## Default

--- a/linkerd/docs/load_balancer.md
+++ b/linkerd/docs/load_balancer.md
@@ -18,7 +18,7 @@ These parameters are available to the loadbalancer regardless of kind. The loadb
 
 Key | Default Value | Description
 --- | ------------- | -----------
-kind | `p2c` | Either `p2c`, `ewma`, `aperture`, or `heap`.
+kind | `p2c` | Either [`p2c`](#power-of-two-choices-least-loaded), [`ewma`](#power-of-two-choices-peak-ewma), [`aperture`](#aperture-least-loaded), or [`heap`](#heap-least-loaded).
 enableProbation | `false` | If `true`, endpoints are eagerly evicted from service discovery. See Finagle's [LoadBalancerFactory.EnableProbation](https://github.com/twitter/finagle/blob/develop/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/LoadBalancerFactory.scala#L28).
 
 [p2c]: https://twitter.github.io/finagle/guide/Clients.html#power-of-two-choices-p2c-least-loaded

--- a/linkerd/docs/namer.md
+++ b/linkerd/docs/namer.md
@@ -15,7 +15,7 @@ These parameters are available to the namer regardless of kind. Namers may also 
 
 Key | Default Value | Description
 --- | ------------- | -----------
-kind | _required_ | Either `io.l5d.fs`, `io.l5d.serversets`, `io.l5d.consul`, `io.l5d.k8s`, `io.l5d.marathon`, or `io.l5d.zkLeader`.
+kind | _required_ | Either [`io.l5d.fs`](#file-based-service-discovery), [`io.l5d.serversets`](#zookeeper-serversets-service-discovery), [`io.l5d.consul`](#consul-service-discovery), [`io.l5d.k8s`](#kubernetes-service-discovery), [`io.l5d.marathon`](#marathon-service-discovery-experimental), [`io.l5d.zkLeader`](#zookeeper-leader), [`io.l5d.curator`](#curator), or [`io.l5d.rewrite`](#rewrite).
 prefix | namer dependent | Resolves names with `/#/<prefix>`.
 experimental | `false` | Set this to `true` to enable the namer if it is experimental.
 transformers | No transformers | A list of [transformers](#transformer) to apply to the resolved addresses.

--- a/linkerd/docs/protocol-http.md
+++ b/linkerd/docs/protocol-http.md
@@ -130,7 +130,7 @@ logical *name* to the request.
 
 Key | Default Value | Description
 --- | ------------- | -----------
-kind | _required_ | Either [`io.l5d.methodAndHost`](#method-and-host-identifier) or [`io.l5d.path`](#path-identifier).
+kind | _required_ | Either [`io.l5d.methodAndHost`](#method-and-host-identifier), [`io.l5d.path`](#path-identifier), [`io.l5d.header`](#header-identifier), [`io.l5d.header.token`](#header-token-identifier), or [`io.l5d.static`](#static-identifier).
 
 <a name="method-and-host-identifier"></a>
 ### Method and Host Identifier

--- a/linkerd/docs/response_classifier.md
+++ b/linkerd/docs/response_classifier.md
@@ -19,7 +19,7 @@ These parameters are available to the classifier regardless of kind. Classifiers
 
 Key | Default Value | Description
 --- | ------------- | -----------
-kind | `io.l5d.nonRetryable5XX` | Either `io.l5d.nonRetryable5XX`, `io.l5d.retryableRead5XX`, or `io.l5d.retryableIdempotent5XX`.
+kind | `io.l5d.nonRetryable5XX` | Either [`io.l5d.nonRetryable5XX`](#non-retryable-5xx), [`io.l5d.retryableRead5XX`](#retryable-read-5xx), or [`io.l5d.retryableIdempotent5XX`](#retryable-idempotent-5xx).
 
 
 ## Non-Retryable 5XX

--- a/linkerd/docs/retries.md
+++ b/linkerd/docs/retries.md
@@ -58,7 +58,7 @@ These parameters are available to the backoff regardless of kind. Backoffs may a
 
 Key | Default Value | Description
 --- | ------------- | -----------
-kind | _required_ | Either `constant` or `jittered`.
+kind | _required_ | Either [`constant`](#constant-backoff) or [`jittered`](#jittered-backoff).
 
 ### Constant Backoff
 

--- a/linkerd/docs/routers.md
+++ b/linkerd/docs/routers.md
@@ -32,7 +32,7 @@ routers:
 
 Key | Default Value | Description
 --- | ------------- | -----------
-protocol | _required_ | Either [`http`](#http-1-1-protocol), [`thrift`](#thrift-protocol), or [`mux`](#mux-protocol-experimental).
+protocol | _required_ | Either [`http`](#http-1-1-protocol), [`h2`](#http-2-protocol), [`thrift`](#thrift-protocol), or [`mux`](#mux-protocol-experimental).
 servers | _required_ | A list of [server objects](#servers).
 announcers | an empty list | A list of service discovery [announcers](#announcers) that servers can announce to.
 baseDtab | an empty dtab | Sets the base delegation table. See [dtabs](https://linkerd.io/doc/dtabs/) for more.

--- a/linkerd/docs/telemetry.md
+++ b/linkerd/docs/telemetry.md
@@ -9,7 +9,7 @@ regardless of kind. Telemeters may also have kind-specific parameters. </aside>
 
 Key | Default Value | Description
 --- | ------------- | -----------
-kind | _required_ | `io.l5d.commonMetrics`, `io.l5d.statsd`, or `io.l5d.tracelog`
+kind | _required_ | Either [`io.l5d.commonMetrics`](#commonmetrics), [`io.l5d.statsd`](#statsd-experimental), [`io.l5d.tracelog`](#tracelog), or [`io.l5d.recentRequests`](#recent-requests).
 experimental | `false` | Set this to `true` to enable the telemeter if it is experimental.
 
 ## CommonMetrics
@@ -93,6 +93,8 @@ telemetry:
   sampleRate: 1.0
   capacity: 10
 ```
+
+kind: `io.l5d.recentRequests`
 
 The recent requests telemeter keeps an in-memory record of recent requests and uses it to populate
 the recent requests table on the admin dashboard.  This table can be viewed at `/requests` on the

--- a/linkerd/docs/tracer.md
+++ b/linkerd/docs/tracer.md
@@ -9,7 +9,7 @@ These parameters are available to the tracer regardless of kind. Tracers may als
 
 Key | Default Value | Description
 --- | ------------- | -----------
-kind | _required_ | Only `io.l5d.zipkin` is available at this time.
+kind | _required_ | Only [`io.l5d.zipkin`](#zipkin) is available at this time.
 
 
 ## Zipkin

--- a/linkerd/docs/transformer.md
+++ b/linkerd/docs/transformer.md
@@ -17,7 +17,7 @@ interpreter.  Transformations are applied sequentially in the order they appear.
 
 Key | Default Value | Description
 --- | ------------- | -----------
-kind | _required_ | One of the transformer kinds listed below.
+kind | _required_ | Either [`io.l5d.localhost`](#localhost), [`io.l5d.port`](#port), [`io.l5d.k8s.daemonset`](#daemonset-kubernetes), [`io.l5d.k8s.localnode`](#localnode-kubernetes), [`io.l5d.replace`](#replace), or [`io.l5d.const`](#const).
 
 ## Localhost
 
@@ -45,7 +45,7 @@ port | _required_ | The port number to use.
 
 kind: `io.l5d.k8s.daemonset`
 
-The DaemonSetTransformer maps each address in the destination NameTree to a 
+The DaemonSetTransformer maps each address in the destination NameTree to a
 member of a given daemonset that is on the same /24 subnet.  Since each k8s
 node is its own /24 subnet, the result is that each destination address is
 mapped to the member of the daemonset that is running on the same node.

--- a/namerd/docs/interface.md
+++ b/namerd/docs/interface.md
@@ -8,7 +8,7 @@ These parameters are available to the interface regardless of kind. Interfaces m
 
 Key | Default Value | Description
 --- | ------------- | -----------
-kind | _required_ | Either `io.l5d.thriftNameInterpreter` or `io.l5d.httpController`.
+kind | _required_ | Either [`io.l5d.thriftNameInterpreter`](#thrift-name-interpreter) or [`io.l5d.httpController`](#http-controller).
 ip | interface dependent | The local IP address on which to serve the namer interface.
 port | interface dependent | The port number on which to server the namer interface.
 

--- a/namerd/docs/storage.md
+++ b/namerd/docs/storage.md
@@ -9,7 +9,7 @@ These parameters are available to the storage regardless of kind. Storage may al
 
 Key | Default Value | Description
 --- | ------------- | -----------
-kind | _required_ | Either `io.l5d.inMemory`, `io.l5d.k8s`, `io.l5d.zk`, `io.l5d.etcd` or `io.l5d.consul`.
+kind | _required_ | Either [`io.l5d.inMemory`](#in-memory), [`io.l5d.k8s`](#kubernetes), [`io.l5d.zk`](#zookeeper), [`io.l5d.etcd`](#etcd) or [`io.l5d.consul`](#consul).
 experimental | `false` | Set this to `true` to enable the storage if it is experimental.
 
 ## In Memory


### PR DESCRIPTION
In browsing the linkerd documentation I noticed some inconsistencies in the descriptions of the `kind` field that appears in multiple config objects. I'm updating each description to list and link to all possible kinds. Let me know though if there's a better way to handle this. Overall, I just want it to be consistent.