### PR TITLE
[grpc] support stream cancelation and grpc status control in responses

### DIFF
--- a/grpc/eg/src/test/scala/io/buoyant/grpc/EgTest.scala
+++ b/grpc/eg/src/test/scala/io/buoyant/grpc/EgTest.scala
@@ -139,7 +139,6 @@ class EgEndToEndTest extends FunSuite {
   }
 
   test("streaming request and unary response") {
-    setLogLevel(com.twitter.logging.Level.ALL)
     val rxP = new Promise[Stream[Eg.Req]]
     val rspP = new Promise[Eg.Rsp]
     val tx = Stream[Eg.Rsp]()
@@ -181,7 +180,6 @@ class EgEndToEndTest extends FunSuite {
 
     } finally {
       await(h2client.close().before(h2srv.close()))
-      setLogLevel(com.twitter.logging.Level.OFF)
     }
   }
 

--- a/grpc/runtime/src/main/scala/io/buoyant/grpc/runtime/ClientDispatcher.scala
+++ b/grpc/runtime/src/main/scala/io/buoyant/grpc/runtime/ClientDispatcher.scala
@@ -1,6 +1,6 @@
 package io.buoyant.grpc.runtime
 
-import com.twitter.finagle.{Service => FinagleService}
+import com.twitter.finagle.{Failure, Service => FinagleService}
 import com.twitter.finagle.buoyant.h2
 import com.twitter.io.Buf
 import com.twitter.util.{Future, Return, Throw}
@@ -16,25 +16,42 @@ object ClientDispatcher {
   }
 
   def requestStreaming[T](path: String, msgs: Stream[T], codec: Codec[T]): h2.Request = {
-    val stream = h2.Stream()
+    val frames = h2.Stream()
     def loop(): Future[Unit] =
       msgs.recv().transform {
         case Return(Stream.Releasable(msg, release)) =>
           val buf = codec.encodeGrpcMessage(msg)
           val frame = h2.Frame.Data(buf, eos = false, release)
-          stream.write(frame).before(loop())
+          frames.write(frame).before(loop())
 
-        case Throw(Stream.Closed) =>
-          val frame = h2.Frame.Data(Buf.Empty, eos = true)
-          stream.write(frame)
+        case Throw(s@GrpcStatus.Ok(_)) =>
+          frames.write(h2.Frame.Data(Buf.Empty, eos = true))
+
+        case Throw(s: GrpcStatus) =>
+          frames.reset(s.toReset)
+          Future.exception(s)
 
         case Throw(e) =>
-          // TODO better
-          stream.reset(h2.Reset.InternalError)
+          frames.reset(h2.Reset.InternalError)
           Future.exception(e)
       }
-    loop()
-    h2.Request("http", h2.Method.Post, "", path, stream)
+
+    val loopF = loop()
+    frames.onEnd.respond {
+      case Return(_) =>
+        loopF.raise(Failure(GrpcStatus.Ok(), Failure.Interrupted))
+
+      case Throw(e) =>
+        val status = e match {
+          case s: GrpcStatus => s
+          case rst: h2.Reset => GrpcStatus.fromReset(rst)
+          case e => GrpcStatus.Unknown(e.getMessage)
+        }
+        msgs.reset(status)
+        loopF.raise(Failure(status, Failure.Interrupted))
+    }
+
+    h2.Request("http", h2.Method.Post, "", path, frames)
   }
 
   def acceptUnary[T](rsp: h2.Response, codec: Codec[T]): Future[T] =

--- a/grpc/runtime/src/main/scala/io/buoyant/grpc/runtime/Codec.scala
+++ b/grpc/runtime/src/main/scala/io/buoyant/grpc/runtime/Codec.scala
@@ -47,7 +47,6 @@ trait Codec[T] {
   val decodeRequest: h2.Request => Stream[T] =
     DecodingStream(_, decodeByteBuffer)
 
-  // TODO should be aware of grpc-status
   val decodeResponse: h2.Response => Stream[T] =
     DecodingStream(_, decodeByteBuffer)
 }
@@ -59,7 +58,7 @@ object Codec {
     val Buf.ByteBuffer.Owned(bb0) = Buf.ByteBuffer.coerce(buf)
     val bb = bb0.duplicate()
     if (GrpcFrameHeaderSz > bb.remaining)
-      throw new IllegalArgumentException("too short for header")
+      throw new IllegalArgumentException(s"too short for header: $bb")
 
     // TODO decompress
     val compressed = bb.get == 1
@@ -74,20 +73,29 @@ object Codec {
     Buf.ByteBuffer.Owned(bb)
   }
 
-  def buffer(stream: h2.Stream): Future[Buf] = {
-    def accum(orig: Buf): Future[Buf] =
+  def bufferWithStatus(stream: h2.Stream): Future[(Buf, GrpcStatus)] = {
+    def accum(orig: Buf): Future[(Buf, GrpcStatus)] =
       stream.read().flatMap {
-        case trls: h2.Frame.Trailers => Future.value(orig)
-        case data: h2.Frame.Data =>
-          val buf = orig.concat(data.buf)
-          if (data.isEnd) Future.value(buf)
+        case t: h2.Frame.Trailers =>
+          val status = GrpcStatus.fromTrailers(t)
+          Future.value(orig -> status)
+
+        case d: h2.Frame.Data =>
+          val buf = orig.concat(d.buf)
+          if (d.isEnd) Future.value(buf -> GrpcStatus.Unknown())
           else accum(buf)
       }
+
     accum(Buf.Empty)
   }
 
   def bufferGrpcFrame(stream: h2.Stream): Future[Buf] =
-    buffer(stream).map(decodeGrpcFrame)
+    bufferWithStatus(stream).flatMap(decodeBufferedGrpcResponseFrame)
+
+  private[this] val decodeBufferedGrpcResponseFrame: ((Buf, GrpcStatus)) => Future[Buf] = {
+    case (buf, GrpcStatus.Ok(_)) if !buf.isEmpty => Future(decodeGrpcFrame(buf))
+    case (_, status) => Future.exception(status)
+  }
 
   private def encodeGrpcMessage[T](msg: T, codec: Codec[T]): Buf = {
     val sz = codec.sizeOf(msg)

--- a/grpc/runtime/src/main/scala/io/buoyant/grpc/runtime/GrpcStatus.scala
+++ b/grpc/runtime/src/main/scala/io/buoyant/grpc/runtime/GrpcStatus.scala
@@ -1,0 +1,91 @@
+package io.buoyant.grpc.runtime
+
+import com.twitter.finagle.buoyant.h2
+import scala.util.control.NoStackTrace
+
+sealed abstract class GrpcStatus(val code: Int) extends NoStackTrace {
+  def message: String
+
+  def toReset: h2.Reset = GrpcStatus.toReset(this)
+  def toTrailers: h2.Frame.Trailers = GrpcStatus.toTrailers(this)
+}
+
+object GrpcStatus {
+
+  case class Ok(message: String = "") extends GrpcStatus(0)
+  case class Canceled(message: String = "") extends GrpcStatus(1)
+  case class Unknown(message: String = "") extends GrpcStatus(2)
+  case class InvalidArgument(message: String = "") extends GrpcStatus(3)
+  case class DeadlineExceeded(message: String = "") extends GrpcStatus(4)
+  case class NotFound(message: String = "") extends GrpcStatus(5)
+  case class AlreadyExists(message: String = "") extends GrpcStatus(6)
+  case class PermissionDenied(message: String = "") extends GrpcStatus(7)
+  case class Unauthenticated(message: String = "") extends GrpcStatus(16)
+  case class ResourceExhausted(message: String = "") extends GrpcStatus(8)
+  case class FailedPrecondition(message: String = "") extends GrpcStatus(9)
+  case class Aborted(message: String = "") extends GrpcStatus(10)
+  case class OutOfRange(message: String = "") extends GrpcStatus(11)
+  case class Unimplemented(message: String = "") extends GrpcStatus(12)
+  case class Internal(message: String = "") extends GrpcStatus(13)
+  case class Unavailable(message: String = "") extends GrpcStatus(14)
+  case class DataLoss(message: String = "") extends GrpcStatus(15)
+
+  case class Other(c: Int, message: String) extends GrpcStatus(c)
+
+  def apply(code: Int, msg: String): GrpcStatus = code match {
+    case 0 => Ok(msg)
+    case 1 => Canceled(msg)
+    case 2 => Unknown(msg)
+    case 3 => InvalidArgument(msg)
+    case 4 => DeadlineExceeded(msg)
+    case 5 => NotFound(msg)
+    case 6 => AlreadyExists(msg)
+    case 7 => PermissionDenied(msg)
+    case 8 => ResourceExhausted(msg)
+    case 9 => FailedPrecondition(msg)
+    case 10 => Aborted(msg)
+    case 11 => OutOfRange(msg)
+    case 12 => Unimplemented(msg)
+    case 13 => Internal(msg)
+    case 14 => Unavailable(msg)
+    case 15 => DataLoss(msg)
+    case 16 => Unauthenticated(msg)
+    case code => Other(code, msg)
+  }
+
+  def unapply(s: GrpcStatus): Option[(Int, String)] = Some((s.code, s.message))
+
+  def fromReset(rst: h2.Reset): GrpcStatus = rst match {
+    case h2.Reset.NoError |
+      h2.Reset.ProtocolError |
+      h2.Reset.InternalError => Internal()
+    case h2.Reset.Refused => Unavailable()
+    case h2.Reset.EnhanceYourCalm => ResourceExhausted("rate limit exceeded")
+    case h2.Reset.Cancel => Canceled()
+    case h2.Reset.Closed => Unknown()
+  }
+
+  private def toReset(status: GrpcStatus): h2.Reset = status match {
+    case Internal(_) => h2.Reset.InternalError
+    case Unavailable(_) => h2.Reset.Refused
+    case ResourceExhausted(_) => h2.Reset.EnhanceYourCalm
+    case _ => h2.Reset.Cancel
+  }
+
+  def fromTrailers(tlrs: h2.Frame.Trailers): GrpcStatus = {
+    val msg = tlrs.get("grpc-message").headOption.getOrElse("")
+    tlrs.get("grpc-status") match {
+      case Seq(code, _*) =>
+        try GrpcStatus(code.toInt, msg)
+        catch { case _: NumberFormatException => GrpcStatus.Unknown(s"bad status code: '$code'") }
+      case _ => GrpcStatus.Unknown(msg)
+    }
+  }
+
+  private def toTrailers(status: GrpcStatus): h2.Frame.Trailers =
+    h2.Frame.Trailers(
+      "grpc-status" -> status.code.toString,
+      "grpc-message" -> status.message
+    )
+
+}

--- a/grpc/runtime/src/main/scala/io/buoyant/grpc/runtime/Stream.scala
+++ b/grpc/runtime/src/main/scala/io/buoyant/grpc/runtime/Stream.scala
@@ -1,6 +1,7 @@
 package io.buoyant.grpc.runtime
 
 import com.twitter.concurrent.{AsyncMutex, AsyncQueue}
+import com.twitter.finagle.Failure
 import com.twitter.finagle.buoyant.h2
 import com.twitter.io.Buf
 import com.twitter.util.{Future, Promise, Return, Throw, Try}
@@ -8,8 +9,7 @@ import com.twitter.util.{Future, Promise, Return, Throw, Try}
 trait Stream[+T] {
   def recv(): Future[Stream.Releasable[T]]
 
-  // TODO support grpc error types
-  // def reset(err: Grpc.Error): Unit
+  def reset(err: GrpcStatus): Unit
 }
 
 object Stream {
@@ -27,6 +27,10 @@ object Stream {
     // TODO bound queue? not strictly necessary if send() future observed...
     private[this] val q = new AsyncQueue[Releasable[T]]
 
+    override def reset(e: GrpcStatus): Unit = {
+      q.fail(e, discard = true)
+    }
+
     override def recv(): Future[Releasable[T]] = q.poll()
 
     override def send(msg: T): Future[Unit] = {
@@ -36,17 +40,19 @@ object Stream {
         Future.Unit
       }
       if (q.offer(Releasable(msg, release))) p
-      else Future.exception(Rejected)
+      else Future.exception(Failure("rejected", Failure.Rejected))
     }
 
     override def close(): Future[Unit] = {
-      q.fail(Closed, discard = false)
+      q.fail(GrpcStatus.Ok(), discard = false)
       Future.Unit
     }
   }
 
-  object Closed extends Throwable
-  object Rejected extends Throwable
+  def empty(status: GrpcStatus): Stream[Nothing] = new Stream[Nothing] {
+    override def reset(e: GrpcStatus): Unit = ()
+    override def recv(): Future[Releasable[Nothing]] = Future.exception(status)
+  }
 
   /**
    * A stream backed by a promised stream.
@@ -74,24 +80,44 @@ object Stream {
       // (which isn't guaranteed without it).
       private[this] val recvMu = new AsyncMutex()
 
-      @volatile private[this] var streamRef: Either[Future[Stream[T]], Try[Stream[T]]] =
+      private[this] var streamRef: Either[Future[Stream[T]], Try[Stream[T]]] =
         Left(streamFut)
 
-      private[this] val _recv: Try[Stream[T]] => Future[Stream.Releasable[T]] = { v =>
-        streamRef = Right(v)
-        v match {
-          case Return(stream) => stream.recv()
-          case Throw(e) => Future.exception(e)
+      def reset(e: GrpcStatus): Unit = synchronized {
+        streamRef match {
+          case Right(_) =>
+          case Left(f) =>
+            f.raise(Failure(e, Failure.Interrupted))
         }
+        streamRef = Right(Throw(e))
       }
 
       override def recv(): Future[Stream.Releasable[T]] =
         recvMu.acquireAndRun {
-          streamRef match {
-            case Left(f) => f.transform(_recv)
-            case Right(Return(stream)) => stream.recv()
-            case Right(Throw(e)) => Future.exception(e)
+          synchronized {
+            streamRef match {
+              case Left(f) => f.transform(_recv) // first time through
+              case Right(Return(s)) => s.recv()
+              case Right(Throw(e)) => Future.exception(e)
+            }
           }
         }
+
+      private[this] val _recv: Try[Stream[T]] => Future[Stream.Releasable[T]] = { v =>
+        val ret = synchronized {
+          streamRef match {
+            case Right(reset) =>
+              // If something has happened to update this, just use that update
+              reset
+            case Left(_) =>
+              streamRef = Right(v)
+              v
+          }
+        }
+        ret match {
+          case Return(s) => s.recv()
+          case Throw(e) => Future.exception(e)
+        }
+      }
     }
 }

--- a/grpc/runtime/src/test/scala/io/buoyant/grpc/runtime/VarEventStreamTest.scala
+++ b/grpc/runtime/src/test/scala/io/buoyant/grpc/runtime/VarEventStreamTest.scala
@@ -26,7 +26,7 @@ class VarEventStreamTest extends FunSuite {
     assert(await(f2).value == 2)
 
     val f3 = stream.recv()
-    assert(await(f3.liftToTry) == Throw(Stream.Closed))
+    assert(await(f3.liftToTry) == Throw(GrpcStatus.Ok()))
   }
 
   test("drops intermediate states") {
@@ -52,6 +52,6 @@ class VarEventStreamTest extends FunSuite {
     assert(await(f2).value == 4)
 
     val f3 = stream.recv()
-    assert(await(f3.liftToTry) == Throw(Stream.Closed))
+    assert(await(f3.liftToTry) == Throw(GrpcStatus.Ok()))
   }
 }


### PR DESCRIPTION
Problem

gRPC response contain a grpc-status and grpc-message trailer fields indicating
the application-level response code (http status codes are ignored). Our grpc
library currently ignores these fields and provides no mechanism for setting
them on responses.

Solution

Introduce the GrpcStatus type, modeling grpc-status codes. Furthermore, grpc
Streams may be `reset` with a status to indicate a failure.