### PR TITLE
Localhost transformer should use loopback interface

### DIFF
--- a/interpreter/per-host/src/main/scala/io/buoyant/transformer/perHost/LocalhostTransformerInitializer.scala
+++ b/interpreter/per-host/src/main/scala/io/buoyant/transformer/perHost/LocalhostTransformerInitializer.scala
@@ -23,7 +23,6 @@ class LocalhostTransformerConfig extends TransformerConfig {
       interface <- NetworkInterface.getNetworkInterfaces.asScala
       if interface.isUp
       inet <- interface.getInetAddresses.asScala
-      if !inet.isLoopbackAddress
     } yield inet
     new SubnetLocalTransformer(prefix, localIPs.toSeq, Netmask("255.255.255.255"))
   }


### PR DESCRIPTION
The localhost transformer should consider the addresses from all network interfaces to be local.  Loopback was mistakenly excluded from this which caused the localhost transformer to filter out endpoints bound to 127.0.0.1.