### PR TITLE
[grpc] Default message fields to None/Nil

### DIFF
--- a/grpc/eg/src/test/scala/io/buoyant/grpc/EgTest.scala
+++ b/grpc/eg/src/test/scala/io/buoyant/grpc/EgTest.scala
@@ -38,10 +38,9 @@ object EgTest {
     Buf.Utf8("baz")
   ))
   val expectedMsg = Eg.Message(
-    Some(expectedEnumeration),
-    Some(Eg.Message.OneofResult.Exception(expectedException)),
-    Some(expectedPath),
-    None
+    enumeration = Some(expectedEnumeration),
+    result = Some(Eg.Message.OneofResult.Exception(expectedException)),
+    path = Some(expectedPath)
   )
 }
 


### PR DESCRIPTION
Problem

Currently, you have to specify None/Nil when constructing a message with
non-required fields. This is awkward.

Solution

By defaulting fields to None/Nil, it's more natural to construct messages like
`Message(foo = Some(Bar()))` instead of `Message(Some(Bar()), None, None)`.