### PR TITLE
[grpc] Fix field name snake-casing

### DIFF
--- a/grpc/eg/src/main/protobuf/eg.proto
+++ b/grpc/eg/src/main/protobuf/eg.proto
@@ -37,6 +37,7 @@ message Message {
 
 message Req {
   Enumeration value = 1;
+  bool destroy_fascism = 2;
 }
 message Rsp {
   Message.Enumeration value = 1;

--- a/grpc/eg/src/test/scala/io/buoyant/grpc/EgTest.scala
+++ b/grpc/eg/src/test/scala/io/buoyant/grpc/EgTest.scala
@@ -96,7 +96,7 @@ class EgEndToEndTest extends FunSuite {
     try {
       val client = new Eg.Eggman.Client(h2client)
 
-      val req = Eg.Req(Some(Eg.Enumeration.TWO))
+      val req = Eg.Req(Some(Eg.Enumeration.TWO), Some(true))
       val rsp = await(client.uplatu(req))
       assert(rsp == sentRsp)
     } finally await(h2client.close().before(h2srv.close()))
@@ -117,7 +117,7 @@ class EgEndToEndTest extends FunSuite {
     val client = new Eg.Eggman.Client(h2client)
 
     try {
-      val req = Eg.Req(Some(Eg.Enumeration.ONE))
+      val req = Eg.Req(Some(Eg.Enumeration.ONE), Some(true))
       val rsps = client.uplats(req)
 
       val rf0 = rsps.recv()
@@ -168,12 +168,14 @@ class EgEndToEndTest extends FunSuite {
       val rf1 = rx.recv()
       assert(!rf1.isDefined)
 
-      await(tx.send(Eg.Req(None)))
-      assert(getAndRelease(rf0) == Eg.Req(None))
+      await(tx.send(Eg.Req(None, Some(true))))
+      val req0 = getAndRelease(rf0)
+      assert(req0.value == None)
+      assert(req0.destroyFascism == Some(true))
 
       assert(!rf1.isDefined)
-      await(tx.send(Eg.Req(Some(Eg.Enumeration.ONE))))
-      assert(getAndRelease(rf1) == Eg.Req(Some(Eg.Enumeration.ONE)))
+      await(tx.send(Eg.Req(Some(Eg.Enumeration.ONE), Some(true))))
+      assert(getAndRelease(rf1) == Eg.Req(Some(Eg.Enumeration.ONE), Some(true)))
 
       rspP.setValue(Eg.Rsp(Some(Eg.Message.Enumeration.THREEFOUR)))
       assert(await(rspF) == Eg.Rsp(Some(Eg.Message.Enumeration.THREEFOUR)))
@@ -196,7 +198,7 @@ class EgEndToEndTest extends FunSuite {
     try {
       val client = new Eg.Eggman.Client(h2client)
 
-      val req = Eg.Req(Some(Eg.Enumeration.TWO))
+      val req = Eg.Req(Some(Eg.Enumeration.TWO), Some(true))
       val status = intercept[GrpcStatus] { await(client.uplatu(req)) }
       assert(status == GrpcStatus.DeadlineExceeded(""))
     } finally await(h2client.close().before(h2srv.close()))
@@ -214,7 +216,7 @@ class EgEndToEndTest extends FunSuite {
     val h2client = H2.newService(s"/$$/inet/127.1/${srvAddr.getPort}")
     try {
       val client = new Eg.Eggman.Client(h2client)
-      val stream = client.uplats(Eg.Req(Some(Eg.Enumeration.TWO)))
+      val stream = client.uplats(Eg.Req(Some(Eg.Enumeration.TWO), Some(true)))
       val status = intercept[GrpcStatus] { await(stream.recv()) }
       assert(status == GrpcStatus.DeadlineExceeded())
     } finally await(h2client.close().before(h2srv.close()))

--- a/grpc/gen/src/main/scala/io/buoyant/grpc/gen/Generator.scala
+++ b/grpc/gen/src/main/scala/io/buoyant/grpc/gen/Generator.scala
@@ -721,7 +721,7 @@ object Generator {
   private[this] val HeadRE = """^(.)""".r
 
   private[this] def snakeToCamel(in: String): String =
-    SnakeRE.replaceAllIn(in, _.group(1))
+    SnakeRE.replaceAllIn(in, m => upperHead(m.group(1)))
 
   private[this] def lowerHead(in: String): String =
     HeadRE.replaceAllIn(in, _.group(1).toLowerCase)

--- a/linkerd/telemeter/usage/src/e2e/scala/io/buoyant/linkerd/telemeter/UsageDataTelemeterEndToEndTest.scala
+++ b/linkerd/telemeter/usage/src/e2e/scala/io/buoyant/linkerd/telemeter/UsageDataTelemeterEndToEndTest.scala
@@ -80,7 +80,7 @@ class UsageDataTelemeterEndToEndTest extends FunSuite with Awaits {
     telemeter.run()
 
     val msg = await(promise)
-    assert(msg.orgid == Some("orgId"))
+    assert(msg.orgId == Some("orgId"))
     assert(msg.namers == Seq("test"))
     assert(msg.routers.head.protocol == Some("plain"))
     assert(msg.routers.last.protocol == Some("fancy"))

--- a/linkerd/telemeter/usage/src/main/scala/io/buoyant/linkerd/telemeter/UsageDataTelemeter.scala
+++ b/linkerd/telemeter/usage/src/main/scala/io/buoyant/linkerd/telemeter/UsageDataTelemeter.scala
@@ -63,12 +63,12 @@ private[telemeter] object UsageDataTelemeter {
   ): UsageMessage =
     UsageMessage(
       pid = Some(pid),
-      orgid = orgId,
-      linkerdversion = Some(Build.load().version),
-      containermanager = mkContainerManager,
-      osname = Some(System.getProperty("os.name")),
-      osversion = Some(System.getProperty("os.version")),
-      starttime = None, //TODO
+      orgId = orgId,
+      linkerdVersion = Some(Build.load().version),
+      containerManager = mkContainerManager,
+      osName = Some(System.getProperty("os.name")),
+      osVersion = Some(System.getProperty("os.version")),
+      startTime = None, //TODO
       routers = mkRouters(config),
       namers = mkNamers(config),
       counters = mkCounters(metrics),


### PR DESCRIPTION
Problem
    
Field names like _destroy_fascism_ should be generated as _destroyFascism_. Currently, our snake-casing doesn't do capitalization properly and so we get _destroyfascism_.
    
Solution
    
Upper-case snake components.

Closes: #992 
Co-Authored-By: @stevej