### PR TITLE
Use more descriptive client and server span labels

### DIFF
--- a/linkerd/protocol/thrift/src/main/scala/com/twitter/finagle/buoyant/linkerd/TTwitterServerFilter.scala
+++ b/linkerd/protocol/thrift/src/main/scala/com/twitter/finagle/buoyant/linkerd/TTwitterServerFilter.scala
@@ -61,11 +61,6 @@ class TTwitterServerFilter(
 
         Dtab.local ++= richHeader.dtab
 
-        Trace.recordRpc({
-          val msg = new InputBuffer(request_, protocolFactory)().readMessageBegin()
-          msg.name
-        })
-
         // If `header.client_id` field is non-null, then allow it to take
         // precedence over an id potentially provided by in the key-value pairs
         // when performing tracing.
@@ -110,8 +105,6 @@ class TTwitterServerFilter(
         isUpgraded = true
         successfulUpgradeReply
       } else {
-        // request from client without tracing support
-        Trace.recordRpc(msg.name)
         Trace.recordBinary("srv/thrift/ttwitter", false)
         service(request)
       }

--- a/router/core/src/main/scala/io/buoyant/router/RoutingFactory.scala
+++ b/router/core/src/main/scala/io/buoyant/router/RoutingFactory.scala
@@ -152,8 +152,6 @@ class RoutingFactory[Req, Rsp](
 
     def apply(req0: Req): Future[Rsp] = {
       if (Trace.isActivelyTracing) {
-        // we treat the router label as the rpc name for this span
-        Trace.recordRpc(label)
         Trace.recordBinary("router.label", label)
       }
 

--- a/router/core/src/test/scala/io/buoyant/router/RoutingFactoryTest.scala
+++ b/router/core/src/test/scala/io/buoyant/router/RoutingFactoryTest.scala
@@ -73,10 +73,6 @@ class RoutingFactoryTest extends FunSuite {
       val service = mkService(label = "customlabel")
       await(service(Request()))
       assert(tracer.annotations.exists {
-        case Rpc(name) => name == "customlabel"
-        case _ => false
-      })
-      assert(tracer.annotations.exists {
         case BinaryAnnotation(key, value) => key == "router.label" && value == "customlabel"
         case _ => false
       })

--- a/router/http/src/main/scala/io/buoyant/router/http/TracingFilter.scala
+++ b/router/http/src/main/scala/io/buoyant/router/http/TracingFilter.scala
@@ -1,9 +1,8 @@
 package io.buoyant.router.http
 
-import com.twitter.conversions.storage._
 import com.twitter.finagle.{Service, ServiceFactory, SimpleFilter, Stack, Stackable, param}
 import com.twitter.finagle.client.StackClient
-import com.twitter.finagle.http.{Request, Response, Status}
+import com.twitter.finagle.http.{Request, Response}
 import com.twitter.finagle.tracing.Trace
 
 object TracingFilter {
@@ -28,7 +27,7 @@ object TracingFilter {
  * Annotates HTTP method, uri, and status code, content-type, and content-length.
  */
 class TracingFilter extends SimpleFilter[Request, Response] {
-  import TracingFilter.{TransferEncoding, MaxBodySize}
+  import TracingFilter.{MaxBodySize, TransferEncoding}
 
   def apply(req: Request, service: Service[Request, Response]) = {
     recordRequest(req)
@@ -37,7 +36,7 @@ class TracingFilter extends SimpleFilter[Request, Response] {
 
   private[this] def recordRequest(req: Request): Unit =
     if (Trace.isActivelyTracing) {
-      Trace.recordRpc(req.method.toString)
+      Trace.recordRpc(s"${req.method.toString} ${req.path}")
       // http.uri is used here for consistency with finagle-http's tracing filter
       Trace.recordBinary("http.uri", req.uri)
       Trace.recordBinary("http.req.method", req.method.toString)

--- a/router/http/src/test/scala/io/buoyant/router/http/TracingFilterTest.scala
+++ b/router/http/src/test/scala/io/buoyant/router/http/TracingFilterTest.scala
@@ -33,7 +33,7 @@ class TracingFilterTest extends FunSuite with Awaits {
       val f = service(req)
 
       val reqEvents = tracer.iterator.toSeq
-      assert(reqEvents.exists(_.annotation == Annotation.Rpc("HEAD")))
+      assert(reqEvents.exists(_.annotation == Annotation.Rpc("HEAD /foo")))
       assert(reqEvents.exists(_.annotation == Annotation.BinaryAnnotation("http.uri", "/foo?bar=bah")))
       assert(reqEvents.exists(_.annotation == Annotation.BinaryAnnotation("http.req.method", "HEAD")))
       assert(reqEvents.exists(_.annotation == Annotation.BinaryAnnotation("http.req.host", "monkeys")))


### PR DESCRIPTION
The existing labels are vague. For server spans, start using the router name plus the dst path for the request. For client http spans, use the http method plus the http path. As part of this change, I realized that the server span labels are generated independent of protocol, so I removed the protocol-specific server span labels that we were generating in the thrift protocol. Relates to #997.

Sample trace with the updated labels:

![screen shot 2017-01-30 at 12 44 47 pm](https://cloud.githubusercontent.com/assets/9226/22444742/1e432cb8-e6f9-11e6-9a78-7005a4b2d423.png)
