### PR TITLE
Add a client-colored border around each client section 

### DIFF
--- a/admin/src/main/resources/io/buoyant/admin/css/dashboard.css
+++ b/admin/src/main/resources/io/buoyant/admin/css/dashboard.css
@@ -237,6 +237,7 @@ nav.navbar {
   float: left;
   width: 100%;
   margin-top: -13px;
+  border-radius: 3px;
 }
 .client-container .header-line {
   width: 100%;

--- a/admin/src/main/resources/io/buoyant/admin/css/dashboard.css
+++ b/admin/src/main/resources/io/buoyant/admin/css/dashboard.css
@@ -233,8 +233,24 @@ nav.navbar {
   margin-bottom: 10px;
 }
 
+.client-content-container {
+  float: left;
+  width: 100%;
+  margin-top: -13px;
+}
+.client-container .header-line {
+  width: 100%;
+  position: relative;
+  top: 18px;
+}
 .client-container .router-header-large {
-  padding: 8px 0;
+  padding: 8px 15px;
+  position: relative;
+  top: -3px;
+}
+.client-container .router-header-large > div {
+  padding: 0px 5px;
+  background-color: #090B34;
 }
 
 .client-toggle {
@@ -278,6 +294,7 @@ nav.navbar {
 .bar-chart-container {
   margin-top: 20px;
   min-height: 80px;
+  padding-left: 15px;
 }
 .bar-chart-label {
   margin: 12px 0;

--- a/admin/src/main/resources/io/buoyant/admin/css/dashboard.css
+++ b/admin/src/main/resources/io/buoyant/admin/css/dashboard.css
@@ -233,6 +233,22 @@ nav.navbar {
   margin-bottom: 10px;
 }
 
+.client-container .client-id {
+  cursor: pointer;
+}
+.client-id .transformer-prefix, .client-id .client-suffix {
+  background-color: #090B34;
+}
+.client-id .client-suffix.is-first {
+  padding-left: 5px;
+}
+.client-id > div:first-child {
+  padding-left: 5px;
+}
+.client-id > div:last-child {
+  padding-right: 5px;
+}
+
 .client-content-container {
   float: left;
   width: 100%;

--- a/admin/src/main/resources/io/buoyant/admin/js/src/admin.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/admin.js
@@ -19,7 +19,7 @@ define([
 
     return $.get("config.json").done(function(routersRsp) {
       var template = Handlebars.compile(templateRsp);
-      var routers = _.sortBy(routersRsp.routers, "label");
+      var routers = routersRsp.routers;
 
       if (!matches && routers.length > 0) {
         selectRouter(routers[0].label || routers[0].protocol);

--- a/admin/src/main/resources/io/buoyant/admin/js/src/admin.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/admin.js
@@ -19,17 +19,16 @@ define([
 
     return $.get("config.json").done(function(routersRsp) {
       var template = Handlebars.compile(templateRsp);
-      var routers = routersRsp.routers;
+      var routers = _.sortBy(routersRsp.routers, "label");
 
-      //Not every page supports a mult-router view!
-      if(!removeRoutersAllOption) {
-        routers.unshift({label: "all"});
-      } else {
-        if (!matches && routers.length > 0) {
-          selectRouter(routers[0].label || routers[0].protocol);
-        }
+      if (!matches && routers.length > 0) {
+        selectRouter(routers[0].label || routers[0].protocol);
       }
 
+      //Not every page supports a mult-router view!
+      if(!removeRoutersAllOption || routers.length === 0) {
+        routers.push({label: "all"});
+      }
       var routerHtml = routers.map(template);
 
       $(".dropdown-menu").html(routerHtml.join(""));
@@ -43,11 +42,6 @@ define([
   }
 
   function selectRouter(label) {
-    if (label === "all") {
-      unselectRouter();
-      return;
-    }
-
     var uriComponent = "router=" + encodeURIComponent(label);
     var re = /router=(.+)(?:&|$)/
     if (window.location.search == "") {

--- a/admin/src/main/resources/io/buoyant/admin/js/src/router_client.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/router_client.js
@@ -171,7 +171,7 @@ define([
       function toggleClientDisplay(expand) {
         if (expand) {
           $contentContainer.css({"border": colorBorder});
-          $headerLine.css("border-bottom", null);
+          $headerLine.css("border-bottom", "0px");
 
           metricsCollector.registerListener(metricsHandler, getDesiredMetrics);
         } else {

--- a/admin/src/main/resources/io/buoyant/admin/js/src/router_client.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/router_client.js
@@ -83,9 +83,8 @@ define([
       });
     }
 
-    function renderMetrics($container, client, summaryData, latencyData, clientColor) {
+    function renderMetrics($container, client, summaryData, latencyData) {
       var clientHtml = template({
-        clientColor: clientColor,
         client: client.label,
         latencies: latencyData,
         data: summaryData
@@ -141,19 +140,21 @@ define([
 
       var $contentContainer = $container.find(".client-content-container");
 
+      var $headerLine = $container.find(".header-line");
+      var colorBorder = "2px solid" + colors.color;
+
       var $metricsEl = $container.find(".metrics-container");
       var $chartEl = $container.find(".chart-container");
       var $toggleLinks = $container.find(".client-toggle");
       var $lbBarChart = $container.find(".lb-bar-chart");
 
-      var clientColor = colors.color;
       var latencyLegend = createLatencyLegend(colors.colorFamily);
       var metricDefinitions = getMetricDefinitions(routerName, client.label);
 
       var $expandLink = $toggleLinks.find(".client-expand");
       var $collapseLink = $toggleLinks.find(".client-collapse");
 
-      renderMetrics($metricsEl, client, [], [], clientColor);
+      renderMetrics($metricsEl, client, [], []);
       var chart = SuccessRateGraph($chartEl.find(".client-success-rate"), colors.color);
       var lbBarChart = new LoadBalancerBarChart($lbBarChart);
 
@@ -169,8 +170,14 @@ define([
 
       function toggleClientDisplay(expand) {
         if (expand) {
+          $contentContainer.css({"border": colorBorder});
+          $headerLine.css("border-bottom", null);
+
           metricsCollector.registerListener(metricsHandler, getDesiredMetrics);
         } else {
+          $contentContainer.css({'border': null});
+          $headerLine.css({'border-bottom': colorBorder});
+
           metricsCollector.deregisterListener(metricsHandler);
         }
 
@@ -187,7 +194,7 @@ define([
         chart.updateMetrics(getSuccessRate(summaryData));
         lbBarChart.update(summaryData);
 
-        renderMetrics($metricsEl, client, summaryData, latencies, clientColor);
+        renderMetrics($metricsEl, client, summaryData, latencies);
       }
 
       function getDesiredMetrics(metrics) {

--- a/admin/src/main/resources/io/buoyant/admin/js/src/router_clients.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/router_clients.js
@@ -55,12 +55,14 @@ define([
           client: match[2]
         })).appendTo($clientEl);
         if (match[1]) {
-          var $clientId = $container.find(".client-id");
-          var $transformerPrefix = $container.find(".transformer-prefix")
-          $clientId.css("cursor", "pointer");
-          $clientId.click(function() {
-            $transformerPrefix.toggle("slow", function() {});
-          });
+          var $transformerPrefix = $container.find(".transformer-prefix");
+          var $clientSuffix = $container.find(".client-suffix");
+          var $clientId = $container.find(".client-id")
+            .click(function() {
+              $transformerPrefix.toggle("slow", function() {
+                $clientSuffix.toggleClass("is-first", !$transformerPrefix.is(":visible"));
+              });
+            });
         }
 
         return RouterClient(metricsCollector, routers, client, $container, routerName, colorsForClient, expandClients);

--- a/admin/src/main/resources/io/buoyant/admin/js/src/router_clients.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/router_clients.js
@@ -57,7 +57,8 @@ define([
         if (match[1]) {
           var $transformerPrefix = $container.find(".transformer-prefix");
           var $clientSuffix = $container.find(".client-suffix");
-          var $clientId = $container.find(".client-id")
+
+          $container.find(".client-id")
             .click(function() {
               $transformerPrefix.toggle("slow", function() {
                 $clientSuffix.toggleClass("is-first", !$transformerPrefix.is(":visible"));

--- a/admin/src/main/resources/io/buoyant/admin/js/src/success_rate_graph.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/success_rate_graph.js
@@ -7,7 +7,7 @@ define([
   var SuccessRateGraph = (function() {
     var neutralLineColor = "#878787"; // greys.neutral
     var defaultWidth = 1181;
-    var colMd6Width = 594; // from our css grid layout spec
+    var colMd6Width = 594 + 15; // from our css grid layout spec + padding
 
     // set default y range such that a graph of purely 100% success rate doesn't
     // blend in to the very top of the graph, and doesn't center

--- a/admin/src/main/resources/io/buoyant/admin/js/template/metric.partial.template
+++ b/admin/src/main/resources/io/buoyant/admin/js/template/metric.partial.template
@@ -1,4 +1,4 @@
-<div class="{{containerClass}}" style={{#if borderColor}}"border-left: 1px solid {{borderColor}}"{{/if}}>
+<div class="{{containerClass}}">
   <div class="metric-header">
     {{#if description}}
       {{description}}

--- a/admin/src/main/resources/io/buoyant/admin/js/template/router_client.template
+++ b/admin/src/main/resources/io/buoyant/admin/js/template/router_client.template
@@ -1,12 +1,12 @@
 <div class="client-metrics row">
   <div class="col-md-2">
-    {{> metricPartial data.successRate containerClass="metric-container" metricClass="success-metric metric-large" borderColor=clientColor}}
-    {{> metricPartial data.requests containerClass="metric-container" metricClass="metric-large" borderColor=clientColor}}
+    {{> metricPartial data.successRate containerClass="metric-container" metricClass="success-metric metric-large"}}
+    {{> metricPartial data.requests containerClass="metric-container" metricClass="metric-large"}}
   </div>
 
   <div class="col-md-2">
-    {{> metricPartial data.connections containerClass="metric-container" metricClass="metric-large" borderColor=clientColor}}
-    {{> metricPartial data.failures containerClass="metric-container" metricClass="failure-metric metric-large" borderColor=clientColor}}
+    {{> metricPartial data.connections containerClass="metric-container" metricClass="metric-large"}}
+    {{> metricPartial data.failures containerClass="metric-container" metricClass="failure-metric metric-large"}}
   </div>
 
   <div class="col-md-2 router-latencies-container">

--- a/admin/src/main/resources/io/buoyant/admin/js/template/router_client_container.template
+++ b/admin/src/main/resources/io/buoyant/admin/js/template/router_client_container.template
@@ -3,7 +3,7 @@
   <div class="router-header-large">
     <div class="client-id">
       <div class="pull-left transformer-prefix" style="display: none">{{prefix}}</div>
-      <div class="pull-left client-name">{{client}}</div>
+      <div class="pull-left client-suffix is-first">{{client}}</div>
     </div>
     <div class="client-toggle pull-right">
       <a class="client-expand" target="blank">expand</a>

--- a/admin/src/main/resources/io/buoyant/admin/js/template/router_client_container.template
+++ b/admin/src/main/resources/io/buoyant/admin/js/template/router_client_container.template
@@ -1,7 +1,10 @@
 <div class="client-container clearfix">
   <div class="header-line">&nbsp;</div>
   <div class="router-header-large">
-    <div class="pull-left transformer-prefix client-id" style="display: none">{{prefix}}</div><div class="pull-left client-id">{{client}}</div>
+    <div class="client-id">
+      <div class="pull-left transformer-prefix" style="display: none">{{prefix}}</div>
+      <div class="pull-left client-name">{{client}}</div>
+    </div>
     <div class="client-toggle pull-right">
       <a class="client-expand" target="blank">expand</a>
       <a class="client-collapse" target="blank">collapse</a>

--- a/admin/src/main/resources/io/buoyant/admin/js/template/router_client_container.template
+++ b/admin/src/main/resources/io/buoyant/admin/js/template/router_client_container.template
@@ -1,6 +1,7 @@
 <div class="client-container clearfix">
-  <div class="router-header-large" style="border-bottom: 2px solid {{clientColor}};">
-    /{{client}}
+  <div class="header-line">&nbsp;</div>
+  <div class="router-header-large">
+    <div class="pull-left">/{{client}}</div>
     <div class="client-toggle pull-right">
       <a class="client-expand" target="blank">expand</a>
       <a class="client-collapse" target="blank">collapse</a>


### PR DESCRIPTION
Try to make the admin page's sections clearer:
* delineate client sections with colored boxes
* move the All routers view to the last one in the nav list, and default "/" to the first router (alphabetically)

Fixes #918

![screen shot 2017-01-31 at 11 46 22 am](https://cloud.githubusercontent.com/assets/549258/22481679/f3f0cce2-e7aa-11e6-8d3b-b15db0bcfa77.png)


![screen shot 2017-01-30 at 11 58 21 am](https://cloud.githubusercontent.com/assets/549258/22450057/fba17faa-e718-11e6-8189-f7c8a7f47252.png)
