### PR TITLE
add usage data telemeter tab to admin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 ## Upcoming Release
 
 * Add `io.l5d.usage` telemeter for opt-in usage data collection
+  * Add Usage tab on Admin dashboard
 * Admin dashboard
   * Sorts clients and servers alphabetically
   * Displays routers in the order that they are defined

--- a/admin/src/main/resources/io/buoyant/admin/js/main-linkerd.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/main-linkerd.js
@@ -29,14 +29,16 @@ require([
   'src/dashboard',
   'src/delegate',
   'src/namerd',
-  'src/logging'
+  'src/logging',
+  'src/usage'
 ], function (
   $, _, bootstrap,
   adminPage,
   dashboard,
   linkerdDtabPlayground,
   namerd,
-  loggingConfig
+  loggingConfig,
+  usage
 ) {
   // poor man's routing
   if (window.location.pathname.endsWith("/delegator")) {
@@ -50,6 +52,10 @@ require([
   } else if (window.location.pathname.endsWith("/logging")) {
     adminPage.initialize().done(function() {
       new loggingConfig();
+    });
+  } else if (window.location.pathname.endsWith("/usage")) {
+    adminPage.initialize().done(function() {
+      new usage();
     });
   } else {
     adminPage.initialize().done(function(routerConfig) {

--- a/admin/src/main/resources/io/buoyant/admin/js/src/usage.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/usage.js
@@ -1,0 +1,21 @@
+"use strict";
+
+define([
+  'jQuery',
+  'Handlebars',
+  'text!template/usage.template',
+], function(
+  $, Handlebars,
+  usageTemplate
+) {
+  return function() {
+    var template = Handlebars.compile(usageTemplate)
+    var $usageContainer = $(".usage-content");
+
+    $.get("admin/metrics/usage").done(function(usageJson) {
+      var view = {usageJson: JSON.stringify(usageJson, null, '  ')};
+      var $templateContainer = $(template(view));
+      $templateContainer.appendTo($usageContainer);
+    });
+  }
+});

--- a/admin/src/main/resources/io/buoyant/admin/js/template/usage.template
+++ b/admin/src/main/resources/io/buoyant/admin/js/template/usage.template
@@ -1,0 +1,21 @@
+<h1 class="title">Usage Data</h1>
+
+<p>
+You are seeing this page because you have enabled the <b><i>io.l5d.usage</i></b> telemeter in your <a href="config.json">config file</a>
+</p>
+
+<p>
+To see the payload endpoint, you can browse to <a href="admin/metrics/usage">/admin/metrics/usage</a>.
+</p>
+
+<p>
+For more information on configuring this telemeter, head over the <a href="https://linkerd.io/config/head/linkerd/index.html#usage">linkerd config reference</a>.
+</p>
+
+<h3>Payload</h3>
+
+<p>
+Below is a snapshot of the payload sent to Buoyant:
+</p>
+
+<pre><code class="language-json">{{usageJson}}</code></pre>

--- a/linkerd/examples/admin.yaml
+++ b/linkerd/examples/admin.yaml
@@ -2,6 +2,9 @@
 # localhost:9990 and localhost:4140/foo/ should display the same page.
 # when running namerd, localhost:9991 and localhost:4141/foo/ should display the same page.
 # Note, to run namerd in parallel, use `./sbt namerd-examples/basic:run`.
+#
+# Usage admin tab at localhost:9990/usage.
+# Usage data available at localhost:9990/admin/metrics/usage.
 
 admin:
   ip: 0.0.0.0
@@ -11,6 +14,9 @@ telemetry:
 - kind: io.l5d.commonMetrics
 - kind: io.l5d.recentRequests
   sampleRate: 1.0
+- kind: io.l5d.usage
+  orgId: usage-example
+  dryRun: true
 
 routers:
 - protocol: http

--- a/linkerd/telemeter/usage/src/main/scala/io/buoyant/linkerd/telemeter/UsageDataAdminHandler.scala
+++ b/linkerd/telemeter/usage/src/main/scala/io/buoyant/linkerd/telemeter/UsageDataAdminHandler.scala
@@ -1,0 +1,19 @@
+package io.buoyant.linkerd.telemeter
+
+import com.twitter.finagle.Service
+import com.twitter.finagle.http.{MediaType, Request, Response}
+import com.twitter.util.Future
+
+class UsageDataAdminHandler extends Service[Request, Response] {
+
+  override def apply(req: Request): Future[Response] = {
+    req.response.contentString =
+      s"""
+       |<div class="container main">
+       |  <div class="usage-content"></div>
+       |</div>
+     """.stripMargin
+    req.response.contentType = MediaType.Html
+    Future.value(req.response)
+  }
+}


### PR DESCRIPTION
<img width="919" alt="screen shot 2017-02-01 at 1 46 22 pm" src="https://cloud.githubusercontent.com/assets/236915/22527723/131ca37c-e885-11e6-9bdd-837003f635d7.png">

test with:
```bash
./sbt linkerd-examples/admin:run
```
and then:
```bash
open http://localhost:9990/usage
open http://localhost:4140/foo/usage
```

fixes #974