### PR TITLE
[h2] Replace netty's Http2FrameCodec

### DIFF
--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4H2Listener.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4H2Listener.scala
@@ -9,7 +9,7 @@ import com.twitter.finagle.transport.{TlsConfig, Transport}
 import io.netty.buffer.ByteBuf
 import io.netty.channel._
 import io.netty.channel.socket.SocketChannel
-import io.netty.handler.codec.http2.{Http2FrameCodec, Http2Frame}
+import io.netty.handler.codec.http2._
 import io.netty.handler.ssl.{ApplicationProtocolNames, ApplicationProtocolNegotiationHandler}
 
 /**
@@ -56,7 +56,13 @@ object Netty4H2Listener {
         proto match {
           case ApplicationProtocolNames.HTTP_2 =>
             ctx.channel.config.setAutoRead(true)
-            ctx.pipeline.replace(PlaceholderKey, "h2 framer", new Http2FrameCodec(true)); ()
+
+            // TODO replace flow controller
+            val connection = new DefaultHttp2Connection(true /*server*/ )
+            // TODO configure settings from params
+            val settings = new Http2Settings
+            val codec = new H2FrameCodec(connection, settings)
+            ctx.pipeline.replace(PlaceholderKey, "h2 framer", codec); ()
 
           // TODO case ApplicationProtocolNames.HTTP_1_1 =>
           case proto => throw new IllegalStateException(s"unknown protocol: $proto")

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4H2Transporter.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4H2Transporter.scala
@@ -8,7 +8,7 @@ import com.twitter.finagle.netty4.Netty4Transporter
 import com.twitter.finagle.netty4.buoyant.{BufferingConnectDelay, Netty4ClientTls}
 import com.twitter.finagle.netty4.channel.DirectToHeapInboundHandler
 import io.netty.channel.{ChannelDuplexHandler, ChannelHandlerContext, ChannelPipeline}
-import io.netty.handler.codec.http2.{Http2FrameCodec, Http2Frame}
+import io.netty.handler.codec.http2._
 import io.netty.handler.ssl.ApplicationProtocolNames
 
 object Netty4H2Transporter {
@@ -25,7 +25,13 @@ object Netty4H2Transporter {
     // transports are not created) until a connection is fully
     // initialized (and protocol initialization has completed). All
     // stream frame writes are buffered until this time.
-    def framer = new Http2FrameCodec(false /*server*/ )
+    def framer = {
+      // TODO replace flow controller
+      val connection = new DefaultHttp2Connection(false /*server*/ )
+      // TODO configure settings from params
+      val settings = new Http2Settings
+      new H2FrameCodec(connection, settings)
+    }
     val pipelineInit: ChannelPipeline => Unit =
       params[TransportSecurity].config match {
         case TransportSecurity.Insecure =>

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/ServerUpgradeHandler.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/ServerUpgradeHandler.scala
@@ -32,7 +32,11 @@ class ServerUpgradeHandler extends ChannelDuplexHandler {
   private[this] val h1Codec = new HttpServerCodec
 
   // Parses HTTP/2 frames
-  private[this] val framer = new Http2FrameCodec(true /*server*/ )
+  private[this] val framer = {
+    // TODO fix flow control
+    val conn = new DefaultHttp2Connection(true /*server*/ )
+    new H2FrameCodec(conn, new Http2Settings)
+  }
 
   // Intercepts HTTP/1 requests with the HTTP2-Settings headers and
   // initiate protocol upgrade.

--- a/finagle/h2/src/main/scala/io/netty/handler/codec/http2/H2FrameCodec.scala
+++ b/finagle/h2/src/main/scala/io/netty/handler/codec/http2/H2FrameCodec.scala
@@ -1,0 +1,252 @@
+package io.netty.handler.codec.http2
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.{ChannelDuplexHandler, ChannelHandlerContext, ChannelPromise}
+import io.netty.handler.codec.http.HttpServerUpgradeHandler.UpgradeEvent;
+
+/**
+ * This is a direct reimplementation of io.netty.handler.codec.http2.Http2FrameCodec.
+ *
+ * Thie Netty API is unstable at the moment and unsuitable for our
+ * current needs, especially with regard to initial settings and flow
+ * control.  We SHOULD feed back whatever we need to Netty, but one
+ * step at a time.
+ *
+ * Copyright 2016 The Netty Project
+ */
+class H2FrameCodec(
+  connection: Http2Connection,
+  initialSettings: Http2Settings
+) extends ChannelDuplexHandler {
+
+  import H2FrameCodec._
+
+  private[this] var channelCtx, http2HandlerCtx: ChannelHandlerContext = null
+
+  val connectionListener = new Http2ConnectionAdapter {
+    override def onStreamActive(stream: Http2Stream): Unit = channelCtx match {
+      case null => // UPGRADE stream is active before handlerAdded
+      case ctx => ctx.fireUserEventTriggered(new Http2StreamActiveEvent(stream.id)); ()
+    }
+
+    override def onStreamClosed(stream: Http2Stream): Unit = {
+      channelCtx.fireUserEventTriggered(new Http2StreamClosedEvent(stream.id)); ()
+    }
+
+    override def onGoAwayReceived(lastStreamId: Int, errorCode: Long, data: ByteBuf): Unit = {
+      channelCtx.fireChannelRead(new DefaultHttp2GoAwayFrame(lastStreamId, errorCode, data)); ()
+    }
+  }
+
+  private[this] val http2Handler = mkHandler(connection, initialSettings)
+  http2Handler.connection.addListener(connectionListener)
+
+  def connectionHandler: Http2ConnectionHandler = http2Handler
+
+  /**
+   * Load any dependencies.
+   */
+  override def handlerAdded(ctx: ChannelHandlerContext): Unit = {
+    channelCtx = ctx
+    ctx.pipeline.addBefore(ctx.executor, ctx.name, null, http2Handler)
+    http2HandlerCtx = ctx.pipeline.context(http2Handler)
+  }
+
+  /**
+   * Clean up any dependencies.
+   */
+  override def handlerRemoved(ctx: ChannelHandlerContext): Unit = {
+    ctx.pipeline.remove(http2Handler); ()
+  }
+
+  /**
+   * Handles the cleartext HTTP upgrade event. If an upgrade occurred,
+   * sends a simple response via HTTP/2 on stream 1 (the stream
+   * specifically reserved for cleartext HTTP upgrade).
+   */
+  override def userEventTriggered(ctx: ChannelHandlerContext, ev: Any): Unit =
+    ev match {
+      case upgrade: UpgradeEvent =>
+        try {
+          val stream = http2Handler.connection.stream(Http2CodecUtil.HTTP_UPGRADE_STREAM_ID)
+          // TODO: improve handler/stream lifecycle so that stream isn't
+          // active before handler added.  The stream was already made
+          // active, but ctx may have been null so it wasn't
+          // initialized.  https://github.com/netty/netty/issues/4942
+          connectionListener.onStreamActive(stream)
+
+          upgrade.upgradeRequest.headers.setInt(
+            HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text(),
+            Http2CodecUtil.HTTP_UPGRADE_STREAM_ID
+          )
+
+          val adapter = new InboundHttpToHttp2Adapter(
+            http2Handler.connection,
+            http2Handler.decoder.frameListener
+          )
+          adapter.channelRead(ctx, upgrade.upgradeRequest.retain())
+        } finally { upgrade.release(); () }
+
+      case ev => super.userEventTriggered(ctx, ev)
+    }
+
+  // Override this to signal it will never throw an exception.
+  override def exceptionCaught(ctx: ChannelHandlerContext, cause: Throwable): Unit = {
+    ctx.fireExceptionCaught(cause); ()
+  }
+
+  /**
+   * Processes all {@link Http2Frame}s. {@link Http2StreamFrame}s may
+   * only originate in child streams.
+   */
+  override def write(ctx: ChannelHandlerContext, msg: Any, promise: ChannelPromise): Unit =
+    msg match {
+      case goaway: Http2GoAwayFrame =>
+        try {
+          if (goaway.lastStreamId > -1) {
+            throw new IllegalArgumentException("Last stream ID must not be set on GOAWAY")
+          }
+          val lastStreamCreated = http2Handler.connection.remote.lastStreamCreated
+          val lastStreamId = (lastStreamCreated + goaway.extraStreamIds * 2) match {
+            case n if n < lastStreamCreated => Int.MaxValue
+            case n => n
+          }
+          http2Handler.goAway(
+            http2HandlerCtx,
+            lastStreamId,
+            goaway.errorCode,
+            goaway.content.retain(),
+            promise
+          ); ()
+        } finally { goaway.release(); () }
+
+      case data: Http2DataFrame =>
+        try {
+          http2Handler.encoder.writeData(
+            http2HandlerCtx,
+            data.streamId,
+            data.content.retain(),
+            data.padding,
+            data.isEndStream,
+            promise
+          ); ()
+        } finally { data.release(); () }
+
+      case headers: Http2HeadersFrame =>
+        http2Handler.encoder.writeHeaders(
+          http2HandlerCtx,
+          headers.streamId,
+          headers.headers(),
+          headers.padding,
+          headers.isEndStream,
+          promise
+        ); ()
+
+      case reset: Http2ResetFrame =>
+        http2Handler.resetStream(
+          http2HandlerCtx,
+          reset.streamId,
+          reset.errorCode,
+          promise
+        ); ()
+
+      case update: Http2WindowUpdateFrame =>
+        try {
+          http2Handler.connection.local.flowController.consumeBytes(
+            http2Handler.connection.stream(update.streamId),
+            update.windowSizeIncrement
+          )
+          promise.setSuccess(); ()
+        } catch {
+          case e: Throwable => promise.setFailure(e); ()
+        }
+
+      case msg => ctx.write(msg, promise); ()
+    }
+
+}
+
+object H2FrameCodec {
+
+  private lazy val frameLogger = new Http2FrameLogger(io.netty.handler.logging.LogLevel.DEBUG, getClass)
+
+  private def mkHandler(connection: Http2Connection, settings: Http2Settings): Http2ConnectionHandler = {
+    val encoder = {
+      val fw = new Http2OutboundFrameLogger(new DefaultHttp2FrameWriter, frameLogger)
+      new DefaultHttp2ConnectionEncoder(connection, fw)
+    }
+    val decoder = {
+      val fr = new Http2InboundFrameLogger(new DefaultHttp2FrameReader, frameLogger)
+      new DefaultHttp2ConnectionDecoder(connection, encoder, fr)
+    }
+    decoder.frameListener(new FrameListener)
+    new ConnectionHandler(decoder, encoder, settings)
+  }
+
+  private class ConnectionHandler(
+    decoder: Http2ConnectionDecoder,
+    encoder: Http2ConnectionEncoder,
+    initialSettings: Http2Settings
+  ) extends Http2ConnectionHandler(decoder, encoder, initialSettings) {
+
+    override protected def onStreamError(
+      ctx: ChannelHandlerContext,
+      cause: Throwable,
+      exc: Http2Exception.StreamException
+    ): Unit =
+      try {
+        if (connection.stream(exc.streamId) != null) {
+          ctx.fireExceptionCaught(exc); ()
+        }
+      } finally {
+        super.onStreamError(ctx, cause, exc)
+      }
+  }
+
+  private class FrameListener extends Http2FrameAdapter {
+
+    override def onRstStreamRead(ctx: ChannelHandlerContext, id: Int, code: Long): Unit = {
+      val rst = new DefaultHttp2ResetFrame(code)
+      rst.setStreamId(id)
+      ctx.fireChannelRead(rst); ()
+    }
+
+    override def onHeadersRead(
+      ctx: ChannelHandlerContext,
+      streamId: Int,
+      headers: Http2Headers,
+      streamDependency: Int,
+      weight: Short,
+      exclusive: Boolean,
+      padding: Int,
+      eos: Boolean
+    ): Unit = onHeadersRead(ctx, streamId, headers, padding, eos)
+
+    override def onHeadersRead(
+      ctx: ChannelHandlerContext,
+      streamId: Int,
+      headers: Http2Headers,
+      padding: Int,
+      eos: Boolean
+    ): Unit = {
+      val hdrs = new DefaultHttp2HeadersFrame(headers, eos, padding)
+      hdrs.setStreamId(streamId)
+      ctx.fireChannelRead(hdrs); ()
+    }
+
+    override def onDataRead(
+      ctx: ChannelHandlerContext,
+      streamId: Int,
+      content: ByteBuf,
+      padding: Int,
+      eos: Boolean
+    ): Int = {
+      val data = new DefaultHttp2DataFrame(content.retain(), eos, padding)
+      data.setStreamId(streamId)
+      ctx.fireChannelRead(data)
+      0 // bytes are marked as consumed via WindowUpdateFrame writes
+    }
+
+  }
+
+}

--- a/finagle/h2/src/main/scala/io/netty/handler/codec/http2/Http2FrameCodecServerUpgrader.scala
+++ b/finagle/h2/src/main/scala/io/netty/handler/codec/http2/Http2FrameCodecServerUpgrader.scala
@@ -5,8 +5,8 @@ import io.netty.channel.ChannelHandler
 /**
  * Adapt Http2ServerUpgradeCodec to be instantiated with an Http2FrameCodec
  */
-class Http2FrameCodecServerUpgrader(name: String, framer: Http2FrameCodec, handler: ChannelHandler)
+class Http2FrameCodecServerUpgrader(name: String, framer: H2FrameCodec, handler: ChannelHandler)
   extends Http2ServerUpgradeCodec(name, framer.connectionHandler, handler) {
-  def this(framer: Http2FrameCodec, handler: ChannelHandler) = this(null, framer, handler)
-  def this(framer: Http2FrameCodec) = this(null, framer, framer)
+  def this(framer: H2FrameCodec, handler: ChannelHandler) = this(null, framer, handler)
+  def this(framer: H2FrameCodec) = this(null, framer, framer)
 }


### PR DESCRIPTION
Problem

Netty's Http2FrameCodec is a nascent API, and hides details that we really want
to control in linkerd: specifically flow control and http2 settings.  In order
to enact this sort of configuration changes we need, we'll need to use the
older Http2Connection API; but all of our transport code uses the new
Http2StreamFrame types.

Solution

Copy netty's [Http2FrameCodec](https://github.com/netty/netty/commit/328510468c3da0f6a37d9710d7723f817eff8ce8#diff-004b9d3b44cadc4c6987434ba0e599be) as H2FrameCodec, which reimplements the netty
codec in Scala. Now that we control this layer within linkerd, we'll be able to
make the needed configuration changes.  Once we're clearer what we need out of
this, we can make the needed changes to the original netty codec.

Related: #1013