### PR TITLE
Use POST request to transfer Dtab in Namerd Admin delegator

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@
 * Remove `io.l5d.commonMetrics` telemeter
 * Remove `io.l5d.adminMetricsExport` as a telemeter plugin, it is now always
   loaded
+* Namerd Admin now works with Dtabs of arbitrary size
 
 ## 0.8.6 2017-01-19
 

--- a/admin/src/main/resources/io/buoyant/admin/js/src/delegator.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/delegator.js
@@ -54,9 +54,12 @@ define([
         e.preventDefault();
         var path = $('#path-input').val();
         window.location.hash = encodeURIComponent(path);
-        var request = $.get(
-          "delegator.json?" + $.param({ path: path, dtab: dtabViewer.dtabStr(), namespace: namespace }),
-          renderAll.bind(this));
+        var request = $.ajax({
+            url: 'delegator.json',
+            method: 'POST',
+            contentType: 'application/json',
+            data: JSON.stringify({ namespace: namespace, dtab: dtabViewer.dtabStr(), path: path })
+        }).done(renderAll.bind(this));
         request.fail(function( jqXHR ) {
           $(".error-modal").html(templates.errorModal(jqXHR.responseText));
           $('.error-modal').modal();


### PR DESCRIPTION
We have a relatively large Dtab (>4k) and when it's being passed via query parameter it results into HTTP 414.

Switching from GET to POST method and passing Dtab in the body eliminates the issue.