### PR TITLE
[h2] Acknowledge window updates aggressively

### DIFF
--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4H2Listener.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4H2Listener.scala
@@ -57,11 +57,8 @@ object Netty4H2Listener {
           case ApplicationProtocolNames.HTTP_2 =>
             ctx.channel.config.setAutoRead(true)
 
-            // TODO replace flow controller
-            val connection = new DefaultHttp2Connection(true /*server*/ )
             // TODO configure settings from params
-            val settings = new Http2Settings
-            val codec = new H2FrameCodec(connection, settings)
+            val codec = H2FrameCodec.server()
             ctx.pipeline.replace(PlaceholderKey, "h2 framer", codec); ()
 
           // TODO case ApplicationProtocolNames.HTTP_1_1 =>

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4H2Listener.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4H2Listener.scala
@@ -9,7 +9,7 @@ import com.twitter.finagle.transport.{TlsConfig, Transport}
 import io.netty.buffer.ByteBuf
 import io.netty.channel._
 import io.netty.channel.socket.SocketChannel
-import io.netty.handler.codec.http2.{Http2FrameCodec, Http2Frame}
+import io.netty.handler.codec.http2._
 import io.netty.handler.ssl.{ApplicationProtocolNames, ApplicationProtocolNegotiationHandler}
 
 /**
@@ -56,7 +56,13 @@ object Netty4H2Listener {
         proto match {
           case ApplicationProtocolNames.HTTP_2 =>
             ctx.channel.config.setAutoRead(true)
-            ctx.pipeline.replace(PlaceholderKey, "h2 framer", new Http2FrameCodec(true)); ()
+
+            // TODO replace flow controller
+            val connection = new DefaultHttp2Connection(true /*server*/ )
+            // TODO configure settings from params
+            val settings = new Http2Settings
+            val codec = new H2FrameCodec(connection, settings)
+            ctx.pipeline.replace(PlaceholderKey, "h2 framer", codec); ()
 
           // TODO case ApplicationProtocolNames.HTTP_1_1 =>
           case proto => throw new IllegalStateException(s"unknown protocol: $proto")

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4H2Transporter.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4H2Transporter.scala
@@ -25,13 +25,10 @@ object Netty4H2Transporter {
     // transports are not created) until a connection is fully
     // initialized (and protocol initialization has completed). All
     // stream frame writes are buffered until this time.
-    def framer = {
-      // TODO replace flow controller
-      val connection = new DefaultHttp2Connection(false /*server*/ )
-      // TODO configure settings from params
-      val settings = new Http2Settings
-      new H2FrameCodec(connection, settings)
-    }
+
+    // TODO configure settings from params
+    def framer = H2FrameCodec.client()
+
     val pipelineInit: ChannelPipeline => Unit =
       params[TransportSecurity].config match {
         case TransportSecurity.Insecure =>

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4H2Transporter.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4H2Transporter.scala
@@ -8,7 +8,7 @@ import com.twitter.finagle.netty4.Netty4Transporter
 import com.twitter.finagle.netty4.buoyant.{BufferingConnectDelay, Netty4ClientTls}
 import com.twitter.finagle.netty4.channel.DirectToHeapInboundHandler
 import io.netty.channel.{ChannelDuplexHandler, ChannelHandlerContext, ChannelPipeline}
-import io.netty.handler.codec.http2.{Http2FrameCodec, Http2Frame}
+import io.netty.handler.codec.http2._
 import io.netty.handler.ssl.ApplicationProtocolNames
 
 object Netty4H2Transporter {
@@ -25,7 +25,13 @@ object Netty4H2Transporter {
     // transports are not created) until a connection is fully
     // initialized (and protocol initialization has completed). All
     // stream frame writes are buffered until this time.
-    def framer = new Http2FrameCodec(false /*server*/ )
+    def framer = {
+      // TODO replace flow controller
+      val connection = new DefaultHttp2Connection(false /*server*/ )
+      // TODO configure settings from params
+      val settings = new Http2Settings
+      new H2FrameCodec(connection, settings)
+    }
     val pipelineInit: ChannelPipeline => Unit =
       params[TransportSecurity].config match {
         case TransportSecurity.Insecure =>

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/ServerUpgradeHandler.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/ServerUpgradeHandler.scala
@@ -32,11 +32,7 @@ class ServerUpgradeHandler extends ChannelDuplexHandler {
   private[this] val h1Codec = new HttpServerCodec
 
   // Parses HTTP/2 frames
-  private[this] val framer = {
-    // TODO fix flow control
-    val conn = new DefaultHttp2Connection(true /*server*/ )
-    new H2FrameCodec(conn, new Http2Settings)
-  }
+  private[this] val framer = H2FrameCodec.server()
 
   // Intercepts HTTP/1 requests with the HTTP2-Settings headers and
   // initiate protocol upgrade.

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/ServerUpgradeHandler.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/ServerUpgradeHandler.scala
@@ -32,7 +32,11 @@ class ServerUpgradeHandler extends ChannelDuplexHandler {
   private[this] val h1Codec = new HttpServerCodec
 
   // Parses HTTP/2 frames
-  private[this] val framer = new Http2FrameCodec(true /*server*/ )
+  private[this] val framer = {
+    // TODO fix flow control
+    val conn = new DefaultHttp2Connection(true /*server*/ )
+    new H2FrameCodec(conn, new Http2Settings)
+  }
 
   // Intercepts HTTP/1 requests with the HTTP2-Settings headers and
   // initiate protocol upgrade.

--- a/finagle/h2/src/main/scala/io/netty/handler/codec/http2/H2FrameCodec.scala
+++ b/finagle/h2/src/main/scala/io/netty/handler/codec/http2/H2FrameCodec.scala
@@ -168,7 +168,7 @@ class H2FrameCodec(
 object H2FrameCodec {
 
   /** Aggressively acknowledge window updates */
-  val DefaultWindowUpdateRatio = 0.95f
+  val DefaultWindowUpdateRatio = 1.0f
 
   def client(
     settings: Http2Settings = new Http2Settings,

--- a/finagle/h2/src/main/scala/io/netty/handler/codec/http2/H2FrameCodec.scala
+++ b/finagle/h2/src/main/scala/io/netty/handler/codec/http2/H2FrameCodec.scala
@@ -15,15 +15,15 @@ import io.netty.handler.codec.http.HttpServerUpgradeHandler.UpgradeEvent;
  * Copyright 2016 The Netty Project
  */
 class H2FrameCodec(
-  connection: Http2Connection,
-  initialSettings: Http2Settings
+  http2Handler: Http2ConnectionHandler
 ) extends ChannelDuplexHandler {
 
   import H2FrameCodec._
 
   private[this] var channelCtx, http2HandlerCtx: ChannelHandlerContext = null
 
-  val connectionListener = new Http2ConnectionAdapter {
+  private[this] val connectionListener = new Http2ConnectionAdapter {
+
     override def onStreamActive(stream: Http2Stream): Unit = channelCtx match {
       case null => // UPGRADE stream is active before handlerAdded
       case ctx => ctx.fireUserEventTriggered(new Http2StreamActiveEvent(stream.id)); ()
@@ -38,7 +38,6 @@ class H2FrameCodec(
     }
   }
 
-  private[this] val http2Handler = mkHandler(connection, initialSettings)
   http2Handler.connection.addListener(connectionListener)
 
   def connectionHandler: Http2ConnectionHandler = http2Handler
@@ -168,20 +167,49 @@ class H2FrameCodec(
 
 object H2FrameCodec {
 
-  private lazy val frameLogger = new Http2FrameLogger(io.netty.handler.logging.LogLevel.DEBUG, getClass)
+  /** Aggressively acknowledge window updates */
+  val DefaultWindowUpdateRatio = 0.95f
 
-  private def mkHandler(connection: Http2Connection, settings: Http2Settings): Http2ConnectionHandler = {
+  def client(
+    settings: Http2Settings = new Http2Settings,
+    windowUpdateRatio: Float = DefaultWindowUpdateRatio,
+    autoRefillConnectionWindow: Boolean = false
+  ): H2FrameCodec =
+    mk(false, settings, windowUpdateRatio, autoRefillConnectionWindow)
+
+  def server(
+    settings: Http2Settings = new Http2Settings,
+    windowUpdateRatio: Float = DefaultWindowUpdateRatio,
+    autoRefillConnectionWindow: Boolean = false
+  ): H2FrameCodec =
+    mk(true, settings, windowUpdateRatio, autoRefillConnectionWindow)
+
+  private[this] def mk(
+    isServer: Boolean,
+    settings: Http2Settings,
+    windowUpdateRatio: Float,
+    autoRefillConnectionWindow: Boolean = false
+  ): H2FrameCodec = {
+    val conn = new DefaultHttp2Connection(isServer)
+    val flow = new DefaultHttp2LocalFlowController(conn, windowUpdateRatio, autoRefillConnectionWindow)
+    conn.local.flowController(flow)
+
     val encoder = {
       val fw = new Http2OutboundFrameLogger(new DefaultHttp2FrameWriter, frameLogger)
-      new DefaultHttp2ConnectionEncoder(connection, fw)
+      new DefaultHttp2ConnectionEncoder(conn, fw)
     }
+
     val decoder = {
       val fr = new Http2InboundFrameLogger(new DefaultHttp2FrameReader, frameLogger)
-      new DefaultHttp2ConnectionDecoder(connection, encoder, fr)
+      new DefaultHttp2ConnectionDecoder(conn, encoder, fr)
     }
     decoder.frameListener(new FrameListener)
-    new ConnectionHandler(decoder, encoder, settings)
+
+    val handler = new ConnectionHandler(decoder, encoder, settings)
+    new H2FrameCodec(handler)
   }
+
+  private[this] lazy val frameLogger = new Http2FrameLogger(io.netty.handler.logging.LogLevel.TRACE, getClass)
 
   private class ConnectionHandler(
     decoder: Http2ConnectionDecoder,

--- a/finagle/h2/src/main/scala/io/netty/handler/codec/http2/H2FrameCodec.scala
+++ b/finagle/h2/src/main/scala/io/netty/handler/codec/http2/H2FrameCodec.scala
@@ -1,0 +1,252 @@
+package io.netty.handler.codec.http2
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.{ChannelDuplexHandler, ChannelHandlerContext, ChannelPromise}
+import io.netty.handler.codec.http.HttpServerUpgradeHandler.UpgradeEvent;
+
+/**
+ * This is a direct reimplementation of io.netty.handler.codec.http2.Http2FrameCodec.
+ *
+ * Thie Netty API is unstable at the moment and unsuitable for our
+ * current needs, especially with regard to initial settings and flow
+ * control.  We SHOULD feed back whatever we need to Netty, but one
+ * step at a time.
+ *
+ * Copyright 2016 The Netty Project
+ */
+class H2FrameCodec(
+  connection: Http2Connection,
+  initialSettings: Http2Settings
+) extends ChannelDuplexHandler {
+
+  import H2FrameCodec._
+
+  private[this] var channelCtx, http2HandlerCtx: ChannelHandlerContext = null
+
+  val connectionListener = new Http2ConnectionAdapter {
+    override def onStreamActive(stream: Http2Stream): Unit = channelCtx match {
+      case null => // UPGRADE stream is active before handlerAdded
+      case ctx => ctx.fireUserEventTriggered(new Http2StreamActiveEvent(stream.id)); ()
+    }
+
+    override def onStreamClosed(stream: Http2Stream): Unit = {
+      channelCtx.fireUserEventTriggered(new Http2StreamClosedEvent(stream.id)); ()
+    }
+
+    override def onGoAwayReceived(lastStreamId: Int, errorCode: Long, data: ByteBuf): Unit = {
+      channelCtx.fireChannelRead(new DefaultHttp2GoAwayFrame(lastStreamId, errorCode, data)); ()
+    }
+  }
+
+  private[this] val http2Handler = mkHandler(connection, initialSettings)
+  http2Handler.connection.addListener(connectionListener)
+
+  def connectionHandler: Http2ConnectionHandler = http2Handler
+
+  /**
+   * Load any dependencies.
+   */
+  override def handlerAdded(ctx: ChannelHandlerContext): Unit = {
+    channelCtx = ctx
+    ctx.pipeline.addBefore(ctx.executor, ctx.name, null, http2Handler)
+    http2HandlerCtx = ctx.pipeline.context(http2Handler)
+  }
+
+  /**
+   * Clean up any dependencies.
+   */
+  override def handlerRemoved(ctx: ChannelHandlerContext): Unit = {
+    ctx.pipeline.remove(http2Handler); ()
+  }
+
+  /**
+   * Handles the cleartext HTTP upgrade event. If an upgrade occurred,
+   * sends a simple response via HTTP/2 on stream 1 (the stream
+   * specifically reserved for cleartext HTTP upgrade).
+   */
+  override def userEventTriggered(ctx: ChannelHandlerContext, ev: Any): Unit =
+    ev match {
+      case upgrade: UpgradeEvent =>
+        try {
+          val stream = http2Handler.connection.stream(Http2CodecUtil.HTTP_UPGRADE_STREAM_ID)
+          // TODO: improve handler/stream lifecycle so that stream isn't
+          // active before handler added.  The stream was already made
+          // active, but ctx may have been null so it wasn't
+          // initialized.  https://github.com/netty/netty/issues/4942
+          connectionListener.onStreamActive(stream)
+
+          upgrade.upgradeRequest.headers.setInt(
+            HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text(),
+            Http2CodecUtil.HTTP_UPGRADE_STREAM_ID
+          )
+
+          val adapter = new InboundHttpToHttp2Adapter(
+            http2Handler.connection,
+            http2Handler.decoder.frameListener
+          )
+          adapter.channelRead(ctx, upgrade.upgradeRequest.retain())
+        } finally { upgrade.release(); () }
+
+      case ev => super.userEventTriggered(ctx, ev)
+    }
+
+  // Override this to signal it will never throw an exception.
+  override def exceptionCaught(ctx: ChannelHandlerContext, cause: Throwable): Unit = {
+    ctx.fireExceptionCaught(cause); ()
+  }
+
+  /**
+   * Processes all {@link Http2Frame}s. {@link Http2StreamFrame}s may
+   * only originate in child streams.
+   */
+  override def write(ctx: ChannelHandlerContext, msg: Any, promise: ChannelPromise): Unit =
+    msg match {
+      case goaway: Http2GoAwayFrame =>
+        try {
+          if (goaway.lastStreamId > -1) {
+            throw new IllegalArgumentException("Last stream ID must not be set on GOAWAY")
+          }
+          val lastStreamCreated = http2Handler.connection.remote.lastStreamCreated
+          val lastStreamId = (lastStreamCreated + goaway.extraStreamIds * 2) match {
+            case n if n < lastStreamCreated => Int.MaxValue
+            case n => n
+          }
+          http2Handler.goAway(
+            http2HandlerCtx,
+            lastStreamId,
+            goaway.errorCode,
+            goaway.content.retain(),
+            promise
+          ); ()
+        } finally { goaway.release(); () }
+
+      case data: Http2DataFrame =>
+        try {
+          http2Handler.encoder.writeData(
+            http2HandlerCtx,
+            data.streamId,
+            data.content.retain(),
+            data.padding,
+            data.isEndStream,
+            promise
+          ); ()
+        } finally { data.release(); () }
+
+      case headers: Http2HeadersFrame =>
+        http2Handler.encoder.writeHeaders(
+          http2HandlerCtx,
+          headers.streamId,
+          headers.headers(),
+          headers.padding,
+          headers.isEndStream,
+          promise
+        ); ()
+
+      case reset: Http2ResetFrame =>
+        http2Handler.resetStream(
+          http2HandlerCtx,
+          reset.streamId,
+          reset.errorCode,
+          promise
+        ); ()
+
+      case update: Http2WindowUpdateFrame =>
+        try {
+          http2Handler.connection.local.flowController.consumeBytes(
+            http2Handler.connection.stream(update.streamId),
+            update.windowSizeIncrement
+          )
+          promise.setSuccess(); ()
+        } catch {
+          case e: Throwable => promise.setFailure(e); ()
+        }
+
+      case msg => ctx.write(msg, promise); ()
+    }
+
+}
+
+object H2FrameCodec {
+
+  private lazy val frameLogger = new Http2FrameLogger(io.netty.handler.logging.LogLevel.DEBUG, getClass)
+
+  private def mkHandler(connection: Http2Connection, settings: Http2Settings): Http2ConnectionHandler = {
+    val encoder = {
+      val fw = new Http2OutboundFrameLogger(new DefaultHttp2FrameWriter, frameLogger)
+      new DefaultHttp2ConnectionEncoder(connection, fw)
+    }
+    val decoder = {
+      val fr = new Http2InboundFrameLogger(new DefaultHttp2FrameReader, frameLogger)
+      new DefaultHttp2ConnectionDecoder(connection, encoder, fr)
+    }
+    decoder.frameListener(new FrameListener)
+    new ConnectionHandler(decoder, encoder, settings)
+  }
+
+  private class ConnectionHandler(
+    decoder: Http2ConnectionDecoder,
+    encoder: Http2ConnectionEncoder,
+    initialSettings: Http2Settings
+  ) extends Http2ConnectionHandler(decoder, encoder, initialSettings) {
+
+    override protected def onStreamError(
+      ctx: ChannelHandlerContext,
+      cause: Throwable,
+      exc: Http2Exception.StreamException
+    ): Unit =
+      try {
+        if (connection.stream(exc.streamId) != null) {
+          ctx.fireExceptionCaught(exc); ()
+        }
+      } finally {
+        super.onStreamError(ctx, cause, exc)
+      }
+  }
+
+  private class FrameListener extends Http2FrameAdapter {
+
+    override def onRstStreamRead(ctx: ChannelHandlerContext, id: Int, code: Long): Unit = {
+      val rst = new DefaultHttp2ResetFrame(code)
+      rst.setStreamId(id)
+      ctx.fireChannelRead(rst); ()
+    }
+
+    override def onHeadersRead(
+      ctx: ChannelHandlerContext,
+      streamId: Int,
+      headers: Http2Headers,
+      streamDependency: Int,
+      weight: Short,
+      exclusive: Boolean,
+      padding: Int,
+      eos: Boolean
+    ): Unit = onHeadersRead(ctx, streamId, headers, padding, eos)
+
+    override def onHeadersRead(
+      ctx: ChannelHandlerContext,
+      streamId: Int,
+      headers: Http2Headers,
+      padding: Int,
+      eos: Boolean
+    ): Unit = {
+      val hdrs = new DefaultHttp2HeadersFrame(headers, eos, padding)
+      hdrs.setStreamId(streamId)
+      ctx.fireChannelRead(hdrs); ()
+    }
+
+    override def onDataRead(
+      ctx: ChannelHandlerContext,
+      streamId: Int,
+      content: ByteBuf,
+      padding: Int,
+      eos: Boolean
+    ): Int = {
+      val data = new DefaultHttp2DataFrame(content.retain(), eos, padding)
+      data.setStreamId(streamId)
+      ctx.fireChannelRead(data)
+      0 // bytes are marked as consumed via WindowUpdateFrame writes
+    }
+
+  }
+
+}

--- a/finagle/h2/src/main/scala/io/netty/handler/codec/http2/H2FrameCodec.scala
+++ b/finagle/h2/src/main/scala/io/netty/handler/codec/http2/H2FrameCodec.scala
@@ -75,7 +75,7 @@ class H2FrameCodec(
           connectionListener.onStreamActive(stream)
 
           upgrade.upgradeRequest.headers.setInt(
-            HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text(),
+            HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text,
             Http2CodecUtil.HTTP_UPGRADE_STREAM_ID
           )
 
@@ -168,7 +168,7 @@ class H2FrameCodec(
 object H2FrameCodec {
 
   /** Aggressively acknowledge window updates */
-  val DefaultWindowUpdateRatio = 1.0f
+  val DefaultWindowUpdateRatio = 0.99f // on (0.0, 1.0)
 
   def client(
     settings: Http2Settings = new Http2Settings,
@@ -190,6 +190,8 @@ object H2FrameCodec {
     windowUpdateRatio: Float,
     autoRefillConnectionWindow: Boolean = false
   ): H2FrameCodec = {
+    require(0.0 < windowUpdateRatio && windowUpdateRatio < 1.0)
+
     val conn = new DefaultHttp2Connection(isServer)
     val flow = new DefaultHttp2LocalFlowController(conn, windowUpdateRatio, autoRefillConnectionWindow)
     conn.local.flowController(flow)

--- a/finagle/h2/src/main/scala/io/netty/handler/codec/http2/Http2FrameCodecServerUpgrader.scala
+++ b/finagle/h2/src/main/scala/io/netty/handler/codec/http2/Http2FrameCodecServerUpgrader.scala
@@ -5,8 +5,8 @@ import io.netty.channel.ChannelHandler
 /**
  * Adapt Http2ServerUpgradeCodec to be instantiated with an Http2FrameCodec
  */
-class Http2FrameCodecServerUpgrader(name: String, framer: Http2FrameCodec, handler: ChannelHandler)
+class Http2FrameCodecServerUpgrader(name: String, framer: H2FrameCodec, handler: ChannelHandler)
   extends Http2ServerUpgradeCodec(name, framer.connectionHandler, handler) {
-  def this(framer: Http2FrameCodec, handler: ChannelHandler) = this(null, framer, handler)
-  def this(framer: Http2FrameCodec) = this(null, framer, framer)
+  def this(framer: H2FrameCodec, handler: ChannelHandler) = this(null, framer, handler)
+  def this(framer: H2FrameCodec) = this(null, framer, framer)
 }


### PR DESCRIPTION
Problem

By default, netty does not send a WINDOW_UPDATE until the available window is at ≥50% capacity. This can lead to starvation (especially for gRPC).

Solution

Change the default window increment ratio from 0.5 to 0.95 so that WINDOW_UPDATE frames are sent much more aggressively.

This branch has been tested against the ver/grpc-interop-server branch (#1024, to be merged soon after this), confirming that this fixes #1013.

In a follow-up, these parameters will be made configurable.