### PR TITLE
[h2] Configure HTTP/2 settings from the stack

### DIFF
--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4H2Settings.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4H2Settings.scala
@@ -1,0 +1,17 @@
+package com.twitter.finagle.buoyant.h2.netty4
+
+import com.twitter.finagle.Stack
+import com.twitter.finagle.buoyant.h2.param.Settings._
+import io.netty.handler.codec.http2.Http2Settings
+
+object Netty4H2Settings {
+  def mk(params: Stack.Params): Http2Settings = {
+    val s = new Http2Settings
+    params[HeaderTableSize].size.foreach { n => s.headerTableSize(n); () }
+    params[InitialWindowSize].size.foreach { n => s.initialWindowSize(n); () }
+    params[MaxConcurrentStreams].streams.foreach { n => s.maxConcurrentStreams(n); () }
+    params[MaxFrameSize].size.foreach { n => s.maxFrameSize(n); () }
+    params[MaxHeaderListSize].size.foreach { n => s.maxHeaderListSize(n); () }
+    s
+  }
+}

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4H2Transporter.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4H2Transporter.scala
@@ -26,8 +26,8 @@ object Netty4H2Transporter {
     // initialized (and protocol initialization has completed). All
     // stream frame writes are buffered until this time.
 
-    // TODO configure settings from params
-    def framer = H2FrameCodec.client()
+    val settings = Netty4H2Settings.mk(params).pushEnabled(false)
+    def framer = H2FrameCodec.client(settings = settings)
 
     val pipelineInit: ChannelPipeline => Unit =
       params[TransportSecurity].config match {

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/ServerUpgradeHandler.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/ServerUpgradeHandler.scala
@@ -25,14 +25,14 @@ object ServerUpgradeHandler {
  * Accept either H2C requests (beginning with a Connection preface)
  * or HTTP requests with h2c protocol upgrading.
  */
-class ServerUpgradeHandler extends ChannelDuplexHandler {
+class ServerUpgradeHandler(settings: Http2Settings) extends ChannelDuplexHandler {
   import ServerUpgradeHandler._
 
   // Parses HTTP/1 objects.
   private[this] val h1Codec = new HttpServerCodec
 
   // Parses HTTP/2 frames
-  private[this] val framer = H2FrameCodec.server()
+  private[this] val framer = H2FrameCodec.server(settings = settings)
 
   // Intercepts HTTP/1 requests with the HTTP2-Settings headers and
   // initiate protocol upgrade.

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/param.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/param.scala
@@ -8,4 +8,32 @@ package object param {
   implicit object ClientPriorKnowledge extends Stack.Param[ClientPriorKnowledge] {
     val default = ClientPriorKnowledge(true)
   }
+
+  object Settings {
+
+    case class HeaderTableSize(size: Option[Int])
+    implicit object HeaderTableSize extends Stack.Param[HeaderTableSize] {
+      val default = HeaderTableSize(None)
+    }
+
+    case class InitialWindowSize(size: Option[Int])
+    implicit object InitialWindowSize extends Stack.Param[InitialWindowSize] {
+      val default = InitialWindowSize(None)
+    }
+
+    case class MaxConcurrentStreams(streams: Option[Int])
+    implicit object MaxConcurrentStreams extends Stack.Param[MaxConcurrentStreams] {
+      val default = MaxConcurrentStreams(None)
+    }
+
+    case class MaxFrameSize(size: Option[Int])
+    implicit object MaxFrameSize extends Stack.Param[MaxFrameSize] {
+      val default = MaxFrameSize(None)
+    }
+
+    case class MaxHeaderListSize(size: Option[Int])
+    implicit object MaxHeaderListSize extends Stack.Param[MaxHeaderListSize] {
+      val default = MaxHeaderListSize(None)
+    }
+  }
 }


### PR DESCRIPTION
Problem

HTTP/2 SETTINGS messages allow endpoints to advertise capabilities and buffer sizes. We have no means to configure these parameters.

Solution

Introduce com.twitter.finagle.buoyant.h2.param.Settings, containing the HeaderTableSize, InitialWindowSize, MaxConcurrentStream, MaxFrameSize, and MaxHeaderListSize params. Netty4H2Listener and Netty4H2Transproter use these parameters to configure servers and
clients, respectively.

Clients additionally disable the ENABLE_PUSH setting, since server-push is not supported.