### PR TITLE
[h2] Expose HTTP/2-specific configuration

### DIFF
--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4H2Settings.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4H2Settings.scala
@@ -1,0 +1,17 @@
+package com.twitter.finagle.buoyant.h2.netty4
+
+import com.twitter.finagle.Stack
+import com.twitter.finagle.buoyant.h2.param.Settings._
+import io.netty.handler.codec.http2.Http2Settings
+
+object Netty4H2Settings {
+  def mk(params: Stack.Params): Http2Settings = {
+    val s = new Http2Settings
+    params[HeaderTableSize].size.foreach { n => s.headerTableSize(n.inBytes.toInt); () }
+    params[InitialWindowSize].size.foreach { n => s.initialWindowSize(n.inBytes.toInt); () }
+    params[MaxConcurrentStreams].streams.foreach { n => s.maxConcurrentStreams(n); () }
+    params[MaxFrameSize].size.foreach { n => s.maxFrameSize(n.inBytes.toInt); () }
+    params[MaxHeaderListSize].size.foreach { n => s.maxHeaderListSize(n.inBytes.toInt); () }
+    s
+  }
+}

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4H2Transporter.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4H2Transporter.scala
@@ -26,8 +26,12 @@ object Netty4H2Transporter {
     // initialized (and protocol initialization has completed). All
     // stream frame writes are buffered until this time.
 
-    // TODO configure settings from params
-    def framer = H2FrameCodec.client()
+    val settings = Netty4H2Settings.mk(params).pushEnabled(false)
+    def framer = H2FrameCodec.client(
+      settings = settings,
+      windowUpdateRatio = params[param.FlowControl.WindowUpdateRatio].ratio,
+      autoRefillConnectionWindow = params[param.FlowControl.AutoRefillConnectionWindow].enabled
+    )
 
     val pipelineInit: ChannelPipeline => Unit =
       params[TransportSecurity].config match {

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/param.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/param.scala
@@ -1,11 +1,122 @@
 package com.twitter.finagle.buoyant.h2
 
 import com.twitter.finagle.Stack
+import com.twitter.util.StorageUnit
 
 package object param {
 
   case class ClientPriorKnowledge(assumed: Boolean)
   implicit object ClientPriorKnowledge extends Stack.Param[ClientPriorKnowledge] {
     val default = ClientPriorKnowledge(true)
+  }
+
+  object FlowControl {
+
+    /**
+     * Controls whether connection windows are automatically updated.
+     *
+     * When enabled, connection-level flow control is effectively
+     * disabled (i.e. constrained by SETTINGS_MAX_CONCURRENT_STREAMS *
+     * SETTINGS_INITIAL_WINDOW_SIZE).
+     */
+    case class AutoRefillConnectionWindow(enabled: Boolean)
+    implicit object AutoRefillConnectionWindow extends Stack.Param[AutoRefillConnectionWindow] {
+      val default = AutoRefillConnectionWindow(false)
+    }
+
+    /**
+     * Controls how frequently WINDOW_UPDATE messages are sent to the remote.
+     */
+    case class WindowUpdateRatio(ratio: Float) {
+      require(0.0 < ratio && ratio < 1.0, "ratio must be on (0.0, 1.0), exclusive")
+    }
+    implicit object WinodwUpdateRatio extends Stack.Param[WindowUpdateRatio] {
+      val default = WindowUpdateRatio(0.99f)
+    }
+  }
+
+  object Settings {
+
+    /**
+     *    SETTINGS_HEADER_TABLE_SIZE (0x1): Allows the sender to
+     *       inform the remote endpoint of the maximum size of the
+     *       header compression table used to decode header blocks, in
+     *       octets.  The encoder can select any size equal to or less
+     *       than this value by using signaling specific to the header
+     *       compression format inside a header block.  The initial
+     *       value is 4,096 octets.
+     */
+    case class HeaderTableSize(size: Option[StorageUnit])
+    implicit object HeaderTableSize extends Stack.Param[HeaderTableSize] {
+      val default = HeaderTableSize(None)
+    }
+
+    /**
+     *    SETTINGS_INITIAL_WINDOW_SIZE (0x4):  Indicates the sender's initial
+     *       window size (in octets) for stream-level flow control.  The
+     *       initial value is 2^16-1 (65,535) octets.
+     *
+     *       This setting affects the window size of all streams (see
+     *       Section 6.9.2).
+     *
+     *       Values above the maximum flow-control window size of 2^31-1 MUST
+     *       be treated as a connection error (Section 5.4.1) of type
+     *       FLOW_CONTROL_ERROR.
+     */
+    case class InitialWindowSize(size: Option[StorageUnit])
+    implicit object InitialWindowSize extends Stack.Param[InitialWindowSize] {
+      val default = InitialWindowSize(None)
+    }
+
+    /**
+     *    SETTINGS_MAX_CONCURRENT_STREAMS (0x3):  Indicates the maximum number
+     *       of concurrent streams that the sender will allow.  This limit is
+     *       directional: it applies to the number of streams that the sender
+     *       permits the receiver to create.  Initially, there is no limit to
+     *       this value.  It is recommended that this value be no smaller than
+     *       100, so as to not unnecessarily limit parallelism.
+     *
+     *       A value of 0 for SETTINGS_MAX_CONCURRENT_STREAMS SHOULD NOT be
+     *       treated as special by endpoints.  A zero value does prevent the
+     *       creation of new streams; however, this can also happen for any
+     *       limit that is exhausted with active streams.  Servers SHOULD only
+     *       set a zero value for short durations; if a server does not wish to
+     *       accept requests, closing the connection is more appropriate.
+     */
+    case class MaxConcurrentStreams(streams: Option[Long])
+    implicit object MaxConcurrentStreams extends Stack.Param[MaxConcurrentStreams] {
+      val default = MaxConcurrentStreams(None)
+    }
+
+    /**
+     *    SETTINGS_MAX_FRAME_SIZE (0x5):  Indicates the size of the largest
+     *       frame payload that the sender is willing to receive, in octets.
+     *
+     *       The initial value is 2^14 (16,384) octets.  The value advertised
+     *       by an endpoint MUST be between this initial value and the maximum
+     *       allowed frame size (2^24-1 or 16,777,215 octets), inclusive.
+     *       Values outside this range MUST be treated as a connection error
+     *       (Section 5.4.1) of type PROTOCOL_ERROR.
+     */
+    case class MaxFrameSize(size: Option[StorageUnit])
+    implicit object MaxFrameSize extends Stack.Param[MaxFrameSize] {
+      val default = MaxFrameSize(None)
+    }
+
+    /**
+     *    SETTINGS_MAX_HEADER_LIST_SIZE (0x6):  This advisory setting informs a
+     *       peer of the maximum size of header list that the sender is
+     *       prepared to accept, in octets.  The value is based on the
+     *       uncompressed size of header fields, including the length of the
+     *       name and value in octets plus an overhead of 32 octets for each
+     *       header field.
+     *
+     *       For any given request, a lower limit than what is advertised MAY
+     *       be enforced.  The initial value of this setting is unlimited.
+     */
+    case class MaxHeaderListSize(size: Option[StorageUnit])
+    implicit object MaxHeaderListSize extends Stack.Param[MaxHeaderListSize] {
+      val default = MaxHeaderListSize(None)
+    }
   }
 }

--- a/linkerd/docs/protocol-h2.md
+++ b/linkerd/docs/protocol-h2.md
@@ -64,6 +64,13 @@ Key | Default Value | Description
 --- | ------------- | -----------
 dstPrefix | `h2` | A path prefix used by [H2-specific identifiers](#h2-identifiers).
 experimental | `false` | Set this to `true` to opt-in to experimental h2 support.
+connectionFlowControl | `true` | Whether connection-level flow control should be enforced in addition to stream-level flow control.
+windowUpdateRatio: | `0.99` | A number between 0 and 1, exclusive, indicating the ratio at which window updates should be sent. With a value of 0.75, updates will be sent when the available window size is 75% of its capacity.
+headerTableBytes | none | Configures `SETTINGS_HEADER_TABLE_SIZE` on new streams.
+initialWindowBytes | 64KB | Configures `SETTINGS_INITIAL_WINDOW_SIZE` on new streams.
+maxConcurrentStreamsPerConnection | unlimited | Configures `SETTINGS_MAX_CONCURRENT_STREAMS` on new streams.
+maxFrameBytes | 16KB | Configures `SETTINGS_MAX_FRAME_SIZE` on new streams.
+maxHeaderListByts | none | Configures `SETTINGS_MAX_HEADER_LIST_SIZE` on new streams.
 
 When TLS is configured, h2 routers negotiate to communicate over
 HTTP/2 via ALPN.

--- a/linkerd/examples/h2.yaml
+++ b/linkerd/examples/h2.yaml
@@ -12,8 +12,12 @@ routers:
     /srv => /#/io.l5d.fs;
     /h2/localhost:4142 => /$/inet/127.1/8888;
     /h2 => /srv;
-  servers:
-  - port: 4142
   identifier:
     kind: io.l5d.headerToken
     header: ":authority"
+  servers:
+  - port: 4142
+    maxConcurrentStreamsPerConnection: 300
+    initialWindowBytes: 1048576 # 1MB
+  client:
+    initialWindowBytes: 1048576 # 1MB

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/H2Config.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/H2Config.scala
@@ -5,7 +5,9 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.core.{JsonParser, TreeNode}
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.databind.{DeserializationContext, JsonDeserializer, JsonNode}
+import com.twitter.conversions.storage._
 import com.twitter.finagle.buoyant.h2.{LinkerdHeaders, Request, Response}
+import com.twitter.finagle.buoyant.h2.param._
 import com.twitter.finagle.client.StackClient
 import com.twitter.finagle.{Path, Stack, param}
 import com.twitter.util.Monitor
@@ -67,7 +69,7 @@ object H2Initializer extends H2Initializer
 
 class H2Config extends RouterConfig {
 
-  var client: Option[ClientConfig] = None
+  var client: Option[H2ClientConfig] = None
   var servers: Seq[H2ServerConfig] = Nil
 
   @JsonDeserialize(using = classOf[H2IdentifierConfigDeserializer])
@@ -101,11 +103,40 @@ class H2Config extends RouterConfig {
   }
 }
 
-class H2ServerConfig extends ServerConfig {
+trait H2EndpointConfig {
+  var connectionFlowControl: Option[Boolean] = None
+  var windowUpdateRatio: Option[Double] = None
+
+  var headerTableBytes: Option[Int] = None
+  var initialWindowBytes: Option[Int] = None
+  var maxConcurrentStreamsPerConnection: Option[Int] = None
+  var maxFrameBytes: Option[Int] = None
+  var maxHeaderListBytes: Option[Int] = None
+
+  def withParams(params: Stack.Params): Stack.Params = params
+    .maybeWith(connectionFlowControl.map(efc => FlowControl.AutoRefillConnectionWindow(!efc)))
+    .maybeWith(windowUpdateRatio.map(r => FlowControl.WindowUpdateRatio(r.toFloat)))
+    .maybeWith(headerTableBytes.map(s => Settings.HeaderTableSize(Some(s.bytes))))
+    .maybeWith(initialWindowBytes.map(s => Settings.InitialWindowSize(Some(s.bytes))))
+    .maybeWith(maxConcurrentStreamsPerConnection.map(s => Settings.MaxConcurrentStreams(Some(s.toLong))))
+    .maybeWith(maxFrameBytes.map(s => Settings.MaxFrameSize(Some(s.bytes))))
+    .maybeWith(maxHeaderListBytes.map(s => Settings.MaxHeaderListSize(Some(s.bytes))))
+}
+
+class H2ClientConfig extends ClientConfig with H2EndpointConfig {
+
+  @JsonIgnore
+  override def clientParams = withParams(super.clientParams)
+}
+
+class H2ServerConfig extends ServerConfig with H2EndpointConfig {
 
   @JsonIgnore
   override val alpnProtocols: Option[Seq[String]] =
     Some(Seq(ApplicationProtocolNames.HTTP_2))
+
+  @JsonIgnore
+  override def serverParams = withParams(super.serverParams)
 }
 
 trait H2IdentifierConfig extends PolymorphicConfig {

--- a/linkerd/protocol/h2/src/test/scala/io/buoyant/linkerd/protocol/h2/H2ConfigTest.scala
+++ b/linkerd/protocol/h2/src/test/scala/io/buoyant/linkerd/protocol/h2/H2ConfigTest.scala
@@ -1,0 +1,61 @@
+package io.buoyant.linkerd.protocol
+package h2
+
+import com.twitter.conversions.storage._
+import com.twitter.finagle.Stack
+import com.twitter.finagle.buoyant.h2.param.FlowControl._
+import com.twitter.finagle.buoyant.h2.param.Settings._
+import io.buoyant.config.Parser
+import io.buoyant.linkerd.RouterConfig
+import io.buoyant.test.FunSuite
+
+class H2ConfigTest extends FunSuite {
+
+  def parse(yaml: String): H2Config = {
+    val mapper = Parser.objectMapper(yaml, Iterable(Seq(H2Initializer)))
+    mapper.readValue[H2Config](yaml)
+  }
+
+  test("parse config") {
+    val yaml =
+      s"""|protocol: h2
+          |client:
+          |  connectionFlowControl: true
+          |  windowUpdateRatio: 0.9
+          |  headerTableBytes: 1024
+          |  initialWindowBytes: 524288
+          |  maxConcurrentStreamsPerConnection: 15
+          |  maxFrameBytes: 8192
+          |  maxHeaderListBytes: 1025
+          |servers:
+          |  - port: 5000
+          |    connectionFlowControl: false
+          |    windowUpdateRatio: 0.5
+          |    headerTableBytes: 2048
+          |    initialWindowBytes: 1048576
+          |    maxConcurrentStreamsPerConnection: 8
+          |    maxFrameBytes: 16384
+          |    maxHeaderListBytes: 2049
+          |""".stripMargin
+    val config = parse(yaml)
+
+    val cparams = config.client.get.withParams(Stack.Params.empty)
+    assert(cparams[AutoRefillConnectionWindow] == AutoRefillConnectionWindow(false))
+    assert(cparams[WindowUpdateRatio] == WindowUpdateRatio(0.9f))
+    assert(cparams[HeaderTableSize] == HeaderTableSize(Some(1.kilobyte)))
+    assert(cparams[InitialWindowSize] == InitialWindowSize(Some(512.kilobytes)))
+    assert(cparams[MaxConcurrentStreams] == MaxConcurrentStreams(Some(15)))
+    assert(cparams[MaxFrameSize] == MaxFrameSize(Some(8.kilobytes)))
+    assert(cparams[MaxHeaderListSize] == MaxHeaderListSize(Some(1025.bytes)))
+
+    val sparams = config.servers.head.withParams(Stack.Params.empty)
+    assert(sparams[AutoRefillConnectionWindow] == AutoRefillConnectionWindow(true))
+    assert(sparams[WindowUpdateRatio] == WindowUpdateRatio(0.5f))
+    assert(sparams[HeaderTableSize] == HeaderTableSize(Some(2.kilobytes)))
+    assert(sparams[InitialWindowSize] == InitialWindowSize(Some(1.megabyte)))
+    assert(sparams[MaxConcurrentStreams] == MaxConcurrentStreams(Some(8)))
+    assert(sparams[MaxFrameSize] == MaxFrameSize(Some(16.kilobytes)))
+    assert(sparams[MaxHeaderListSize] == MaxHeaderListSize(Some(2049.bytes)))
+  }
+
+}


### PR DESCRIPTION
Problem

The HTTP/2 spec allows for a number of per-stream settings to advertise capabilities and constraints. None of these parameters are configurable in linkerd today.

Solution

Update H2Config to read specialized client and server types that allow several h2 settings to be configured.