### PR TITLE
Fix typo in bindingcache stat name.

### DIFF
--- a/namerd/iface/interpreter-thrift/src/main/scala/io/buoyant/namerd/iface/ThriftNamerInterface.scala
+++ b/namerd/iface/interpreter-thrift/src/main/scala/io/buoyant/namerd/iface/ThriftNamerInterface.scala
@@ -402,7 +402,7 @@ class ThriftNamerInterface(
   private[this] val bindingCache = new ObserverCache[(String, Dtab, Path), NameTree[Name.Bound]](
     activeCapacity = capacity.bindingCacheActive,
     inactiveCapacity = capacity.bindingCacheInactive,
-    stats = stats.scope("bindindcache"),
+    stats = stats.scope("bindingcache"),
     mkObserver = (observeBind _).tupled
   )
 


### PR DESCRIPTION
I didn't file an issue about this as directed in your contribution guidelines since it seems like a no-brainer, but I can if you would like.

I was setting up a Prometheus alert around this cache size, and I think this is a typo. Looking at the code around where the stat is defined, I'm pretty sure this isn't intentional. I don't know jack about Scala, but I don't think there is a test around this, so this change should just work. I guess your CI server will tell me!

I suppose there is the potential to break your users' existing metrics that are tied to the old name if any exist.