### PR TITLE
Add zipkin telemeter plugin

### DIFF
--- a/linkerd/docs/telemetry.md
+++ b/linkerd/docs/telemetry.md
@@ -9,7 +9,7 @@ regardless of kind. Telemeters may also have kind-specific parameters. </aside>
 
 Key | Default Value | Description
 --- | ------------- | -----------
-kind | _required_ | Either [`io.l5d.commonMetrics`](#commonmetrics), [`io.l5d.statsd`](#statsd-experimental), [`io.l5d.tracelog`](#tracelog), or [`io.l5d.recentRequests`](#recent-requests).
+kind | _required_ | Either [`io.l5d.commonMetrics`](#commonmetrics), [`io.l5d.statsd`](#statsd-experimental), [`io.l5d.tracelog`](#tracelog), [`io.l5d.recentRequests`](#recent-requests), [`io.l5d.usage`](#usage), or [`io.l5d.zipkin`](#zipkin-telemeter).
 experimental | `false` | Set this to `true` to enable the telemeter if it is experimental.
 
 ## CommonMetrics
@@ -160,3 +160,26 @@ Key | Default Value | Description
 --- | ------------- | -----------
 orgId | empty by default | Optional string of your choosing that identifies your organization
 dryRun | false | If set to true, the usage telemeter is loaded but no data is sent
+
+## Zipkin telemeter
+
+> Example zipkin config
+
+```yaml
+telemetry:
+- kind: io.l5d.zipkin
+  host: localhost
+  port: 9410
+  sampleRate: 0.02
+```
+
+kind: `io.l5d.zipkin`
+
+Finagle's [zipkin-tracer](https://github.com/twitter/finagle/tree/develop/finagle-zipkin).
+Use this telemeter to send trace data to a Zipkin Scribe collector.
+
+Key | Default Value | Description
+--- | ------------- | -----------
+host | `localhost` | Host to send trace data to.
+port | `9410` | Port to send trace data to.
+sampleRate | `0.001` | What percentage of requests to trace.

--- a/linkerd/examples/zipkin.yaml
+++ b/linkerd/examples/zipkin.yaml
@@ -11,6 +11,7 @@ routers:
   - port: 4140
 
 telemetry:
+- kind: io.l5d.commonMetrics
 - kind: io.l5d.zipkin
   host: localhost
   port: 9410

--- a/linkerd/examples/zipkin.yaml
+++ b/linkerd/examples/zipkin.yaml
@@ -10,6 +10,8 @@ routers:
   servers:
   - port: 4140
 
-tracers:
+telemetry:
 - kind: io.l5d.zipkin
+  host: localhost
+  port: 9410
   sampleRate: 1.0

--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -157,7 +157,12 @@ object LinkerdBuild extends Base {
     val recentRequests = projectDir("telemetry/recent-requests")
       .dependsOn(admin, core, Router.core)
 
-    val all = aggregateDir("telemetry", adminMetricsExport, core, commonMetrics, recentRequests, statsd, tracelog)
+    val zipkin = projectDir("telemetry/zipkin")
+      .withTwitterLibs(Deps.finagle("zipkin-core"), Deps.finagle("zipkin"))
+      .dependsOn(core, Router.core)
+      .withTests()
+
+    val all = aggregateDir("telemetry", adminMetricsExport, core, commonMetrics, recentRequests, statsd, tracelog, zipkin)
   }
 
   val ConfigFileRE = """^(.*)\.yaml$""".r
@@ -535,7 +540,7 @@ object LinkerdBuild extends Base {
       Interpreter.namerd, Interpreter.fs, Interpreter.perHost, Interpreter.k8s,
       Protocol.h2, Protocol.http, Protocol.mux, Protocol.thrift,
       Announcer.serversets,
-      Telemetry.adminMetricsExport, Telemetry.core, Telemetry.recentRequests, Telemetry.statsd, Telemetry.tracelog,
+      Telemetry.adminMetricsExport, Telemetry.core, Telemetry.recentRequests, Telemetry.statsd, Telemetry.tracelog, Telemetry.zipkin,
       Tracer.zipkin,
       Telemeter.usage,
       tls,
@@ -613,6 +618,7 @@ object LinkerdBuild extends Base {
   val telemetryRecentRequests = Telemetry.recentRequests
   val telemetryStatsD = Telemetry.statsd
   val telemetryTracelog = Telemetry.tracelog
+  val telemetryZipkin = Telemetry.zipkin
 
   val namer = Namer.all
   val namerCore = Namer.core

--- a/telemetry/zipkin/src/main/resources/META-INF/services/io.buoyant.telemetry.TelemeterInitializer
+++ b/telemetry/zipkin/src/main/resources/META-INF/services/io.buoyant.telemetry.TelemeterInitializer
@@ -1,0 +1,1 @@
+io.buoyant.telemetry.ZipkinInitializer

--- a/telemetry/zipkin/src/main/scala/io/buoyant/telemetry/ZipkinInitializer.scala
+++ b/telemetry/zipkin/src/main/scala/io/buoyant/telemetry/ZipkinInitializer.scala
@@ -1,0 +1,83 @@
+package io.buoyant.telemetry
+
+import com.twitter.conversions.time._
+import com.twitter.finagle._
+import com.twitter.finagle.client.DefaultPool
+import com.twitter.finagle.stats.{ClientStatsReceiver, NullStatsReceiver}
+import com.twitter.finagle.thrift.Protocols
+import com.twitter.finagle.tracing._
+import com.twitter.finagle.util.DefaultTimer
+import com.twitter.finagle.zipkin.core.Sampler
+import com.twitter.finagle.zipkin.thrift.{ScribeRawZipkinTracer, ZipkinTracer}
+import com.twitter.finagle.zipkin.thriftscala.Scribe
+
+class ZipkinInitializer extends TelemeterInitializer {
+  type Config = ZipkinConfig
+  val configClass = classOf[ZipkinConfig]
+  override val configId = "io.l5d.zipkin"
+}
+
+case class ZipkinConfig(
+  host: Option[String],
+  port: Option[Int],
+  sampleRate: Option[Double]
+) extends TelemeterConfig {
+
+  private[this] val tracer: Tracer = new Tracer {
+    val underlying: Tracer = {
+      // Cribbed heavily from com.twitter.finagle.zipkin.thrift.RawZipkinTracer
+      val transport = Thrift.client
+        .withStatsReceiver(ClientStatsReceiver)
+        .withSessionPool.maxSize(5)
+        .configured(DefaultPool.Param.param.default.copy(maxWaiters = 250))
+        // reduce timeouts because trace requests should be fast
+        .withRequestTimeout(100.millis)
+        // disable failure accrual so that we don't evict nodes when connections
+        // are saturated
+        .withSessionQualifier.noFailureAccrual
+        // disable fail fast since we often be sending to a load balancer
+        .withSessionQualifier.noFailFast
+        .withTracer(NullTracer)
+        .newService(Name.bound(Address(host.getOrElse("localhost"), port.getOrElse(9410))), "zipkin-tracer")
+
+      val client = new Scribe.FinagledClient(
+        new TracelessFilter andThen transport,
+        Protocols.binaryFactory()
+      )
+
+      val rawTracer = ScribeRawZipkinTracer(
+        client,
+        NullStatsReceiver,
+        DefaultTimer.twitter
+      )
+      new ZipkinTracer(
+        rawTracer,
+        sampleRate.map(_.toFloat).getOrElse(Sampler.DefaultSampleRate)
+      )
+    }
+
+    def sampleTrace(t: TraceId) = underlying.sampleTrace(t)
+    def record(r: Record) = underlying.record(r)
+  }
+
+  def mk(params: Stack.Params): ZipkinTelemeter = new ZipkinTelemeter(tracer)
+}
+
+class ZipkinTelemeter(underlying: Tracer) extends Telemeter {
+  val stats = NullStatsReceiver
+  lazy val tracer = underlying
+  def run() = Telemeter.nopRun
+}
+
+/**
+ * _Copied from Finagle's RawZipkinTracer.scala_
+ *
+ * Makes sure we don't trace the Scribe logging.
+ */
+private class TracelessFilter[Req, Rep] extends SimpleFilter[Req, Rep] {
+  def apply(request: Req, service: Service[Req, Rep]) = {
+    Trace.letClear {
+      service(request)
+    }
+  }
+}

--- a/telemetry/zipkin/src/test/scala/io/buoyant/telemetry/ZipkinInitializerTest.scala
+++ b/telemetry/zipkin/src/test/scala/io/buoyant/telemetry/ZipkinInitializerTest.scala
@@ -5,11 +5,11 @@ import com.twitter.finagle.util.LoadService
 import io.buoyant.config.Parser
 import org.scalatest._
 
-class TracelogInitializerTest extends FunSuite {
+class ZipkinInitializerTest extends FunSuite {
 
-  test("io.l5d.tracelog telemeter loads") {
+  test("io.l5d.zipkin telemeter loads") {
     val yaml =
-      """|kind: io.l5d.tracelog
+      """|kind: io.l5d.zipkin
          |sampleRate: 0.02
          |""".stripMargin
 
@@ -21,10 +21,11 @@ class TracelogInitializerTest extends FunSuite {
     assert(!telemeter.tracer.isNull)
   }
 
-  test("io.l5d.tracelog telemeter loads, with log level") {
+  test("io.l5d.zipkin telemeter loads, with host and port") {
     val yaml =
-      """|kind: io.l5d.tracelog
-         |level: trace
+      """|kind: io.l5d.zipkin
+         |host: 127.0.0.1
+         |port: 9411
          |""".stripMargin
 
     val config = Parser.objectMapper(yaml, Seq(LoadService[TelemeterInitializer]))
@@ -34,17 +35,4 @@ class TracelogInitializerTest extends FunSuite {
     assert(telemeter.stats.isNull)
     assert(!telemeter.tracer.isNull)
   }
-
-  test("io.l5d.tracelog telemeter fails with invalid log level") {
-    val yaml =
-      """|kind: io.l5d.tracelog
-         |level: supergood
-         |""".stripMargin
-
-    val mapper = Parser.objectMapper(yaml, Seq(LoadService[TelemeterInitializer]))
-    val _ = intercept[com.fasterxml.jackson.databind.JsonMappingException] {
-      mapper.readValue[TelemeterConfig](yaml)
-    }
-  }
-
 }


### PR DESCRIPTION
This telemeter is intended to replace the zipkin tracer that is currently provided, allowing us to deprecate the tracers config section. Fixes #994.

I was planning on removing the tracers config in a follow-up branch (#995), but I could do it as part of this branch if that's preferable.