### PR TITLE
Re-add commonMetrics as default telemeter

### DIFF
--- a/linkerd/main/src/main/scala/io/buoyant/linkerd/Main.scala
+++ b/linkerd/main/src/main/scala/io/buoyant/linkerd/Main.scala
@@ -20,6 +20,8 @@ import sun.misc.{Signal, SignalHandler}
  */
 object Main extends App {
 
+  private[this] val DefaultTelemeter =
+    new CommonMetricsTelemeter
   private[this] val DefaultShutdownGrace =
     Duration.fromSeconds(10)
 
@@ -30,7 +32,7 @@ object Main extends App {
     args match {
       case Array(path) =>
         val config = loadLinker(path)
-        val linker = config.mk()
+        val linker = config.mk(DefaultTelemeter)
         val admin = initAdmin(config, linker)
         val telemeters = linker.telemeters.map(_.run())
         val routers = linker.routers.map(initRouter(_))

--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -398,7 +398,7 @@ object LinkerdBuild extends Base {
       .dependsOn(
         configCore,
         LinkerdBuild.admin,
-        Telemetry.core % "compile->compile;test->test", Telemetry.commonMetrics,
+        Telemetry.core % "compile->compile;test->test",
         Namer.core % "compile->compile;test->test",
         Router.core
       )


### PR DESCRIPTION
io.l5d.commonMetrics was mistakenly removed as the default telemeter.  This adds it back.