### PR TITLE
[h2] Refine HTTP/2 configuration

### DIFF
--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4H2Settings.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4H2Settings.scala
@@ -8,7 +8,7 @@ object Netty4H2Settings {
   def mk(params: Stack.Params): Http2Settings = {
     val s = new Http2Settings
     params[HeaderTableSize].size.foreach { n => s.headerTableSize(n.inBytes.toInt); () }
-    params[InitialWindowSize].size.foreach { n => s.initialWindowSize(n.inBytes.toInt); () }
+    params[InitialStreamWindowSize].size.foreach { n => s.initialWindowSize(n.inBytes.toInt); () }
     params[MaxConcurrentStreams].streams.foreach { n => s.maxConcurrentStreams(n); () }
     params[MaxFrameSize].size.foreach { n => s.maxFrameSize(n.inBytes.toInt); () }
     params[MaxHeaderListSize].size.foreach { n => s.maxHeaderListSize(n.inBytes.toInt); () }

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/param.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/param.scala
@@ -21,7 +21,13 @@ package object param {
      */
     case class AutoRefillConnectionWindow(enabled: Boolean)
     implicit object AutoRefillConnectionWindow extends Stack.Param[AutoRefillConnectionWindow] {
-      val default = AutoRefillConnectionWindow(false)
+      /**
+       * By default, the connection window is ignored.
+       *
+       * This should be changed on resolution of
+       * https://github.com/linkerd/linkerd/issues/1044
+       */
+      val default = AutoRefillConnectionWindow(true)
     }
 
     /**
@@ -63,10 +69,12 @@ package object param {
      *       be treated as a connection error (Section 5.4.1) of type
      *       FLOW_CONTROL_ERROR.
      */
-    case class InitialWindowSize(size: Option[StorageUnit])
-    implicit object InitialWindowSize extends Stack.Param[InitialWindowSize] {
-      val default = InitialWindowSize(None)
+    case class InitialStreamWindowSize(size: Option[StorageUnit])
+    implicit object InitialStreamWindowSize extends Stack.Param[InitialStreamWindowSize] {
+      val default = InitialStreamWindowSize(None)
     }
+
+    // TODO case class InitialConnectionWindowSize(size: Option[StorageUnit])
 
     /**
      *    SETTINGS_MAX_CONCURRENT_STREAMS (0x3):  Indicates the maximum number

--- a/linkerd/docs/protocol-h2.md
+++ b/linkerd/docs/protocol-h2.md
@@ -64,13 +64,6 @@ Key | Default Value | Description
 --- | ------------- | -----------
 dstPrefix | `h2` | A path prefix used by [H2-specific identifiers](#h2-identifiers).
 experimental | `false` | Set this to `true` to opt-in to experimental h2 support.
-connectionFlowControl | `true` | Whether connection-level flow control should be enforced in addition to stream-level flow control.
-windowUpdateRatio: | `0.99` | A number between 0 and 1, exclusive, indicating the ratio at which window updates should be sent. With a value of 0.75, updates will be sent when the available window size is 75% of its capacity.
-headerTableBytes | none | Configures `SETTINGS_HEADER_TABLE_SIZE` on new streams.
-initialWindowBytes | 64KB | Configures `SETTINGS_INITIAL_WINDOW_SIZE` on new streams.
-maxConcurrentStreamsPerConnection | unlimited | Configures `SETTINGS_MAX_CONCURRENT_STREAMS` on new streams.
-maxFrameBytes | 16KB | Configures `SETTINGS_MAX_FRAME_SIZE` on new streams.
-maxHeaderListByts | none | Configures `SETTINGS_MAX_HEADER_LIST_SIZE` on new streams.
 
 When TLS is configured, h2 routers negotiate to communicate over
 HTTP/2 via ALPN.
@@ -80,6 +73,28 @@ When TLS is not configured, h2 servers accept both
 [HTTP Upgrade](https://http2.github.io/http2-spec/#discover-http)
 requests.  Plaintext clients are currently only capable of issuing
 prior-knowledge requests.
+
+## HTTP/2 Server Parameters
+
+Key | Default Value | Description
+--- | ------------- | -----------
+windowUpdateRatio: | `0.99` | A number between 0 and 1, exclusive, indicating the ratio at which window updates should be sent. With a value of 0.75, updates will be sent when the available window size is 75% of its capacity.
+headerTableBytes | none | Configures `SETTINGS_HEADER_TABLE_SIZE` on new streams.
+initialStreamWindowBytes | 64KB | Configures `SETTINGS_INITIAL_WINDOW_SIZE` on streams.
+maxConcurrentStreamsPerConnection | unlimited | Configures `SETTINGS_MAX_CONCURRENT_STREAMS` on new streams.
+maxFrameBytes | 16KB | Configures `SETTINGS_MAX_FRAME_SIZE` on new streams.
+maxHeaderListByts | none | Configures `SETTINGS_MAX_HEADER_LIST_SIZE` on new streams.
+
+## HTTP/2 Client Parameters
+
+Key | Default Value | Description
+--- | ------------- | -----------
+windowUpdateRatio: | `0.99` | A number between 0 and 1, exclusive, indicating the ratio at which window updates should be sent. With a value of 0.75, updates will be sent when the available window size is 75% of its capacity.
+headerTableBytes | none | Configures `SETTINGS_HEADER_TABLE_SIZE` on new streams.
+initialStreamWindowBytes | 64KB | Configures `SETTINGS_INITIAL_WINDOW_SIZE` on streams.
+maxFrameBytes | 16KB | Configures `SETTINGS_MAX_FRAME_SIZE` on new streams.
+maxHeaderListByts | none | Configures `SETTINGS_MAX_HEADER_LIST_SIZE` on new streams.
+
 
 <a name="h2-identifiers"></a>
 ## HTTP/2 Identifiers

--- a/linkerd/examples/h2.yaml
+++ b/linkerd/examples/h2.yaml
@@ -18,6 +18,6 @@ routers:
   servers:
   - port: 4142
     maxConcurrentStreamsPerConnection: 300
-    initialWindowBytes: 1048576 # 1MB
+    initialStreamWindowBytes: 1048576 # 1MB
   client:
-    initialWindowBytes: 1048576 # 1MB
+    initialStreamWindowBytes: 1048576 # 1MB

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/H2Config.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/H2Config.scala
@@ -104,39 +104,38 @@ class H2Config extends RouterConfig {
 }
 
 trait H2EndpointConfig {
-  var connectionFlowControl: Option[Boolean] = None
-  var windowUpdateRatio: Option[Double] = None
 
+  var initialStreamWindowBytes: Option[Int] = None
   var headerTableBytes: Option[Int] = None
-  var initialWindowBytes: Option[Int] = None
-  var maxConcurrentStreamsPerConnection: Option[Int] = None
   var maxFrameBytes: Option[Int] = None
   var maxHeaderListBytes: Option[Int] = None
+  var windowUpdateRatio: Option[Double] = None
 
-  def withParams(params: Stack.Params): Stack.Params = params
-    .maybeWith(connectionFlowControl.map(efc => FlowControl.AutoRefillConnectionWindow(!efc)))
+  def withEndpointParams(params: Stack.Params): Stack.Params = params
     .maybeWith(windowUpdateRatio.map(r => FlowControl.WindowUpdateRatio(r.toFloat)))
     .maybeWith(headerTableBytes.map(s => Settings.HeaderTableSize(Some(s.bytes))))
-    .maybeWith(initialWindowBytes.map(s => Settings.InitialWindowSize(Some(s.bytes))))
-    .maybeWith(maxConcurrentStreamsPerConnection.map(s => Settings.MaxConcurrentStreams(Some(s.toLong))))
+    .maybeWith(initialStreamWindowBytes.map(s => Settings.InitialStreamWindowSize(Some(s.bytes))))
     .maybeWith(maxFrameBytes.map(s => Settings.MaxFrameSize(Some(s.bytes))))
     .maybeWith(maxHeaderListBytes.map(s => Settings.MaxHeaderListSize(Some(s.bytes))))
 }
 
-class H2ClientConfig extends ClientConfig with H2EndpointConfig {
+class H2ClientConfig extends ClientConfig extends H2EndpointConfig {
 
   @JsonIgnore
-  override def clientParams = withParams(super.clientParams)
+  override def clientParams = withEndpointParams(super.clientParams)
 }
 
 class H2ServerConfig extends ServerConfig with H2EndpointConfig {
+
+  var maxConcurrentStreamsPerConnection: Option[Int] = None
 
   @JsonIgnore
   override val alpnProtocols: Option[Seq[String]] =
     Some(Seq(ApplicationProtocolNames.HTTP_2))
 
   @JsonIgnore
-  override def serverParams = withParams(super.serverParams)
+  override def serverParams = withEndpointParams(super.serverParams)
+    .maybeWith(maxConcurrentStreamsPerConnection.map(s => Settings.MaxConcurrentStreams(Some(s.toLong))))
 }
 
 trait H2IdentifierConfig extends PolymorphicConfig {

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/H2Config.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/H2Config.scala
@@ -119,7 +119,7 @@ trait H2EndpointConfig {
     .maybeWith(maxHeaderListBytes.map(s => Settings.MaxHeaderListSize(Some(s.bytes))))
 }
 
-class H2ClientConfig extends ClientConfig extends H2EndpointConfig {
+class H2ClientConfig extends ClientConfig with H2EndpointConfig {
 
   @JsonIgnore
   override def clientParams = withEndpointParams(super.clientParams)
@@ -133,9 +133,11 @@ class H2ServerConfig extends ServerConfig with H2EndpointConfig {
   override val alpnProtocols: Option[Seq[String]] =
     Some(Seq(ApplicationProtocolNames.HTTP_2))
 
+  override def withEndpointParams(params: Stack.Params): Stack.Params = super.withEndpointParams(params)
+    .maybeWith(maxConcurrentStreamsPerConnection.map(c => Settings.MaxConcurrentStreams(Some(c.toLong))))
+
   @JsonIgnore
   override def serverParams = withEndpointParams(super.serverParams)
-    .maybeWith(maxConcurrentStreamsPerConnection.map(s => Settings.MaxConcurrentStreams(Some(s.toLong))))
 }
 
 trait H2IdentifierConfig extends PolymorphicConfig {

--- a/linkerd/protocol/h2/src/test/scala/io/buoyant/linkerd/protocol/h2/H2ConfigTest.scala
+++ b/linkerd/protocol/h2/src/test/scala/io/buoyant/linkerd/protocol/h2/H2ConfigTest.scala
@@ -20,40 +20,36 @@ class H2ConfigTest extends FunSuite {
     val yaml =
       s"""|protocol: h2
           |client:
-          |  connectionFlowControl: true
           |  windowUpdateRatio: 0.9
           |  headerTableBytes: 1024
-          |  initialWindowBytes: 524288
-          |  maxConcurrentStreamsPerConnection: 15
+          |  initialStreamWindowBytes: 524288
           |  maxFrameBytes: 8192
           |  maxHeaderListBytes: 1025
           |servers:
           |  - port: 5000
-          |    connectionFlowControl: false
           |    windowUpdateRatio: 0.5
           |    headerTableBytes: 2048
-          |    initialWindowBytes: 1048576
-          |    maxConcurrentStreamsPerConnection: 8
+          |    initialStreamWindowBytes: 1048576
+          |    maxConcurrentStreamsPerConnection: 800
           |    maxFrameBytes: 16384
           |    maxHeaderListBytes: 2049
           |""".stripMargin
     val config = parse(yaml)
 
-    val cparams = config.client.get.withParams(Stack.Params.empty)
-    assert(cparams[AutoRefillConnectionWindow] == AutoRefillConnectionWindow(false))
+    val cparams = config.client.get.withEndpointParams(Stack.Params.empty)
+    assert(cparams[AutoRefillConnectionWindow] == AutoRefillConnectionWindow(true))
     assert(cparams[WindowUpdateRatio] == WindowUpdateRatio(0.9f))
     assert(cparams[HeaderTableSize] == HeaderTableSize(Some(1.kilobyte)))
-    assert(cparams[InitialWindowSize] == InitialWindowSize(Some(512.kilobytes)))
-    assert(cparams[MaxConcurrentStreams] == MaxConcurrentStreams(Some(15)))
+    assert(cparams[InitialStreamWindowSize] == InitialStreamWindowSize(Some(512.kilobytes)))
     assert(cparams[MaxFrameSize] == MaxFrameSize(Some(8.kilobytes)))
     assert(cparams[MaxHeaderListSize] == MaxHeaderListSize(Some(1025.bytes)))
 
-    val sparams = config.servers.head.withParams(Stack.Params.empty)
+    val sparams = config.servers.head.withEndpointParams(Stack.Params.empty)
     assert(sparams[AutoRefillConnectionWindow] == AutoRefillConnectionWindow(true))
     assert(sparams[WindowUpdateRatio] == WindowUpdateRatio(0.5f))
     assert(sparams[HeaderTableSize] == HeaderTableSize(Some(2.kilobytes)))
-    assert(sparams[InitialWindowSize] == InitialWindowSize(Some(1.megabyte)))
-    assert(sparams[MaxConcurrentStreams] == MaxConcurrentStreams(Some(8)))
+    assert(sparams[InitialStreamWindowSize] == InitialStreamWindowSize(Some(1.megabyte)))
+    assert(sparams[MaxConcurrentStreams] == MaxConcurrentStreams(Some(800)))
     assert(sparams[MaxFrameSize] == MaxFrameSize(Some(16.kilobytes)))
     assert(sparams[MaxHeaderListSize] == MaxHeaderListSize(Some(2049.bytes)))
   }


### PR DESCRIPTION
Some aspects of HTTP/2 router configuration don't really add up:
- Only stream window sizes are currently configurable (until #1044), so rename
  `initialWindowSize` to `initialStreamWindowSize`.
- In light of this, it doesn't make sense to expose `connectionFlowControl`
  as configuration.
- Furthermore, it doesn't make sense to enable connection-level flow control
  until it can be configured. Default AutoRefillConnectionWindow to true.
- It doesn't make sense to expose `maxConcurrentStreamsPerConnection` on
  clients, since we disable support for PUSH messages.