### PR TITLE
Don't show collapsed clients in the combined request chart

### DIFF
--- a/admin/src/main/resources/io/buoyant/admin/js/src/combined_client_graph.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/combined_client_graph.js
@@ -18,6 +18,11 @@ define([
       };
     }
 
+    function getQuery(routers, routerName) {
+      var clients = _.map(routers.clients(routerName), 'label');
+      return Query.clientQuery().withRouter(routerName).withClients(clients).withMetric("requests").build();
+    }
+
     return function(metricsCollector, routers, routerName, $root, colors) {
       var chart = new Utils.UpdateableChart(
         {
@@ -42,9 +47,7 @@ define([
         timeseriesParamsFn(colors)
       );
 
-      var clients = _.map(routers.clients(routerName), 'label');
-
-      var query = Query.clientQuery().withRouter(routerName).withClients(clients).withMetric("requests").build();
+      var query = getQuery(routers, routerName);
       var desiredMetrics = _.map(Query.filter(query, metricsCollector.getCurrentMetrics()), clientToMetric);
       chart.setMetrics(desiredMetrics);
 
@@ -55,9 +58,8 @@ define([
           // where the first values from /metrics are very large [linkerd#485]
           count++;
         } else {
-          var clients = _.map(routers.clients(routerName), 'label');
-          var query = Query.clientQuery().withRouter(routerName).withClients(clients).withMetric("requests").build();
-          var filteredData = Query.filter(query, data.specific);
+          var metricQuery = getQuery(routers, routerName);
+          var filteredData = Query.filter(metricQuery, data.specific);
           chart.updateMetrics(filteredData);
         }
       };

--- a/admin/src/main/resources/io/buoyant/admin/js/src/router_client.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/router_client.js
@@ -133,7 +133,7 @@ define([
       return summary;
     }
 
-    return function (metricsCollector, routers, client, $container, routerName, colors, shouldExpandInitially) {
+    return function (metricsCollector, routers, client, $container, routerName, colors, shouldExpandInitially, combinedClientGraph) {
       var metricPartial = templates["metric.partial"];
       Handlebars.registerPartial('metricPartial', metricPartial);
 
@@ -158,11 +158,7 @@ define([
       var lbBarChart = new LoadBalancerBarChart($lbBarChart);
 
       // collapse client section by default (deal with large # of clients)
-      if(shouldExpandInitially) {
-        toggleClientDisplay(true);
-      } else {
-        toggleClientDisplay(false);
-      }
+      toggleClientDisplay(shouldExpandInitially);
 
       $expandLink.click(function() { toggleClientDisplay(true); });
       $collapseLink.click(function() { toggleClientDisplay(false); });
@@ -172,11 +168,13 @@ define([
           $contentContainer.css({"border": colorBorder});
           $headerLine.css("border-bottom", "0px");
 
+          combinedClientGraph.unIgnoreClient(client);
           metricsCollector.registerListener(metricsHandler, getDesiredMetrics);
         } else {
           $contentContainer.css({'border': null});
           $headerLine.css({'border-bottom': colorBorder});
 
+          combinedClientGraph.ignoreClient(client);
           metricsCollector.deregisterListener(metricsHandler);
         }
 

--- a/admin/src/main/resources/io/buoyant/admin/js/src/router_client.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/router_client.js
@@ -154,7 +154,7 @@ define([
       var $collapseLink = $toggleLinks.find(".client-collapse");
 
       renderMetrics($metricsEl, client, [], []);
-      var chart = SuccessRateGraph($chartEl.find(".client-success-rate"), colors.color);
+      var successRateChart = SuccessRateGraph($chartEl.find(".client-success-rate"), colors.color);
       var lbBarChart = new LoadBalancerBarChart($lbBarChart);
 
       // collapse client section by default (deal with large # of clients)
@@ -190,7 +190,7 @@ define([
         var summaryData = getSummaryData(filteredData, metricDefinitions);
         var latencies = getLatencyData(client, latencyKeys, latencyLegend); // this legend is no longer used in any charts: consider removing
 
-        chart.updateMetrics(getSuccessRate(summaryData));
+        successRateChart.updateMetrics(getSuccessRate(summaryData));
         lbBarChart.update(summaryData);
 
         renderMetrics($metricsEl, client, summaryData, latencies);

--- a/admin/src/main/resources/io/buoyant/admin/js/src/router_clients.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/router_clients.js
@@ -21,7 +21,7 @@ define([
       }, {});
     }
 
-    function shouldExpandClients(numClients) {
+    function shouldExpandClient(numClients) {
       // if there are many clients, collapse them by default to improve page perfomance
       return numClients < EXPAND_CLIENT_THRESHOLD;
     }
@@ -33,8 +33,6 @@ define([
       var colorList = colors;
       var clientToColor = assignColorsToClients(colorList, clients);
       var combinedClientGraph = CombinedClientGraph(metricsCollector, routers, routerName, $combinedClientGraphEl, clientToColor);
-
-      var expandClients = shouldExpandClients(clients.length);
 
       var routerClients = _.map(clients, function(client) {
         return initializeClient(client);
@@ -67,7 +65,8 @@ define([
             });
         }
 
-        return RouterClient(metricsCollector, routers, client, $container, routerName, colorsForClient, expandClients);
+        var shouldExpand = shouldExpandClient(routers.clients(routerName).length);
+        return RouterClient(metricsCollector, routers, client, $container, routerName, colorsForClient, shouldExpand, combinedClientGraph);
       }
 
       function addClients(addedClients) {


### PR DESCRIPTION
* Collapsing a client removes it from the top graph, expanding it re-adds
* Also fix autocollapsed behaviour on added clients (if a new client is added and we're already past 5 clients, it'll be collapsed)

Fixes #956

![screen shot 2017-02-03 at 1 25 08 pm](https://cloud.githubusercontent.com/assets/549258/22611761/51d01b06-ea21-11e6-9c4f-4f20a6c1d6b8.png)
![screen shot 2017-02-03 at 1 26 55 pm](https://cloud.githubusercontent.com/assets/549258/22611762/51d3afc8-ea21-11e6-8ac9-44852347a1ec.png)
