### PR TITLE
Switches all logging to include the time zone

### DIFF
--- a/admin/src/main/scala/io/buoyant/admin/App.scala
+++ b/admin/src/main/scala/io/buoyant/admin/App.scala
@@ -8,7 +8,7 @@ trait App extends TApp
   with Linters
   with Logging
   with EventSink
-  with LogFormat
+  with TimeZoneLogFormat
   with Hooks
   with Lifecycle
   with Stats

--- a/admin/src/main/scala/io/buoyant/admin/TimeZoneLogFormat.scala
+++ b/admin/src/main/scala/io/buoyant/admin/TimeZoneLogFormat.scala
@@ -1,0 +1,88 @@
+package io.buoyant.admin
+
+import com.twitter.app.{App => TApp}
+import com.twitter.finagle.tracing.Trace
+import com.twitter.logging.{Level => TwLevel}
+import com.twitter.util.Time
+import java.util.logging.{Formatter, Level, LogRecord, Logger}
+import java.io.{PrintWriter, StringWriter}
+import scala.reflect.NameTransformer
+
+/**
+ * A fork of twitter-server's LogFormat.scala which adds a TimeZone.
+ * https://raw.githubusercontent.com/twitter/twitter-server/7e52ba10aacbcb269da9fcb3c1a87289525848c2/src/main/scala/com/twitter/server/LogFormat.scala
+ */
+
+trait TimeZoneLogFormat { app: TApp =>
+  premain {
+    for (h <- Logger.getLogger("").getHandlers)
+      h.setFormatter(new LogFormatter)
+  }
+}
+
+/**
+ * Implements "glog" style log formatting. Adds a timezone after the timestamp.
+ */
+private class LogFormatter extends Formatter {
+  private val levels = Map[Level, Char](
+    Level.FINEST -> 'D',
+    Level.FINER -> 'D',
+    Level.FINE -> 'D',
+    TwLevel.TRACE -> 'D',
+    TwLevel.DEBUG -> 'D',
+    Level.CONFIG -> 'I',
+    Level.INFO -> 'I',
+    TwLevel.INFO -> 'I',
+    Level.WARNING -> 'W',
+    TwLevel.WARNING -> 'W',
+    Level.SEVERE -> 'E',
+    TwLevel.ERROR -> 'E',
+    TwLevel.CRITICAL -> 'E',
+    TwLevel.FATAL -> 'E'
+  )
+
+  // Make some effort to demangle scala names.
+  private def prettyClass(name: String): String = {
+    var s = NameTransformer.decode(name)
+    val dolladolla = s.indexOf("$$")
+    if (dolladolla > 0) {
+      s = s.substring(0, dolladolla)
+      s += "~"
+    }
+
+    s
+  }
+
+  override def format(r: LogRecord): String = {
+    val msg = formatMessage(r)
+
+    val str = new StringBuilder(msg.length + 30 + 150)
+      .append(levels.getOrElse(r.getLevel, 'U'))
+      .append(Time.fromMilliseconds(r.getMillis).format(" MMdd HH:mm:ss.SSS z"))
+      .append(" THREAD")
+      .append(r.getThreadID)
+
+    for (id <- Trace.idOption) {
+      str.append(" TraceId:")
+      str.append(id.traceId)
+    }
+
+    if (r.getSourceClassName != null) {
+      str.append(' ').append(prettyClass(r.getSourceClassName))
+      if (r.getSourceMethodName != null)
+        str.append('.').append(r.getSourceMethodName)
+    }
+
+    str.append(": ")
+    str.append(msg)
+
+    if (r.getThrown != null) {
+      val w = new StringWriter
+      r.getThrown.printStackTrace(new PrintWriter(w))
+      str.append('\n').append(w.toString)
+    }
+
+    str.append('\n')
+    str.toString
+  }
+}

--- a/linkerd/main/src/main/resources/log4j.properties
+++ b/linkerd/main/src/main/resources/log4j.properties
@@ -2,4 +2,4 @@ log4j.rootLogger=WARN, stderr
 log4j.appender.stderr=org.apache.log4j.ConsoleAppender
 log4j.appender.stderr.Target=System.err
 log4j.appender.stderr.layout=org.apache.log4j.PatternLayout
-log4j.appender.stderr.layout.ConversionPattern=%p %d{MMdd HH:mm:ss.SSS} %t: %m%n
+log4j.appender.stderr.layout.ConversionPattern=%p %d{MMdd HH:mm:ss.SSS z} %t: %m%n

--- a/namerd/main/src/main/resources/log4j.properties
+++ b/namerd/main/src/main/resources/log4j.properties
@@ -2,4 +2,4 @@ log4j.rootLogger=WARN, stderr
 log4j.appender.stderr=org.apache.log4j.ConsoleAppender
 log4j.appender.stderr.Target=System.err
 log4j.appender.stderr.layout=org.apache.log4j.PatternLayout
-log4j.appender.stderr.layout.ConversionPattern=%p %d{MMdd HH:mm:ss.SSS} %t: %m%n
+log4j.appender.stderr.layout.ConversionPattern=%p %d{MMdd HH:mm:ss.SSS z} %t: %m%n


### PR DESCRIPTION
First pass at fixing #945.

Tested this by running a local linkerd and insuring that there was only a single log format.

Logging at startup now looks like:

```
[info] Running io.buoyant.linkerd.Main linkerd/examples/http.yaml
I 0206 23:21:43.103 UTC THREAD190: HttpMuxer[/admin/metrics.json] = com.twitter.finagle.stats.MetricsExporter(<function1>)
I 0206 23:21:43.109 UTC THREAD190: HttpMuxer[/admin/per_host_metrics.json] = com.twitter.finagle.stats.HostMetricsExporter(<function1>)
I 0206 23:21:43.566 UTC THREAD190: linkerd 0.8.6-SNAPSHOT (rev=c1262ce87d81fdbee99c5a0287077009b4987517) built at 20170206-152137
I 0206 23:21:43.734 UTC THREAD190: Finagle version 6.41.0 (rev=95eedf5f41f78414fae25d93cc8fae02eeb5a75d) built at 20161220-164342
I 0206 23:21:45.146 UTC THREAD190: Tracer: com.twitter.finagle.zipkin.thrift.ScribeZipkinTracer
I 0206 23:21:45.407 UTC THREAD190: serving http admin on /0.0.0.0:9990
I 0206 23:21:45.425 UTC THREAD190: serving netty3 on /0.0.0.0:4140
I 0206 23:21:45.446 UTC THREAD190: serving netty4 on /0.0.0.0:4141
I 0206 23:21:45.791 UTC THREAD190: initialized
```

and subsequent log lines appear to all be consistent.