### PR TITLE
Allow export of traces via Zipkin HTTP

### DIFF
--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -58,4 +58,7 @@ object Deps {
 
   // statsd client
   val statsd = "com.datadoghq" % "java-dogstatsd-client" % "2.3"
+
+  // zipkin-finagle
+  val zipkinFinagle = "io.zipkin.finagle" % "zipkin-finagle-http_2.11" % "0.3.4"
 }

--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -456,6 +456,7 @@ object LinkerdBuild extends Base {
     object Tracer {
       val zipkin = projectDir("linkerd/tracer/zipkin")
         .withTwitterLibs(Deps.finagle("zipkin-core"), Deps.finagle("zipkin"))
+        .withLibs(Deps.zipkinFinagle)
         .dependsOn(core)
         .withTests()
 


### PR DESCRIPTION
This adds the ability to use the Zipkin HTTP protocol for traces. I'm not a Scala expert but wanted to get this in front of you folks to so that its clear that this is easy to add. No hurt feelings if you choose to implement it some other way.

In my case, I needed this in order to make Stackdriver Trace's [stackdriver-zipkin](https://github.com/GoogleCloudPlatform/stackdriver-zipkin) proxy work with l5d.

![screen shot 2017-02-06 at 6 58 50 pm](https://cloud.githubusercontent.com/assets/410279/22676089/560e3a34-ec9e-11e6-910e-bb371f922c4d.png)
