### PR TITLE
Calculate metrics deltas in metrics_collector.js

### DIFF
--- a/admin/src/main/resources/io/buoyant/admin/README.md
+++ b/admin/src/main/resources/io/buoyant/admin/README.md
@@ -11,19 +11,19 @@ The tests are written using [Jasmine](https://jasmine.github.io/) and run by
 If you'd like to run eslint or tests locally, first install the necessary
 node modules:
 ```
-cd /linkerd/admin/src/main/resources/io/buoyant/admin
+cd admin/src/main/resources/io/buoyant/admin
 npm install
 ```
 
 To run the tests:
 ```
-cd /linkerd/admin/src/main/resources/io/buoyant/admin
+cd admin/src/main/resources/io/buoyant/admin
 npm test # karma start
 ```
 
 To run eslint:
 ```
-cd /linkerd/admin/src/main/resources/io/buoyant/admin
+cd admin/src/main/resources/io/buoyant/admin
 npm run eslint # eslint js
 ```
 

--- a/admin/src/main/resources/io/buoyant/admin/js/spec/MetricsCollectorSpec.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/spec/MetricsCollectorSpec.js
@@ -1,0 +1,60 @@
+"use strict";
+
+define([
+  'jQuery',
+  'lodash',
+  'spec/fixtures/metrics',
+  'src/metrics_collector'
+], function($, _, metricsJson, MetricsCollector) {
+  describe("MetricsCollector", function() {
+    var collector;
+    beforeEach(function () {
+      collector = MetricsCollector(metricsJson);
+    });
+
+    describe("registerListener", function() {
+      it("registers listener to receive specific metrics on update", function() {
+        var targetMetric = "rt/subtractor/bindcache/path/misses";
+        var expectedDelta = 3;
+        var data;
+        var handler = function(resp) {
+          data = resp.specific;
+        }
+        collector.registerListener(handler, function() { return [targetMetric];})
+        var updateMetrics = _.clone(metricsJson);
+        updateMetrics[targetMetric] += expectedDelta;
+        collector.__update__(updateMetrics);
+
+        expect(data.length).toEqual(1);
+        expect(data[0].name).toEqual(targetMetric);
+        expect(data[0].delta).toEqual(expectedDelta);
+        expect(data[0].value).toEqual(metricsJson[targetMetric] + expectedDelta);
+      });
+
+      it("registers listener to receive full metrics response on update", function() {
+        var data;
+        var handler = function(resp) {
+          data = resp.general;
+        }
+        collector.registerListener(handler, function() { return [];})
+        collector.__update__(metricsJson);
+
+        expect(typeof data).toEqual("object");
+        expect(data["rt/subtractor/bindcache/path/misses"]).toEqual(1);
+      });
+    });
+
+    describe("deregisterListener", function() {
+      it("removes listener", function() {
+        var wasCalled = false;
+        var handler = function() {
+          wasCalled = true;
+        }
+        collector.registerListener(handler, function() { return [];});
+        collector.deregisterListener(handler);
+        collector.__update__(metricsJson);
+        expect(wasCalled).toEqual(false);
+      });
+    });
+  });
+});

--- a/admin/src/main/resources/io/buoyant/admin/js/src/combined_client_graph.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/combined_client_graph.js
@@ -48,18 +48,8 @@ define([
       var desiredMetrics = _.map(Query.filter(query, metricsCollector.getCurrentMetrics()), clientToMetric);
       chart.setMetrics(desiredMetrics);
 
-      var count = 0;
       var metricsListener = function(data) {
-        if (count < 5) {
-          // Hacky bug fix: discard the first few data points to fix the issue
-          // where the first values from /metrics are very large [linkerd#485]
-          count++;
-        } else {
-          var clients = _.map(routers.clients(routerName), 'label');
-          var query = Query.clientQuery().withRouter(routerName).withClients(clients).withMetric("requests").build();
-          var filteredData = Query.filter(query, data.specific);
-          chart.updateMetrics(filteredData);
-        }
+        chart.updateMetrics(data.specific);
       };
 
       metricsCollector.registerListener(metricsListener, function(metrics) { return Query.filter(query, metrics); });

--- a/admin/src/main/resources/io/buoyant/admin/js/src/metrics_collector.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/metrics_collector.js
@@ -14,7 +14,7 @@ define(['jQuery'], function($) {
       handler: function called with incoming data of the form:
         {
           general: {}, // data obtained from /metrics.json
-          specific: {} // data obtained from /metrics?m=...
+          specific: {} // deltas derived from current and previous /metrics.json calls
         }
       metrics: returns a list of metrics the listener wants.
         Called with a list of metric names to choose from.
@@ -29,9 +29,9 @@ define(['jQuery'], function($) {
 
     function generateDeltaPayload(generalData, defaultMetrics, prevMetrics) {
       var metrics = _(listeners)
-        .map(function(listener){ return listener.metrics(defaultMetrics); })
-        .flatten()
+        .flatMap(function(listener){ return listener.metrics(defaultMetrics); })
         .uniq()
+        .compact()
         .value();
 
       return _.flatMap(metrics, function(metricName) {

--- a/admin/src/main/resources/io/buoyant/admin/js/src/request_totals.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/request_totals.js
@@ -16,15 +16,18 @@ define([
       },
       {
         description: "Pending",
-        query: Query.serverQuery().allRouters().allServers().withMetric("load").build()
+        query: Query.serverQuery().allRouters().allServers().withMetric("load").build(),
+        isGauge: true
       },
       {
         description: "Incoming Connections",
-        query: Query.serverQuery().allRouters().allServers().withMetric("connections").build()
+        query: Query.serverQuery().allRouters().allServers().withMetric("connections").build(),
+        isGauge: true
       },
       {
         description: "Outgoing Connections",
-        query: Query.clientQuery().allRouters().allClients().withMetric("connections").build()
+        query: Query.clientQuery().allRouters().allClients().withMetric("connections").build(),
+        isGauge: true
       }
     ];
 
@@ -43,7 +46,8 @@ define([
       function onMetricsUpdate(data) {
         var transformedData = _.map(metricDefinitions, function(defn) {
           var metricsByQuery = Query.filter(defn.query, data.specific);
-          var value = _.sumBy(metricsByQuery, 'delta');
+          var sumBy = defn.isGauge ? 'value' : 'delta';
+          var value = _.sumBy(metricsByQuery, sumBy);
           return {
             description: defn.description,
             value: value
@@ -53,7 +57,7 @@ define([
         render($root, transformedData);
       }
 
-      if (!selectedRouter) {
+      if (!selectedRouter || selectedRouter === "all") { //welcome to my world of hacks
         render($root, metricDefinitions);
         metricsCollector.registerListener(onMetricsUpdate, desiredMetrics);
       } else {

--- a/admin/src/main/resources/io/buoyant/admin/js/src/router_client.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/router_client.js
@@ -186,8 +186,7 @@ define([
       }
 
       function metricsHandler(data) {
-        var filteredData = _.filter(data.specific, function (d) { return d.name.indexOf(routerName) !== -1 });
-        var summaryData = getSummaryData(filteredData, metricDefinitions);
+        var summaryData = getSummaryData(data.specific, metricDefinitions);
         var latencies = getLatencyData(client, latencyKeys, latencyLegend); // this legend is no longer used in any charts: consider removing
 
         chart.updateMetrics(getSuccessRate(summaryData));

--- a/admin/src/main/resources/io/buoyant/admin/js/src/router_client.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/router_client.js
@@ -68,7 +68,7 @@ define([
     function getMetricDefinitions(routerName, clientName) {
       return _.map([
           {suffix: "requests", label: "Requests"},
-          {suffix: "connections", label: "Connections"},
+          {suffix: "connections", label: "Connections", isGauge: true},
           {suffix: "success", label: "Successes"},
           {suffix: "failures", label: "Failures"},
           {suffix: "loadbalancer/size", label: "Load balancer pool size"},
@@ -77,6 +77,7 @@ define([
         return {
           metricSuffix: metric.suffix,
           label: metric.label,
+          isGauge: metric.isGauge,
           query: Query.clientQuery().withRouter(routerName).withClient(clientName).withMetric(metric.suffix).build()
         }
       });
@@ -114,11 +115,12 @@ define([
     function getSummaryData(data, metricDefinitions) {
       var summary = _.reduce(metricDefinitions, function(mem, defn) {
         var clientData = Query.filter(defn.query, data);
+        var value = _.isEmpty(clientData) ? null :
+          (defn.isGauge ? clientData[0].value : clientData[0].delta);
         mem[defn.metricSuffix] = {
           description: defn.label,
-          value: _.isEmpty(clientData) ? null : clientData[0].delta
+          value: value
         };
-
         return mem;
       }, {});
 

--- a/admin/src/main/resources/io/buoyant/admin/js/src/router_client.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/router_client.js
@@ -71,8 +71,8 @@ define([
           {suffix: "connections", label: "Connections", isGauge: true},
           {suffix: "success", label: "Successes"},
           {suffix: "failures", label: "Failures"},
-          {suffix: "loadbalancer/size", label: "Load balancer pool size"},
-          {suffix: "loadbalancer/available", label: "Load balancers available"}
+          {suffix: "loadbalancer/size", label: "Load balancer pool size", isGauge: true},
+          {suffix: "loadbalancer/available", label: "Load balancers available", isGauge: true}
         ], function(metric) {
         return {
           metricSuffix: metric.suffix,

--- a/admin/src/main/resources/io/buoyant/admin/js/src/router_server.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/router_server.js
@@ -19,6 +19,7 @@ define([
         {
           description: "Pending",
           metricSuffix: "load",
+          isGauge: true,
           query: Query.serverQuery().withRouter(routerName).withServer(serverName).withMetric("load").build()
         },
         {
@@ -65,7 +66,7 @@ define([
         var serverData = Query.filter(defn.query, data);
 
         if (!_.isEmpty(serverData)) {
-          defn.value = serverData[0].delta;
+          defn.value = defn.isGauge ? serverData[0].value : serverData[0].delta;
           lookup[defn.metricSuffix] = defn.value;
         }
 

--- a/admin/src/main/resources/io/buoyant/admin/js/src/router_server.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/router_server.js
@@ -96,9 +96,7 @@ define([
       var chart = SuccessRateGraph($chartEl, "#4AD8AC");
 
       var metricsHandler = function(data) {
-        var filteredData = _.filter(data.specific, function (d) { return d.name.indexOf(routerName) !== -1 });
-        var transformedData = processData(filteredData, routerName, server.label);
-
+        var transformedData = processData(data.specific, routerName, server.label);
         renderServer($metricsEl, server, transformedData);
         chart.updateMetrics(getSuccessRate(transformedData));
       }

--- a/admin/src/main/resources/io/buoyant/admin/js/src/router_summary.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/router_summary.js
@@ -52,13 +52,13 @@ define([
     var template = templates.router_summary;
 
     function processResponses(data, routerName) {
-      var process = function(metricName) { return processServerResponse(data, routerName, metricName); };
+      var process = function(metricName, isGauge) { return processServerResponse(data, routerName, metricName, isGauge); };
       var pathRetries = processPathResponse(data, routerName, "retries/total");
       var requeues = processClientResponse(data, routerName, "retries/requeues");
 
       var result = {
         router: routerName,
-        load: process("load"),
+        load: process("load", true),
         requests: process("requests"),
         success: process("success"),
         failures: process("failures"),
@@ -68,9 +68,9 @@ define([
       return  $.extend(result, rates);
     }
 
-    function processServerResponse(data, routerName, metricName) {
+    function processServerResponse(data, routerName, metricName, isGauge) {
       var datum = Query.filter(Query.serverQuery().allServers().withRouter(routerName).withMetric(metricName).build(), data);
-      return _.sumBy(datum, "delta");
+      return _.sumBy(datum, isGauge ? "value" : "delta");
     }
 
     function processClientResponse(data, routerName, metricName) {


### PR DESCRIPTION
Problem:
We'd like to drop support of delta values in `admin/metrics.json`.

Solution:
Calculate deltas client-side instead.
Fixes #966

This is a very surgical change in the interest of #1040 
Going forward I'd like to add a metrics endpoint that better reflects the MetricsTree structure. This would allow the frontend to simplify `routers.js` and any components currently using `query.js`