### PR TITLE
Prometheus telemeter now uses snapshotted values for histograms

### DIFF
--- a/telemetry/core/src/main/scala/io/buoyant/telemetry/Metric.scala
+++ b/telemetry/core/src/main/scala/io/buoyant/telemetry/Metric.scala
@@ -22,6 +22,7 @@ object Metric {
   class Stat extends FStat with Metric {
     // Access must be synchronized
     private[this] val underlying = BucketedHistogram()
+    private[this] var summarySnapshot: HistogramSummary = null
 
     private[this] var resetTime = Time.now
     def startingAt: Time = resetTime
@@ -33,6 +34,11 @@ object Metric {
 
     def peek: Seq[BucketAndCount] = underlying.synchronized {
       underlying.bucketAndCounts
+    }
+
+    def snapshot(): HistogramSummary = underlying.synchronized {
+      summarySnapshot = summary
+      summarySnapshot
     }
 
     def reset(): (Seq[BucketAndCount], Duration) = underlying.synchronized {
@@ -59,6 +65,8 @@ object Metric {
         underlying.average
       )
     }
+
+    def snapshottedSummary: HistogramSummary = summarySnapshot
   }
 
   class Gauge(f: => Float) extends Metric {

--- a/telemetry/prometheus/src/main/scala/io/buoyant/telemetry/prometheus/PrometheusTelemeter.scala
+++ b/telemetry/prometheus/src/main/scala/io/buoyant/telemetry/prometheus/PrometheusTelemeter.scala
@@ -87,33 +87,35 @@ class PrometheusTelemeter(metrics: MetricsTree) extends Telemeter with Admin.Wit
         sb.append(g.get)
         sb.append("\n")
       case s: Metric.Stat =>
-        val summary = s.summary
-        for (
-          (stat, value) <- Seq(
-            "count" -> summary.count, "sum" -> summary.sum, "avg" -> summary.avg
-          )
-        ) {
-          sb.append(key)
-          sb.append("_")
-          sb.append(stat)
-          sb.append(formatLabels(labels1))
-          sb.append(" ")
-          sb.append(value)
-          sb.append("\n")
-        }
-        for (
-          (percentile, value) <- Seq(
-            "0" -> summary.min, "0.5" -> summary.p50,
-            "0.9" -> summary.p90, "0.95" -> summary.p95, "0.99" -> summary.p99,
-            "0.999" -> summary.p9990, "0.9999" -> summary.p9999,
-            "1" -> summary.max
-          )
-        ) {
-          sb.append(key)
-          sb.append(formatLabels(labels1 :+ ("quantile" -> percentile)))
-          sb.append(" ")
-          sb.append(value)
-          sb.append("\n")
+        val summary = s.snapshottedSummary
+        if (summary != null) {
+          for (
+            (stat, value) <- Seq(
+              "count" -> summary.count, "sum" -> summary.sum, "avg" -> summary.avg
+            )
+          ) {
+            sb.append(key)
+            sb.append("_")
+            sb.append(stat)
+            sb.append(formatLabels(labels1))
+            sb.append(" ")
+            sb.append(value)
+            sb.append("\n")
+          }
+          for (
+            (percentile, value) <- Seq(
+              "0" -> summary.min, "0.5" -> summary.p50,
+              "0.9" -> summary.p90, "0.95" -> summary.p95, "0.99" -> summary.p99,
+              "0.999" -> summary.p9990, "0.9999" -> summary.p9999,
+              "1" -> summary.max
+            )
+          ) {
+            sb.append(key)
+            sb.append(formatLabels(labels1 :+ ("quantile" -> percentile)))
+            sb.append(" ")
+            sb.append(value)
+            sb.append("\n")
+          }
         }
       case _ =>
     }


### PR DESCRIPTION
Fixes #1076 

# Problem

The Prometheus telemeter serves stats summaries from live histograms.  These histograms are reset once per minute.  This means that the summaries being served will always have a partial minute's worth of data.

# Solution

Move snapshotting into Metric.Stat.  This allows the Prometheus telemeter to serve the most recently snapshotted summary which will include a full minute's worth of data.