### PR TITLE
Switch PolymorphicConfig to abstract class

### DIFF
--- a/config/src/main/scala/io/buoyant/config/PolymorphicConfig.scala
+++ b/config/src/main/scala/io/buoyant/config/PolymorphicConfig.scala
@@ -3,8 +3,8 @@ package io.buoyant.config
 import com.fasterxml.jackson.annotation.{JsonProperty, JsonTypeInfo}
 
 /**
- * A trait that defines the property "kind" as both a var on the object
- *   and as type information for JSON de/serialization.
+ * An abstract class that defines the property "kind" as both a var on
+ * the object and as type information for JSON de/serialization.
  *
  * Config objects that expect to be subclassed by multiple other configs
  *   with different "kind" values should extend this trait.
@@ -15,7 +15,7 @@ import com.fasterxml.jackson.annotation.{JsonProperty, JsonTypeInfo}
   property = "kind",
   visible = true
 )
-trait PolymorphicConfig {
+abstract class PolymorphicConfig {
   @JsonProperty("kind")
   var kind: String = ""
 }

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/AnnouncerInitializer.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/AnnouncerInitializer.scala
@@ -5,7 +5,7 @@ import com.twitter.finagle.Path
 import io.buoyant.config.{PolymorphicConfig, ConfigInitializer}
 import io.buoyant.namer.Paths
 
-trait AnnouncerConfig extends PolymorphicConfig {
+abstract class AnnouncerConfig extends PolymorphicConfig {
 
   @JsonProperty("prefix")
   var _prefix: Option[Path] = None

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/FailureAccrualInitializer.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/FailureAccrualInitializer.scala
@@ -9,7 +9,7 @@ import io.buoyant.config.{PolymorphicConfig, ConfigInitializer}
 
 abstract class FailureAccrualInitializer extends ConfigInitializer
 
-trait FailureAccrualConfig extends PolymorphicConfig {
+abstract class FailureAccrualConfig extends PolymorphicConfig {
   @JsonIgnore
   def policy: () => FailureAccrualPolicy
 

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/LoadBalancerConfig.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/LoadBalancerConfig.scala
@@ -15,7 +15,7 @@ import io.buoyant.config.PolymorphicConfig
   new Type(value = classOf[Heap], name = "heap"),
   new Type(value = classOf[RoundRobin], name = "roundRobin")
 ))
-trait LoadBalancerConfig extends PolymorphicConfig {
+abstract class LoadBalancerConfig extends PolymorphicConfig {
   val factory: LoadBalancerFactory
 
   val enableProbation: Option[Boolean] = None

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/ResponseClassifierInitializer.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/ResponseClassifierInitializer.scala
@@ -6,7 +6,7 @@ import io.buoyant.config.{PolymorphicConfig, ConfigInitializer}
 
 abstract class ResponseClassifierInitializer extends ConfigInitializer
 
-trait ResponseClassifierConfig extends PolymorphicConfig {
+abstract class ResponseClassifierConfig extends PolymorphicConfig {
   @JsonIgnore
   def mk: ResponseClassifier
 }

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/Router.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/Router.scala
@@ -251,7 +251,7 @@ case class RetriesConfig(
   new JsonSubTypes.Type(value = classOf[ConstantBackoffConfig], name = "constant"),
   new JsonSubTypes.Type(value = classOf[JitteredBackoffConfig], name = "jittered")
 ))
-trait BackoffConfig extends PolymorphicConfig {
+abstract class BackoffConfig extends PolymorphicConfig {
   @JsonIgnore
   def mk: Stream[Duration]
 }

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/TlsClientInitializer.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/TlsClientInitializer.scala
@@ -13,7 +13,7 @@ import io.buoyant.config.{PolymorphicConfig, ConfigInitializer}
  */
 abstract class TlsClientInitializer extends ConfigInitializer
 
-trait TlsClientConfig extends PolymorphicConfig {
+abstract class TlsClientConfig extends PolymorphicConfig {
   @JsonIgnore
   def tlsClientPrep[Req, Rsp]: Stackable[ServiceFactory[Req, Rsp]]
 }

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/H2Config.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/H2Config.scala
@@ -145,7 +145,7 @@ class H2ServerConfig extends ServerConfig with H2EndpointConfig {
   override def serverParams = withEndpointParams(super.serverParams)
 }
 
-trait H2IdentifierConfig extends PolymorphicConfig {
+abstract class H2IdentifierConfig extends PolymorphicConfig {
 
   @JsonIgnore
   def newIdentifier(params: Stack.Params): RoutingFactory.Identifier[Request]

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpIdentifierConfig.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpIdentifierConfig.scala
@@ -6,7 +6,7 @@ import com.twitter.finagle.{Dtab, Path}
 import io.buoyant.config.PolymorphicConfig
 import io.buoyant.router.RoutingFactory.Identifier
 
-trait HttpIdentifierConfig extends PolymorphicConfig {
+abstract class HttpIdentifierConfig extends PolymorphicConfig {
   @JsonIgnore
   def newIdentifier(
     prefix: Path,

--- a/namer/core/src/main/scala/io/buoyant/namer/InterpreterInitializer.scala
+++ b/namer/core/src/main/scala/io/buoyant/namer/InterpreterInitializer.scala
@@ -6,7 +6,7 @@ import com.twitter.finagle.naming.NameInterpreter
 import io.buoyant.config.{PolymorphicConfig, ConfigInitializer}
 import scala.util.control.NoStackTrace
 
-trait InterpreterConfig extends PolymorphicConfig {
+abstract class InterpreterConfig extends PolymorphicConfig {
 
   /** This property must be set to true in order to use this interpreter if it is experimental */
   @JsonProperty("experimental")

--- a/namer/core/src/main/scala/io/buoyant/namer/TransformerConfig.scala
+++ b/namer/core/src/main/scala/io/buoyant/namer/TransformerConfig.scala
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.{JsonIgnore, JsonProperty}
 import com.twitter.finagle.Path
 import io.buoyant.config.{PolymorphicConfig, ConfigInitializer}
 
-trait TransformerConfig extends PolymorphicConfig {
+abstract class TransformerConfig extends PolymorphicConfig {
 
   def defaultPrefix: Path
 

--- a/namerd/core/src/main/scala/io/buoyant/namerd/DtabStoreInitializer.scala
+++ b/namerd/core/src/main/scala/io/buoyant/namerd/DtabStoreInitializer.scala
@@ -5,7 +5,7 @@ import io.buoyant.config.{PolymorphicConfig, ConfigInitializer}
 
 abstract class DtabStoreInitializer extends ConfigInitializer
 
-trait DtabStoreConfig extends PolymorphicConfig {
+abstract class DtabStoreConfig extends PolymorphicConfig {
   /** This property must be set to true in order to use this dtab store if it is experimental */
   @JsonProperty("experimental")
   var _experimentalEnenabled: Option[Boolean] = None

--- a/namerd/core/src/main/scala/io/buoyant/namerd/InterfaceConfig.scala
+++ b/namerd/core/src/main/scala/io/buoyant/namerd/InterfaceConfig.scala
@@ -10,7 +10,7 @@ import java.net.{InetAddress, InetSocketAddress}
 /**
  * Configures a network interface to namerd functionality.
  */
-trait InterfaceConfig extends PolymorphicConfig {
+abstract class InterfaceConfig extends PolymorphicConfig {
   var ip: Option[InetAddress] = None
   var port: Option[Port] = None
 

--- a/telemetry/core/src/main/scala/io/buoyant/telemetry/TelemeterInitializer.scala
+++ b/telemetry/core/src/main/scala/io/buoyant/telemetry/TelemeterInitializer.scala
@@ -12,7 +12,7 @@ trait TelemeterInitializer extends ConfigInitializer {
   def configClass: Class[Config]
 }
 
-trait TelemeterConfig extends PolymorphicConfig {
+abstract class TelemeterConfig extends PolymorphicConfig {
   /**
    * This property must be set to true in order to use this telemeter if it is
    * experimental


### PR DESCRIPTION
## Problem

Most of our plugin config traits extend the `PolymorphicConfig` trait, and traits have Java interoperability issues.

## Solution

Switch `PolymorphicConfig` and all objects that extend it to instead be abstract classes.