### PR TITLE
linkerd should ignore the dtab-local header

### DIFF
--- a/linkerd/protocol/h2/src/main/scala/com/twitter/finagle/buoyant/h2/LinkerdHeaders.scala
+++ b/linkerd/protocol/h2/src/main/scala/com/twitter/finagle/buoyant/h2/LinkerdHeaders.scala
@@ -55,10 +55,8 @@ object LinkerdHeaders {
      *   - Deadline
      *   - Dtab
      *
-     * Note that currently, the dtabs read by this module are
-     * appeneded to that specified by the `l5d-dtab` header.  The
-     * `dtab-local` header should be considered deprecated in favor of
-     * `l5d-dtab`, and will not be supported in the future.
+     * Note that the dtabs read by this module are appeneded to that specified
+     * by the `l5d-dtab` header.
      *
      * Note that trace configuration is handled separately.
      */
@@ -93,11 +91,6 @@ object LinkerdHeaders {
      * A clientside stack module that injects local contextual
      * information onto downstream requests.  Currently this includes:
      *   - Deadline
-     *
-     * Note that Dtabs are *not* encoded by this filter, since the
-     * HttpClientDispatcher is currently responsible for encoding the
-     * `dtab-local` header. In a future release, Dtabs will be encoded
-     * into the `l5d-ctx-dtab` header.
      *
      * Note that trace configuration is handled separately.
      */
@@ -210,11 +203,6 @@ object LinkerdHeaders {
      *   1. `l5d-ctx-dtab` is read and _written_ by linkerd. It is
      *      intended to managed entirely by linkerd, and applications
      *      should only forward requests prefixed by `l5d-ctx-*`.
-     *
-     *      *NOTE*: the client module does not yet encode
-     *      `l5d-ctx-dtab`. `dtab-local` is still to be relied on
-     *      until https://github.com/twitter/finagle/pull/514 is
-     *      complete.
      *
      *   2. `l5d-dtab` is to be provided by users. Applications are
      *       not required to forward `l5d-dtab` when fronted by

--- a/linkerd/protocol/http/src/e2e/scala/io/buoyant/linkerd/protocol/HttpEndToEndTest.scala
+++ b/linkerd/protocol/http/src/e2e/scala/io/buoyant/linkerd/protocol/HttpEndToEndTest.scala
@@ -29,7 +29,8 @@ class HttpEndToEndTest extends FunSuite with Awaits {
   object Downstream {
     def mk(name: String)(f: Request=>Response): Downstream = {
       val service = Service.mk { req: Request => Future(f(req)) }
-      val server = FinagleHttp.server
+      val stack = FinagleHttp.server.stack.remove(Headers.Ctx.serverModule.role)
+      val server = FinagleHttp.server.withStack(stack)
         .configured(param.Label(name))
         .configured(param.Tracer(NullTracer))
         .serve(":*", service)
@@ -48,7 +49,8 @@ class HttpEndToEndTest extends FunSuite with Awaits {
   def upstream(server: ListeningServer) = {
     val address = Address(server.boundAddress.asInstanceOf[InetSocketAddress])
     val name = Name.Bound(Var.value(Addr.Bound(address)), address)
-    FinagleHttp.client
+    val stack = FinagleHttp.client.stack.remove(Headers.Ctx.clientModule.role)
+    FinagleHttp.client.withStack(stack)
       .configured(param.Stats(NullStatsReceiver))
       .configured(param.Tracer(NullTracer))
       .newClient(name, "upstream").toService
@@ -318,10 +320,6 @@ class HttpEndToEndTest extends FunSuite with Awaits {
   for (readHeader <- dtabReadHeaders) test(s"dtab read from $readHeader header") {
     val stats = NullStatsReceiver
     val tracer = new BufferingTracer
-    def withAnnotations(f: Seq[Annotation] => Unit): Unit = {
-      f(tracer.iterator.map(_.annotation).toSeq)
-      tracer.clear()
-    }
 
     @volatile var headers: HeaderMap = null
 
@@ -350,6 +348,36 @@ class HttpEndToEndTest extends FunSuite with Awaits {
       else assert(!headers.contains(header))
     }
     assert(!headers.contains("dtab-local"))
+  }
+
+  test("dtab-local header is ignored") {
+    val stats = NullStatsReceiver
+    val tracer = new BufferingTracer
+
+    @volatile var headers: HeaderMap = null
+
+    val dog = Downstream.mk("dog") { req =>
+      headers = req.headerMap
+      req.response
+    }
+    val dtab = Dtab.read(s"""
+      /svc/* => /$$/inet/127.1/${dog.port} ;
+    """)
+
+    val linker = Linker.Initializers(Seq(HttpInitializer)).load(basicConfig(dtab))
+      .configured(param.Stats(stats))
+      .configured(param.Tracer(tracer))
+    val router = linker.routers.head.initialize()
+    val server = router.servers.head.serve()
+
+    val client = upstream(server)
+
+    val req = Request()
+    req.host = "dog"
+    req.headerMap.set("dtab-local", "/a=>/b")
+    await(client(req))
+    assert(headers("dtab-local") == "/a=>/b")
+    assert(!headers.contains(dtabWriteHeader))
   }
 
   test("with clearContext") {

--- a/linkerd/protocol/http/src/main/scala/com/twitter/finagle/buoyant/linkerd/LinkerdHeaders.scala
+++ b/linkerd/protocol/http/src/main/scala/com/twitter/finagle/buoyant/linkerd/LinkerdHeaders.scala
@@ -55,17 +55,15 @@ object Headers {
      *   - Deadline
      *   - Dtab
      *
-     * Note that currently, the dtabs read by this module are
-     * appeneded to that specified by the `l5d-dtab` header.  The
-     * `dtab-local` header should be considered deprecated in favor of
-     * `l5d-dtab`, and will not be supported in the future.
+     * Note that the dtabs read by this module are appeneded to that specified
+     * by the `l5d-dtab` header.
      *
      * Note that trace configuration is handled by
      * [[HttpTraceInitializer.serverModule]].
      */
     val serverModule: Stackable[ServiceFactory[Request, Response]] =
       new Stack.Module0[ServiceFactory[Request, Response]] {
-        val role = Stack.Role("ServerContextFilter")
+        val role = Stack.Role("ServerContext")
         val description = "Extracts linkerd context from http headers"
 
         val deadline = new Deadline.ServerFilter
@@ -94,11 +92,7 @@ object Headers {
      * A clientside stack module that injects local contextual
      * information onto downstream requests.  Currently this includes:
      *   - Deadline
-     *
-     * Note that Dtabs are *not* encoded by this filter, since the
-     * HttpClientDispatcher is currently responsible for encoding the
-     * `dtab-local` header. In a future release, Dtabs will be encoded
-     * into the `l5d-ctx-dtab` header.
+     *   - Dtab
      *
      * Note that trace configuration is handled by
      * [[HttpTraceInitializer.clientModule]].
@@ -214,11 +208,6 @@ object Headers {
      *   1. `l5d-ctx-dtab` is read and _written_ by linkerd. It is
      *      intended to managed entirely by linkerd, and applications
      *      should only forward requests prefixed by `l5d-ctx-*`.
-     *
-     *      *NOTE*: the client module does not yet encode
-     *      `l5d-ctx-dtab`. `dtab-local` is still to be relied on
-     *      until https://github.com/twitter/finagle/pull/514 is
-     *      complete.
      *
      *   2. `l5d-dtab` is to be provided by users. Applications are
      *       not required to forward `l5d-dtab` when fronted by

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpConfig.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpConfig.scala
@@ -61,7 +61,7 @@ class HttpInitializer extends ProtocolInitializer.Simple {
   protected val defaultServer = {
     val stk = Http.server.stack
       .replace(HttpTraceInitializer.role, HttpTraceInitializer.serverModule)
-      .prepend(Headers.Ctx.serverModule)
+      .replace(Headers.Ctx.serverModule.role, Headers.Ctx.serverModule)
       .prepend(http.ErrorResponder.module)
       .prepend(http.StatusCodeStatsFilter.module)
       .insertBefore(AddForwardedHeader.module.role, AddForwardedHeaderConfig.module)


### PR DESCRIPTION
Fixes #1088

linkerd should ignore the dtab-local header and forward it along unchanged.