### PR TITLE
Guard against unspecified namerd namespace

### DIFF
--- a/interpreter/namerd/src/main/scala/io/buoyant/namerd/iface/NamerdHandler.scala
+++ b/interpreter/namerd/src/main/scala/io/buoyant/namerd/iface/NamerdHandler.scala
@@ -23,7 +23,7 @@ class NamerdHandler(
         namerdInterpreters.get(key) match {
           case Some(delegator) =>
             val dtab = delegator.dtab.values.toFuture().flatMap(Future.const)
-            Some(dtab.map(DelegatorConfig(key, config.namespace.get, _)))
+            Some(dtab.map(DelegatorConfig(key, config.namespace.getOrElse("default"), _)))
           case None => None
         }
     }


### PR DESCRIPTION
Problem:

The namerd interpreter's namespace field is optional, but omitting it causes `:9990/namerd` to 500.

Solution:

`getOrElse`