### PR TITLE
Indicate the primary path in the delegator ui

### DIFF
--- a/admin/src/main/resources/io/buoyant/admin/.eslintrc.json
+++ b/admin/src/main/resources/io/buoyant/admin/.eslintrc.json
@@ -20,5 +20,8 @@
   "rules": {
     "no-console": ["warn", { "allow": ["warn", "error"] }],
     "no-unused-vars": ["error", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }]
+  },
+  "parserOptions": {
+    "ecmaVersion": 6
   }
 }

--- a/admin/src/main/resources/io/buoyant/admin/css/delegator.css
+++ b/admin/src/main/resources/io/buoyant/admin/css/delegator.css
@@ -11,6 +11,10 @@
   box-shadow: none;
 }
 
+.panel-default>.panel-heading-primary, .panel>.list-group .list-group>.list-group-item-primary {
+  border-left: 10px solid green;
+}
+
 .panel {
   margin-bottom: 0px;
 }

--- a/admin/src/main/resources/io/buoyant/admin/css/delegator.css
+++ b/admin/src/main/resources/io/buoyant/admin/css/delegator.css
@@ -11,8 +11,9 @@
   box-shadow: none;
 }
 
-.panel-default>.panel-heading-primary, .panel>.list-group .list-group>.list-group-item-primary {
-  border-left: 10px solid green;
+.list-group-item {
+  background-color: #f5f5f5;
+  color: #333;
 }
 
 .panel {

--- a/admin/src/main/resources/io/buoyant/admin/css/delegator.css
+++ b/admin/src/main/resources/io/buoyant/admin/css/delegator.css
@@ -11,9 +11,19 @@
   box-shadow: none;
 }
 
-.list-group-item {
+.list-group-item.list-group-item-plain {
   background-color: #f5f5f5;
   color: #333;
+}
+
+.panel-default>.panel-heading-danger {
+  color: #a94442;
+  background-color: #f2dede;
+}
+
+.panel-default>.panel-heading-success {
+  color: #3c763d;
+  background-color: #dff0d8;
 }
 
 .panel {

--- a/admin/src/main/resources/io/buoyant/admin/js/src/delegator.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/delegator.js
@@ -30,9 +30,9 @@ define([
           }
           return "neg";
         case "union":
-          if (obj.union.some(function(e,_i){return subtreeType(e) == "fail";})) {
+          if (obj.union.some(function(e,_i){return treeType(e.tree) == "fail";})) {
             return "fail";
-          } else if (obj.union.some(function(e,_i){return subtreeType(e) == "success";})) {
+          } else if (obj.union.some(function(e,_i){return treeType(e.tree) == "success";})) {
             return "success";
           } else {
             return "neg";

--- a/admin/src/main/resources/io/buoyant/admin/js/src/delegator.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/delegator.js
@@ -17,6 +17,10 @@ define([
       $('.result').html(renderNode(resp, true));
     }
 
+    const neg = "neg";
+    const fail = "fail";
+    const success = "success";
+
     function treeType(obj){
       switch(obj.type) {
         case "delegate": return treeType(obj.delegate);
@@ -24,35 +28,38 @@ define([
         case "alt":
           for (var i = 0; i < obj.alt.length; i++) {
             var subtreeType = treeType(obj.alt[i]);
-            if (subtreeType != "neg") {
+            if (subtreeType != neg) {
               return subtreeType;
             }
           }
-          return "neg";
+          return neg;
         case "union":
-          if (obj.union.some(function(e,_i){return treeType(e.tree) == "fail";})) {
-            return "fail";
-          } else if (obj.union.some(function(e,_i){return treeType(e.tree) == "success";})) {
-            return "success";
+          if (obj.union.some(function(e,_i){return treeType(e.tree) == fail;})) {
+            return fail;
+          } else if (obj.union.some(function(e,_i){return treeType(e.tree) == success;})) {
+            return success;
           } else {
-            return "neg";
+            return neg;
           }
-        case "neg": return "neg";
-        case "fail": return "fail";
+        case "neg": return neg;
+        case "fail": return fail;
         case "leaf": return treeType(obj.bound);
-        case "exception": return "fail";
+        case "exception": return fail;
       }
       if (obj.addr.type == "neg") {
-        return "neg";
+        return neg;
       } else {
-        return "success";
+        return success;
       }
     }
 
     function renderNode(obj, primary, weight){
       var ttype = treeType(obj);
       switch(obj.type) {
-        case "delegate": obj.isDelegate = true; obj.child = renderNode(obj.delegate, primary); break;
+        case "delegate":
+          obj.isDelegate = true;
+          obj.child = renderNode(obj.delegate, primary);
+          break;
         case "transformation":
           obj.isLeaf = true;
           obj.dentry = obj.tree.dentry;
@@ -66,7 +73,7 @@ define([
           obj.isAlt = true;
           var foundPrimaryBranch = false;
           obj.child = obj.alt.map(function(e,_i){
-            if (primary && !foundPrimaryBranch && treeType(e) != "neg"){
+            if (primary && !foundPrimaryBranch && treeType(e) != neg){
               foundPrimaryBranch = true;
               return renderNode(e, true);
             } else {
@@ -80,14 +87,23 @@ define([
             return renderNode(e.tree, primary, e.weight);
           }).join("");
           break;
-        case "neg": obj.isNeg = true; break;
-        case "fail": obj.isFail = true; break;
-        case "leaf": obj.isLeaf = true; obj.child = renderNode(obj.bound, primary); break;
-        case "exception": obj.isException = true; break;
+        case "neg":
+          obj.isNeg = true;
+          break;
+        case "fail":
+          obj.isFail = true;
+          break;
+        case "leaf":
+          obj.isLeaf = true;
+          obj.child = renderNode(obj.bound, primary);
+          break;
+        case "exception":
+          obj.isException = true;
+          break;
       }
       obj.weight = weight;
       obj.isPrimary = primary;
-      obj.isSuccess = ttype == "success";
+      obj.isSuccess = ttype == success;
       return templates.node(obj);
     }
 

--- a/admin/src/main/resources/io/buoyant/admin/js/src/delegator.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/delegator.js
@@ -22,12 +22,12 @@ define([
         case "delegate": return treeType(obj.delegate);
         case "transformation": return treeType(obj.tree);
         case "alt":
-          obj.alt.forEach(function(e,_i){
-            var subtreeType = treeType(e);
+          for (var i = 0; i < obj.alt.length; i++) {
+            var subtreeType = treeType(obj.alt[i]);
             if (subtreeType != "neg") {
               return subtreeType;
             }
-          });
+          }
           return "neg";
         case "union":
           if (obj.union.some(function(e,_i){return subtreeType(e) == "fail";})) {
@@ -39,13 +39,13 @@ define([
           }
         case "neg": return "neg";
         case "fail": return "fail";
-        case "leaf":
-          if (obj.bound.addr.type == "neg") {
-            return "neg";
-          } else {
-            return "success";
-          }
+        case "leaf": return treeType(obj.bound);
         case "exception": return "fail";
+      }
+      if (obj.addr.type == "neg") {
+        return "neg";
+      } else {
+        return "success";
       }
     }
 
@@ -66,7 +66,7 @@ define([
           obj.isAlt = true;
           var foundPrimaryBranch = false;
           obj.child = obj.alt.map(function(e,_i){
-            if (primary && !foundPrimaryBranch && ttype != "neg"){
+            if (primary && !foundPrimaryBranch && treeType(e) != "neg"){
               foundPrimaryBranch = true;
               return renderNode(e, true);
             } else {

--- a/admin/src/main/resources/io/buoyant/admin/js/template/compiled_templates.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/template/compiled_templates.js
@@ -28,20 +28,24 @@ templates['barchart'] = template({"1":function(container,depth0,helpers,partials
 templates['delegatenode'] = template({"1":function(container,depth0,helpers,partials,data) {
     var stack1, helper, alias1=depth0 != null ? depth0 : {}, alias2=helpers.helperMissing, alias3="function";
 
-  return "  <div class='panel panel-default'>\n    <div class='panel-heading'"
-    + ((stack1 = helpers["with"].call(alias1,(depth0 != null ? depth0.dentry : depth0),{"name":"with","hash":{},"fn":container.program(2, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+  return "  <div class='panel panel-default'>\n    <div class='panel-heading"
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.primary : depth0),{"name":"if","hash":{},"fn":container.program(2, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + "'"
+    + ((stack1 = helpers["with"].call(alias1,(depth0 != null ? depth0.dentry : depth0),{"name":"with","hash":{},"fn":container.program(4, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + ">\n      <div class='node-info'>\n"
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.isDelegate : depth0),{"name":"if","hash":{},"fn":container.program(4, data, 0),"inverse":container.program(6, data, 0),"data":data})) != null ? stack1 : "")
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.weight : depth0),{"name":"if","hash":{},"fn":container.program(18, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.isDelegate : depth0),{"name":"if","hash":{},"fn":container.program(6, data, 0),"inverse":container.program(8, data, 0),"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.weight : depth0),{"name":"if","hash":{},"fn":container.program(20, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "      </div>\n      "
     + container.escapeExpression(((helper = (helper = helpers.path || (depth0 != null ? depth0.path : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"path","hash":{},"data":data}) : helper)))
     + "\n"
-    + ((stack1 = helpers["with"].call(alias1,(depth0 != null ? depth0.dentry : depth0),{"name":"with","hash":{},"fn":container.program(20, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.transformation : depth0),{"name":"if","hash":{},"fn":container.program(22, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["with"].call(alias1,(depth0 != null ? depth0.dentry : depth0),{"name":"with","hash":{},"fn":container.program(22, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.transformation : depth0),{"name":"if","hash":{},"fn":container.program(24, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "    </div>\n    <ul class='list-group'>"
     + ((stack1 = ((helper = (helper = helpers.child || (depth0 != null ? depth0.child : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"child","hash":{},"data":data}) : helper))) != null ? stack1 : "")
     + "</ul>\n  </div>\n";
 },"2":function(container,depth0,helpers,partials,data) {
+    return " panel-heading-primary";
+},"4":function(container,depth0,helpers,partials,data) {
     var helper, alias1=depth0 != null ? depth0 : {}, alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
 
   return "\n      data-dentry-prefix='"
@@ -49,39 +53,39 @@ templates['delegatenode'] = template({"1":function(container,depth0,helpers,part
     + "' data-dentry-dst='"
     + alias4(((helper = (helper = helpers.dst || (depth0 != null ? depth0.dst : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"dst","hash":{},"data":data}) : helper)))
     + "'\n    ";
-},"4":function(container,depth0,helpers,partials,data) {
-    return "          Possible Resolution Path\n";
 },"6":function(container,depth0,helpers,partials,data) {
+    return "          Possible Resolution Path\n";
+},"8":function(container,depth0,helpers,partials,data) {
     var stack1;
 
-  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : {},(depth0 != null ? depth0.isAlt : depth0),{"name":"if","hash":{},"fn":container.program(7, data, 0),"inverse":container.program(9, data, 0),"data":data})) != null ? stack1 : "");
-},"7":function(container,depth0,helpers,partials,data) {
-    return "          Several Possible Resolution Paths\n";
+  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : {},(depth0 != null ? depth0.isAlt : depth0),{"name":"if","hash":{},"fn":container.program(9, data, 0),"inverse":container.program(11, data, 0),"data":data})) != null ? stack1 : "");
 },"9":function(container,depth0,helpers,partials,data) {
+    return "          Several Possible Resolution Paths\n";
+},"11":function(container,depth0,helpers,partials,data) {
     var stack1;
 
-  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : {},(depth0 != null ? depth0.isUnion : depth0),{"name":"if","hash":{},"fn":container.program(10, data, 0),"inverse":container.program(12, data, 0),"data":data})) != null ? stack1 : "");
-},"10":function(container,depth0,helpers,partials,data) {
-    return "          Several Simultaneous Resolution Paths\n";
+  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : {},(depth0 != null ? depth0.isUnion : depth0),{"name":"if","hash":{},"fn":container.program(12, data, 0),"inverse":container.program(14, data, 0),"data":data})) != null ? stack1 : "");
 },"12":function(container,depth0,helpers,partials,data) {
+    return "          Several Simultaneous Resolution Paths\n";
+},"14":function(container,depth0,helpers,partials,data) {
     var stack1;
 
-  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : {},(depth0 != null ? depth0.isTransformation : depth0),{"name":"if","hash":{},"fn":container.program(13, data, 0),"inverse":container.program(15, data, 0),"data":data})) != null ? stack1 : "");
-},"13":function(container,depth0,helpers,partials,data) {
-    return "          Transformation\n";
+  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : {},(depth0 != null ? depth0.isTransformation : depth0),{"name":"if","hash":{},"fn":container.program(15, data, 0),"inverse":container.program(17, data, 0),"data":data})) != null ? stack1 : "");
 },"15":function(container,depth0,helpers,partials,data) {
+    return "          Transformation\n";
+},"17":function(container,depth0,helpers,partials,data) {
     var stack1;
 
-  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : {},(depth0 != null ? depth0.isLeaf : depth0),{"name":"if","hash":{},"fn":container.program(16, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "");
-},"16":function(container,depth0,helpers,partials,data) {
-    return "          Namer Match\n        ";
+  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : {},(depth0 != null ? depth0.isLeaf : depth0),{"name":"if","hash":{},"fn":container.program(18, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "");
 },"18":function(container,depth0,helpers,partials,data) {
+    return "          Namer Match\n        ";
+},"20":function(container,depth0,helpers,partials,data) {
     var helper;
 
   return "          (weight: "
     + container.escapeExpression(((helper = (helper = helpers.weight || (depth0 != null ? depth0.weight : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : {},{"name":"weight","hash":{},"data":data}) : helper)))
     + ")\n";
-},"20":function(container,depth0,helpers,partials,data) {
+},"22":function(container,depth0,helpers,partials,data) {
     var helper, alias1=depth0 != null ? depth0 : {}, alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
 
   return "        <span class='node-dentry'>"
@@ -89,43 +93,46 @@ templates['delegatenode'] = template({"1":function(container,depth0,helpers,part
     + " => "
     + alias4(((helper = (helper = helpers.dst || (depth0 != null ? depth0.dst : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"dst","hash":{},"data":data}) : helper)))
     + "</span>\n";
-},"22":function(container,depth0,helpers,partials,data) {
+},"24":function(container,depth0,helpers,partials,data) {
     var helper;
 
   return "        <span class='node-dentry'>"
     + container.escapeExpression(((helper = (helper = helpers.transformation || (depth0 != null ? depth0.transformation : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : {},{"name":"transformation","hash":{},"data":data}) : helper)))
     + "</span>\n";
-},"24":function(container,depth0,helpers,partials,data) {
+},"26":function(container,depth0,helpers,partials,data) {
     var stack1, helper, alias1=depth0 != null ? depth0 : {};
 
   return "  <li class='list-group-item\n"
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.isNeg : depth0),{"name":"if","hash":{},"fn":container.program(25, data, 0),"inverse":container.program(27, data, 0),"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.isNeg : depth0),{"name":"if","hash":{},"fn":container.program(27, data, 0),"inverse":container.program(29, data, 0),"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.primary : depth0),{"name":"if","hash":{},"fn":container.program(33, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "'\n"
-    + ((stack1 = helpers["with"].call(alias1,(depth0 != null ? depth0.dentry : depth0),{"name":"with","hash":{},"fn":container.program(31, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["with"].call(alias1,(depth0 != null ? depth0.dentry : depth0),{"name":"with","hash":{},"fn":container.program(35, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + ">\n    <div class='node-info'>\n"
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.isNeg : depth0),{"name":"if","hash":{},"fn":container.program(33, data, 0),"inverse":container.program(35, data, 0),"data":data})) != null ? stack1 : "")
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.weight : depth0),{"name":"if","hash":{},"fn":container.program(46, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.isNeg : depth0),{"name":"if","hash":{},"fn":container.program(37, data, 0),"inverse":container.program(39, data, 0),"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.weight : depth0),{"name":"if","hash":{},"fn":container.program(50, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "    </div>\n"
-    + ((stack1 = helpers["with"].call(alias1,(depth0 != null ? depth0.addr : depth0),{"name":"with","hash":{},"fn":container.program(48, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["with"].call(alias1,(depth0 != null ? depth0.addr : depth0),{"name":"with","hash":{},"fn":container.program(52, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "    "
     + container.escapeExpression(((helper = (helper = helpers.path || (depth0 != null ? depth0.path : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(alias1,{"name":"path","hash":{},"data":data}) : helper)))
     + "\n"
-    + ((stack1 = helpers["with"].call(alias1,(depth0 != null ? depth0.dentry : depth0),{"name":"with","hash":{},"fn":container.program(51, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["with"].call(alias1,(depth0 != null ? depth0.dentry : depth0),{"name":"with","hash":{},"fn":container.program(55, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "  </li>\n"
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.transformed : depth0),{"name":"if","hash":{},"fn":container.program(53, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "");
-},"25":function(container,depth0,helpers,partials,data) {
-    return "      list-group-item-danger\n";
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.transformed : depth0),{"name":"if","hash":{},"fn":container.program(57, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "");
 },"27":function(container,depth0,helpers,partials,data) {
-    var stack1;
-
-  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : {},(depth0 != null ? depth0.isFail : depth0),{"name":"if","hash":{},"fn":container.program(25, data, 0),"inverse":container.program(28, data, 0),"data":data})) != null ? stack1 : "");
-},"28":function(container,depth0,helpers,partials,data) {
-    var stack1;
-
-  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : {},(depth0 != null ? depth0.isException : depth0),{"name":"if","hash":{},"fn":container.program(25, data, 0),"inverse":container.program(29, data, 0),"data":data})) != null ? stack1 : "");
+    return "      list-group-item-danger\n";
 },"29":function(container,depth0,helpers,partials,data) {
-    return "      list-group-item-success\n    ";
+    var stack1;
+
+  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : {},(depth0 != null ? depth0.isFail : depth0),{"name":"if","hash":{},"fn":container.program(27, data, 0),"inverse":container.program(30, data, 0),"data":data})) != null ? stack1 : "");
+},"30":function(container,depth0,helpers,partials,data) {
+    var stack1;
+
+  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : {},(depth0 != null ? depth0.isException : depth0),{"name":"if","hash":{},"fn":container.program(27, data, 0),"inverse":container.program(31, data, 0),"data":data})) != null ? stack1 : "");
 },"31":function(container,depth0,helpers,partials,data) {
+    return "      list-group-item-success\n    ";
+},"33":function(container,depth0,helpers,partials,data) {
+    return " list-group-item-primary";
+},"35":function(container,depth0,helpers,partials,data) {
     var helper, alias1=depth0 != null ? depth0 : {}, alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
 
   return "      data-dentry-prefix='"
@@ -133,43 +140,43 @@ templates['delegatenode'] = template({"1":function(container,depth0,helpers,part
     + "' data-dentry-dst='"
     + alias4(((helper = (helper = helpers.dst || (depth0 != null ? depth0.dst : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"dst","hash":{},"data":data}) : helper)))
     + "'\n    ";
-},"33":function(container,depth0,helpers,partials,data) {
+},"37":function(container,depth0,helpers,partials,data) {
     return "        No Further Branch Matches\n";
-},"35":function(container,depth0,helpers,partials,data) {
-    var stack1;
-
-  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : {},(depth0 != null ? depth0.isFail : depth0),{"name":"if","hash":{},"fn":container.program(36, data, 0),"inverse":container.program(38, data, 0),"data":data})) != null ? stack1 : "");
-},"36":function(container,depth0,helpers,partials,data) {
-    return "        Explicit Failure\n";
-},"38":function(container,depth0,helpers,partials,data) {
-    var stack1;
-
-  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : {},(depth0 != null ? depth0.isException : depth0),{"name":"if","hash":{},"fn":container.program(39, data, 0),"inverse":container.program(44, data, 0),"data":data})) != null ? stack1 : "");
 },"39":function(container,depth0,helpers,partials,data) {
     var stack1;
 
-  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : {},(depth0 != null ? depth0.message : depth0),{"name":"if","hash":{},"fn":container.program(40, data, 0),"inverse":container.program(42, data, 0),"data":data})) != null ? stack1 : "");
+  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : {},(depth0 != null ? depth0.isFail : depth0),{"name":"if","hash":{},"fn":container.program(40, data, 0),"inverse":container.program(42, data, 0),"data":data})) != null ? stack1 : "");
 },"40":function(container,depth0,helpers,partials,data) {
+    return "        Explicit Failure\n";
+},"42":function(container,depth0,helpers,partials,data) {
+    var stack1;
+
+  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : {},(depth0 != null ? depth0.isException : depth0),{"name":"if","hash":{},"fn":container.program(43, data, 0),"inverse":container.program(48, data, 0),"data":data})) != null ? stack1 : "");
+},"43":function(container,depth0,helpers,partials,data) {
+    var stack1;
+
+  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : {},(depth0 != null ? depth0.message : depth0),{"name":"if","hash":{},"fn":container.program(44, data, 0),"inverse":container.program(46, data, 0),"data":data})) != null ? stack1 : "");
+},"44":function(container,depth0,helpers,partials,data) {
     var helper;
 
   return "          Exception: "
     + container.escapeExpression(((helper = (helper = helpers.message || (depth0 != null ? depth0.message : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : {},{"name":"message","hash":{},"data":data}) : helper)))
     + "\n";
-},"42":function(container,depth0,helpers,partials,data) {
-    return "          Unknown Exception\n";
-},"44":function(container,depth0,helpers,partials,data) {
-    return "        Bound Path\n      ";
 },"46":function(container,depth0,helpers,partials,data) {
+    return "          Unknown Exception\n";
+},"48":function(container,depth0,helpers,partials,data) {
+    return "        Bound Path\n      ";
+},"50":function(container,depth0,helpers,partials,data) {
     var helper;
 
   return "        (weight: "
     + container.escapeExpression(((helper = (helper = helpers.weight || (depth0 != null ? depth0.weight : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : {},{"name":"weight","hash":{},"data":data}) : helper)))
     + ")\n";
-},"48":function(container,depth0,helpers,partials,data) {
+},"52":function(container,depth0,helpers,partials,data) {
     var stack1;
 
-  return ((stack1 = helpers.each.call(depth0 != null ? depth0 : {},(depth0 != null ? depth0.addrs : depth0),{"name":"each","hash":{},"fn":container.program(49, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "");
-},"49":function(container,depth0,helpers,partials,data) {
+  return ((stack1 = helpers.each.call(depth0 != null ? depth0 : {},(depth0 != null ? depth0.addrs : depth0),{"name":"each","hash":{},"fn":container.program(53, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "");
+},"53":function(container,depth0,helpers,partials,data) {
     var helper, alias1=depth0 != null ? depth0 : {}, alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
 
   return "        "
@@ -177,7 +184,7 @@ templates['delegatenode'] = template({"1":function(container,depth0,helpers,part
     + ":"
     + alias4(((helper = (helper = helpers.port || (depth0 != null ? depth0.port : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"port","hash":{},"data":data}) : helper)))
     + "\n";
-},"51":function(container,depth0,helpers,partials,data) {
+},"55":function(container,depth0,helpers,partials,data) {
     var helper, alias1=depth0 != null ? depth0 : {}, alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
 
   return "      <span class='node-dentry'>"
@@ -185,7 +192,7 @@ templates['delegatenode'] = template({"1":function(container,depth0,helpers,part
     + " => "
     + alias4(((helper = (helper = helpers.dst || (depth0 != null ? depth0.dst : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"dst","hash":{},"data":data}) : helper)))
     + "</span>\n";
-},"53":function(container,depth0,helpers,partials,data) {
+},"57":function(container,depth0,helpers,partials,data) {
     var stack1, helper;
 
   return "  <ul class='list-group'>"
@@ -194,7 +201,7 @@ templates['delegatenode'] = template({"1":function(container,depth0,helpers,part
 },"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {
     var stack1;
 
-  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : {},(depth0 != null ? depth0.child : depth0),{"name":"if","hash":{},"fn":container.program(1, data, 0),"inverse":container.program(24, data, 0),"data":data})) != null ? stack1 : "");
+  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : {},(depth0 != null ? depth0.child : depth0),{"name":"if","hash":{},"fn":container.program(1, data, 0),"inverse":container.program(26, data, 0),"data":data})) != null ? stack1 : "");
 },"useData":true});
 templates['delegator'] = template({"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {
     return "<div class=\"row\">\n  <div class=\"col-lg-6\">\n    <div class=\"input-group path\">\n      <span class=\"input-group-addon\" id=\"basic-addon1\">Path</span>\n      <input type=\"text\" class=\"form-control\" id=\"path-input\" placeholder=\"/path/to/resource\" aria-describedby=\"basic-addon1\">\n      <span class=\"input-group-btn\">\n        <button class=\"btn btn-default go\" type=\"button\">Go!</button>\n      </span>\n    </div>\n  </div>\n</div>\n<div class=\"dtab\">\n  <h4 class=\"header\">\n    Dtab\n    <button id=\"edit-dtab-btn\" class=\"btn btn-info btn-sm\">Edit</button>\n    <button id=\"save-dtab-btn\" class=\"btn btn-success btn-sm hide disabled\">Save</button>\n  </h4>\n  <div id=\"dtab\"></div>\n  <div id=\"dtab-base\"></div>\n  <div id=\"dtab-edit\" class=\"hide\">\n    <textarea type=\"text\" class=\"form-control\" id=\"dtab-input\" placeholder=\"\"></textarea>\n  </div>\n  </div>\n</div>\n<div class=\"result\">\n</div>\n<div class=\"modal fade error-modal\" tabindex=\"-1\" role=\"dialog\">\n</div>\n";

--- a/admin/src/main/resources/io/buoyant/admin/js/template/compiled_templates.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/template/compiled_templates.js
@@ -28,9 +28,9 @@ templates['barchart'] = template({"1":function(container,depth0,helpers,partials
 templates['delegatenode'] = template({"1":function(container,depth0,helpers,partials,data) {
     var stack1, helper, alias1=depth0 != null ? depth0 : {}, alias2=helpers.helperMissing, alias3="function";
 
-  return "  <div class='panel panel-default\n"
+  return "  <div class='panel panel-default'>\n    <div class='panel-heading\n"
     + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.isPrimary : depth0),{"name":"if","hash":{},"fn":container.program(2, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
-    + "'>\n    <div class='panel-heading'"
+    + "'"
     + ((stack1 = helpers["with"].call(alias1,(depth0 != null ? depth0.dentry : depth0),{"name":"with","hash":{},"fn":container.program(7, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + ">\n      <div class='node-info'>\n"
     + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.isDelegate : depth0),{"name":"if","hash":{},"fn":container.program(9, data, 0),"inverse":container.program(11, data, 0),"data":data})) != null ? stack1 : "")
@@ -49,9 +49,9 @@ templates['delegatenode'] = template({"1":function(container,depth0,helpers,part
   return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : {},(depth0 != null ? depth0.isSuccess : depth0),{"name":"if","hash":{},"fn":container.program(3, data, 0),"inverse":container.program(5, data, 0),"data":data})) != null ? stack1 : "")
     + "  ";
 },"3":function(container,depth0,helpers,partials,data) {
-    return "      panel-success\n";
+    return "      panel-heading-success\n";
 },"5":function(container,depth0,helpers,partials,data) {
-    return "      panel-danger\n";
+    return "      panel-heading-danger\n";
 },"7":function(container,depth0,helpers,partials,data) {
     var helper, alias1=depth0 != null ? depth0 : {}, alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
 
@@ -110,30 +110,31 @@ templates['delegatenode'] = template({"1":function(container,depth0,helpers,part
     var stack1, helper, alias1=depth0 != null ? depth0 : {};
 
   return "  <li class='list-group-item\n"
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.isPrimary : depth0),{"name":"if","hash":{},"fn":container.program(30, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.isPrimary : depth0),{"name":"if","hash":{},"fn":container.program(30, data, 0),"inverse":container.program(35, data, 0),"data":data})) != null ? stack1 : "")
     + "'\n"
-    + ((stack1 = helpers["with"].call(alias1,(depth0 != null ? depth0.dentry : depth0),{"name":"with","hash":{},"fn":container.program(35, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["with"].call(alias1,(depth0 != null ? depth0.dentry : depth0),{"name":"with","hash":{},"fn":container.program(37, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + ">\n    <div class='node-info'>\n"
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.isNeg : depth0),{"name":"if","hash":{},"fn":container.program(37, data, 0),"inverse":container.program(39, data, 0),"data":data})) != null ? stack1 : "")
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.weight : depth0),{"name":"if","hash":{},"fn":container.program(50, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.isNeg : depth0),{"name":"if","hash":{},"fn":container.program(39, data, 0),"inverse":container.program(41, data, 0),"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.weight : depth0),{"name":"if","hash":{},"fn":container.program(52, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "    </div>\n"
-    + ((stack1 = helpers["with"].call(alias1,(depth0 != null ? depth0.addr : depth0),{"name":"with","hash":{},"fn":container.program(52, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["with"].call(alias1,(depth0 != null ? depth0.addr : depth0),{"name":"with","hash":{},"fn":container.program(54, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "    "
     + container.escapeExpression(((helper = (helper = helpers.path || (depth0 != null ? depth0.path : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(alias1,{"name":"path","hash":{},"data":data}) : helper)))
     + "\n"
-    + ((stack1 = helpers["with"].call(alias1,(depth0 != null ? depth0.dentry : depth0),{"name":"with","hash":{},"fn":container.program(55, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["with"].call(alias1,(depth0 != null ? depth0.dentry : depth0),{"name":"with","hash":{},"fn":container.program(57, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "  </li>\n"
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.transformed : depth0),{"name":"if","hash":{},"fn":container.program(57, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "");
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.transformed : depth0),{"name":"if","hash":{},"fn":container.program(59, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "");
 },"30":function(container,depth0,helpers,partials,data) {
     var stack1;
 
-  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : {},(depth0 != null ? depth0.isSuccess : depth0),{"name":"if","hash":{},"fn":container.program(31, data, 0),"inverse":container.program(33, data, 0),"data":data})) != null ? stack1 : "")
-    + "    ";
+  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : {},(depth0 != null ? depth0.isSuccess : depth0),{"name":"if","hash":{},"fn":container.program(31, data, 0),"inverse":container.program(33, data, 0),"data":data})) != null ? stack1 : "");
 },"31":function(container,depth0,helpers,partials,data) {
     return "        list-group-item-success\n";
 },"33":function(container,depth0,helpers,partials,data) {
     return "        list-group-item-danger\n";
 },"35":function(container,depth0,helpers,partials,data) {
+    return "      list-group-item-plain\n    ";
+},"37":function(container,depth0,helpers,partials,data) {
     var helper, alias1=depth0 != null ? depth0 : {}, alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
 
   return "      data-dentry-prefix='"
@@ -141,43 +142,43 @@ templates['delegatenode'] = template({"1":function(container,depth0,helpers,part
     + "' data-dentry-dst='"
     + alias4(((helper = (helper = helpers.dst || (depth0 != null ? depth0.dst : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"dst","hash":{},"data":data}) : helper)))
     + "'\n    ";
-},"37":function(container,depth0,helpers,partials,data) {
-    return "        No Further Branch Matches\n";
 },"39":function(container,depth0,helpers,partials,data) {
+    return "        No Further Branch Matches\n";
+},"41":function(container,depth0,helpers,partials,data) {
     var stack1;
 
-  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : {},(depth0 != null ? depth0.isFail : depth0),{"name":"if","hash":{},"fn":container.program(40, data, 0),"inverse":container.program(42, data, 0),"data":data})) != null ? stack1 : "");
-},"40":function(container,depth0,helpers,partials,data) {
-    return "        Explicit Failure\n";
+  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : {},(depth0 != null ? depth0.isFail : depth0),{"name":"if","hash":{},"fn":container.program(42, data, 0),"inverse":container.program(44, data, 0),"data":data})) != null ? stack1 : "");
 },"42":function(container,depth0,helpers,partials,data) {
-    var stack1;
-
-  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : {},(depth0 != null ? depth0.isException : depth0),{"name":"if","hash":{},"fn":container.program(43, data, 0),"inverse":container.program(48, data, 0),"data":data})) != null ? stack1 : "");
-},"43":function(container,depth0,helpers,partials,data) {
-    var stack1;
-
-  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : {},(depth0 != null ? depth0.message : depth0),{"name":"if","hash":{},"fn":container.program(44, data, 0),"inverse":container.program(46, data, 0),"data":data})) != null ? stack1 : "");
+    return "        Explicit Failure\n";
 },"44":function(container,depth0,helpers,partials,data) {
+    var stack1;
+
+  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : {},(depth0 != null ? depth0.isException : depth0),{"name":"if","hash":{},"fn":container.program(45, data, 0),"inverse":container.program(50, data, 0),"data":data})) != null ? stack1 : "");
+},"45":function(container,depth0,helpers,partials,data) {
+    var stack1;
+
+  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : {},(depth0 != null ? depth0.message : depth0),{"name":"if","hash":{},"fn":container.program(46, data, 0),"inverse":container.program(48, data, 0),"data":data})) != null ? stack1 : "");
+},"46":function(container,depth0,helpers,partials,data) {
     var helper;
 
   return "          Exception: "
     + container.escapeExpression(((helper = (helper = helpers.message || (depth0 != null ? depth0.message : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : {},{"name":"message","hash":{},"data":data}) : helper)))
     + "\n";
-},"46":function(container,depth0,helpers,partials,data) {
-    return "          Unknown Exception\n";
 },"48":function(container,depth0,helpers,partials,data) {
-    return "        Bound Path\n      ";
+    return "          Unknown Exception\n";
 },"50":function(container,depth0,helpers,partials,data) {
+    return "        Bound Path\n      ";
+},"52":function(container,depth0,helpers,partials,data) {
     var helper;
 
   return "        (weight: "
     + container.escapeExpression(((helper = (helper = helpers.weight || (depth0 != null ? depth0.weight : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : {},{"name":"weight","hash":{},"data":data}) : helper)))
     + ")\n";
-},"52":function(container,depth0,helpers,partials,data) {
+},"54":function(container,depth0,helpers,partials,data) {
     var stack1;
 
-  return ((stack1 = helpers.each.call(depth0 != null ? depth0 : {},(depth0 != null ? depth0.addrs : depth0),{"name":"each","hash":{},"fn":container.program(53, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "");
-},"53":function(container,depth0,helpers,partials,data) {
+  return ((stack1 = helpers.each.call(depth0 != null ? depth0 : {},(depth0 != null ? depth0.addrs : depth0),{"name":"each","hash":{},"fn":container.program(55, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "");
+},"55":function(container,depth0,helpers,partials,data) {
     var helper, alias1=depth0 != null ? depth0 : {}, alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
 
   return "        "
@@ -185,7 +186,7 @@ templates['delegatenode'] = template({"1":function(container,depth0,helpers,part
     + ":"
     + alias4(((helper = (helper = helpers.port || (depth0 != null ? depth0.port : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"port","hash":{},"data":data}) : helper)))
     + "\n";
-},"55":function(container,depth0,helpers,partials,data) {
+},"57":function(container,depth0,helpers,partials,data) {
     var helper, alias1=depth0 != null ? depth0 : {}, alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
 
   return "      <span class='node-dentry'>"
@@ -193,7 +194,7 @@ templates['delegatenode'] = template({"1":function(container,depth0,helpers,part
     + " => "
     + alias4(((helper = (helper = helpers.dst || (depth0 != null ? depth0.dst : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"dst","hash":{},"data":data}) : helper)))
     + "</span>\n";
-},"57":function(container,depth0,helpers,partials,data) {
+},"59":function(container,depth0,helpers,partials,data) {
     var stack1, helper;
 
   return "  <ul class='list-group'>"

--- a/admin/src/main/resources/io/buoyant/admin/js/template/compiled_templates.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/template/compiled_templates.js
@@ -47,11 +47,11 @@ templates['delegatenode'] = template({"1":function(container,depth0,helpers,part
     var stack1;
 
   return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : {},(depth0 != null ? depth0.isSuccess : depth0),{"name":"if","hash":{},"fn":container.program(3, data, 0),"inverse":container.program(5, data, 0),"data":data})) != null ? stack1 : "")
-    + "  ";
+    + "    ";
 },"3":function(container,depth0,helpers,partials,data) {
-    return "      panel-heading-success\n";
+    return "        panel-heading-success\n";
 },"5":function(container,depth0,helpers,partials,data) {
-    return "      panel-heading-danger\n";
+    return "        panel-heading-danger\n";
 },"7":function(container,depth0,helpers,partials,data) {
     var helper, alias1=depth0 != null ? depth0 : {}, alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
 

--- a/admin/src/main/resources/io/buoyant/admin/js/template/compiled_templates.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/template/compiled_templates.js
@@ -28,24 +28,31 @@ templates['barchart'] = template({"1":function(container,depth0,helpers,partials
 templates['delegatenode'] = template({"1":function(container,depth0,helpers,partials,data) {
     var stack1, helper, alias1=depth0 != null ? depth0 : {}, alias2=helpers.helperMissing, alias3="function";
 
-  return "  <div class='panel panel-default'>\n    <div class='panel-heading"
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.primary : depth0),{"name":"if","hash":{},"fn":container.program(2, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
-    + "'"
-    + ((stack1 = helpers["with"].call(alias1,(depth0 != null ? depth0.dentry : depth0),{"name":"with","hash":{},"fn":container.program(4, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+  return "  <div class='panel panel-default\n"
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.isPrimary : depth0),{"name":"if","hash":{},"fn":container.program(2, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + "'>\n    <div class='panel-heading'"
+    + ((stack1 = helpers["with"].call(alias1,(depth0 != null ? depth0.dentry : depth0),{"name":"with","hash":{},"fn":container.program(7, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + ">\n      <div class='node-info'>\n"
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.isDelegate : depth0),{"name":"if","hash":{},"fn":container.program(6, data, 0),"inverse":container.program(8, data, 0),"data":data})) != null ? stack1 : "")
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.weight : depth0),{"name":"if","hash":{},"fn":container.program(20, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.isDelegate : depth0),{"name":"if","hash":{},"fn":container.program(9, data, 0),"inverse":container.program(11, data, 0),"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.weight : depth0),{"name":"if","hash":{},"fn":container.program(23, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "      </div>\n      "
     + container.escapeExpression(((helper = (helper = helpers.path || (depth0 != null ? depth0.path : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"path","hash":{},"data":data}) : helper)))
     + "\n"
-    + ((stack1 = helpers["with"].call(alias1,(depth0 != null ? depth0.dentry : depth0),{"name":"with","hash":{},"fn":container.program(22, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.transformation : depth0),{"name":"if","hash":{},"fn":container.program(24, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["with"].call(alias1,(depth0 != null ? depth0.dentry : depth0),{"name":"with","hash":{},"fn":container.program(25, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.transformation : depth0),{"name":"if","hash":{},"fn":container.program(27, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "    </div>\n    <ul class='list-group'>"
     + ((stack1 = ((helper = (helper = helpers.child || (depth0 != null ? depth0.child : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"child","hash":{},"data":data}) : helper))) != null ? stack1 : "")
     + "</ul>\n  </div>\n";
 },"2":function(container,depth0,helpers,partials,data) {
-    return " panel-heading-primary";
-},"4":function(container,depth0,helpers,partials,data) {
+    var stack1;
+
+  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : {},(depth0 != null ? depth0.isSuccess : depth0),{"name":"if","hash":{},"fn":container.program(3, data, 0),"inverse":container.program(5, data, 0),"data":data})) != null ? stack1 : "")
+    + "  ";
+},"3":function(container,depth0,helpers,partials,data) {
+    return "      panel-success\n";
+},"5":function(container,depth0,helpers,partials,data) {
+    return "      panel-danger\n";
+},"7":function(container,depth0,helpers,partials,data) {
     var helper, alias1=depth0 != null ? depth0 : {}, alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
 
   return "\n      data-dentry-prefix='"
@@ -53,39 +60,39 @@ templates['delegatenode'] = template({"1":function(container,depth0,helpers,part
     + "' data-dentry-dst='"
     + alias4(((helper = (helper = helpers.dst || (depth0 != null ? depth0.dst : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"dst","hash":{},"data":data}) : helper)))
     + "'\n    ";
-},"6":function(container,depth0,helpers,partials,data) {
-    return "          Possible Resolution Path\n";
-},"8":function(container,depth0,helpers,partials,data) {
-    var stack1;
-
-  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : {},(depth0 != null ? depth0.isAlt : depth0),{"name":"if","hash":{},"fn":container.program(9, data, 0),"inverse":container.program(11, data, 0),"data":data})) != null ? stack1 : "");
 },"9":function(container,depth0,helpers,partials,data) {
-    return "          Several Possible Resolution Paths\n";
+    return "          Possible Resolution Path\n";
 },"11":function(container,depth0,helpers,partials,data) {
     var stack1;
 
-  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : {},(depth0 != null ? depth0.isUnion : depth0),{"name":"if","hash":{},"fn":container.program(12, data, 0),"inverse":container.program(14, data, 0),"data":data})) != null ? stack1 : "");
+  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : {},(depth0 != null ? depth0.isAlt : depth0),{"name":"if","hash":{},"fn":container.program(12, data, 0),"inverse":container.program(14, data, 0),"data":data})) != null ? stack1 : "");
 },"12":function(container,depth0,helpers,partials,data) {
-    return "          Several Simultaneous Resolution Paths\n";
+    return "          Several Possible Resolution Paths\n";
 },"14":function(container,depth0,helpers,partials,data) {
     var stack1;
 
-  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : {},(depth0 != null ? depth0.isTransformation : depth0),{"name":"if","hash":{},"fn":container.program(15, data, 0),"inverse":container.program(17, data, 0),"data":data})) != null ? stack1 : "");
+  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : {},(depth0 != null ? depth0.isUnion : depth0),{"name":"if","hash":{},"fn":container.program(15, data, 0),"inverse":container.program(17, data, 0),"data":data})) != null ? stack1 : "");
 },"15":function(container,depth0,helpers,partials,data) {
-    return "          Transformation\n";
+    return "          Several Simultaneous Resolution Paths\n";
 },"17":function(container,depth0,helpers,partials,data) {
     var stack1;
 
-  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : {},(depth0 != null ? depth0.isLeaf : depth0),{"name":"if","hash":{},"fn":container.program(18, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "");
+  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : {},(depth0 != null ? depth0.isTransformation : depth0),{"name":"if","hash":{},"fn":container.program(18, data, 0),"inverse":container.program(20, data, 0),"data":data})) != null ? stack1 : "");
 },"18":function(container,depth0,helpers,partials,data) {
-    return "          Namer Match\n        ";
+    return "          Transformation\n";
 },"20":function(container,depth0,helpers,partials,data) {
+    var stack1;
+
+  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : {},(depth0 != null ? depth0.isLeaf : depth0),{"name":"if","hash":{},"fn":container.program(21, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "");
+},"21":function(container,depth0,helpers,partials,data) {
+    return "          Namer Match\n        ";
+},"23":function(container,depth0,helpers,partials,data) {
     var helper;
 
   return "          (weight: "
     + container.escapeExpression(((helper = (helper = helpers.weight || (depth0 != null ? depth0.weight : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : {},{"name":"weight","hash":{},"data":data}) : helper)))
     + ")\n";
-},"22":function(container,depth0,helpers,partials,data) {
+},"25":function(container,depth0,helpers,partials,data) {
     var helper, alias1=depth0 != null ? depth0 : {}, alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
 
   return "        <span class='node-dentry'>"
@@ -93,18 +100,17 @@ templates['delegatenode'] = template({"1":function(container,depth0,helpers,part
     + " => "
     + alias4(((helper = (helper = helpers.dst || (depth0 != null ? depth0.dst : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"dst","hash":{},"data":data}) : helper)))
     + "</span>\n";
-},"24":function(container,depth0,helpers,partials,data) {
+},"27":function(container,depth0,helpers,partials,data) {
     var helper;
 
   return "        <span class='node-dentry'>"
     + container.escapeExpression(((helper = (helper = helpers.transformation || (depth0 != null ? depth0.transformation : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : {},{"name":"transformation","hash":{},"data":data}) : helper)))
     + "</span>\n";
-},"26":function(container,depth0,helpers,partials,data) {
+},"29":function(container,depth0,helpers,partials,data) {
     var stack1, helper, alias1=depth0 != null ? depth0 : {};
 
   return "  <li class='list-group-item\n"
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.isNeg : depth0),{"name":"if","hash":{},"fn":container.program(27, data, 0),"inverse":container.program(29, data, 0),"data":data})) != null ? stack1 : "")
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.primary : depth0),{"name":"if","hash":{},"fn":container.program(33, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.isPrimary : depth0),{"name":"if","hash":{},"fn":container.program(30, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "'\n"
     + ((stack1 = helpers["with"].call(alias1,(depth0 != null ? depth0.dentry : depth0),{"name":"with","hash":{},"fn":container.program(35, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + ">\n    <div class='node-info'>\n"
@@ -118,20 +124,15 @@ templates['delegatenode'] = template({"1":function(container,depth0,helpers,part
     + ((stack1 = helpers["with"].call(alias1,(depth0 != null ? depth0.dentry : depth0),{"name":"with","hash":{},"fn":container.program(55, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "  </li>\n"
     + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.transformed : depth0),{"name":"if","hash":{},"fn":container.program(57, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "");
-},"27":function(container,depth0,helpers,partials,data) {
-    return "      list-group-item-danger\n";
-},"29":function(container,depth0,helpers,partials,data) {
-    var stack1;
-
-  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : {},(depth0 != null ? depth0.isFail : depth0),{"name":"if","hash":{},"fn":container.program(27, data, 0),"inverse":container.program(30, data, 0),"data":data})) != null ? stack1 : "");
 },"30":function(container,depth0,helpers,partials,data) {
     var stack1;
 
-  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : {},(depth0 != null ? depth0.isException : depth0),{"name":"if","hash":{},"fn":container.program(27, data, 0),"inverse":container.program(31, data, 0),"data":data})) != null ? stack1 : "");
+  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : {},(depth0 != null ? depth0.isSuccess : depth0),{"name":"if","hash":{},"fn":container.program(31, data, 0),"inverse":container.program(33, data, 0),"data":data})) != null ? stack1 : "")
+    + "    ";
 },"31":function(container,depth0,helpers,partials,data) {
-    return "      list-group-item-success\n    ";
+    return "        list-group-item-success\n";
 },"33":function(container,depth0,helpers,partials,data) {
-    return " list-group-item-primary";
+    return "        list-group-item-danger\n";
 },"35":function(container,depth0,helpers,partials,data) {
     var helper, alias1=depth0 != null ? depth0 : {}, alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
 
@@ -201,7 +202,7 @@ templates['delegatenode'] = template({"1":function(container,depth0,helpers,part
 },"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {
     var stack1;
 
-  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : {},(depth0 != null ? depth0.child : depth0),{"name":"if","hash":{},"fn":container.program(1, data, 0),"inverse":container.program(26, data, 0),"data":data})) != null ? stack1 : "");
+  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : {},(depth0 != null ? depth0.child : depth0),{"name":"if","hash":{},"fn":container.program(1, data, 0),"inverse":container.program(29, data, 0),"data":data})) != null ? stack1 : "");
 },"useData":true});
 templates['delegator'] = template({"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {
     return "<div class=\"row\">\n  <div class=\"col-lg-6\">\n    <div class=\"input-group path\">\n      <span class=\"input-group-addon\" id=\"basic-addon1\">Path</span>\n      <input type=\"text\" class=\"form-control\" id=\"path-input\" placeholder=\"/path/to/resource\" aria-describedby=\"basic-addon1\">\n      <span class=\"input-group-btn\">\n        <button class=\"btn btn-default go\" type=\"button\">Go!</button>\n      </span>\n    </div>\n  </div>\n</div>\n<div class=\"dtab\">\n  <h4 class=\"header\">\n    Dtab\n    <button id=\"edit-dtab-btn\" class=\"btn btn-info btn-sm\">Edit</button>\n    <button id=\"save-dtab-btn\" class=\"btn btn-success btn-sm hide disabled\">Save</button>\n  </h4>\n  <div id=\"dtab\"></div>\n  <div id=\"dtab-base\"></div>\n  <div id=\"dtab-edit\" class=\"hide\">\n    <textarea type=\"text\" class=\"form-control\" id=\"dtab-input\" placeholder=\"\"></textarea>\n  </div>\n  </div>\n</div>\n<div class=\"result\">\n</div>\n<div class=\"modal fade error-modal\" tabindex=\"-1\" role=\"dialog\">\n</div>\n";

--- a/admin/src/main/resources/io/buoyant/admin/js/template/delegatenode.handlebars
+++ b/admin/src/main/resources/io/buoyant/admin/js/template/delegatenode.handlebars
@@ -1,13 +1,13 @@
 {{#if child}}
-  <div class='panel panel-default
+  <div class='panel panel-default'>
+    <div class='panel-heading
   {{#if isPrimary}}
     {{#if isSuccess}}
-      panel-success
+      panel-heading-success
     {{else}}
-      panel-danger
+      panel-heading-danger
     {{/if}}
-  {{/if}}'>
-    <div class='panel-heading'{{#with dentry}}
+  {{/if}}'{{#with dentry}}
       data-dentry-prefix='{{prefix}}' data-dentry-dst='{{dst}}'
     {{/with}}>
       <div class='node-info'>
@@ -44,6 +44,8 @@
       {{else}}
         list-group-item-danger
       {{/if}}
+    {{else}}
+      list-group-item-plain
     {{/if}}'
     {{#with dentry}}
       data-dentry-prefix='{{prefix}}' data-dentry-dst='{{dst}}'

--- a/admin/src/main/resources/io/buoyant/admin/js/template/delegatenode.handlebars
+++ b/admin/src/main/resources/io/buoyant/admin/js/template/delegatenode.handlebars
@@ -1,6 +1,6 @@
 {{#if child}}
   <div class='panel panel-default'>
-    <div class='panel-heading'{{#with dentry}}
+    <div class='panel-heading{{#if primary}} panel-heading-primary{{/if}}'{{#with dentry}}
       data-dentry-prefix='{{prefix}}' data-dentry-dst='{{dst}}'
     {{/with}}>
       <div class='node-info'>
@@ -39,7 +39,7 @@
       list-group-item-danger
     {{else}}
       list-group-item-success
-    {{/if}}'
+    {{/if}}{{#if primary}} list-group-item-primary{{/if}}'
     {{#with dentry}}
       data-dentry-prefix='{{prefix}}' data-dentry-dst='{{dst}}'
     {{/with}}>

--- a/admin/src/main/resources/io/buoyant/admin/js/template/delegatenode.handlebars
+++ b/admin/src/main/resources/io/buoyant/admin/js/template/delegatenode.handlebars
@@ -1,6 +1,13 @@
 {{#if child}}
-  <div class='panel panel-default'>
-    <div class='panel-heading{{#if primary}} panel-heading-primary{{/if}}'{{#with dentry}}
+  <div class='panel panel-default
+  {{#if isPrimary}}
+    {{#if isSuccess}}
+      panel-success
+    {{else}}
+      panel-danger
+    {{/if}}
+  {{/if}}'>
+    <div class='panel-heading'{{#with dentry}}
       data-dentry-prefix='{{prefix}}' data-dentry-dst='{{dst}}'
     {{/with}}>
       <div class='node-info'>
@@ -31,15 +38,13 @@
   </div>
 {{else}}
   <li class='list-group-item
-    {{#if isNeg}}
-      list-group-item-danger
-    {{else if isFail}}
-      list-group-item-danger
-    {{else if isException}}
-      list-group-item-danger
-    {{else}}
-      list-group-item-success
-    {{/if}}{{#if primary}} list-group-item-primary{{/if}}'
+    {{#if isPrimary}}
+      {{#if isSuccess}}
+        list-group-item-success
+      {{else}}
+        list-group-item-danger
+      {{/if}}
+    {{/if}}'
     {{#with dentry}}
       data-dentry-prefix='{{prefix}}' data-dentry-dst='{{dst}}'
     {{/with}}>

--- a/admin/src/main/resources/io/buoyant/admin/js/template/delegatenode.handlebars
+++ b/admin/src/main/resources/io/buoyant/admin/js/template/delegatenode.handlebars
@@ -1,13 +1,13 @@
 {{#if child}}
   <div class='panel panel-default'>
     <div class='panel-heading
-  {{#if isPrimary}}
-    {{#if isSuccess}}
-      panel-heading-success
-    {{else}}
-      panel-heading-danger
-    {{/if}}
-  {{/if}}'{{#with dentry}}
+    {{#if isPrimary}}
+      {{#if isSuccess}}
+        panel-heading-success
+      {{else}}
+        panel-heading-danger
+      {{/if}}
+    {{/if}}'{{#with dentry}}
       data-dentry-prefix='{{prefix}}' data-dentry-dst='{{dst}}'
     {{/with}}>
       <div class='node-info'>


### PR DESCRIPTION
Fixes #1074 

# Problem

When the delegation tree has alternate branches, it can be unclear which branch will be used by linkerd.  

# Solution

<img width="1256" alt="screen shot 2017-02-21 at 3 00 21 pm" src="https://cloud.githubusercontent.com/assets/3979810/23189688/fd5ef53e-f848-11e6-9663-5c4acfbbaba3.png">

Visually indicate the "active" or "primary" path through the delegation tree.  I've attempted to do this by adding a green bar to the left hand side, but I'm not really happy with how it looks and I don't think it's very clear.  I need some help coming up with a better way of visually indicating this.

I tried giving solid or dashed borders to the "primary" path cells, but it looked pretty horrible.  Maybe with some more skilled use of CSS it might look better.