### PR TITLE
Remove scaladoc links in finagle-h2 package

### DIFF
--- a/finagle/h2/src/main/scala/io/netty/handler/codec/http2/H2FrameCodec.scala
+++ b/finagle/h2/src/main/scala/io/netty/handler/codec/http2/H2FrameCodec.scala
@@ -95,8 +95,8 @@ class H2FrameCodec(
   }
 
   /**
-   * Processes all {@link Http2Frame}s. {@link Http2StreamFrame}s may
-   * only originate in child streams.
+   * Processes all Http2Frame messages. Http2StreamFrame messages
+   * may only originate in child streams.
    */
   override def write(ctx: ChannelHandlerContext, msg: Any, promise: ChannelPromise): Unit =
     msg match {


### PR DESCRIPTION
# Problem

`./sbt finagle-h2/compile:doc` fails after running `./sbt finagle-h2/clean`, with the following error:

```
[error] H2FrameCodec.scala:97: Could not find any member to link for "Http2Frame".
[error]   /**
[error]   ^
[error] one error found
[error] (finagle-h2/compile:doc) Scaladoc generation failed
```

This is the result of a bad link tag in the scaladoc comment.

# Solution

Remove links from the comment.