### PR TITLE
Remove extraneous .toInt causing date bugs.

### DIFF
--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/telemeter/UsageDataTelemeter.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/telemeter/UsageDataTelemeter.scala
@@ -93,7 +93,7 @@ private[telemeter] object UsageDataTelemeter {
     val df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm'Z'")
     df.setTimeZone(tz)
     val uptime = gaugeValue(metrics.resolve(Seq("jvm", "uptime")).metric).map(_.toLong).getOrElse(0l)
-    Some(df.format(new Date((System.currentTimeMillis() - uptime).toInt)))
+    Some(df.format(new Date(System.currentTimeMillis() - uptime)))
   }
 
   def mkNamers(config: Linker.LinkerConfig): Seq[String] =


### PR DESCRIPTION
Problem: 

Usage telemeter is sending startTimes from the 1970s.

Solution:
...the input for `new Date()` should be a long, not an int