### PR TITLE
Hide the routers list dropdown on all pages except / and /delegator

### DIFF
--- a/admin/src/main/resources/io/buoyant/admin/js/main-linkerd.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/main-linkerd.js
@@ -38,10 +38,9 @@ require([
   namerd,
   loggingConfig
 ) {
-  var $routerDropdown = $(".navbar-right .dropdown");
   // poor man's routing
   if (window.location.pathname.endsWith("/")) {
-    adminPage.initialize(false).done(function(routerConfig) {
+    adminPage.initialize().done(function(routerConfig) {
       new dashboard(routerConfig);
     });
   } else if (window.location.pathname.endsWith("/delegator")) {
@@ -50,16 +49,13 @@ require([
     });
   } else if (window.location.pathname.endsWith("/namerd")) {
     adminPage.initialize().done(function() {
-      $routerDropdown.addClass("hide");
       new namerd();
     });
   } else if (window.location.pathname.endsWith("/logging")) {
     adminPage.initialize().done(function() {
-      $routerDropdown.addClass("hide");
       new loggingConfig();
     });
   } else {
     adminPage.initialize();
-    $routerDropdown.addClass("hide");
   }
 });

--- a/admin/src/main/resources/io/buoyant/admin/js/main-linkerd.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/main-linkerd.js
@@ -38,6 +38,7 @@ require([
   namerd,
   loggingConfig
 ) {
+  var $routerDropdown = $(".navbar-right .dropdown");
   // poor man's routing
   if (window.location.pathname.endsWith("/")) {
     adminPage.initialize(false).done(function(routerConfig) {
@@ -49,13 +50,16 @@ require([
     });
   } else if (window.location.pathname.endsWith("/namerd")) {
     adminPage.initialize().done(function() {
+      $routerDropdown.addClass("hide");
       new namerd();
     });
   } else if (window.location.pathname.endsWith("/logging")) {
     adminPage.initialize().done(function() {
+      $routerDropdown.addClass("hide");
       new loggingConfig();
     });
   } else {
     adminPage.initialize();
+    $routerDropdown.addClass("hide");
   }
 });

--- a/admin/src/main/resources/io/buoyant/admin/js/src/admin.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/admin.js
@@ -14,7 +14,12 @@ define([
     }
 
     return $.get("config.json").done(function(routersRsp) {
-      addAllRoutersLabel(routersRsp.routers, removeRoutersAllOption);
+      var routers = routersRsp.routers;
+      addAllRoutersLabel(routers, removeRoutersAllOption);
+
+      if(window.location.pathname === "/" && !matches && routers.length > 0) {
+        selectRouter(routers[0].label || routers[0].protocol);
+      }
       return routersRsp;
     });
   }

--- a/admin/src/main/resources/io/buoyant/admin/js/src/admin.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/admin.js
@@ -14,22 +14,25 @@ define([
     }
 
     return $.get("config.json").done(function(routersRsp) {
-      var template = templates.router_option;
-      var routers = routersRsp.routers;
-
-      //Not every page supports a mult-router view!
-      if(!removeRoutersAllOption || routers.length === 0) {
-        routers.push({label: "all"});
-      }
-      var routerHtml = routers.map(template);
-
-      $(".dropdown-menu").html(routerHtml.join(""));
-
-      $(".router-menu-option").click(function() {
-        selectRouter($(this).text());
-      });
-
+      addAllRoutersLabel(routersRsp, removeRoutersAllOption);
       return routersRsp;
+    });
+  }
+
+  function addAllRoutersLabel(routersRsp, removeRoutersAllOption) {
+    var template = templates.router_option;
+    var routers = routersRsp.routers;
+
+    //Not every page supports a mult-router view!
+    if(!removeRoutersAllOption || routers.length === 0) {
+      // routers.push({label: "all"});
+    }
+    var routerHtml = routers.map(template);
+
+    $(".dropdown-menu").html(routerHtml.join(""));
+
+    $(".router-menu-option").click(function() {
+      selectRouter($(this).text());
     });
   }
 

--- a/admin/src/main/resources/io/buoyant/admin/js/src/admin.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/admin.js
@@ -14,18 +14,17 @@ define([
     }
 
     return $.get("config.json").done(function(routersRsp) {
-      addAllRoutersLabel(routersRsp, removeRoutersAllOption);
+      addAllRoutersLabel(routersRsp.routers, removeRoutersAllOption);
       return routersRsp;
     });
   }
 
-  function addAllRoutersLabel(routersRsp, removeRoutersAllOption) {
+  function addAllRoutersLabel(routers, removeRoutersAllOption) {
     var template = templates.router_option;
-    var routers = routersRsp.routers;
 
     //Not every page supports a mult-router view!
     if(!removeRoutersAllOption || routers.length === 0) {
-      // routers.push({label: "all"});
+      routers.push({label: "all"});
     }
     var routerHtml = routers.map(template);
 

--- a/admin/src/main/scala/io/buoyant/admin/HtmlView.scala
+++ b/admin/src/main/scala/io/buoyant/admin/HtmlView.scala
@@ -8,7 +8,8 @@ trait HtmlView {
     content: String,
     tailContent: String = "",
     csses: Seq[String] = Nil,
-    navHighlight: String = ""
+    navHighlight: String = "",
+    showRouterDropdown: Boolean = false
   ): String
 
   def mkResponse(

--- a/admin/src/main/scala/io/buoyant/admin/names/DelegateHandler.scala
+++ b/admin/src/main/scala/io/buoyant/admin/names/DelegateHandler.scala
@@ -53,7 +53,8 @@ class DelegateHandler(
         <script id="dtab-data" type="application/json">${DelegateApiHandler.Codec.writeStr(dtab)}</script>
         <script id="dtab-base-data" type="application/json">${DelegateApiHandler.Codec.writeStr(dtabBase)}</script>
       """,
-      csses = Seq("delegator.css")
+      csses = Seq("delegator.css"),
+      showRouterDropdown = true
     )
   }.tupled
 
@@ -66,6 +67,7 @@ class DelegateHandler(
           </div>
         </div>
       """,
-    csses = Seq("delegator.css")
+    csses = Seq("delegator.css"),
+    showRouterDropdown = true
   )
 }

--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/AdminHandler.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/AdminHandler.scala
@@ -13,7 +13,19 @@ class AdminHandler(navItems: Seq[NavItem]) extends HtmlView {
     s"""<li class=$activeClass><a href="${item.url}">${item.name}</a></li>"""
   }.mkString("\n")
 
-  def navBar(highlightedItem: String = "") =
+  def navBar(highlightedItem: String = "", showRouterDropdown: Boolean = false) = {
+    val routerDropdown = if (showRouterDropdown) {
+      """
+      <li class="dropdown">
+        <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
+          <span class="router-label">all</span> <span class="caret"></span>
+        </a>
+        <ul class="dropdown-menu">
+        </ul>
+      </li>
+      """
+    } else ""
+
     s"""<nav class="navbar navbar-inverse">
       <div class="navbar-container">
         <div class="navbar-header">
@@ -33,18 +45,13 @@ class AdminHandler(navItems: Seq[NavItem]) extends HtmlView {
           ${navHtml(highlightedItem)}
           </ul>
           <ul class="nav navbar-nav navbar-right">
-            <li class="dropdown">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
-                <span class="router-label">all</span> <span class="caret"></span>
-              </a>
-              <ul class="dropdown-menu">
-              </ul>
-            </li>
+            ${routerDropdown}
             <li class="version">version ${Build.load().version}</li>
           </ul>
         </div>
       </div>
     </nav>"""
+  }
 
   def mkResponse(
     content: String,
@@ -60,7 +67,8 @@ class AdminHandler(navItems: Seq[NavItem]) extends HtmlView {
     content: String,
     tailContent: String = "",
     csses: Seq[String] = Nil,
-    navHighlight: String = ""
+    navHighlight: String = "",
+    showRouterDropdown: Boolean = false
   ): String = {
     val cssesHtml = csses.map { css =>
       s"""<link type="text/css" href="files/css/$css" rel="stylesheet"/>"""
@@ -79,7 +87,7 @@ class AdminHandler(navItems: Seq[NavItem]) extends HtmlView {
           $cssesHtml
         </head>
         <body>
-          ${navBar(navHighlight)}
+          ${navBar(navHighlight, showRouterDropdown)}
 
           <div class="container-fluid">
             $content

--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/DashboardHandler.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/DashboardHandler.scala
@@ -27,7 +27,8 @@ private[admin] class DashboardHandler(adminHandler: AdminHandler) extends Servic
         <div class="dashboard-container"></div>
         <div class="row proc-info">
         </div>
-      """
+      """,
+      showRouterDropdown = true
     )
   }
 }


### PR DESCRIPTION
Fixes #1091

I'm hiding after render rather than on the server side because in / and delegator, the flicker when you select a new router would be worse than the flicker on the other pages where the dropdown appears briefly and then disappears.