### PR TITLE
0.9.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,8 @@
 ## 0.9.0 2017-02-22
 
 * Admin dashboard:
-  * Added reties stat, retry budget bar, and client pool bar.
-  * Added colored border to clients to make them easier to distinguish.
+  * Add retries stat, retry budget bar, and client pool bar.
+  * Add colored border to clients to make them easier to distinguish.
   * Sorts clients and servers alphabetically.
   * Displays routers in the order that they are defined.
   * Namerd Admin now works with Dtabs of arbitrary size.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,29 +1,29 @@
-## Upcoming Release
+## 0.9.0 2017-02-22
 
-* Add `io.l5d.usage` telemeter for opt-in usage data collection
-* Admin dashboard
+* Admin dashboard:
+  * Added reties stat, retry budget bar, and client pool bar.
+  * Added colored border to clients to make them easier to distinguish.
   * Sorts clients and servers alphabetically.
   * Displays routers in the order that they are defined.
-* Update Marathon namer to evaluate an app's running state.
+  * Namerd Admin now works with Dtabs of arbitrary size.
+* Naming and Routing:
+  * Rename `baseDtab` router property to `dtab`.
+  * Change the default `dstPrefix` from the protocol name to `/svc`.
+  * Change the default HTTP identifier to the `io.l5d.header.token` identifier.
+  * Add the ability to route basted on the `dest` request header when using the
+    TTwitter Thrift protocol.
+* Metrics and Tracing:
+  * Remove `io.l5d.commonMetrics` telemeter.
+  * Add `io.l5d.prometheus` telemeter.
+  * Remove the `tracers` router config in favor of the `io.l5d.zipkin` telemeter.
+  * Add opt-out usage data collection.
+* Namers:
+  * Update Marathon namer to evaluate an app's running state.
+  * Add `preferServiceAddress` option to `io.l5d.consul` namer
+  * Make `io.l5d.consul` case-insensitive
 * Add `roundRobin` as a load balancer option.
-* Add the ability to route basted on the `dest` request header when using the
-  TTwitter Thrift protocol.
-* Add `preferServiceAddress` option to `io.l5d.consul` namer
-* Rename `baseDtab` router property to `dtab`
-* Add `io.l5d.adminMetricsExport` telemeter as an eventual replacement for the
-  `io.l5d.commonMetrics` telemeter.
-* Remove the `tracers` router config in favor of the `io.l5d.zipkin` telemeter.
-* Change the default `dstPrefix` from the protocol name to `/svc`.
-* Change the default HTTP identifier to the `io.l5d.header.token` identifier.
 * Add the `clearContext` server configuration option.
-* Make `io.l5d.consul` case-insensitive
-* Add `io.l5d.prometheus` telemeter
-* Remove `io.l5d.commonMetrics` telemeter
-* Remove `io.l5d.adminMetricsExport` as a telemeter plugin, it is now always
-  loaded
-* Namerd Admin now works with Dtabs of arbitrary size
 * Fix query parameter decoding when rewriting proxied requests
-* Usage reporting is now opt-out.
 
 ## 0.8.6 2017-01-19
 

--- a/README.md
+++ b/README.md
@@ -260,14 +260,14 @@ _path/to/myapp/linkerd.yml_, you could start linkerd in docker with
 the following command:
 
 ```
-$ docker run -p 4140:4140 -p 9990:9990 -v /absolute/path/to/myapp:/myapp buoyantio/linkerd:0.0.10-SNAPSHOT /myapp/linkerd.yml
+$ docker run -p 4140:4140 -p 9990:9990 -v /absolute/path/to/myapp:/myapp buoyantio/linkerd:0.9.0-SNAPSHOT /myapp/linkerd.yml
 ```
 
 For local testing convenience, we supply a config that routes to a single
 backend on _localhost:8080_.
 
 ```
-$ docker run -p 4140:4140 -p 9990:9990 -v /path/to/linkerd/linkerd/examples:/config buoyantio/linkerd:0.8.6-SNAPSHOT /config/static_namer.yaml
+$ docker run -p 4140:4140 -p 9990:9990 -v /path/to/linkerd/linkerd/examples:/config buoyantio/linkerd:0.9.0-SNAPSHOT /config/static_namer.yaml
 ```
 
 The list of image names may be changed with a command like:
@@ -302,14 +302,14 @@ The assembly script executes two commands serially:
 
 ```bash
 $ ./sbt namerd/dcos:assembly
-$ namerd/target/scala-2.11/namerd-0.8.6-SNAPSHOT-dcos-exec namerd/examples/zk.yaml
+$ namerd/target/scala-2.11/namerd-0.9.0-SNAPSHOT-dcos-exec namerd/examples/zk.yaml
 ```
 
 ##### Run assembly script in docker #####
 
 ```bash
 $ ./sbt namerd/dcos:docker
-$ docker run -p 2181:2181 -p 4180:4180 -v /path/to/repo:/myapp -w /myapp buoyantio/namerd:0.8.6-SNAPSHOT-dcos namerd/examples/zk.yaml
+$ docker run -p 2181:2181 -p 4180:4180 -v /path/to/repo:/myapp -w /myapp buoyantio/namerd:0.9.0-SNAPSHOT-dcos namerd/examples/zk.yaml
 ```
 
 ### Contributing ###

--- a/project/Base.scala
+++ b/project/Base.scala
@@ -32,7 +32,7 @@ object Base {
 class Base extends Build {
   import Base._
 
-  val headVersion = "0.8.6"
+  val headVersion = "0.9.0"
 
   object Git {
     def git(arg: String, args: String*) = Process("git" +: arg +: args)


### PR DESCRIPTION
* Admin dashboard:
  * Added reties stat, retry budget bar, and client pool bar.
  * Added colored border to clients to make them easier to distinguish.
  * Sorts clients and servers alphabetically.
  * Displays routers in the order that they are defined.
  * Namerd Admin now works with Dtabs of arbitrary size.
* Naming and Routing:
  * Rename `baseDtab` router property to `dtab`.
  * Change the default `dstPrefix` from the protocol name to `/svc`.
  * Change the default HTTP identifier to the `io.l5d.header.token` identifier.
  * Add the ability to route basted on the `dest` request header when using the
    TTwitter Thrift protocol.
* Metrics and Tracing:
  * Remove `io.l5d.commonMetrics` telemeter.
  * Add `io.l5d.prometheus` telemeter.
  * Remove the `tracers` router config in favor of the `io.l5d.zipkin` telemeter.
  * Add opt-out usage data collection.
* Namers:
  * Update Marathon namer to evaluate an app's running state.
  * Add `preferServiceAddress` option to `io.l5d.consul` namer
  * Make `io.l5d.consul` case-insensitive
* Add `roundRobin` as a load balancer option.
* Add the `clearContext` server configuration option.
* Fix query parameter decoding when rewriting proxied requests