### PR TITLE
Addr.Neg addresses should be tinted red in delegator UI

### DIFF
--- a/admin/src/main/resources/io/buoyant/admin/js/src/delegator.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/delegator.js
@@ -36,6 +36,9 @@ define([
         case "leaf": obj.isLeaf = true; obj.child = renderNode(obj.bound); break;
         case "exception": obj.isException = true; break;
       }
+      if (obj.addr && obj.addr.type == "neg") {
+        obj.isNeg = true;
+      }
       obj.weight = weight;
       return templates.node(obj);
     }


### PR DESCRIPTION
# Problem

If a transformer filters an address set down to empty, the result is an Addr.Neg.  In the delegator UI such addresses were being highlighted as green "Bound Address" when they should be highlighted as red "No further branch matches".  This was causing confusion for users who thought that the delegator UI was showing a successful delegation.

# Solution

Highlight Addr.Neg as red.