### PR TITLE
Update install guide, about protobuf installation.

### DIFF
--- a/linkerd/README.md
+++ b/linkerd/README.md
@@ -4,6 +4,8 @@
 
 ## Quickstart ##
 
+Before starting on, you'll need to install protoc 3.0+ either via a package manager like homebrew, or by downloading a binary from the protobuf release page: https://github.com/google/protobuf/releases.
+
 To get up and running quickly, run:
 
 ```


### PR DESCRIPTION
I updated quick start guide as @olix0r mentioned. This is for avoid failure in running as #1106 .
Please look on. Thanks.