### PR TITLE
Fix: rewrite Location & Refresh response headers when Linkerd rewrites request Host header

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 ## In the next release
 
 * Add tree and q params to /admin/metrics.json
+* Fix: rewrite Location & Refresh HTTP response headers when Linkerd
+  rewrites request Host header 
 
 ## 0.9.0 2017-02-22
 

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/RewriteHostHeader.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/RewriteHostHeader.scala
@@ -1,17 +1,35 @@
 package io.buoyant.linkerd.protocol.http
 
 import com.twitter.finagle.client.AddrMetadataExtraction.AddrMetadata
-import com.twitter.finagle.http.{Request, Response}
+import com.twitter.finagle.http.{Fields, Request, Response}
 import com.twitter.finagle.{Service, ServiceFactory, SimpleFilter, Stack}
 import io.buoyant.namer.Metadata
 
 object RewriteHostHeader {
 
+  val headers = Set(
+    Fields.Location,
+    "Refresh" // Not present in Fields... Probably because it's not widely used but still...
+  )
+
   case class Filter(host: String) extends SimpleFilter[Request, Response] {
     def apply(req: Request, svc: Service[Request, Response]) = {
-      // TODO: switch between Host/:authority for HTTP1.1/2.0 when Finagle will support it
+      // Location and Refresh response header MUST contain absolute URLs
+      // As we rewrite the Host header before passing it to a service there might be incorrect
+      // values in those headers if service relies solely on Host header to generate them
+      // Therefore we need to rewrite those response headers as nginx and Apache do
+      val originalHost = req.host
       req.host = host
-      svc(req)
+      svc(req).map { rsp =>
+        for {
+          orig <- originalHost
+          header <- headers
+          value <- rsp.headerMap.get(header)
+        } {
+          rsp.headerMap.set(header, value.replace(host, orig))
+        }
+        rsp
+      }
     }
   }
 


### PR DESCRIPTION
This is essentially similar to Nginx `proxy_redirect` option. When Linkerd rewrites `Host` header the endpoint doesn't know about the original `Host` value so it generates `Location`/`Refresh` headers with the value of host headers it gets  (those must be absolute URLs).

We ran into this issue after trying to sue Linkerd as an "edge" web server.
