### PR TITLE
Add support for weights to the io.l5d.fs namer

### DIFF
--- a/linkerd/docs/namer.md
+++ b/linkerd/docs/namer.md
@@ -55,7 +55,7 @@ apps    users   web
 $ cat config/web
 192.0.2.220 8080
 192.0.2.105 8080
-192.0.2.210 8080
+192.0.2.210 8080 * 2.0
 ```
 
 linkerd ships with a simple file-based service discovery mechanism, called the

--- a/namer/fs/src/test/scala/io/buoyant/namer/fs/FsTest.scala
+++ b/namer/fs/src/test/scala/io/buoyant/namer/fs/FsTest.scala
@@ -1,7 +1,9 @@
+
 package io.buoyant.namer.fs
 
+import com.twitter.finagle.{Addr, Address, Path, Stack}
+import com.twitter.finagle.addr.WeightedAddress
 import com.twitter.finagle.util.LoadService
-import com.twitter.finagle.{Path, Stack}
 import io.buoyant.config.Parser
 import io.buoyant.config.types.Directory
 import io.buoyant.namer.{NamerConfig, NamerInitializer, NamerTestUtil}
@@ -63,6 +65,43 @@ class FsTest extends FunSuite with NamerTestUtil {
     } finally {
       val _ = Seq("rm", "-rf", dir.getPath).!
     }
+  }
 
+  test("supports weights") {
+    val path = Path.read("/#/io.l5d.fs/default")
+
+    val dir = new File("mktemp -d -t disco.XXX".!!.stripLineEnd)
+    try {
+
+      val default = new File(dir, "default")
+      val writer = new PrintWriter(default)
+      writer.println("127.0.0.1 8080")
+      writer.println("127.0.0.1 8081 * 0.23")
+      writer.close()
+
+      val yaml = s"""
+                    |kind: io.l5d.fs
+                    |rootDir: ${dir.getAbsolutePath}
+      """.stripMargin
+
+      val mapper = Parser.objectMapper(yaml, Iterable(Seq(FsInitializer)))
+      val fs = mapper.readValue[NamerConfig](yaml)
+      val namer = fs.mk(Stack.Params.empty)
+
+      val bound = lookupBound(namer, path.drop(fs.prefix.size))
+      assert(bound.size == 1)
+      bound.head.addr.sample() match {
+        case Addr.Bound(addrs, _) =>
+          assert(addrs == Set(
+            Address("127.0.0.1", 8080),
+            WeightedAddress(Address("127.0.0.1", 8081), 0.23)
+          ))
+
+        case addr => fail(s"unexpected addr: $addr")
+      }
+
+    } finally {
+      val _ = Seq("rm", "-rf", dir.getPath).!
+    }
   }
 }

--- a/namer/fs/src/test/scala/io/buoyant/namer/fs/FsTest.scala
+++ b/namer/fs/src/test/scala/io/buoyant/namer/fs/FsTest.scala
@@ -1,4 +1,3 @@
-
 package io.buoyant.namer.fs
 
 import com.twitter.finagle.{Addr, Address, Path, Stack}


### PR DESCRIPTION
Problem

Finagle supports the ability to specify a "weight" on an address, which impacts
load balancing decisions. Most of our namers don't expose any weighting
functionality, though.

Solution

As a first step towards broader support for endpoint weighting, we extend the
io.l5d.fs namer to accept an optional weight.

Now addresses are specified in the following format:

    HOST PORT ['*' WEIGHT]