### PR TITLE
Add weight metadata to io.l5d.thriftNameInterpreter

### DIFF
--- a/namer/core/src/main/scala/io/buoyant/namer/Metadata.scala
+++ b/namer/core/src/main/scala/io/buoyant/namer/Metadata.scala
@@ -1,6 +1,9 @@
 package io.buoyant.namer
 
+import com.twitter.finagle.addr.WeightedAddress
+
 object Metadata {
   val authority = "authority" // HTTP/1.1 Host or HTTP/2.0 :authority
   val nodeName = "nodeName"
+  val endpointWeight = WeightedAddress.weightKey
 }

--- a/namerd/iface/interpreter-thrift-idl/src/main/thrift/namer.thrift
+++ b/namerd/iface/interpreter-thrift-idl/src/main/thrift/namer.thrift
@@ -81,9 +81,15 @@ struct AddrReq {
 }
 
 struct AddrMeta {
-  1: optional string authority // HTTP/1.1 Host or HTTP/2.0 :authority
-  2: optional string nodeName // In scheduled environments, the name of the node
-                              // that this address is scheduled on.
+  // HTTP/1.1 Host or HTTP/2.0 :authority to use on outbound requests.
+  1: optional string authority
+
+  // In scheduled environments, the name of the node that this
+  // address is scheduled on.
+  2: optional string nodeName
+
+  // Endpoints may be weighted. Ignored on BoundAddr.
+  3: optional double endpoint_addr_weight
 }
 
 struct TransportAddress {

--- a/namerd/iface/interpreter-thrift/src/main/scala/io/buoyant/namerd/iface/ThriftNamerClient.scala
+++ b/namerd/iface/interpreter-thrift/src/main/scala/io/buoyant/namerd/iface/ThriftNamerClient.scala
@@ -157,7 +157,8 @@ class ThriftNamerClient(
   private[this] def convertMeta(thriftMeta: Option[thrift.AddrMeta]): Addr.Metadata = {
     val authority = thriftMeta.flatMap(_.authority).map(Metadata.authority -> _)
     val nodeName = thriftMeta.flatMap(_.nodeName).map(Metadata.nodeName -> _)
-    (authority ++ nodeName).toMap
+    val weight = thriftMeta.flatMap(_.endpointAddrWeight).map(Metadata.endpointWeight -> _)
+    (authority ++ nodeName ++ weight).toMap
   }
 
   private[this] def watchAddr(id: TPath): Var[Addr] = {

--- a/namerd/iface/interpreter-thrift/src/main/scala/io/buoyant/namerd/iface/ThriftNamerInterface.scala
+++ b/namerd/iface/interpreter-thrift/src/main/scala/io/buoyant/namerd/iface/ThriftNamerInterface.scala
@@ -410,15 +410,18 @@ class ThriftNamerInterface(
    * Converts Addr.Metadata into Thrift AddrMeta
    */
   private[this] def convertMeta(scalaMeta: Addr.Metadata): Option[thrift.AddrMeta] = {
-    // TODO translate metadata (weight info, latency compensation, etc)
+    // TODO translate metadata (latency compensation, etc)
 
     val authority = scalaMeta.get(Metadata.authority).map(_.toString)
     val nodeName = scalaMeta.get(Metadata.nodeName).map(_.toString)
+    val weight = scalaMeta.get(Metadata.endpointWeight)
+      .flatMap(w => Try(w.toString.toDouble).toOption)
 
     if (authority.isDefined || nodeName.isDefined)
       Some(thrift.AddrMeta(
         authority = authority,
-        nodeName = nodeName
+        nodeName = nodeName,
+        endpointAddrWeight = weight
       ))
     else
       None


### PR DESCRIPTION
Problem

Finagle addresses may contain weight metadata. Namerd, however, does not currently propagate weights across the thrift interpreter interface, and so they do not factor into endpoint-level load balancing decisions.

Solution

Add the `endpoint_addr_weight` field to the `AddrMeta` thrift type. Servers may now encode this double value, if it is specified and valid; and clients will use this weight when making load balancing decisions.

This is useful, for instance, when instrumenting "red line" tests.