### PR TITLE
Increase binding cache size

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,8 @@
 
 * Add tree and q params to /admin/metrics.json
 * Fix: rewrite Location & Refresh HTTP response headers when Linkerd
-  rewrites request Host header 
+  rewrites request Host header
+* Increase default binding cache size
 
 ## 0.9.0 2017-02-22
 

--- a/router/core/src/main/scala/com/twitter/finagle/buoyant/DstBindingFactory.scala
+++ b/router/core/src/main/scala/com/twitter/finagle/buoyant/DstBindingFactory.scala
@@ -104,7 +104,7 @@ object DstBindingFactory {
   }
 
   implicit object Capacity extends Stack.Param[Capacity] {
-    val default = Capacity(100, 100, 100, 10)
+    val default = Capacity(1000, 1000, 1000, 1000)
   }
 
   case class BindingTimeout(timeout: Duration)


### PR DESCRIPTION
Fixes #1104 

Increase the default size of the binding cache to 1000 for each of paths, trees, bounds, and clients.  I picked 1000 as the new default size by this highly mathematical method: 1000 is larger than 10.  

Suggestions for more sophisticated defaults are welcomed.