### PR TITLE
Bumping sbt-docker plugin version to fix docker 17.03-ce compatibility

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -15,7 +15,7 @@ addSbtPlugin("com.eed3si9n"   % "sbt-unidoc"    % "0.3.3")
 // packaging
 addSbtPlugin("com.eed3si9n"      % "sbt-assembly"  % "0.14.1")
 
-addSbtPlugin("se.marcuslonnberg" % "sbt-docker"    % "1.4.0")
+addSbtPlugin("se.marcuslonnberg" % "sbt-docker"    % "1.4.1")
 
 // scrooge
 addSbtPlugin("com.twitter" %% "scrooge-sbt-plugin" % "4.6.0")


### PR DESCRIPTION
Sbt task **linkerd/docker** fails with the following version exception:

```
[info] Sending build context to Docker daemon 50.49 MB
[info]
[info] Step 1/7 : FROM library/java:openjdk-8-jre
[info]  ---> e44d62cf8862
[info] Step 2/7 : RUN mkdir -p /io.buoyant/linkerd/0.9.0
[info]  ---> Using cache
[info]  ---> 210965e83b9d
[info] Step 3/7 : WORKDIR /io.buoyant/linkerd/0.9.0
[info]  ---> Using cache
[info]  ---> df28998bff7e
[info] Step 4/7 : ENV L5D_HOME "/io.buoyant/linkerd/0.9.0"
[info]  ---> Using cache
[info]  ---> e65c28da0fa8
[info] Step 5/7 : ENV L5D_EXEC "/io.buoyant/linkerd/0.9.0/bundle-exec"
[info]  ---> Using cache
[info]  ---> 27c06e4c08a3
[info] Step 6/7 : COPY 0/linkerd-0.9.0-exec /io.buoyant/linkerd/0.9.0/bundle-exec
[info]  ---> 83dcc3e093ce
[info] Removing intermediate container 4be33271920b
[info] Step 7/7 : ENTRYPOINT /io.buoyant/linkerd/0.9.0/bundle-exec
[info]  ---> Running in fa923a530be8
[info]  ---> 5a6eb37779ab
[info] Removing intermediate container fa923a530be8
[info] Successfully built 5a6eb37779ab
[info] Tagging image 5a6eb37779ab with name: buoyantio/linkerd:0.9.0
[trace] Stack trace suppressed: run last linkerd/bundle:docker for the full output.
[error] (linkerd/bundle:docker) Could not parse Version from 17.03.0-ce
[error] : `.' expected but `3' found
[error] Total time: 29 s, completed Mar 7, 2017 5:45:26 PM
```

This issue has been fixed in 1.4.1 version of sbt-docker plugin, see this commit: https://github.com/marcuslonnberg/sbt-docker/commit/bee473483fa05a228259cb47a707834e945ce940