### PR TITLE
Set zipkin service name to host header on http requests

### DIFF
--- a/router/http/src/main/scala/io/buoyant/router/http/TracingFilter.scala
+++ b/router/http/src/main/scala/io/buoyant/router/http/TracingFilter.scala
@@ -41,7 +41,9 @@ class TracingFilter extends SimpleFilter[Request, Response] {
       Trace.recordBinary("http.uri", req.uri)
       Trace.recordBinary("http.req.method", req.method.toString)
       req.host match {
-        case Some(h) => Trace.recordBinary("http.req.host", h)
+        case Some(h) =>
+          Trace.recordServiceName(h)
+          Trace.recordBinary("http.req.host", h)
         case None =>
       }
       Trace.recordBinary("http.req.version", req.version.toString)

--- a/router/http/src/test/scala/io/buoyant/router/http/TracingFilterTest.scala
+++ b/router/http/src/test/scala/io/buoyant/router/http/TracingFilterTest.scala
@@ -34,6 +34,7 @@ class TracingFilterTest extends FunSuite with Awaits {
 
       val reqEvents = tracer.iterator.toSeq
       assert(reqEvents.exists(_.annotation == Annotation.Rpc("HEAD /foo")))
+      assert(reqEvents.exists(_.annotation == Annotation.ServiceName("monkeys")))
       assert(reqEvents.exists(_.annotation == Annotation.BinaryAnnotation("http.uri", "/foo?bar=bah")))
       assert(reqEvents.exists(_.annotation == Annotation.BinaryAnnotation("http.req.method", "HEAD")))
       assert(reqEvents.exists(_.annotation == Annotation.BinaryAnnotation("http.req.host", "monkeys")))


### PR DESCRIPTION
## Problem

Finagle's default ClientTracingFilter sets the `ServiceName` annotation on traced client spans to be the value of `param.Label` on the client stack. In Linkerd's case, `param.Label` is the destination ID, but our destination IDs don't display well in the Zipkin UI. For instance, a traced request to the hello world services running in kubernetes daemonsets:

![screen shot 2017-03-09 at 4 07 53 pm](https://cloud.githubusercontent.com/assets/9226/23776396/f01cc8fa-04e2-11e7-8674-bc8d425b8f07.png)

## Solution

For HTTP requests, override the client span's `serviceName` to be the HTTP Host header, if available. For comparison, the same hello world request:

![screen shot 2017-03-09 at 4 14 27 pm](https://cloud.githubusercontent.com/assets/9226/23776486/87d611f6-04e3-11e7-8e58-f4cc0f3f9193.png)

We might want to consider doing this for other protocols as well, but I didn't do that as part of this branch. Fixes #1132.