### PR TITLE
Add protoc script which downloads and runs protoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ project/plugins/src_managed/
 http.pid
 npm-debug.log
 .sbt-launch.jar
+.protoc
 .idea
 .iml
 .DS_Store

--- a/project/Grpc.scala
+++ b/project/Grpc.scala
@@ -76,6 +76,7 @@ object Grpc extends Base {
       javaSource <<= (javaSource in Compile),
       scalaSource <<= (sourceManaged in Compile) { _ / "compiled_protobuf" },
       generatedTargets <<= scalaSource { d => Seq(d -> "*.pb.scala") },
+      protoc := "./protoc",
       grpcGenExec <<= grpcGenExec0,
       runProtoc <<= runProtoc0,
       protocOptions <<= scalaSource { ss =>

--- a/protoc
+++ b/protoc
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+
+if [ `uname -s` = "Darwin" ]; then
+  os=osx
+else
+  os=linux
+fi
+arch=`uname -m`
+
+protocbin=.protoc
+protocversion=3.0.0
+protocurl=https://github.com/google/protobuf/releases/download/v$protocversion/protoc-$protocversion-$os-$arch.zip
+
+if [ ! -f $protocbin ]; then
+  echo "downloading $protocbin" >&2
+  tmp=`mktemp -d`
+  curl -L --silent --fail -o $tmp/$protocbin.zip $protocurl
+  unzip -q $tmp/$protocbin.zip -d $tmp
+  mv $tmp/bin/protoc $protocbin
+  rm -rf $tmp
+fi
+
+./$protocbin $@

--- a/protoc
+++ b/protoc
@@ -2,24 +2,24 @@
 
 set -e
 
-if [ `uname -s` = "Darwin" ]; then
+if [ "$(uname -s)" = "Darwin" ]; then
   os=osx
 else
   os=linux
 fi
-arch=`uname -m`
+arch=$(uname -m)
 
 protocbin=.protoc
 protocversion=3.0.0
-protocurl=https://github.com/google/protobuf/releases/download/v$protocversion/protoc-$protocversion-$os-$arch.zip
+protocurl="https://github.com/google/protobuf/releases/download/v${protocversion}/protoc-${protocversion}-${os}-${arch}.zip"
 
-if [ ! -f $protocbin ]; then
+if [ ! -f "$protocbin" ]; then
   echo "downloading $protocbin" >&2
-  tmp=`mktemp -d -t protoc.XXX`
-  curl -L --silent --fail -o $tmp/$protocbin.zip $protocurl
-  unzip -q $tmp/$protocbin.zip -d $tmp
-  mv $tmp/bin/protoc $protocbin
-  rm -rf $tmp
+  tmp=$(mktemp -d -t protoc.XXX)
+  curl -L --silent --fail -o "$tmp/$protocbin.zip" "$protocurl"
+  unzip -q "$tmp/$protocbin.zip" -d "$tmp"
+  mv "$tmp/bin/protoc" "$protocbin"
+  rm -rf "$tmp"
 fi
 
-./$protocbin $@
+./$protocbin "$@"

--- a/protoc
+++ b/protoc
@@ -15,7 +15,7 @@ protocurl=https://github.com/google/protobuf/releases/download/v$protocversion/p
 
 if [ ! -f $protocbin ]; then
   echo "downloading $protocbin" >&2
-  tmp=`mktemp -d`
+  tmp=`mktemp -d -t protoc.XXX`
   curl -L --silent --fail -o $tmp/$protocbin.zip $protocurl
   unzip -q $tmp/$protocbin.zip -d $tmp
   mv $tmp/bin/protoc $protocbin


### PR DESCRIPTION
Fixes #1033 

The `./protoc` script fetches and cashes the correct version of `protoc` as `.protoc` and runs it.  Note that the binaries differ depending on os and arch so we don't checksum the binary.