### PR TITLE
0.9.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,12 +1,18 @@
-## In the next release
+## 0.9.1 2017-03-15
 
-* Add `tree` and `q` params to /admin/metrics.json
-* Add tree and q params to /admin/metrics.json
-* Fix: rewrite Location & Refresh HTTP response headers when Linkerd
-  rewrites request Host header
-* Increase default binding cache size
-* Allow k8s namer to accept port numbers
-* Make k8s namer case insensitive
+* Admin dashboard:
+  * Fix display issues for long dtabs in the namerd tab.
+  * Indicate the primary path in the dtab tab.
+  * Add `tree` and `q` params to /admin/metrics.json.
+* Kubernetes:
+  * Allow k8s namer to accept port numbers.
+  * Make k8s namer case insensitive.
+  * Add k8s ingress identifiers to allow linkerd to act as an ingress controller.
+* Fix TTwitter thrift protocol upgrade bug.
+* Rewrite Location & Refresh HTTP response headers when Linkerd
+  rewrites request Host header.
+* Increase default binding cache size to reduce connection churn.
+* Fetch correct protoc version on demand.
 * Introduce the `io.l5d.mesh` linkerd interpreter and namerd iface. The mesh
   iface exposes a gRPC API that can be used for multiplexed, streaming updates.
   (*Experimental*)

--- a/README.md
+++ b/README.md
@@ -261,14 +261,14 @@ _path/to/myapp/linkerd.yml_, you could start linkerd in docker with
 the following command:
 
 ```
-$ docker run -p 4140:4140 -p 9990:9990 -v /absolute/path/to/myapp:/myapp buoyantio/linkerd:0.9.0-SNAPSHOT /myapp/linkerd.yml
+$ docker run -p 4140:4140 -p 9990:9990 -v /absolute/path/to/myapp:/myapp buoyantio/linkerd:0.9.1-SNAPSHOT /myapp/linkerd.yml
 ```
 
 For local testing convenience, we supply a config that routes to a single
 backend on _localhost:8080_.
 
 ```
-$ docker run -p 4140:4140 -p 9990:9990 -v /path/to/linkerd/linkerd/examples:/config buoyantio/linkerd:0.9.0-SNAPSHOT /config/static_namer.yaml
+$ docker run -p 4140:4140 -p 9990:9990 -v /path/to/linkerd/linkerd/examples:/config buoyantio/linkerd:0.9.1-SNAPSHOT /config/static_namer.yaml
 ```
 
 The list of image names may be changed with a command like:
@@ -303,14 +303,14 @@ The assembly script executes two commands serially:
 
 ```bash
 $ ./sbt namerd/dcos:assembly
-$ namerd/target/scala-2.11/namerd-0.9.0-SNAPSHOT-dcos-exec namerd/examples/zk.yaml
+$ namerd/target/scala-2.11/namerd-0.9.1-SNAPSHOT-dcos-exec namerd/examples/zk.yaml
 ```
 
 ##### Run assembly script in docker #####
 
 ```bash
 $ ./sbt namerd/dcos:docker
-$ docker run -p 2181:2181 -p 4180:4180 -v /path/to/repo:/myapp -w /myapp buoyantio/namerd:0.9.0-SNAPSHOT-dcos namerd/examples/zk.yaml
+$ docker run -p 2181:2181 -p 4180:4180 -v /path/to/repo:/myapp -w /myapp buoyantio/namerd:0.9.1-SNAPSHOT-dcos namerd/examples/zk.yaml
 ```
 
 ### Contributing ###

--- a/project/Base.scala
+++ b/project/Base.scala
@@ -32,7 +32,7 @@ object Base {
 class Base extends Build {
   import Base._
 
-  val headVersion = "0.9.0"
+  val headVersion = "0.9.1"
 
   object Git {
     def git(arg: String, args: String*) = Process("git" +: arg +: args)


### PR DESCRIPTION
Changelog:

* Admin dashboard:
  * Fix display issues for long dtabs in the namerd tab.
  * Indicate the primary path in the dtab tab.
  * Add `tree` and `q` params to /admin/metrics.json.
* Kubernetes:
  * Allow k8s namer to accept port numbers.
  * Make k8s namer case insensitive.
  * Add k8s ingress identifiers to allow linkerd to act as an ingress controller.
* Fix TTwitter thrift protocol upgrade bug.
* Rewrite Location & Refresh HTTP response headers when Linkerd
  rewrites request Host header.
* Increase default binding cache size to reduce connection churn.
* Fetch correct protoc version on demand.
* Introduce the `io.l5d.mesh` linkerd interpreter and namerd iface. The mesh
  iface exposes a gRPC API that can be used for multiplexed, streaming updates.
  (*Experimental*)