### PR TITLE
Add support for Marathon HTTP basic authentication

### DIFF
--- a/linkerd/docs/namer.md
+++ b/linkerd/docs/namer.md
@@ -376,7 +376,7 @@ appId | yes | The app id of a marathon application. This id can be multiple path
 
 ### Marathon Authentication
 
-> Example environment variable
+> Example DCOS environment variable
 
 ```json
 {
@@ -387,12 +387,20 @@ appId | yes | The app id of a marathon application. This id can be multiple path
 }
 ```
 
-The Marathon namer supports loading authentication data from a
-`DCOS_SERVICE_ACCOUNT_CREDENTIAL` environment variable at boot time.
+> Example basic HTTP authentication variable
+
+```bash
+dXNlcm5hbWU6cGFzc3dvcmQ=
+```
+
+The Marathon namer supports loading authentication data from an environment variable for DCOS private key in the `DCOS_SERVICE_ACCOUNT_CREDENTIAL` variable and standalone Marathon basic HTTP authentication in the `MARATHON_HTTP_AUTH_CREDENTIAL` environment variable. If both are provided the `DCOS_SERVICE_ACCOUNT_CREDENTIAL` takes precedence.
+
+Basic authentication token is base64 encoded and should not include the `Basic` prefix, only in the format `username:password`.
 
 Further reading:
 
-* [Mesosphere Docs](https://docs.mesosphere.com/1.8/administration/id-and-access-mgt/service-auth/custom-service-auth/)
+* [Mesosphere DCOS Authentication Docs](https://docs.mesosphere.com/1.8/administration/id-and-access-mgt/service-auth/custom-service-auth/)
+* [Marathon basic HTTP Authentication Docs](https://mesosphere.github.io/marathon/docs/ssl-basic-access-authentication.html#enabling-basic-access-authentication)
 * [Mesosphere Universe Repo](https://github.com/mesosphere/universe/search?utf8=%E2%9C%93&q=DCOS_SERVICE_ACCOUNT_CREDENTIAL)
 
 <a name="zkLeader"></a>

--- a/namer/marathon/src/main/scala/io/buoyant/namer/marathon/BasicAuthenticatorFilter.scala
+++ b/namer/marathon/src/main/scala/io/buoyant/namer/marathon/BasicAuthenticatorFilter.scala
@@ -1,0 +1,13 @@
+package io.buoyant.namer.marathon
+
+import com.twitter.finagle.{http, SimpleFilter, Service}
+import com.twitter.util.Future
+import io.buoyant.marathon.v2.Api
+
+class BasicAuthenticatorFilter(http_auth_token: String) extends SimpleFilter[http.Request, http.Response] {
+
+  def apply(req: http.Request, svc: Service[http.Request, http.Response]): Future[http.Response] = {
+    req.headerMap.set("Authorization", s"Basic $http_auth_token")
+    svc(req)
+  }
+}


### PR DESCRIPTION
Running standalone Marathon (without DCOS), it is possible to [enable HTTP basic authentication](https://mesosphere.github.io/marathon/docs/ssl-basic-access-authentication.html#enabling-basic-access-authentication). Currently Linkerd only supports getting access tokens from DCOS. This is my first time on a Scala codebase but I've got HTTP authentication working to Marathon, but it's probably not very neat or tidy. 

Keen to get Linkerd working with HTTP auth as hoping to be able to use it in a Mesos/Marathon env without DCOS, so very happy to work on the implementation. 