### PR TITLE
The daemonset transformer should return Addr.Neg for empty sets

### DIFF
--- a/admin/src/main/resources/io/buoyant/admin/js/src/delegator.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/delegator.js
@@ -67,6 +67,9 @@ define([
           obj.tree.transformation = obj.name;
           obj.tree.isTransformation = true;
           obj.bound.transformed = renderNode(obj.tree, primary);
+          if (ttype != success) {
+            obj.bound.addr.type = "neg";
+          }
           obj.child = renderNode(obj.bound, primary);
           break;
         case "alt":

--- a/interpreter/subnet/src/main/scala/io/buoyant/transformer/SubnetGatewayTransformer.scala
+++ b/interpreter/subnet/src/main/scala/io/buoyant/transformer/SubnetGatewayTransformer.scala
@@ -63,7 +63,10 @@ class GatewayTransformer(
           // select the gateway addresses that share a subnet with addr
           gatewayAddrs.filter(gatewayPredicate(addr, _))
         }
-        Addr.Bound(selected, meta)
+        if (selected.isEmpty)
+          Addr.Neg
+        else
+          Addr.Bound(selected, meta)
       case List(addr, _) => addr
     }
     bound.id match {


### PR DESCRIPTION
Fixes #1169

If the daemonset transformation results in an empty address set, the delegator UI will now display the tree in red instead of green.