### PR TITLE
Graduate some modules out of experimental

### DIFF
--- a/linkerd/docs/namer.md
+++ b/linkerd/docs/namer.md
@@ -15,7 +15,7 @@ These parameters are available to the namer regardless of kind. Namers may also 
 
 Key | Default Value | Description
 --- | ------------- | -----------
-kind | _required_ | Either [`io.l5d.fs`](#file-based-service-discovery), [`io.l5d.serversets`](#zookeeper-serversets-service-discovery), [`io.l5d.consul`](#consul-service-discovery), [`io.l5d.k8s`](#kubernetes-service-discovery), [`io.l5d.marathon`](#marathon-service-discovery-experimental), [`io.l5d.zkLeader`](#zookeeper-leader), [`io.l5d.curator`](#curator), or [`io.l5d.rewrite`](#rewrite).
+kind | _required_ | Either [`io.l5d.fs`](#file-based-service-discovery), [`io.l5d.serversets`](#zookeeper-serversets-service-discovery), [`io.l5d.consul`](#consul-service-discovery), [`io.l5d.k8s`](#kubernetes-service-discovery), [`io.l5d.marathon`](#marathon-service-discovery), [`io.l5d.zkLeader`](#zookeeper-leader), [`io.l5d.curator`](#curator), or [`io.l5d.rewrite`](#rewrite).
 prefix | namer dependent | Resolves names with `/#/<prefix>`.
 experimental | `false` | Set this to `true` to enable the namer if it is experimental.
 transformers | No transformers | A list of [transformers](#transformer) to apply to the resolved addresses.
@@ -320,7 +320,7 @@ label-value | yes if `labelSelector` is defined | The label value used to filter
 
 
 <a name="marathon"></a>
-## Marathon service discovery (experimental)
+## Marathon service discovery
 
 kind: `io.l5d.marathon`
 
@@ -331,7 +331,6 @@ kind: `io.l5d.marathon`
 ```yaml
 namers:
 - kind:           io.l5d.marathon
-  experimental:   true
   prefix:         /io.l5d.marathon
   host:           marathon.mesos
   port:           80
@@ -354,7 +353,6 @@ linkerd provides support for service discovery via
 Key | Default Value | Description
 --- | ------------- | -----------
 prefix | `io.l5d.marathon` | Resolves names with `/#/<prefix>`.
-experimental | _required_ | Because this namer is still considered experimental, you must set this to `true` to use it.
 host | `marathon.mesos` | The Marathon master host.
 port | `80` | The Marathon master port.
 uriPrefix | none | The Marathon API prefix. This prefix depends on your Marathon configuration. For example, running Marathon locally, the API is available at `localhost:8080/v2/`, while the default setup on AWS/DCOS is `$(dcos config show core.dcos_url)/marathon/v2/apps`.

--- a/linkerd/examples/marathon-leader.yaml
+++ b/linkerd/examples/marathon-leader.yaml
@@ -3,7 +3,6 @@
 # master itself is discovered by leader election.
 namers:
 - kind:         io.l5d.marathon
-  experimental: true
   prefix:       /io.l5d.marathon
   # Discover the marathon master by leader election
   dst:          /$/io.buoyant.namer.zk.leader/localhost:2181/marathon/leader

--- a/linkerd/examples/marathon.yaml
+++ b/linkerd/examples/marathon.yaml
@@ -1,7 +1,6 @@
 # Do service discovery lookups against the marathon app API.
 namers:
 - kind:           io.l5d.marathon
-  experimental:   true
   prefix:         /io.l5d.marathon
   # The host and port of the marathon master are statically configured here.
   host:           localhost

--- a/namer/marathon/src/main/scala/io/buoyant/namer/marathon/MarathonInitializer.scala
+++ b/namer/marathon/src/main/scala/io/buoyant/namer/marathon/MarathonInitializer.scala
@@ -19,7 +19,6 @@ import scala.util.control.NoStackTrace
  * <pre>
  * namers:
  * - kind:           io.l5d.marathon
- *   experimental:   true
  *   prefix:         /io.l5d.marathon
  *   host:           marathon.mesos
  *   port:           80
@@ -103,9 +102,6 @@ case class MarathonConfig(
   useHealthCheck: Option[Boolean]
 ) extends NamerConfig {
   import MarathonConfig._
-
-  @JsonIgnore
-  override val experimentalRequired = true
 
   @JsonIgnore
   override def defaultPrefix: Path = DefaultPrefix

--- a/namer/marathon/src/test/scala/io/buoyant/namer/marathon/MarathonTest.scala
+++ b/namer/marathon/src/test/scala/io/buoyant/namer/marathon/MarathonTest.scala
@@ -22,7 +22,6 @@ class MarathonTest extends FunSuite {
   test("parse config") {
     val yaml = s"""
                   |kind:           io.l5d.marathon
-                  |experimental:   true
                   |prefix:         /io.l5d.marathon
                   |host:           localhost
                   |port:           80
@@ -39,26 +38,5 @@ class MarathonTest extends FunSuite {
     assert(marathon._prefix.contains(Path.read("/io.l5d.marathon")))
     assert(marathon.ttlMs.contains(300))
     assert(!marathon.disabled)
-  }
-
-  test("parse config without experimental param") {
-    val yaml = s"""
-                  |kind:           io.l5d.marathon
-                  |prefix:         /io.l5d.marathon
-                  |host:           localhost
-                  |port:           80
-                  |uriPrefix:      /marathon
-                  |ttlMs:          300
-                  |useHealthCheck: false
-      """.stripMargin
-
-    val mapper = Parser.objectMapper(yaml, Iterable(Seq(MarathonInitializer)))
-    val marathon = mapper.readValue[NamerConfig](yaml).asInstanceOf[MarathonConfig]
-    assert(marathon.host.contains("localhost"))
-    assert(marathon.port.contains(Port(80)))
-    assert(marathon.uriPrefix.contains("/marathon"))
-    assert(marathon._prefix.contains(Path.read("/io.l5d.marathon")))
-    assert(marathon.ttlMs.contains(300))
-    assert(marathon.disabled)
   }
 }

--- a/namerd/docs/storage.md
+++ b/namerd/docs/storage.md
@@ -31,7 +31,6 @@ running Kubernetes 1.2+ with the ThirdPartyResource feature enabled.
 
 Key | Default Value | Description
 --- | ------------- | -----------
-experimental | _required_ | Because this storage is still considered experimental, you must set this to `true` to use it.
 host | `localhost` | The Kubernetes master host.
 port | `8001` | The Kubernetes master port.
 namespace | `default` | The Kubernetes namespace in which dtabs will be stored. This should usually be the same namespace in which namerd is running.
@@ -116,10 +115,8 @@ data:
       port: 9991
     storage:
       kind: io.l5d.k8s
-      experimental: true
     namers:
       - kind: io.l5d.k8s
-        experimental: true
         host: 127.0.0.1
         port: 8001
     interfaces:
@@ -184,7 +181,6 @@ Stores the dtab in ZooKeeper.
 
 Key | Default Value | Description
 --- | ------------- | -----------
-experimental | _required_ | Because this storage is still considered experimental, you must set this to `true` to use it.
 zkAddrs | _required_ | A list of ZooKeeper addresses, each of which have `host` and `port` parameters.
 pathPrefix | `/dtabs` | The ZooKeeper path under which dtabs should be stored.
 sessionTimeoutMs | `10000` | ZooKeeper session timeout in milliseconds.
@@ -227,7 +223,6 @@ Stores the dtab in Consul KV storage.
 
 Key | Default Value | Description
 --- | ------------- | -----------
-experimental | _required_ | Because this storage is still considered experimental, you must set this to `true` to use it.
 host | `localhost` | The location of the consul API.
 port | `8500` | The port used to connect to the consul API.
 pathPrefix | `/namerd/dtabs` | The key path under which dtabs should be stored.

--- a/namerd/examples/consul.yaml
+++ b/namerd/examples/consul.yaml
@@ -1,6 +1,5 @@
 namers:
 - kind: io.l5d.consul
-  experimental: true
   useHealthCheck: true
 admin:
   port: 9991

--- a/namerd/examples/k8s-mesh.yaml
+++ b/namerd/examples/k8s-mesh.yaml
@@ -2,7 +2,6 @@ admin:
   port: 9990
 namers:
 - kind: io.l5d.k8s
-  experimental: true
   host: localhost
   port: 8001
   prefix: /ds
@@ -12,7 +11,6 @@ namers:
     port: incoming
     service: l5d
 - kind: io.l5d.k8s
-  experimental: true
   host: localhost
   port: 8001
 

--- a/namerd/examples/k8s.yaml
+++ b/namerd/examples/k8s.yaml
@@ -1,7 +1,6 @@
 # This file assumes you are running through `kubectl proxy` on localhost:8001.
 storage:
   kind: io.l5d.k8s
-  experimental: true
   host: localhost
   port: 8001 # Running through kubectl proxy
 interfaces:

--- a/namerd/examples/zk.yaml
+++ b/namerd/examples/zk.yaml
@@ -1,7 +1,6 @@
 storage:
   kind: io.l5d.zk
   pathPrefix: /dtabs
-  experimental: true
   zkAddrs:
   - host: localhost
     port: 2181

--- a/namerd/storage/consul/src/main/scala/io/buoyant/namerd/storage/consul/ConsulDtabStoreInitializer.scala
+++ b/namerd/storage/consul/src/main/scala/io/buoyant/namerd/storage/consul/ConsulDtabStoreInitializer.scala
@@ -21,9 +21,6 @@ case class ConsulConfig(
   import ConsulConfig._
 
   @JsonIgnore
-  override val experimentalRequired = true
-
-  @JsonIgnore
   override def mkDtabStore: DtabStore = {
     val serviceHost = host.getOrElse(DefaultHost)
     val servicePort = port.getOrElse(DefaultPort).port

--- a/namerd/storage/k8s/src/main/scala/io/buoyant/namerd/storage/K8sDtabStoreInitializer.scala
+++ b/namerd/storage/k8s/src/main/scala/io/buoyant/namerd/storage/K8sDtabStoreInitializer.scala
@@ -12,9 +12,6 @@ case class K8sConfig(
 ) extends DtabStoreConfig with ClientConfig {
 
   @JsonIgnore
-  override val experimentalRequired = true
-
-  @JsonIgnore
   def portNum = port.map(_.port)
 
   @JsonIgnore

--- a/namerd/storage/zk/src/main/scala/io/buoyant/namerd/storage/ZkDtabStoreInitializer.scala
+++ b/namerd/storage/zk/src/main/scala/io/buoyant/namerd/storage/ZkDtabStoreInitializer.scala
@@ -19,9 +19,6 @@ case class ZkConfig(
   acls: Option[Seq[Acl]]
 ) extends DtabStoreConfig {
 
-  @JsonIgnore
-  override val experimentalRequired = true
-
   @JsonIgnore val sessionTimeout = sessionTimeoutMs.map(_.millis)
 
   @JsonIgnore


### PR DESCRIPTION
Removing the experimental flag from the following modules:

* Marathon namer
* Consul dtab store
* K8s dtab store
* Zk dtab store