### PR TITLE
Expire and prune idle metrics

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## In the next release...
+
+* Expire and prune metrics which are idle for 24 hours.
+
 ## 1.0.0 2017-04-24
 
 * Configuration:
@@ -35,8 +39,6 @@
 * Experimental ThriftMux protocol support.
 * Automatically upgrade all HTTP/1.0 messages to HTTP/1.1.
 * Allow dtab fallback when consul returns an empty address set.
-* Fixed k8s namer to handle null endpoint subsets.
-* Add support for Marathon HTTP basic authentication,
 
 ## 0.9.1 2017-03-15
 

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/Linker.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/Linker.scala
@@ -16,7 +16,7 @@ import io.buoyant.namer.Param.Namers
 import io.buoyant.namer._
 import io.buoyant.linkerd.telemeter.UsageDataTelemeterConfig
 import io.buoyant.telemetry._
-import io.buoyant.telemetry.admin.{AdminMetricsExportTelemeter, histogramSnapshotInterval}
+import io.buoyant.telemetry.admin.{AdminMetricsExportTelemeter, histogramSnapshotInterval, metricsExpiryTtl}
 import java.net.InetSocketAddress
 import scala.util.control.NoStackTrace
 
@@ -112,7 +112,7 @@ object Linker {
       val metrics = MetricsTree()
 
       val telemeterParams = Stack.Params.empty + param.LinkerConfig(this) + metrics
-      val adminTelemeter = new AdminMetricsExportTelemeter(metrics, histogramSnapshotInterval(), DefaultTimer.twitter)
+      val adminTelemeter = new AdminMetricsExportTelemeter(metrics, histogramSnapshotInterval(), metricsExpiryTtl(), DefaultTimer.twitter)
       val usageTelemeter = usage.getOrElse(UsageDataTelemeterConfig()).mk(telemeterParams)
 
       val telemeters = telemetry.toSeq.flatten.map {

--- a/namerd/core/src/main/scala/io/buoyant/namerd/NamerdConfig.scala
+++ b/namerd/core/src/main/scala/io/buoyant/namerd/NamerdConfig.scala
@@ -9,7 +9,7 @@ import io.buoyant.admin.AdminConfig
 import io.buoyant.config.{ConfigError, ConfigInitializer, Parser}
 import io.buoyant.namer.{NamerConfig, NamerInitializer, TransformerInitializer}
 import io.buoyant.telemetry.{MetricsTree, MetricsTreeStatsReceiver, Telemeter}
-import io.buoyant.telemetry.admin.{AdminMetricsExportTelemeter, histogramSnapshotInterval}
+import io.buoyant.telemetry.admin.{AdminMetricsExportTelemeter, histogramSnapshotInterval, metricsExpiryTtl}
 import java.net.InetSocketAddress
 import scala.util.control.NoStackTrace
 
@@ -33,7 +33,7 @@ private[namerd] case class NamerdConfig(
 
     val metrics = MetricsTree()
 
-    val telemeter = new AdminMetricsExportTelemeter(metrics, histogramSnapshotInterval(), DefaultTimer.twitter)
+    val telemeter = new AdminMetricsExportTelemeter(metrics, histogramSnapshotInterval(), metricsExpiryTtl(), DefaultTimer.twitter)
 
     val stats = new MetricsTreeStatsReceiver(metrics)
     JvmStats.register(stats)


### PR DESCRIPTION
If a counter or stat goes no updates for a configurable TTL (default: 24 hours) then we remove the metric from the MetricsTree.  This is done as part of the periodic snapshotting loop of the AdminMetricsExportTelemeter.  

The ttl can be configured with the `-io.buoyant.telemetry.admin.metricsExpiryTtl` flag.

Gauges are never expired by time, but will be pruned if they are manually removed.  Gauges created using `StatsReceiver`'s `addGauge` method are weakly referenced and will be removed and pruned from the MetricsTree after the gauge falls out of scope.  This should pair very nicely with the client expiration that is currently in Finagle that we will pick up on the next Finagle release.