### PR TITLE
Fix some small issues in linkerd docs

### DIFF
--- a/linkerd/docs/protocol-h2.md
+++ b/linkerd/docs/protocol-h2.md
@@ -219,7 +219,7 @@ routers:
 - protocol: h2
   experimental: true
   identifier:
-    kind: io.l5d.http.ingress
+    kind: io.l5d.h2.ingress
     namespace: default
   servers:
   - port: 4140

--- a/linkerd/docs/protocol-h2.md
+++ b/linkerd/docs/protocol-h2.md
@@ -106,10 +106,10 @@ logical *name* to the request.
 
 Key | Default Value | Description
 --- | ------------- | -----------
-kind | _required_ | The name of an identifier plugin, such as [`io.l5d.headerToken`](#header-token-identifier) or [`io.l5d.headerPath`](#headerpath-identifier).
+kind | _required_ | Either [`io.l5d.headerToken`](#http-2-header-token-identifier), [`io.l5d.headerPath`](#http-2-headerpath-identifier), or [`io.l5d.h2.ingress`](#http-2-ingress-identifier).
 
 <a name="header-token-identifier"></a>
-### Header Token identifier
+### HTTP/2 Header Token identifier
 
 kind: `io.l5d.headerToken`.
 
@@ -151,7 +151,7 @@ dstPrefix | `/svc` | The `dstPrefix` as set in the routers block.
 headerValue | N/A | The value of the header.
 
 <a name="header-path-identifier"></a>
-### Header Path Identifier
+### HTTP/2 Header Path Identifier
 
 kind: `io.l5d.headerPath`
 
@@ -196,14 +196,18 @@ dstPrefix | `/svc` | The `dstPrefix` as set in the routers block.
 urlPath | N/A | The first `segments` elements of the path from the URL
 
 <a name="h2-ingress-identifier"></a>
-### Ingress Identifier
+### HTTP/2 Ingress Identifier
 
 kind: `io.l5d.h2.ingress`
 
-Using this identifier enables linkerd to function as a Kubernetes ingress controller. The ingress identifier compares HTTP/2 requests to [ingress resource](https://kubernetes.io/docs/user-guide/ingress/) rules, and assigns a name based on those rules.
+Using this identifier enables linkerd to function as a Kubernetes ingress
+controller. The ingress identifier compares HTTP/2 requests to [ingress
+resource](https://kubernetes.io/docs/user-guide/ingress/) rules, and assigns a
+name based on those rules.
 
 <aside class="notice">
-The HTTP/2 Ingress Identifier compares an ingress rule's `host` field to the `:authority` header, instead of the `host` header.
+The HTTP/2 Ingress Identifier compares an ingress rule's `host` field to the
+`:authority` header, instead of the `host` header.
 </aside>
 
 #### Identifier Configuration:
@@ -215,7 +219,7 @@ routers:
 - protocol: h2
   experimental: true
   identifier:
-    kind: io.l5d.ingress
+    kind: io.l5d.http.ingress
     namespace: default
   servers:
   - port: 4140

--- a/linkerd/docs/protocol-http.md
+++ b/linkerd/docs/protocol-http.md
@@ -51,7 +51,8 @@ significantly alter linkerd's performance characteristics.
 HTTP servers accept additional configuration parameters.
 
 > Example: default
-```
+
+```yaml
 addForwardedHeader: {}
 ```
 
@@ -80,8 +81,7 @@ The `Forwarded` header includes labels describing the endpoints of the
 upstream connection. Because this is sensitive information, it is
 typically randomized.
 
-> Example
-```
+```yaml
 addForwardedHeader:
   for: {kind: ip}
   by:
@@ -90,7 +90,7 @@ addForwardedHeader:
 ```
 
 Kind | Description
----- |
+---- | -----------
 ip | A textual IP address like `192.168.1.1` or `"[2001:db8:cafe::17]"`.
 ip:port | A textual IP:PORT address like `"192.168.1.1:80"` or `"[2001:db8:cafe::17]:80"`.
 connectionRandom | An obfuscated random label like `_6Oq8jJ` _generated for all requests on a connection_.
@@ -211,8 +211,8 @@ urlPath | N/A | A path from the URL whose number of segments is set in the ident
 kind: `io.l5d.header`
 
 With this identifier, HTTP requests are turned into names based only on the
-value of an HTTP header.  The value of the HTTP header is interpreted as a path and therefore must
-start with a `/`.
+value of an HTTP header.  The value of the HTTP header is interpreted as a path
+and therefore must start with a `/`.
 
 #### Identifier Configuration:
 
@@ -252,8 +252,8 @@ headerValue | N/A | The value of the HTTP header as a path.
 kind: `io.l5d.header.token`
 
 With this identifier, HTTP requests are turned into names based only on the
-value of an HTTP header.  The name is a path with one segment and the value of that segment is
-taken from the HTTP header.
+value of an HTTP header.  The name is a path with one segment and the value of
+that segment is taken from the HTTP header.
 
 #### Identifier Configuration:
 
@@ -290,9 +290,12 @@ headerValue | N/A | The value of the HTTP header as a path segment.
 <a name="ingress-identifier"></a>
 ### Ingress Identifier
 
-kind: `io.l5d.ingress`
+kind: `io.l5d.http.ingress`
 
-Using this identifier enables linkerd to function as a Kubernetes ingress controller. The ingress identifier compares HTTP requests to [ingress resource](https://kubernetes.io/docs/user-guide/ingress/) rules, and assigns a name based on those rules.
+Using this identifier enables linkerd to function as a Kubernetes ingress
+controller. The ingress identifier compares HTTP requests to [ingress
+resource](https://kubernetes.io/docs/user-guide/ingress/) rules, and assigns a
+name based on those rules.
 
 #### Identifier Configuration:
 
@@ -302,7 +305,7 @@ Using this identifier enables linkerd to function as a Kubernetes ingress contro
 routers:
 - protocol: http
   identifier:
-    kind: io.l5d.ingress
+    kind: io.l5d.http.ingress
     namespace: default
   servers:
   - port: 4140

--- a/linkerd/docs/routers.md
+++ b/linkerd/docs/routers.md
@@ -62,10 +62,10 @@ timeoutMs | no timeout | Per-request timeout in milliseconds.
 
 Key | Default Value | Description
 -------------- | -------------- | --------------
-paths | `100` | Max number of paths in the path cache.
-trees | `100` | Max number of trees in the tree cache.
-bounds | `100` | Max number of bounds in the bounds cache.
-clients | `10` | Max number of clients in the clients cache.
+paths | `1000` | Max number of paths in the path cache.
+trees | `1000` | Max number of trees in the tree cache.
+bounds | `1000` | Max number of bounds in the bounds cache.
+clients | `1000` | Max number of clients in the clients cache.
 
 <a name="server-parameters"></a>
 ## Server Parameters


### PR DESCRIPTION
This fixes a few broken anchors, tables, and code snippets in our documentation. There was also an issue with the `io.l5d.ingress` identifier being renamed (relates to #1176). And I've fixed the default values for binding cache configuration.