### PR TITLE
Reorganize high-level repo documentation

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -2,8 +2,8 @@
 
 This document will help you build linkerd from source.
 
-This repo contains two main application build targets: 
-- linkerd, a service mesh router 
+This repo contains two main application build targets:
+- linkerd, a service mesh router
 - namerd, a service for centrally managing routing policy and fronting service discovery.
 
 More details at [namerd's quickstart](namerd/README.md#quickstart)
@@ -63,12 +63,12 @@ or
 The _inspect_ command helps describe how a command is configured:
 
 ```
-> inspect tree examples/http:run
-[info] examples/http:run = InputTask[Unit]
-[info]   +-examples/http:configFile = examples/http.yaml
-[info]   | +-examples/http:configuration = http
+> inspect tree linkerd-examples/http:run
+[info] linkerd-examples/http:run = InputTask[Unit]
+[info]   +-linkerd-examples/http:configFile = linkerd/examples/http.yaml
+[info]   | +-linkerd-examples/http:configuration = http
 [info]   |
-[info]   +-examples/http:runtimeConfiguration = minimal
+[info]   +-linkerd-examples/http:runtimeConfiguration = bundle
 [info]   +-*/*:settingsData = Task[sbt.Settings[sbt.Scope]]
 [info]
 ```
@@ -152,20 +152,6 @@ configurations to support packaging:
 [info] Packaging ...linkerd/target/scala-2.11/linkerd-0.0.10-SNAPSHOT-exec ...
 [info] Done packaging.
 [success] Total time: 14 s, completed Jan 29, 2016 4:29:40 PM
-```
-
-##### _minimal_ build configuration #####
-
-The '_minimal_' sbt configuration, supporting only the `http` protocol
-and the `io.l5d.fs` namer, is useful for running linkerd during
-development. This configuration may be specified explicitly to scope
-build commands:
-
-```
-> linkerd/minimal:assembly
-[info] Packaging ...linkerd/target/scala-2.11/linkerd-minimal-0.0.10-SNAPSHOT-exec ...
-[info] Done packaging.
-[success] Total time: 13 s, completed Jan 29, 2016 4:30:58 PM
 ```
 
 Similarly, a namerd executable can be produced with the command:

--- a/BUILD.md
+++ b/BUILD.md
@@ -1,0 +1,264 @@
+## Development guide ##
+
+This document will help you build linkerd from source.
+
+This repo contains two main application build targets: 
+- linkerd, a service mesh router 
+- namerd, a service for centrally managing routing policy and fronting service discovery.
+
+More details at [namerd's quickstart](namerd/README.md#quickstart)
+
+## Working in this repository ##
+
+[sbt][sbt] is used to build and test linkerd. Developers should not
+use a system-installed version of sbt, and should instead use the
+`./sbt` script, which ensures that a compatible version of sbt is
+available.
+
+`./sbt` accepts commands on the command line, or if it is invoked with
+no arguments it loads an interactive sbt shell:
+
+```
+$ ./sbt
+>
+```
+
+The sbt project consists of many sub-projects. To list all projects run:
+
+```
+> projects
+```
+
+These projects are configured in
+[`project/LinkerdBuild.scala`](project/LinkerdBuild.scala), which may
+be edited to include additional sub-projects, build configurations,
+etc. [`project/Base.scala`](project/Base.scala) is used to augment
+sbt's api.
+
+You may run commands, for instance, _compile_ on the aggregate
+project, _all_, by invoking:
+
+```
+> compile
+```
+
+Commands may be scoped by project, as in:
+
+```
+> router-http/test
+```
+
+Or by configuration as in:
+
+```
+> e2e:test
+```
+
+or
+
+```
+> router-http/e2e:test
+```
+
+The _inspect_ command helps describe how a command is configured:
+
+```
+> inspect tree examples/http:run
+[info] examples/http:run = InputTask[Unit]
+[info]   +-examples/http:configFile = examples/http.yaml
+[info]   | +-examples/http:configuration = http
+[info]   |
+[info]   +-examples/http:runtimeConfiguration = minimal
+[info]   +-*/*:settingsData = Task[sbt.Settings[sbt.Scope]]
+[info]
+```
+
+### Tests ###
+
+There are several supported test configurations:
+- `test`: pure unit tests that do not require system or network
+- `e2e`: tests that compose multiple modules; may allocate random
+ephemeral ports and write temporary files
+- `integration`: tests that rely on external services or programs that
+require external installation and/or configuration.
+
+Both unit and end-to-end tests are run as part of our
+[Continuous Integration][l5d-ci] setup.
+
+Tests may be run with:
+
+```
+> test
+...
+[success] Total time: 14 s, completed Jan 29, 2016 4:24:16 PM
+```
+```
+> e2e:test
+...
+[success] Total time: 8 s, completed Jan 29, 2016 4:25:18 PM
+```
+
+sbt also provides a `testQuick` command which is especially useful
+when actively editing code:
+
+```
+> ~testQuick
+```
+
+The `validator` project provides an integration test that operates on
+assembled artifacts. It may be run with:
+```
+> validator/validateAssembled
+```
+
+#### Writing tests ####
+
+Test files for each of the above test configurations are stored in a
+per-configuration directory structure, e.g.:
+
+```
+$ ls -l router/http/src
+e2e
+main
+test
+```
+
+Tests are written using the [ScalaTest][scalatest] testing framework,
+and specifically the [`FunSuite`][funsuite] mixin, which supports
+xUnit-like semantics. We avoid using mocking frameworks when testing
+our own code, as they tend to introduce as many problems as they
+solve. Tests may leverage the `test-util` project, which provides some
+helpers for writing tests against Finagle's asynchronous APIs.
+
+#### JS tests ####
+
+See the [javascript readme](/admin/src/main/resources/io/buoyant/admin/README.md).
+
+### Packaging ###
+
+#### Building an executable ####
+
+linkerd provides a plugin system so that features may be chosen at
+packaging time.  To this end, there are multiple configurations for
+running and packaging linkerd executables.
+
+The _assembly_ plugin can be used to produce an executable containing
+all library dependencies.  The `linkerd` subproject has several build
+configurations to support packaging:
+
+```
+> linkerd/assembly
+[info] SHA-1: 5599e65540ebe6122da114be4a8b9a763475b789
+[info] Packaging ...linkerd/target/scala-2.11/linkerd-0.0.10-SNAPSHOT-exec ...
+[info] Done packaging.
+[success] Total time: 14 s, completed Jan 29, 2016 4:29:40 PM
+```
+
+##### _minimal_ build configuration #####
+
+The '_minimal_' sbt configuration, supporting only the `http` protocol
+and the `io.l5d.fs` namer, is useful for running linkerd during
+development. This configuration may be specified explicitly to scope
+build commands:
+
+```
+> linkerd/minimal:assembly
+[info] Packaging ...linkerd/target/scala-2.11/linkerd-minimal-0.0.10-SNAPSHOT-exec ...
+[info] Done packaging.
+[success] Total time: 13 s, completed Jan 29, 2016 4:30:58 PM
+```
+
+Similarly, a namerd executable can be produced with the command:
+```
+> namerd/assembly
+```
+
+#### Releasing ####
+
+Before releasing ensure that [CHANGES.md](CHANGES.md) is updated to include the
+version that you're trying to release.
+
+By default, the _-SNAPSHOT_ suffix is appended to the version number when
+building linkerd.  In order to build a non-snapshot (i.e. releasable) version of
+linkerd, the build must occur from a release tag in git.
+
+For example, in order to build the 0.0.10 release of linkerd:
+
+1. Ensure that the head version is 0.0.10
+2. `git tag 0.0.10 && git push origin 0.0.10`
+3. `./sbt linkerd/assembly namerd/assembly` will produce executables
+  in _linkerd/target/scala-2.11/linkerd-0.0.10-exec_ and
+  _namerd/target/scala-2.11/namerd-0.0.10-exec_.
+
+#### Docker ####
+
+Each of these configurations may be used to build a docker image.
+```
+> ;linkerd/docker ;namerd/docker
+...
+[info] Tagging image 94ab0793addf with name: buoyantio/linkerd:0.0.10-SNAPSHOT
+```
+
+The produced image does not contain any configuration.  It's expected
+that configuration is provided by another docker layer or volume.  For
+example, if you have linkerd configuration in
+_path/to/myapp/linkerd.yml_, you could start linkerd in docker with
+the following command:
+
+```
+$ docker run -p 4140:4140 -p 9990:9990 -v /absolute/path/to/myapp:/myapp buoyantio/linkerd:0.9.1-SNAPSHOT /myapp/linkerd.yml
+```
+
+For local testing convenience, we supply a config that routes to a single
+backend on _localhost:8080_.
+
+```
+$ docker run -p 4140:4140 -p 9990:9990 -v /path/to/linkerd/linkerd/examples:/config buoyantio/linkerd:0.9.1-SNAPSHOT /config/static_namer.yaml
+```
+
+The list of image names may be changed with a command like:
+
+```
+> set imageNames in docker in (linkerd, Bundle) += ImageName("gcr.io/gce-project/linkerd:v"+version.value)
+...
+> show linkerd/bundle:docker::imageNames
+[info] List(buoyantio/linkerd:0.0.10-SNAPSHOT, gcr.io/gce-project/linkerd:v0.0.10-SNAPSHOT)
+```
+
+#### DCOS ####
+
+Namerd supports a DCOS-specific configuration. When used in conjunction with
+namerd's `io.l5d.zk` dtab storage, this
+configuration provides bootstrapping of the ZooKeeper `pathPrefix`, along with
+a default dtab.
+
+##### Run locally #####
+
+This executes only the namerd-dcos-bootstrap command, it does not boot namerd.
+
+```bash
+$ ./sbt "namerd/dcos:run-main io.buoyant.namerd.DcosBootstrap namerd/examples/zk.yaml"
+```
+
+##### Run assembly script locally #####
+
+The assembly script executes two commands serially:
+1. runs namerd-dcos-bootstrap
+2. boots namerd
+
+```bash
+$ ./sbt namerd/dcos:assembly
+$ namerd/target/scala-2.11/namerd-0.9.1-SNAPSHOT-dcos-exec namerd/examples/zk.yaml
+```
+
+##### Run assembly script in docker #####
+
+```bash
+$ ./sbt namerd/dcos:docker
+$ docker run -p 2181:2181 -p 4180:4180 -v /path/to/repo:/myapp -w /myapp buoyantio/namerd:0.9.1-SNAPSHOT-dcos namerd/examples/zk.yaml
+```
+
+[funsuite]: http://www.scalatest.org/getting_started_with_fun_suite
+[l5d-ci]: https://circleci.com/gh/linkerd/linkerd
+[sbt]: http://www.scala-sbt.org/
+[scalatest]: http://www.scalatest.org/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,9 +13,9 @@ Do you have an improvement?
 
 1. Submit an [issue][issue] describing your proposed change.
 2. We will try to respond to your issue promptly.
-3. If your proposed change is accepted, and you haven't already done so, sign our [Contributor License Agreement][cla].
-4. Fork this repo, develop and test your code changes. See the project's [README](README.md) for further information about working in this repository.
-5. Submit a pull request against this repo's `master` branch.
+3. Fork this repo, develop and test your code changes. See the project's [README](README.md) for further information about working in this repository.
+4. Submit a pull request against this repo's `master` branch.
+5. You'll need to have signed our [Contributor License Agreement][cla] before we can accept any non-trivial changes.
 6. Your branch may be merged once all configured checks pass, including:
     - 2 code review approvals, at least 1 of which is from a [linkerd organization member][members].
     - The branch has passed tests in CI.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,51 +1,84 @@
-# Contributing to linkerd #
+# Contributing to linkerd
 
-:balloon: Thank you for using the linkerd project!
+:balloon: Thanks for your help improving the project!
 
-## Getting Help ##
+## Getting Help
 
-If you have a question about linkerd or have encountered problems
-using linkerd, you may [file an issue][issue] or join us on
-[Slack][slack].
+If you have a question about linkerd or have encountered problems using it, you may [file
+an issue][issue] or join us on [Slack][slack].
 
-## Submitting Changes ##
+## Submitting a Pull Request
 
-If you'd like to make a change to linkerd, you should do the
-following:
+Do you have an improvement?
 
 1. Submit an [issue][issue] describing your proposed change.
-2. We will respond to your issue promptly.
-3. If your proposed change is accepted, and you haven't already done
-so, sign [Buoyant's Contributor License Agreement][cla].  Before we
-can accept your patches, our lawyers would like to be assured that:
-    - The code you're contributing is yours, and you have the right to
-    license it.
-    - You're granting us a license to distribute said code under the
-    terms of this agreement.
-4. Fork the linkerd repo, develop and test your code
-changes. See the project's [README](README.md) for further information
-about working in this repository.
-5. Submit a pull request against linkerd's `master` branch.
-6. Your branch may be merged once all configured checks pass,
-including:
+2. We will try to respond to your issue promptly.
+3. If your proposed change is accepted, and you haven't already done so, sign our [Contributor License Agreement][cla].
+4. Fork this repo, develop and test your code changes. See the project's [README](README.md) for further information about working in this repository.
+5. Submit a pull request against this repo's `master` branch.
+6. Your branch may be merged once all configured checks pass, including:
     - 2 code review approvals, at least 1 of which is from a buoyant member
     - The branch has passed tests in CI.
 
-### Git history ###
+## Code Style
 
-Prior to submitting a pull request, please revise the commit history
-of your branch such that each commit is self-explanatory, even without
-the context of the pull request, and that it compiles & tests
-cleanly.
+We generally follow [Effective Scala][es] and the
+[Scala Style Guide][ssg]. When in doubt, we try to use Finagle's
+idioms. 
 
-Typically, a pull request consists of a single commit.  It may
-occasionally be preferable to submit a change with several commits,
-but each should be a complete change needed to complete a larger
-feature.  Each commit should be documented appropriately.
+## Committing
 
-Thank you for getting involved!
-:heart: Team Buoyant
+We prefer squash or rebase commits so that all changes from a branch are committed to
+master a single commit.
+
+### Commit messages
+
+Finalized commit messages should be in the following format:
+
+```
+Subject
+
+Problem
+
+Solution
+
+Validation
+```
+
+#### Subject
+
+- one line, <= 50 characters
+- describe what is done; not the result
+- use the active voice
+- capitalize properly
+- do not end in a period — this is a title/subject
+- reference the pull request by number
+
+##### Examples
+
+bad: server disconnects should cause dst client disconnects.
+good: Propagate disconnects from source to destination
+
+bad: support tls servers
+good: Introduce support for server-side TLS (#347)
+
+#### Problem
+
+Explain the context and why you're making that change.  What is the
+problem you're trying to solve? In some cases there is not a problem
+and this can be thought of being the motivation for your change.
+
+#### Solution
+
+Describe the modifications you've made.
+
+#### Validation
+
+Describe the testing you've done to validate your change.  Performance-related changes
+should include before- and after- benchmark results.
 
 [cla]: https://buoyant.io/cla/
+[es]: https://twitter.github.io/effectivescala/
 [issue]: https://github.com/linkerd/linkerd/issues/new
 [slack]: http://slack.linkerd.io/
+[ssg]: http://docs.scala-lang.org/style/scaladoc.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,13 @@
-# Contributing to linkerd
+# Contributing to linkerd #
 
 :balloon: Thanks for your help improving the project!
 
-## Getting Help
+## Getting Help ##
 
 If you have a question about linkerd or have encountered problems using it, you
 may [file an issue][issue] or join us on [Slack][slack].
 
-## Submitting a Pull Request
+## Submitting a Pull Request ##
 
 Do you have an improvement?
 
@@ -20,19 +20,19 @@ Do you have an improvement?
     - 2 code review approvals, at least 1 of which is from a [linkerd organization member][members].
     - The branch has passed tests in CI.
 
-## Code Style
+## Code Style ##
 
 We generally follow [Effective Scala][es] and the [Scala Style Guide][ssg]. When
 in doubt, we try to use Finagle's idioms.
 
-## Committing
+## Committing ##
 
 We prefer squash or rebase commits so that all changes from a branch are
 committed to master as a single commit. All pull requests are squashed when
 merged, but rebasing prior to merge gives you better control over the commit
 message.
 
-### Commit messages
+### Commit messages ###
 
 Finalized commit messages should be in the following format:
 
@@ -46,7 +46,7 @@ Solution
 Validation
 ```
 
-#### Subject
+#### Subject ####
 
 - one line, <= 50 characters
 - describe what is done; not the result
@@ -55,7 +55,7 @@ Validation
 - do not end in a period — this is a title/subject
 - reference the github issue by number
 
-##### Examples
+##### Examples #####
 
 ```
 bad: server disconnects should cause dst client disconnects.
@@ -67,17 +67,17 @@ bad: support tls servers
 good: Introduce support for server-side TLS (#347)
 ```
 
-#### Problem
+#### Problem ####
 
 Explain the context and why you're making that change.  What is the problem
 you're trying to solve? In some cases there is not a problem and this can be
 thought of as being the motivation for your change.
 
-#### Solution
+#### Solution ####
 
 Describe the modifications you've made.
 
-#### Validation
+#### Validation ####
 
 Describe the testing you've done to validate your change.  Performance-related
 changes should include before- and after- benchmark results.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,8 +4,8 @@
 
 ## Getting Help
 
-If you have a question about linkerd or have encountered problems using it, you may [file
-an issue][issue] or join us on [Slack][slack].
+If you have a question about linkerd or have encountered problems using it, you
+may [file an issue][issue] or join us on [Slack][slack].
 
 ## Submitting a Pull Request
 
@@ -17,19 +17,20 @@ Do you have an improvement?
 4. Fork this repo, develop and test your code changes. See the project's [README](README.md) for further information about working in this repository.
 5. Submit a pull request against this repo's `master` branch.
 6. Your branch may be merged once all configured checks pass, including:
-    - 2 code review approvals, at least 1 of which is from a buoyant member
+    - 2 code review approvals, at least 1 of which is from a [linkerd organization member][members].
     - The branch has passed tests in CI.
 
 ## Code Style
 
-We generally follow [Effective Scala][es] and the
-[Scala Style Guide][ssg]. When in doubt, we try to use Finagle's
-idioms. 
+We generally follow [Effective Scala][es] and the [Scala Style Guide][ssg]. When
+in doubt, we try to use Finagle's idioms.
 
 ## Committing
 
-We prefer squash or rebase commits so that all changes from a branch are committed to
-master a single commit.
+We prefer squash or rebase commits so that all changes from a branch are
+committed to master as a single commit. All pull requests are squashed when
+merged, but rebasing prior to merge gives you better control over the commit
+message.
 
 ### Commit messages
 
@@ -50,23 +51,27 @@ Validation
 - one line, <= 50 characters
 - describe what is done; not the result
 - use the active voice
-- capitalize properly
+- capitalize first word and proper nouns
 - do not end in a period — this is a title/subject
-- reference the pull request by number
+- reference the github issue by number
 
 ##### Examples
 
+```
 bad: server disconnects should cause dst client disconnects.
 good: Propagate disconnects from source to destination
+```
 
+```
 bad: support tls servers
 good: Introduce support for server-side TLS (#347)
+```
 
 #### Problem
 
-Explain the context and why you're making that change.  What is the
-problem you're trying to solve? In some cases there is not a problem
-and this can be thought of being the motivation for your change.
+Explain the context and why you're making that change.  What is the problem
+you're trying to solve? In some cases there is not a problem and this can be
+thought of as being the motivation for your change.
 
 #### Solution
 
@@ -74,11 +79,12 @@ Describe the modifications you've made.
 
 #### Validation
 
-Describe the testing you've done to validate your change.  Performance-related changes
-should include before- and after- benchmark results.
+Describe the testing you've done to validate your change.  Performance-related
+changes should include before- and after- benchmark results.
 
 [cla]: https://buoyant.io/cla/
 [es]: https://twitter.github.io/effectivescala/
 [issue]: https://github.com/linkerd/linkerd/issues/new
+[members]: https://github.com/orgs/linkerd/people
 [slack]: http://slack.linkerd.io/
 [ssg]: http://docs.scala-lang.org/style/scaladoc.html

--- a/README.md
+++ b/README.md
@@ -1,21 +1,20 @@
 ![linkerd][l5d-logo]
 
-[![GitHub license](https://img.shields.io/github/license/linkerd/linkerd.svg)](LICENSE)
-[![Circle CI][l5d-ci-status]][l5d-ci]
-[![Slack Status](http://slack.linkerd.io/badge.svg)](http://slack.linkerd.io)
-[![Docker Pulls](https://img.shields.io/docker/pulls/buoyantio/linkerd.svg)](https://hub.docker.com/r/buoyantio/linkerd/)
+[![GitHub license][license-badge]](LICENSE)
+[![Circle CI][l5d-ci-badge]][l5d-ci]
+[![Slack Status][slack-badge]][slack]
+[![Docker Pulls][docker-badge]][docker]
 
 :balloon: Welcome to linkerd! :wave:
 
 linkerd is a transparent *service mesh*, designed to make modern applications
-safe and sane by transparently adding service discovery, load balancing,
-failure handling, instrumentation, and routing to all inter-service
-communication.
+safe and sane by transparently adding service discovery, load balancing, failure
+handling, instrumentation, and routing to all inter-service communication.
 
 linkerd (pronouned "linker-DEE") acts as a transparent HTTP/gRPC/thrift/etc
 proxy, and can usually be dropped into existing applications with a minimum of
-configuration, regardless of what language they're written in. It works with many
-common protocols and service discovery backends, including scheduled
+configuration, regardless of what language they're written in. It works with
+many common protocols and service discovery backends, including scheduled
 environments like Mesos and Kubernetes.
 
 linkerd is built on top of [Netty][netty] and [Finagle][finagle], a
@@ -26,8 +25,9 @@ linkerd is hosted by the Cloud Native Computing Foundation ([CNCF][cncf]).
 
 ## Want to try it? ##
 
-We distribute binaries which you can download from
-the [linkerd releases page](releases).
+We distribute binaries which you can download from the [linkerd releases
+page](releases). We also publish docker images for each release, which you can
+find on [docker hub][docker].
 
 For instructions on how to configure and run linkerd, see the [user
 documentation on linkerd.io](https://linkerd.io).
@@ -35,14 +35,15 @@ documentation on linkerd.io](https://linkerd.io).
 ## Working in this repo ##
 
 [BUILD.md](BUILD.md) includes general information on how to work in this repo.
-Additionally, there are documents on how to build several of the application subprojects:
+Additionally, there are documents on how to build several of the application
+subprojects:
 
 * [linkerd](linkerd/README.md) -- produces `linkerd` router artifacts
 * [namerd](namerd/README.md) -- produces `namerd` service discovery artifacts
 * [grpc](grpc/README.md) -- produces the `protoc-gen-io.buoyant.grpc` code generator
 
-We :heart: pull requests! See [CONTRIBUTING.md](CONTRIBUTING.md) for info on contributing
-changes.
+We :heart: pull requests! See [CONTRIBUTING.md](CONTRIBUTING.md) for info on
+contributing changes.
 
 ## Related Repos ##
 
@@ -54,8 +55,8 @@ changes.
 
 ## Code of Conduct ##
 
-This project is for everyone. We ask that our users and contributors take a few minutes to
-review our [code of conduct][coc].
+This project is for everyone. We ask that our users and contributors take a few
+minutes to review our [code of conduct][coc].
 
 ## License ##
 
@@ -73,16 +74,22 @@ CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 
 <!-- references -->
-[coc]: wiki/Linkerd-code-of-conduct
 [cncf]: https://www.cncf.io/about
+[coc]: wiki/Linkerd-code-of-conduct
+[docker-badge]: https://img.shields.io/docker/pulls/buoyantio/linkerd.svg
+[docker]: https://hub.docker.com/r/buoyantio/linkerd/
 [finagle]: https://twitter.github.io/finagle/
 [k8s]: https://k8s.io/
-[l5d-ci-status]: https://circleci.com/gh/linkerd/linkerd/tree/master.svg?style=shield&circle-token=06d80fc52dbaeaac316d09b7ad4ada6f7d2bf31f
+[l5d-ci-badge]: https://circleci.com/gh/linkerd/linkerd/tree/master.svg?style=shield&circle-token=06d80fc52dbaeaac316d09b7ad4ada6f7d2bf31f
+[l5d-ci]: https://circleci.com/gh/linkerd/linkerd
 [l5d-eg]: https://github.com/linkerd/linkerd-examples
 [l5d-logo]: https://cloud.githubusercontent.com/assets/9226/12433413/c6fff880-beb5-11e5-94d1-1afb1258f464.png
 [l5d-tcp]: https://github.com/linkerd/linkerd-tcp
 [l5d-viz]: https://github.com/linkerd/linkerd-viz
 [l5d-zipkin]: https://github.com/linkerd/linkerd-zipkin
+[license-badge]: https://img.shields.io/github/license/linkerd/linkerd.svg
 [namerctl]: https://github.com/linkerd/namerctl
 [netty]: https://netty.io/
+[slack-badge]: http://slack.linkerd.io/badge.svg
+[slack]: http://slack.linkerd.io
 [zipkin]: https://github.com/openzipkin/zipkin

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![linkerd][l5d-logo]
 
-[![GitHub license](https://img.shields.io/github/license/buoyantio/linkerd.svg)](LICENSE)
+[![GitHub license](https://img.shields.io/github/license/linkerd/linkerd.svg)](LICENSE)
 [![Circle CI][l5d-ci-status]][l5d-ci]
 [![Slack Status](http://slack.linkerd.io/badge.svg)](http://slack.linkerd.io)
 [![Docker Pulls](https://img.shields.io/docker/pulls/buoyantio/linkerd.svg)](https://hub.docker.com/r/buoyantio/linkerd/)
@@ -22,6 +22,8 @@ linkerd is built on top of [Netty][netty] and [Finagle][finagle], a
 production-tested RPC framework used by high-traffic companies like Twitter,
 Pinterest, Tumblr, PagerDuty, and others.
 
+linkerd is hosted by the Cloud Native Computing Foundation ([CNCF][cncf]).
+
 ## Want to try it? ##
 
 We distribute binaries which you can download from
@@ -30,303 +32,34 @@ the [linkerd releases page](releases).
 For instructions on how to configure and run linkerd, see the [user
 documentation on linkerd.io](https://linkerd.io).
 
-## Want to build it? ##
+## Working in this repo ##
 
-The rest of this document will help you build linkerd from source and how to
-contribute code.
+[BUILD.md](BUILD.md) includes general information on how to work in this repo.
+Additionally, there are documents on how to build several of the application subprojects:
 
-This repo contains two main projects: linkerd itself and namerd, a service for
-centrally managing routing policy and fronting service discovery.
+* [linkerd](linkerd/README.md) -- produces `linkerd` router artifacts
+* [namerd](namerd/README.md) -- produces `namerd` service discovery artifacts
+* [grpc](grpc/README.md) -- produces the `protoc-gen-io.buoyant.grpc` code generator
 
-* [linkerd](linkerd/README.md)
-* [namerd](namerd/README.md)
+We :heart: pull requests! See [CONTRIBUTING.md](CONTRIBUTING.md) for info on contributing
+changes.
 
-## Development quickstart ##
+## Related Repos ##
 
-### Boot linkerd ###
+* [linkerd-examples][l5d-eg]: A variety of configuration examples and explanations
+* [linkerd-tcp][l5d-tcp]: A lightweight TCP/TLS load balancer that uses namerd
+* [linkerd-viz][l5d-viz]: Zero-configuration service dashboard for linkerd
+* [linkerd-zipkin][l5d-zipkin]: [Zipkin][zipkin] tracing plugins
+* [namerctl][namerctl]: A commandline utility for controlling namerd
 
-```
-$ ./sbt linkerd-examples/http:run # build and run linkerd
-$ open http://localhost:9990      # open linkerd's admin interface in a browser
-```
+## Code of Conduct ##
 
-More details at [linkerd's quickstart](linkerd/README.md#quickstart)
-
-
-### Boot namerd ###
-
-```
-$ ./sbt namerd-examples/basic:run # build and run namerd
-$ open http://localhost:9991      # open namerd's admin interface in a browser
-$ curl :4180/api/1/dtabs          # test namerd's http interface
-```
-
-More details at [namerd's quickstart](namerd/README.md#quickstart)
-
-## Working in this repository ##
-
-[sbt][sbt] is used to build and test linkerd. Developers should not
-use a system-installed version of sbt, and should instead use the
-`./sbt` script, which ensures that a compatible version of sbt is
-available.
-
-`./sbt` accepts commands on the command line, or if it is invoked with
-no arguments it loads an interactive sbt shell:
-
-```
-$ ./sbt
->
-```
-
-The sbt project consists of many sub-projects. To list all projects run:
-
-```
-> projects
-```
-
-These projects are configured in
-[`project/LinkerdBuild.scala`](project/LinkerdBuild.scala), which may
-be edited to include additional sub-projects, build configurations,
-etc. [`project/Base.scala`](project/Base.scala) is used to augment
-sbt's api.
-
-You may run commands, for instance, _compile_ on the aggregate
-project, _all_, by invoking:
-
-```
-> compile
-```
-
-Commands may be scoped by project, as in:
-
-```
-> router-http/test
-```
-
-Or by configuration as in:
-
-```
-> e2e:test
-```
-
-or
-
-```
-> router-http/e2e:test
-```
-
-The _inspect_ command helps describe how a command is configured:
-
-```
-> inspect tree examples/http:run
-[info] examples/http:run = InputTask[Unit]
-[info]   +-examples/http:configFile = examples/http.yaml
-[info]   | +-examples/http:configuration = http
-[info]   |
-[info]   +-examples/http:runtimeConfiguration = minimal
-[info]   +-*/*:settingsData = Task[sbt.Settings[sbt.Scope]]
-[info]
-```
-
-### Tests ###
-
-There are several supported test configurations:
-- `test`: pure unit tests that do not require system or network
-- `e2e`: tests that compose multiple modules; may allocate random
-ephemeral ports and write temporary files
-- `integration`: tests that rely on external services or programs that
-require external installation and/or configuration.
-
-Both unit and end-to-end tests are run as part of our
-[Continuous Integration][l5d-ci] setup.
-
-Tests may be run with:
-
-```
-> test
-...
-[success] Total time: 14 s, completed Jan 29, 2016 4:24:16 PM
-```
-```
-> e2e:test
-...
-[success] Total time: 8 s, completed Jan 29, 2016 4:25:18 PM
-```
-
-sbt also provides a `testQuick` command which is especially useful
-when actively editing code:
-
-```
-> ~testQuick
-```
-
-The `validator` project provides an integration test that operates on
-assembled artifacts. It may be run with:
-```
-> validator/validateAssembled
-```
-
-#### Writing tests ####
-
-Test files for each of the above test configurations are stored in a
-per-configuration directory structure, e.g.:
-
-```
-$ ls -l router/http/src
-e2e
-main
-test
-```
-
-Tests are written using the [ScalaTest][scalatest] testing framework,
-and specifically the [`FunSuite`][funsuite] mixin, which supports
-xUnit-like semantics. We avoid using mocking frameworks when testing
-our own code, as they tend to introduce as many problems as they
-solve. Tests may leverage the `test-util` project, which provides some
-helpers for writing tests against Finagle's asynchronous APIs.
-
-#### JS tests ####
-
-See the [javascript readme](/admin/src/main/resources/io/buoyant/admin/README.md).
-
-### Packaging ###
-
-#### Building an executable ####
-
-linkerd provides a plugin system so that features may be chosen at
-packaging time.  To this end, there are multiple configurations for
-running and packaging linkerd executables.
-
-The _assembly_ plugin can be used to produce an executable containing
-all library dependencies.  The `linkerd` subproject has several build
-configurations to support packaging:
-
-```
-> linkerd/assembly
-[info] SHA-1: 5599e65540ebe6122da114be4a8b9a763475b789
-[info] Packaging ...linkerd/target/scala-2.11/linkerd-0.0.10-SNAPSHOT-exec ...
-[info] Done packaging.
-[success] Total time: 14 s, completed Jan 29, 2016 4:29:40 PM
-```
-
-##### _minimal_ build configuration #####
-
-The '_minimal_' sbt configuration, supporting only the `http` protocol
-and the `io.l5d.fs` namer, is useful for running linkerd during
-development. This configuration may be specified explicitly to scope
-build commands:
-
-```
-> linkerd/minimal:assembly
-[info] Packaging ...linkerd/target/scala-2.11/linkerd-minimal-0.0.10-SNAPSHOT-exec ...
-[info] Done packaging.
-[success] Total time: 13 s, completed Jan 29, 2016 4:30:58 PM
-```
-
-Similarly, a namerd executable can be produced with the command:
-```
-> namerd/assembly
-```
-
-#### Releasing ####
-
-Before releasing ensure that [CHANGES.md](CHANGES.md) is updated to include the
-version that you're trying to release.
-
-By default, the _-SNAPSHOT_ suffix is appended to the version number when
-building linkerd.  In order to build a non-snapshot (i.e. releasable) version of
-linkerd, the build must occur from a release tag in git.
-
-For example, in order to build the 0.0.10 release of linkerd:
-
-1. Ensure that the head version is 0.0.10
-2. `git tag 0.0.10 && git push origin 0.0.10`
-3. `./sbt linkerd/assembly namerd/assembly` will produce executables
-  in _linkerd/target/scala-2.11/linkerd-0.0.10-exec_ and
-  _namerd/target/scala-2.11/namerd-0.0.10-exec_.
-
-#### Docker ####
-
-Each of these configurations may be used to build a docker image.
-```
-> ;linkerd/docker ;namerd/docker
-...
-[info] Tagging image 94ab0793addf with name: buoyantio/linkerd:0.0.10-SNAPSHOT
-```
-
-The produced image does not contain any configuration.  It's expected
-that configuration is provided by another docker layer or volume.  For
-example, if you have linkerd configuration in
-_path/to/myapp/linkerd.yml_, you could start linkerd in docker with
-the following command:
-
-```
-$ docker run -p 4140:4140 -p 9990:9990 -v /absolute/path/to/myapp:/myapp buoyantio/linkerd:0.9.1-SNAPSHOT /myapp/linkerd.yml
-```
-
-For local testing convenience, we supply a config that routes to a single
-backend on _localhost:8080_.
-
-```
-$ docker run -p 4140:4140 -p 9990:9990 -v /path/to/linkerd/linkerd/examples:/config buoyantio/linkerd:0.9.1-SNAPSHOT /config/static_namer.yaml
-```
-
-The list of image names may be changed with a command like:
-
-```
-> set imageNames in docker in (linkerd, Bundle) += ImageName("gcr.io/gce-project/linkerd:v"+version.value)
-...
-> show linkerd/bundle:docker::imageNames
-[info] List(buoyantio/linkerd:0.0.10-SNAPSHOT, gcr.io/gce-project/linkerd:v0.0.10-SNAPSHOT)
-```
-
-#### DCOS ####
-
-Namerd supports a DCOS-specific configuration. When used in conjunction with
-namerd's `io.l5d.zk` dtab storage, this
-configuration provides bootstrapping of the ZooKeeper `pathPrefix`, along with
-a default dtab.
-
-##### Run locally #####
-
-This executes only the namerd-dcos-bootstrap command, it does not boot namerd.
-
-```bash
-$ ./sbt "namerd/dcos:run-main io.buoyant.namerd.DcosBootstrap namerd/examples/zk.yaml"
-```
-
-##### Run assembly script locally #####
-
-The assembly script executes two commands serially:
-1. runs namerd-dcos-bootstrap
-2. boots namerd
-
-```bash
-$ ./sbt namerd/dcos:assembly
-$ namerd/target/scala-2.11/namerd-0.9.1-SNAPSHOT-dcos-exec namerd/examples/zk.yaml
-```
-
-##### Run assembly script in docker #####
-
-```bash
-$ ./sbt namerd/dcos:docker
-$ docker run -p 2181:2181 -p 4180:4180 -v /path/to/repo:/myapp -w /myapp buoyantio/namerd:0.9.1-SNAPSHOT-dcos namerd/examples/zk.yaml
-```
-
-### Contributing ###
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for more details about how to
-contribute.
-
-### Style ###
-
-We generally follow [Effective Scala][es] and the
-[Scala Style Guide][ssg]. When in doubt, we try to use Finagle's
-idioms.
+This project is for everyone. We ask that our users and contributors take a few minutes to
+review our [code of conduct][coc].
 
 ## License ##
 
-Copyright 2016, Buoyant Inc. All rights reserved.
+Copyright 2016-2017, Buoyant Inc. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 these files except in compliance with the License. You may obtain a copy of the
@@ -340,16 +73,16 @@ CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 
 <!-- references -->
-[consul]: https://consul.io/
-[es]: https://twitter.github.io/effectivescala/
+[coc]: wiki/Linkerd-code-of-conduct
+[cncf]: https://www.cncf.io/about
 [finagle]: https://twitter.github.io/finagle/
-[funsuite]: http://www.scalatest.org/getting_started_with_fun_suite
 [k8s]: https://k8s.io/
-[l5d-ci]: https://circleci.com/gh/linkerd/linkerd
 [l5d-ci-status]: https://circleci.com/gh/linkerd/linkerd/tree/master.svg?style=shield&circle-token=06d80fc52dbaeaac316d09b7ad4ada6f7d2bf31f
+[l5d-eg]: https://github.com/linkerd/linkerd-examples
 [l5d-logo]: https://cloud.githubusercontent.com/assets/9226/12433413/c6fff880-beb5-11e5-94d1-1afb1258f464.png
+[l5d-tcp]: https://github.com/linkerd/linkerd-tcp
+[l5d-viz]: https://github.com/linkerd/linkerd-viz
+[l5d-zipkin]: https://github.com/linkerd/linkerd-zipkin
+[namerctl]: https://github.com/linkerd/namerctl
 [netty]: https://netty.io/
-[sbt]: http://www.scala-sbt.org/
-[scalatest]: http://www.scalatest.org/
-[ssg]: http://docs.scala-lang.org/style/scaladoc.html
-[releases]: https://github.com/linkerd/linkerd/releases
+[zipkin]: https://github.com/openzipkin/zipkin

--- a/linkerd/README.md
+++ b/linkerd/README.md
@@ -25,7 +25,7 @@ The `linkerd` project's packaging configurations may also be used to
 run linkerd locally, e.g.:
 
 ```
-> linkerd/minimal:run path/to/config.yml
+> linkerd/bundle:run path/to/config.yml
 ```
 
 #### Example configurations ####


### PR DESCRIPTION
The project's README was becoming a bit verbose.

- Build instructions have been moved to a dedicated BUILD.md
- CONTRIBUTING.md has been updated with instructions on writing commit
  messages
- The README now references the code of conduct

Fixes #1179.