### PR TITLE
Sync up http and h2 identifier ids (#1176)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,11 @@
 * Add timeoutMs option to server section in linkerd config.
 * Automatically upgrade all HTTP/1.0 messages to HTTP/1.1.
 * Add `io.l5d.influxdb` LINE telemeter
+* Refactor http and h2 identifiers for consistency:
+  * The `io.l5d.headerToken` id has been renamed to `io.l5d.header.token`.
+  * The `io.l5d.headerPath` id has been renamed to `io.l5d.header.path`.
+  * The `io.l5d.h2.ingress` id has been renamed to `io.l5d.ingress`.
+  * The `io.l5d.http.ingress` id has been renamed to `io.l5d.ingress`.
 
 ## 0.9.1 2017-03-15
 

--- a/config/src/main/scala/io/buoyant/config/Parser.scala
+++ b/config/src/main/scala/io/buoyant/config/Parser.scala
@@ -82,9 +82,9 @@ object Parser {
     mapper.setSerializationInclusion(Include.NON_ABSENT)
     mapper.setVisibility(PropertyAccessor.ALL, Visibility.PUBLIC_ONLY)
 
-    // Subtypes must not conflict
+    // Subtypes with the same config deserializer parent must not conflict
     for (kinds <- configInitializers) {
-      ensureUniqueKinds(kinds)
+      kinds.groupBy(_.configClass.getSuperclass).values.foreach(ensureUniqueKinds)
       for (k <- kinds) k.registerSubtypes(mapper)
     }
 

--- a/config/src/test/scala/io/buoyant/config/ParserTest.scala
+++ b/config/src/test/scala/io/buoyant/config/ParserTest.scala
@@ -1,0 +1,45 @@
+package io.buoyant.config
+
+import io.buoyant.test.FunSuite
+
+class ParserTest extends FunSuite {
+
+  abstract class SubConfig extends PolymorphicConfig
+
+  class AConfig extends PolymorphicConfig
+  class ASubConfig extends SubConfig
+  class BConfig extends PolymorphicConfig
+
+  class A1 extends ConfigInitializer {
+    val configClass = classOf[AConfig]
+    override val configId = "io.l5d.a"
+  }
+
+  class A2 extends ConfigInitializer {
+    val configClass = classOf[ASubConfig]
+    override val configId = "io.l5d.a"
+  }
+
+  class B extends ConfigInitializer {
+    val configClass = classOf[BConfig]
+    override val configId = "io.l5d.b"
+  }
+
+  test("allows different ids for the same parent config class") {
+    val _ = Parser.objectMapper("{}", Seq(Seq(new A1(), new B())))
+  }
+
+  test("disallows same id for same parent config class") {
+    assertThrows[ConflictingSubtypes] {
+      val _ = Parser.objectMapper("{}", Seq(Seq(new A1(), new A1())))
+    }
+  }
+
+  test("allows same id for different parent config classes") {
+    val _ = Parser.objectMapper("{}", Seq(Seq(new A1(), new A2())))
+  }
+
+  test("allows same id for different initializers") {
+    val _ = Parser.objectMapper("{}", Seq(Seq(new A1()), Seq(new A1())))
+  }
+}

--- a/linkerd/docs/protocol-h2.md
+++ b/linkerd/docs/protocol-h2.md
@@ -1,4 +1,4 @@
-# HTTP/2 protocol #
+# HTTP/2 protocol
 
 <!-- examples -->
 
@@ -15,7 +15,7 @@ routers:
       keyPath: .../private/linkerd.pem
       caCertPath: .../ca.pem
   identifier:
-    kind: io.l5d.headerToken
+    kind: io.l5d.header.token
     header: ":authority"
   dtab: |
     /svc => /#/io.l5d.fs ;
@@ -38,7 +38,7 @@ routers:
   servers:
   - port: 4142
   identifier:
-    kind: io.l5d.headerPath
+    kind: io.l5d.header.path
     segments: 2
   dtab: |
     /svc => /#/io.l5d.fs ;
@@ -51,8 +51,7 @@ accordingly. Note that gRPC may be configured over TLS as well.
 
 protocol: `h2`
 
-linkerd now has _experimental_ support for HTTP/2. There are a number
-of
+linkerd now has _experimental_ support for HTTP/2. There are a number of
 [open issues](https://github.com/linkerd/linkerd/issues?q=is%3Aopen+is%3Aissue+label%3Ah2)
 that are being addressed. Please
 [report](https://github.com/linkerd/linkerd/issues/new) any
@@ -60,8 +59,9 @@ additional issues with this protocol!
 
 Key | Default Value | Description
 --- | ------------- | -----------
-dstPrefix | `/svc` | A path prefix used by [H2-specific identifiers](#h2-identifiers).
+dstPrefix | `/svc` | A path prefix used by [H2-specific identifiers](#http-2-identifiers).
 experimental | `false` | Set this to `true` to opt-in to experimental h2 support.
+identifier | The `io.l5d.header.token` identifier | An identifier or list of identifiers. See [HTTP/2 Identifiers](#http-2-identifiers).
 
 When TLS is configured, h2 routers negotiate to communicate over
 HTTP/2 via ALPN.
@@ -94,24 +94,22 @@ maxFrameBytes | 16KB | Configures `SETTINGS_MAX_FRAME_SIZE` on new streams.
 maxHeaderListByts | none | Configures `SETTINGS_MAX_HEADER_LIST_SIZE` on new streams.
 
 
-<a name="h2-identifiers"></a>
 ## HTTP/2 Identifiers
 
 Identifiers are responsible for creating logical *names* from an incoming
 request; these names are then matched against the dtab. (See the [linkerd
-routing overview](https://linkerd.io/doc/latest/routing/) for more details on
+routing overview](https://linkerd.io/in-depth/routing/) for more details on
 this.) All h2 identifiers have a `kind`.  If a list of identifiers is
 provided, each identifier is tried in turn until one successfully assigns a
 logical *name* to the request.
 
 Key | Default Value | Description
 --- | ------------- | -----------
-kind | _required_ | Either [`io.l5d.headerToken`](#http-2-header-token-identifier), [`io.l5d.headerPath`](#http-2-headerpath-identifier), or [`io.l5d.h2.ingress`](#http-2-ingress-identifier).
+kind | _required_ | Either [`io.l5d.header.token`](#http-2-header-token-identifier), [`io.l5d.header.path`](#http-2-header-path-identifier), or [`io.l5d.ingress`](#http-2-ingress-identifier).
 
-<a name="header-token-identifier"></a>
 ### HTTP/2 Header Token identifier
 
-kind: `io.l5d.headerToken`.
+kind: `io.l5d.header.token`.
 
 With this identifier, requests are turned into logical names using the
 value of the named header. By default, the `:authority` pseudo-header
@@ -127,7 +125,7 @@ routers:
 - protocol: h2
   experimental: true
   identifier:
-    kind: io.l5d.headerToken
+    kind: io.l5d.header.token
     header: my-header
   servers:
   - port: 5000
@@ -150,10 +148,9 @@ Key | Default Value | Description
 dstPrefix | `/svc` | The `dstPrefix` as set in the routers block.
 headerValue | N/A | The value of the header.
 
-<a name="header-path-identifier"></a>
 ### HTTP/2 Header Path Identifier
 
-kind: `io.l5d.headerPath`
+kind: `io.l5d.header.path`
 
 With this identifier, requests are identified using a path read from a
 header. This is useful for routing gRPC requests. By default, the `:path`
@@ -170,7 +167,7 @@ routers:
 - protocol: h2
   experimental: true
   identifier:
-    kind: io.l5d.headerPath
+    kind: io.l5d.header.path
     segments: 2
   servers:
   - port: 5000
@@ -195,10 +192,9 @@ Key | Default Value | Description
 dstPrefix | `/svc` | The `dstPrefix` as set in the routers block.
 urlPath | N/A | The first `segments` elements of the path from the URL
 
-<a name="h2-ingress-identifier"></a>
 ### HTTP/2 Ingress Identifier
 
-kind: `io.l5d.h2.ingress`
+kind: `io.l5d.ingress`
 
 Using this identifier enables linkerd to function as a Kubernetes ingress
 controller. The ingress identifier compares HTTP/2 requests to [ingress
@@ -219,7 +215,7 @@ routers:
 - protocol: h2
   experimental: true
   identifier:
-    kind: io.l5d.h2.ingress
+    kind: io.l5d.ingress
     namespace: default
   servers:
   - port: 4140
@@ -272,14 +268,12 @@ namespace | N/A | The Kubernetes namespace.
 port | N/A | The port name.
 svc | N/A | The name of the service.
 
-<a name="h2-headers"></a>
-## Headers
+## HTTP/2 Headers
 
 linkerd reads and sets several headers prefixed by `l5d-`, as is done
 by the `http` protocol.
 
-<a name="context-headers"></a>
-### Context Headers
+### HTTP/2 Context Headers
 
 _Context headers_ (`l5d-ctx-*`) are generated and read by linkerd
 instances. Applications should forward all context headers in order
@@ -296,7 +290,7 @@ Edge services should take care to ensure these headers are not set
 from untrusted sources.
 </aside>
 
-### User Headers
+### HTTP/2 User Headers
 
 > Append a dtab override to the dtab for this request
 
@@ -325,7 +319,7 @@ Edge services should take care to ensure these headers are not set
 from untrusted sources.
 </aside>
 
-### Informational Request Headers
+### HTTP/2 Informational Request Headers
 
 The informational headers linkerd emits on outgoing requests.
 
@@ -345,7 +339,7 @@ information including host names.  Operators may opt to remove these
 headers from requests sent to the outside world.
 </aside>
 
-### Informational Response Headers
+### HTTP/2 Informational Response Headers
 
 The informational headers linkerd emits on outgoing responses.
 

--- a/linkerd/docs/protocol-http.md
+++ b/linkerd/docs/protocol-http.md
@@ -290,7 +290,7 @@ headerValue | N/A | The value of the HTTP header as a path segment.
 <a name="ingress-identifier"></a>
 ### Ingress Identifier
 
-kind: `io.l5d.http.ingress`
+kind: `io.l5d.ingress`
 
 Using this identifier enables linkerd to function as a Kubernetes ingress
 controller. The ingress identifier compares HTTP requests to [ingress
@@ -305,7 +305,7 @@ name based on those rules.
 routers:
 - protocol: http
   identifier:
-    kind: io.l5d.http.ingress
+    kind: io.l5d.ingress
     namespace: default
   servers:
   - port: 4140

--- a/linkerd/docs/response_classifier.md
+++ b/linkerd/docs/response_classifier.md
@@ -25,6 +25,7 @@ kind | `io.l5d.nonRetryable5XX` | Either [`io.l5d.nonRetryable5XX`](#non-retryab
 ## Non-Retryable 5XX
 
 kind: `io.l5d.nonRetryable5XX`
+kind: `io.l5d.h2.nonRetryable5XX`
 
 All 5XX responses are considered to be failures and none of these
 requests are considered to be retryable.
@@ -32,6 +33,7 @@ requests are considered to be retryable.
 ## Retryable Read 5XX
 
 kind: `io.l5d.retryableRead5XX`
+kind: `io.l5d.h2.retryableRead5XX`
 
 All 5XX responses are considered to be failures. However, `GET`,
 `HEAD`, `OPTIONS`, and `TRACE` requests may be retried automatically.
@@ -43,6 +45,7 @@ Requests with chunked bodies are NEVER considered to be retryable.
 ## Retryable Idempotent 5XX
 
 kind: `io.l5d.retryableIdempotent5XX`
+kind: `io.l5d.h2.retryableIdempotent5XX`
 
 Like _io.l5d.retryableRead5XX_, but `PUT` and `DELETE` requests may
 also be retried.

--- a/linkerd/examples/h2.yaml
+++ b/linkerd/examples/h2.yaml
@@ -11,7 +11,7 @@ routers:
     /svc/localhost:4142 => /$/inet/127.1/8888;
     /svc => /srv;
   identifier:
-    kind: io.l5d.headerToken
+    kind: io.l5d.header.token
     header: ":authority"
   servers:
   - port: 4142

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/HeaderPathIdentifier.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/HeaderPathIdentifier.scala
@@ -5,7 +5,7 @@ package h2
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.twitter.finagle.{Dtab, Path, Stack}
 import com.twitter.finagle.buoyant.Dst
-import com.twitter.finagle.buoyant.h2.{Headers => H2Headers, LinkerdHeaders, Request}
+import com.twitter.finagle.buoyant.h2.{Request, Headers => H2Headers}
 import com.twitter.util.Future
 import io.buoyant.router.H2
 import io.buoyant.router.RoutingFactory._
@@ -109,7 +109,7 @@ class HeaderPathIdentifierConfig extends H2IdentifierConfig {
 
 class HeaderPathIdentifierInitializer extends IdentifierInitializer {
   val configClass = classOf[HeaderPathIdentifierConfig]
-  override val configId = "io.l5d.headerPath"
+  override val configId = "io.l5d.header.path"
 }
 
 object HeaderPathIdentifierInitializer extends HeaderPathIdentifierInitializer

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/HeaderTokenIdentifier.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/HeaderTokenIdentifier.scala
@@ -53,7 +53,7 @@ class HeaderTokenIdentifierConfig extends H2IdentifierConfig {
 }
 
 object HeaderTokenIdentifierConfig {
-  val kind = "io.l5d.headerToken"
+  val kind = "io.l5d.header.token"
 }
 
 class HeaderTokenIdentifierInitializer extends IdentifierInitializer {

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/IngressIdentifier.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/IngressIdentifier.scala
@@ -55,7 +55,7 @@ case class IngressIdentifierConfig(
 }
 
 object IngressIdentifierConfig {
-  val kind = "io.l5d.h2.ingress"
+  val kind = "io.l5d.ingress"
 }
 
 class IngressIdentifierInitializer extends IdentifierInitializer {

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/IngressIdentifier.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/IngressIdentifier.scala
@@ -55,7 +55,7 @@ case class IngressIdentifierConfig(
 }
 
 object IngressIdentifierConfig {
-  val kind = "io.l5d.http.ingress"
+  val kind = "io.l5d.ingress"
 }
 
 class IngressIdentifierInitializer extends IdentifierInitializer {

--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -19,6 +19,7 @@ object LinkerdBuild extends Base {
     .withTwitterLibs(Deps.finagle("core"))
     .withLibs(Deps.jackson)
     .withLib(Deps.jacksonYaml)
+    .withTests()
 
   val consul = projectDir("consul")
     .dependsOn(configCore)


### PR DESCRIPTION
## Problem

The existing http and h2 identifier IDs are slightly inconsistent (e.g.
`io.l5d.header.token` and `io.l5d.headerToken`). Additionally, some of
the ids are scoped by protocol, and others are not.

## Solution

Rename identifier IDs to make them more consistent. Update the
documentation accordingly, and fix some issues with broken anchors.

Fixes #1176.