### PR TITLE
Document namerd's io.l5d.mesh interpreter (#1190)

### DIFF
--- a/linkerd/docs/interpreter.md
+++ b/linkerd/docs/interpreter.md
@@ -18,7 +18,7 @@ These parameters are available to the identifier regardless of kind. Identifiers
 
 Key | Default Value | Description
 --- | ------------- | -----------
-kind | `default` | Either [`default`](#default), [`io.l5d.namerd`](#namerd), or [`io.l5d.fs`](#file-system).
+kind | `default` | Either [`default`](#default), [`io.l5d.namerd`](#namerd-thrift), [`io.l5d.namerd.http`](#namerd-http), [`io.l5d.mesh`](#namerd-mesh), or [`io.l5d.fs`](#file-system).
 transformers | No transformers | A list of [transformers](#transformer) to apply to the resolved addresses.
 
 ## Default
@@ -29,21 +29,18 @@ The default interpreter resolves names via the configured
 [`namers`](#namers), with a fallback to the default Finagle
 `Namer.Global` that handles paths of the form `/$/`.
 
-## namerd
+## namerd thrift
 
 kind: `io.l5d.namerd`
-kind: `io.l5d.namerd.http`
 
-The namerd interpreter offloads the responsibilities of name resolution to the
-namerd service.  Any namers configured in this linkerd are not used.  The
-`io.l5d.namerd` interpreter uses namerd's long-poll thrift interface and the
-`io.l5d.namerd.http` interpreter uses namerd's HTTP streaming interface.  Note
-that the protocol that the interpreter uses to talk to namerd is unrelated to
-the protocols of linkerd's routers.
+The namerd thrift interpreter offloads the responsibilities of name resolution
+to the namerd service.  Any namers configured in this linkerd are not used.  The
+interpreter users namerd's long-poll thrift interface. Note that the protocol
+that the interpreter uses to talk to namerd is unrelated to the protocols of
+linkerd's routers.
 
 Key | Default Value | Description
 --- | ------------- | -----------
-experimental | _required_ | Because the http version is still considered experimental, you must set this to `true` to use it.
 dst | _required_ | A Finagle path locating the namerd service.
 namespace | `default` | The name of the namerd dtab to use.
 retry | see [namerd retry](#namerd-retry) | An object configuring retry backoffs for requests to namerd.
@@ -62,6 +59,42 @@ Key | Default Value | Description
 --- | ------------- | -----------
 commonName | _required_ | The common name to use for namerd requests.
 caCert | N/A | The path to the CA cert used for common name validation.
+
+## namerd http
+
+kind: `io.l5d.namerd.http`
+
+The namerd http interpreter offloads the responsibilities of name resolution to
+the namerd service.  Any namers configured in this linkerd are not used.  The
+interpreter uses namerd's HTTP streaming interface.  Note that the protocol that
+the interpreter uses to talk to namerd is unrelated to the protocols of
+linkerd's routers.
+
+Key | Default Value | Description
+--- | ------------- | -----------
+experimental | _required_ | Because the http interpreter is still considered experimental, you must set this to `true` to use it.
+dst | _required_ | A Finagle path locating the namerd service.
+namespace | `default` | The name of the namerd dtab to use.
+retry | see [namerd retry](#namerd-retry) | An object configuring retry backoffs for requests to namerd.
+tls | no tls | Requests to namerd will be made using TLS if this parameter is provided.  It must be a [namerd client TLS](#namerd-client-tls) object.
+
+## namerd mesh
+
+kind: `io.l5d.mesh`
+
+The namerd mesh interpreter offloads the responsibilities of name resolution to
+the namerd service.  Any namers configured in this linkerd are not used.  The
+interpreter uses namerd's mesh interface via gRPC.  Note that the protocol that
+the interpreter uses to talk to namerd is unrelated to the protocols of
+linkerd's routers.
+
+Key | Default Value | Description
+--- | ------------- | -----------
+experimental | _required_ | Because the mesh interpreter is still considered experimental, you must set this to `true` to use it.
+dst | _required_ | A Finagle path locating the namerd service.
+namespace | `default` | The name of the namerd dtab to use.
+retry | see [namerd retry](#namerd-retry) | An object configuring retry backoffs for requests to namerd.
+tls | no tls | The namerd mesh interface does not support server TLS configuration at this time.
 
 ## File-System
 

--- a/linkerd/docs/interpreter.md
+++ b/linkerd/docs/interpreter.md
@@ -92,7 +92,7 @@ Key | Default Value | Description
 --- | ------------- | -----------
 experimental | _required_ | Because the mesh interpreter is still considered experimental, you must set this to `true` to use it.
 dst | _required_ | A Finagle path locating the namerd service.
-namespace | `default` | The name of the namerd dtab to use.
+root | `/default` | A single-element Finagle path representing the namerd namespace.
 retry | see [namerd retry](#namerd-retry) | An object configuring retry backoffs for requests to namerd.
 tls | no tls | The namerd mesh interface does not support server TLS configuration at this time.
 

--- a/linkerd/docs/interpreter.md
+++ b/linkerd/docs/interpreter.md
@@ -35,9 +35,9 @@ kind: `io.l5d.namerd`
 
 The namerd thrift interpreter offloads the responsibilities of name resolution
 to the namerd service.  Any namers configured in this linkerd are not used.  The
-interpreter users namerd's long-poll thrift interface. Note that the protocol
-that the interpreter uses to talk to namerd is unrelated to the protocols of
-linkerd's routers.
+interpreter users namerd's long-poll thrift interface
+(`io.l5d.thriftNameInterpreter`). Note that the protocol that the interpreter
+uses to talk to namerd is unrelated to the protocols of linkerd's routers.
 
 Key | Default Value | Description
 --- | ------------- | -----------
@@ -66,9 +66,9 @@ kind: `io.l5d.namerd.http`
 
 The namerd http interpreter offloads the responsibilities of name resolution to
 the namerd service.  Any namers configured in this linkerd are not used.  The
-interpreter uses namerd's HTTP streaming interface.  Note that the protocol that
-the interpreter uses to talk to namerd is unrelated to the protocols of
-linkerd's routers.
+interpreter uses namerd's HTTP streaming interface (`io.l5d.httpController`).
+Note that the protocol that the interpreter uses to talk to namerd is unrelated
+to the protocols of linkerd's routers.
 
 Key | Default Value | Description
 --- | ------------- | -----------
@@ -84,9 +84,9 @@ kind: `io.l5d.mesh`
 
 The namerd mesh interpreter offloads the responsibilities of name resolution to
 the namerd service.  Any namers configured in this linkerd are not used.  The
-interpreter uses namerd's mesh interface via gRPC.  Note that the protocol that
-the interpreter uses to talk to namerd is unrelated to the protocols of
-linkerd's routers.
+interpreter uses namerd's gRPC mesh interface (`io.l5d.mesh`). Note that the
+protocol that the interpreter uses to talk to namerd is unrelated to the
+protocols of linkerd's routers.
 
 Key | Default Value | Description
 --- | ------------- | -----------

--- a/namerd/docs/interface.md
+++ b/namerd/docs/interface.md
@@ -1,9 +1,16 @@
 # Interfaces
 
-An interface is a published network interface to namerd.
+An interface is a published network interface to namerd. All of the interfaces
+listed below provide Finage's [`NameInterpreter`](
+https://twitter.github.io/finagle/docs/com/twitter/finagle/naming/NameInterpreter.html)
+functionality for remote resolution of destinations using dtabs stored in
+namerd. Additionally, the [`io.l5d.httpController`](#http-controller) interface
+provides a dtab read/write API that's used by
+[namerctl](https://github.com/linkerd/namerctl).
 
 <aside class="notice">
-These parameters are available to the interface regardless of kind. Interfaces may also have kind-specific parameters.
+These parameters are available to the interface regardless of kind. Interfaces
+may also have kind-specific parameters.
 </aside>
 
 Key | Default Value | Description
@@ -16,7 +23,9 @@ port | interface dependent | The port number on which to server the namer interf
 
 kind: `io.l5d.thriftNameInterpreter`
 
-A read-only interface providing `NameInterpreter` functionality over the ThriftMux protocol.
+A read-only interface providing `NameInterpreter` functionality over the
+ThriftMux protocol. Use linkerd's `io.l5d.namerd` interpreter to resolve
+destinations via this interface.
 
 Key | Default Value | Description
 --- | ------------- | -----------
@@ -49,7 +58,9 @@ keyPath | _required_ | File path to the TLS key file.
 
 kind: `io.l5d.mesh`
 
-An interface providing `NameInterpreter` functionality over gRPC.
+A read-only interface providing `NameInterpreter` functionality over the gRCP
+protocol. Use linkerd's `io.l5d.mesh` interpreter to resolve destinations via
+this interface.
 
 Key | Default Value | Description
 --- | ------------- | -----------
@@ -63,6 +74,9 @@ kind: `io.l5d.httpController`
 The HTTP controller provides APIs for reading and writing dtabs, as well as for
 viewing how names are resolved.  This API can also be accessed using the
 [namerctl](https://github.com/linkerd/namerctl) command line tool.
+Additionally, this API provides an HTTP implementation of the `NameInterpreter`
+interface. Use linkerd's `io.l5d.namerd.http` interpreter to resolve
+destinations via this interface.
 
 Key | Default Value | Description
 --- | ------------- | -----------

--- a/namerd/docs/interface.md
+++ b/namerd/docs/interface.md
@@ -8,7 +8,7 @@ These parameters are available to the interface regardless of kind. Interfaces m
 
 Key | Default Value | Description
 --- | ------------- | -----------
-kind | _required_ | Either [`io.l5d.thriftNameInterpreter`](#thrift-name-interpreter) or [`io.l5d.httpController`](#http-controller).
+kind | _required_ | Either [`io.l5d.thriftNameInterpreter`](#thrift-name-interpreter), [`io.l5d.mesh`](#grpc-mesh-interface), or [`io.l5d.httpController`](#http-controller).
 ip | interface dependent | The local IP address on which to serve the namer interface.
 port | interface dependent | The port number on which to server the namer interface.
 
@@ -44,6 +44,17 @@ Key | Default Value | Description
 --- | ------------- | -----------
 certPath | _required_ | File path to the TLS certificate file.
 keyPath | _required_ | File path to the TLS key file.
+
+## gRPC Mesh Interface
+
+kind: `io.l5d.mesh`
+
+An interface providing `NameInterpreter` functionality over gRPC.
+
+Key | Default Value | Description
+--- | ------------- | -----------
+ip | `0.0.0.0` | The local IP address on which to serve the namer interface.
+port | `4321` | The port number on which to server the namer interface.
 
 ## Http Controller
 


### PR DESCRIPTION
## Problem

The io.l5d.mesh interpreter was added in #1065, but does not include any documentation on how to use it.

## Solution

Add documentation. Fixes #1190.