### PR TITLE
Use the openjdk:8-jre-alpine base docker image

### DIFF
--- a/project/Base.scala
+++ b/project/Base.scala
@@ -135,7 +135,7 @@ class Base extends Build {
     assemblyJarName in assembly := s"${name.value}-${version.value}-${configuration.value}-exec",
     docker <<= docker dependsOn (assembly in configuration),
     dockerEnvPrefix := "",
-    dockerJavaImage <<= (dockerJavaImage in Global).?(_.getOrElse("library/java:openjdk-8-jre")),
+    dockerJavaImage <<= (dockerJavaImage in Global).?(_.getOrElse("library/openjdk:8-jre-alpine")),
     dockerfile in docker := new Dockerfile {
       val envPrefix = dockerEnvPrefix.value.toUpperCase
       val home = s"/${organization.value}/${name.value}/${version.value}"


### PR DESCRIPTION
The library/java repo has been deprecated in favor of library/openjdk. This
repo now has the 8-jre-alpine tag, which provides a slimmed down base image,
reducing our total image size by roughly 30%.

I've verified that the process runs, but haven't actually run traffic through this yet.

Fixes #1211 