### PR TITLE
Use service and client as dst stat names

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,13 @@
 * Split the timeoutMs router option into a requestAttemptTimeoutMs client option
   and a totalTimeoutMs service option.
 * Fixed k8s namer to handle null endpoint subsets.
+* Rename the "dst/path" metrics scope to "service".
+* Rename the "dst/id" metrics scope to "client".
+* Rename the "namer.path" trace annotation to "service".
+* Rename the "dst.id" trace annotation to "client".
+* Rename the "dst.path" trace annotation to "residual".
+* Rename the "l5d-dst-logical" HTTP and H2 headers to "l5d-dst-service".
+* Rename the "l5d-dst-concrete" HTTP and H2 headers to "l5d-dst-client".
 
 ## 0.9.1 2017-03-15
 

--- a/admin/src/main/resources/io/buoyant/admin/js/spec/fixtures/metrics.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/spec/fixtures/metrics.js
@@ -682,2358 +682,136 @@ return {
             "gauge": 0.0
           }
         },
-      "client": {
-        "$/inet/127.1/9091": {
-          "connect_latency_ms": {
-            "stat.count": 86,
-            "stat.max": 6,
-            "stat.min": 0,
-            "stat.p50": 0,
-            "stat.p90": 0,
-            "stat.p95": 0,
-            "stat.p99": 2,
-            "stat.p9990": 6,
-            "stat.p9999": 6,
-            "stat.sum": 8,
-            "stat.avg": 0.09302325581395349
-          },
-          "failed_connect_latency_ms": {
-            "stat.count": 0
-          },
-          "sent_bytes": {
-            "counter": 454350
-          },
-          "service_creation": {
-            "service_acquisition_latency_ms": {
-              "stat.count": 159,
-              "stat.max": 7,
+        "client": {
+          "$/inet/127.1/9091": {
+            "connect_latency_ms": {
+              "stat.count": 86,
+              "stat.max": 6,
               "stat.min": 0,
               "stat.p50": 0,
               "stat.p90": 0,
-              "stat.p95": 1,
-              "stat.p99": 1,
-              "stat.p9990": 7,
-              "stat.p9999": 7,
-              "stat.sum": 17,
-              "stat.avg": 0.1069182389937107
-            }
-          },
-          "connection_received_bytes": {
-            "stat.count": 87,
-            "stat.max": 230,
-            "stat.min": 23,
-            "stat.p50": 23,
-            "stat.p90": 69,
-            "stat.p95": 92,
-            "stat.p99": 161,
-            "stat.p9990": 230,
-            "stat.p9999": 230,
-            "stat.sum": 3680,
-            "stat.avg": 42.298850574712645
-          },
-          "connection_duration": {
-            "stat.count": 87,
-            "stat.max": 2268,
-            "stat.min": 20,
-            "stat.p50": 41,
-            "stat.p90": 1379,
-            "stat.p95": 1538,
-            "stat.p99": 1877,
-            "stat.p9990": 2268,
-            "stat.p9999": 2268,
-            "stat.sum": 27822,
-            "stat.avg": 319.7931034482759
-          },
-          "failure_accrual": {
-            "removals": {
-              "counter": 0
+              "stat.p95": 0,
+              "stat.p99": 2,
+              "stat.p9990": 6,
+              "stat.p9999": 6,
+              "stat.sum": 8,
+              "stat.avg": 0.09302325581395349
             },
-            "probes": {
-              "counter": 0
+            "failed_connect_latency_ms": {
+              "stat.count": 0
             },
-            "removed_for_ms": {
-              "counter": 0
+            "sent_bytes": {
+              "counter": 454350
             },
-            "revivals": {
-              "counter": 0
-            }
-          },
-          "connects": {
-            "counter": 7887
-          },
-          "pool_num_waited": {
-            "counter": 0
-          },
-          "success": {
-            "counter": 15145
-          },
-          "service": {
-            "svc": {
-              "request_latency_ms": {
+            "service_creation": {
+              "service_acquisition_latency_ms": {
                 "stat.count": 159,
-                "stat.max": 4,
+                "stat.max": 7,
                 "stat.min": 0,
                 "stat.p50": 0,
                 "stat.p90": 0,
                 "stat.p95": 1,
-                "stat.p99": 3,
-                "stat.p9990": 4,
-                "stat.p9999": 4,
-                "stat.sum": 23,
-                "stat.avg": 0.14465408805031446
-              },
-              "success": {
-                "counter": 15145
-              },
-              "pending": {
-                "gauge": 0.0
-              },
-              "requests": {
-                "counter": 15145
-              }
-            }
-          },
-          "request_latency_ms": {
-            "stat.count": 159,
-            "stat.max": 4,
-            "stat.min": 0,
-            "stat.p50": 0,
-            "stat.p90": 0,
-            "stat.p95": 1,
-            "stat.p99": 3,
-            "stat.p9990": 4,
-            "stat.p9999": 4,
-            "stat.sum": 23,
-            "stat.avg": 0.14465408805031446
-          },
-          "pool_waiters": {
-            "gauge": 0.0
-          },
-          "retries": {
-            "requeues_per_request": {
-              "stat.count": 159,
-              "stat.max": 0,
-              "stat.min": 0,
-              "stat.p50": 0,
-              "stat.p90": 0,
-              "stat.p95": 0,
-              "stat.p99": 0,
-              "stat.p9990": 0,
-              "stat.p9999": 0,
-              "stat.sum": 0,
-              "stat.avg": 0.0
-            },
-            "request_limit": {
-              "counter": 0
-            },
-            "budget_exhausted": {
-              "counter": 0
-            },
-            "cannot_retry": {
-              "counter": 0
-            },
-            "not_open": {
-              "counter": 0
-            },
-            "budget": {},
-            "requeues": {
-              "counter": 0
-            }
-          },
-          "received_bytes": {
-            "counter": 348335
-          },
-          "connection_sent_bytes": {
-            "stat.count": 87,
-            "stat.max": 301,
-            "stat.min": 30,
-            "stat.p50": 30,
-            "stat.p90": 90,
-            "stat.p95": 121,
-            "stat.p99": 211,
-            "stat.p9990": 301,
-            "stat.p9999": 301,
-            "stat.sum": 4800,
-            "stat.avg": 55.172413793103445
-          },
-          "connection_requests": {
-            "stat.count": 87,
-            "stat.max": 10,
-            "stat.min": 1,
-            "stat.p50": 1,
-            "stat.p90": 3,
-            "stat.p95": 4,
-            "stat.p99": 7,
-            "stat.p9990": 10,
-            "stat.p9999": 10,
-            "stat.sum": 160,
-            "stat.avg": 1.839080459770115
-          },
-          "pool_num_too_many_waiters": {
-            "counter": 0
-          },
-          "socket_unwritable_ms": {
-            "counter": 0
-          },
-          "closes": {
-            "counter": 7887
-          },
-          "pool_cached": {
-            "gauge": 0.0
-          },
-          "pool_size": {
-            "gauge": 0.0
-          },
-          "available": {
-            "gauge": 0.0
-          },
-          "request_payload_bytes": {
-            "stat.count": 159,
-            "stat.max": 30,
-            "stat.min": 30,
-            "stat.p50": 30,
-            "stat.p90": 30,
-            "stat.p95": 30,
-            "stat.p99": 30,
-            "stat.p9990": 30,
-            "stat.p9999": 30,
-            "stat.sum": 4770,
-            "stat.avg": 30.0
-          },
-          "socket_writable_ms": {
-            "counter": 0
-          },
-          "cancelled_connects": {
-            "counter": 0
-          },
-          "response_payload_bytes": {
-            "stat.count": 159,
-            "stat.max": 23,
-            "stat.min": 23,
-            "stat.p50": 23,
-            "stat.p90": 23,
-            "stat.p95": 23,
-            "stat.p99": 23,
-            "stat.p9990": 23,
-            "stat.p9999": 23,
-            "stat.sum": 3657,
-            "stat.avg": 23.0
-          },
-          "dtab": {
-            "size": {
-              "stat.count": 0
-            }
-          },
-          "requests": {
-            "counter": 15145
-          },
-          "loadbalancer": {
-            "size": {},
-            "rebuilds": {
-              "counter": 7912
-            },
-            "closed": {},
-            "load": {},
-            "meanweight": {},
-            "adds": {
-              "counter": 7887
-            },
-            "p2c": {
-              "gauge": 22.0
-            },
-            "updates": {
-              "counter": 7912
-            },
-            "available": {},
-            "max_effort_exhausted": {
-              "counter": 0
-            },
-            "busy": {},
-            "removes": {
-              "counter": 7887
-            }
-          },
-          "pending": {
-            "gauge": 0.0
-          },
-          "dispatcher": {
-            "serial": {
-              "queue_size": {
-                "gauge": 0.0
-              }
-            }
-          },
-          "connections": {
-            "gauge": 0.0
-          }
-        },
-        "$/inet/127.1/9090": {
-          "connect_latency_ms": {
-            "stat.count": 92,
-            "stat.max": 31,
-            "stat.min": 0,
-            "stat.p50": 0,
-            "stat.p90": 0,
-            "stat.p95": 0,
-            "stat.p99": 3,
-            "stat.p9990": 31,
-            "stat.p9999": 31,
-            "stat.sum": 37,
-            "stat.avg": 0.40217391304347827
-          },
-          "failed_connect_latency_ms": {
-            "stat.count": 0
-          },
-          "sent_bytes": {
-            "counter": 458460
-          },
-          "service_creation": {
-            "service_acquisition_latency_ms": {
-              "stat.count": 187,
-              "stat.max": 32,
-              "stat.min": 0,
-              "stat.p50": 0,
-              "stat.p90": 0,
-              "stat.p95": 1,
-              "stat.p99": 2,
-              "stat.p9990": 32,
-              "stat.p9999": 32,
-              "stat.sum": 46,
-              "stat.avg": 0.24598930481283424
-            }
-          },
-          "connection_received_bytes": {
-            "stat.count": 91,
-            "stat.max": 230,
-            "stat.min": 23,
-            "stat.p50": 46,
-            "stat.p90": 92,
-            "stat.p95": 115,
-            "stat.p99": 207,
-            "stat.p9990": 230,
-            "stat.p9999": 230,
-            "stat.sum": 4278,
-            "stat.avg": 47.010989010989015
-          },
-          "connection_duration": {
-            "stat.count": 91,
-            "stat.max": 2290,
-            "stat.min": 18,
-            "stat.p50": 45,
-            "stat.p90": 1508,
-            "stat.p95": 1601,
-            "stat.p99": 2094,
-            "stat.p9990": 2290,
-            "stat.p9999": 2290,
-            "stat.sum": 31468,
-            "stat.avg": 345.8021978021978
-          },
-          "failure_accrual": {
-            "removals": {
-              "counter": 0
-            },
-            "probes": {
-              "counter": 0
-            },
-            "removed_for_ms": {
-              "counter": 0
-            },
-            "revivals": {
-              "counter": 0
-            }
-          },
-          "connects": {
-            "counter": 7937
-          },
-          "pool_num_waited": {
-            "counter": 0
-          },
-          "success": {
-            "counter": 15282
-          },
-          "service": {
-            "svc": {
-              "request_latency_ms": {
-                "stat.count": 187,
-                "stat.max": 55,
-                "stat.min": 0,
-                "stat.p50": 0,
-                "stat.p90": 0,
-                "stat.p95": 0,
                 "stat.p99": 1,
-                "stat.p9990": 55,
-                "stat.p9999": 55,
-                "stat.sum": 59,
-                "stat.avg": 0.3155080213903743
-              },
-              "success": {
-                "counter": 15282
-              },
-              "pending": {
-                "gauge": 0.0
-              },
-              "requests": {
-                "counter": 15282
+                "stat.p9990": 7,
+                "stat.p9999": 7,
+                "stat.sum": 17,
+                "stat.avg": 0.1069182389937107
               }
-            }
-          },
-          "request_latency_ms": {
-            "stat.count": 187,
-            "stat.max": 55,
-            "stat.min": 0,
-            "stat.p50": 0,
-            "stat.p90": 0,
-            "stat.p95": 0,
-            "stat.p99": 1,
-            "stat.p9990": 55,
-            "stat.p9999": 55,
-            "stat.sum": 59,
-            "stat.avg": 0.3155080213903743
-          },
-          "pool_waiters": {
-            "gauge": 0.0
-          },
-          "retries": {
-            "requeues_per_request": {
-              "stat.count": 187,
-              "stat.max": 0,
-              "stat.min": 0,
-              "stat.p50": 0,
-              "stat.p90": 0,
-              "stat.p95": 0,
-              "stat.p99": 0,
-              "stat.p9990": 0,
-              "stat.p9999": 0,
-              "stat.sum": 0,
-              "stat.avg": 0.0
             },
-            "request_limit": {
-              "counter": 0
+            "connection_received_bytes": {
+              "stat.count": 87,
+              "stat.max": 230,
+              "stat.min": 23,
+              "stat.p50": 23,
+              "stat.p90": 69,
+              "stat.p95": 92,
+              "stat.p99": 161,
+              "stat.p9990": 230,
+              "stat.p9999": 230,
+              "stat.sum": 3680,
+              "stat.avg": 42.298850574712645
             },
-            "budget_exhausted": {
-              "counter": 0
+            "connection_duration": {
+              "stat.count": 87,
+              "stat.max": 2268,
+              "stat.min": 20,
+              "stat.p50": 41,
+              "stat.p90": 1379,
+              "stat.p95": 1538,
+              "stat.p99": 1877,
+              "stat.p9990": 2268,
+              "stat.p9999": 2268,
+              "stat.sum": 27822,
+              "stat.avg": 319.7931034482759
             },
-            "cannot_retry": {
-              "counter": 0
-            },
-            "not_open": {
-              "counter": 0
-            },
-            "budget": {},
-            "requeues": {
-              "counter": 0
-            }
-          },
-          "received_bytes": {
-            "counter": 351486
-          },
-          "connection_sent_bytes": {
-            "stat.count": 91,
-            "stat.max": 301,
-            "stat.min": 30,
-            "stat.p50": 60,
-            "stat.p90": 121,
-            "stat.p95": 150,
-            "stat.p99": 270,
-            "stat.p9990": 301,
-            "stat.p9999": 301,
-            "stat.sum": 5580,
-            "stat.avg": 61.31868131868132
-          },
-          "connection_requests": {
-            "stat.count": 91,
-            "stat.max": 10,
-            "stat.min": 1,
-            "stat.p50": 2,
-            "stat.p90": 4,
-            "stat.p95": 5,
-            "stat.p99": 9,
-            "stat.p9990": 10,
-            "stat.p9999": 10,
-            "stat.sum": 186,
-            "stat.avg": 2.043956043956044
-          },
-          "pool_num_too_many_waiters": {
-            "counter": 0
-          },
-          "socket_unwritable_ms": {
-            "counter": 0
-          },
-          "closes": {
-            "counter": 7937
-          },
-          "pool_cached": {
-            "gauge": 0.0
-          },
-          "pool_size": {
-            "gauge": 0.0
-          },
-          "available": {
-            "gauge": 0.0
-          },
-          "request_payload_bytes": {
-            "stat.count": 187,
-            "stat.max": 30,
-            "stat.min": 30,
-            "stat.p50": 30,
-            "stat.p90": 30,
-            "stat.p95": 30,
-            "stat.p99": 30,
-            "stat.p9990": 30,
-            "stat.p9999": 30,
-            "stat.sum": 5610,
-            "stat.avg": 30.0
-          },
-          "socket_writable_ms": {
-            "counter": 0
-          },
-          "cancelled_connects": {
-            "counter": 0
-          },
-          "response_payload_bytes": {
-            "stat.count": 187,
-            "stat.max": 23,
-            "stat.min": 23,
-            "stat.p50": 23,
-            "stat.p90": 23,
-            "stat.p95": 23,
-            "stat.p99": 23,
-            "stat.p9990": 23,
-            "stat.p9999": 23,
-            "stat.sum": 4301,
-            "stat.avg": 23.0
-          },
-          "dtab": {
-            "size": {
-              "stat.count": 0
-            }
-          },
-          "requests": {
-            "counter": 15282
-          },
-          "loadbalancer": {
-            "size": {},
-            "rebuilds": {
-              "counter": 7960
-            },
-            "closed": {},
-            "load": {},
-            "meanweight": {},
-            "adds": {
-              "counter": 7937
-            },
-            "p2c": {
-              "gauge": 27.0
-            },
-            "updates": {
-              "counter": 7960
-            },
-            "available": {},
-            "max_effort_exhausted": {
-              "counter": 0
-            },
-            "busy": {},
-            "removes": {
-              "counter": 7937
-            }
-          },
-          "pending": {
-            "gauge": 0.0
-          },
-          "dispatcher": {
-            "serial": {
-              "queue_size": {
-                "gauge": 0.0
+            "failure_accrual": {
+              "removals": {
+                "counter": 0
+              },
+              "probes": {
+                "counter": 0
+              },
+              "removed_for_ms": {
+                "counter": 0
+              },
+              "revivals": {
+                "counter": 0
               }
-            }
-          },
-          "connections": {
-            "gauge": 0.0
-          }
-        },
-        "$/inet/127.1/9093": {
-          "connect_latency_ms": {
-            "stat.count": 82,
-            "stat.max": 49,
-            "stat.min": 0,
-            "stat.p50": 0,
-            "stat.p90": 0,
-            "stat.p95": 0,
-            "stat.p99": 2,
-            "stat.p9990": 49,
-            "stat.p9999": 49,
-            "stat.sum": 52,
-            "stat.avg": 0.6341463414634146
-          },
-          "failed_connect_latency_ms": {
-            "stat.count": 0
-          },
-          "sent_bytes": {
-            "counter": 445680
-          },
-          "service_creation": {
-            "service_acquisition_latency_ms": {
-              "stat.count": 169,
-              "stat.max": 49,
+            },
+            "connects": {
+              "counter": 7887
+            },
+            "pool_num_waited": {
+              "counter": 0
+            },
+            "success": {
+              "counter": 15145
+            },
+            "service": {
+              "svc": {
+                "request_latency_ms": {
+                  "stat.count": 159,
+                  "stat.max": 4,
+                  "stat.min": 0,
+                  "stat.p50": 0,
+                  "stat.p90": 0,
+                  "stat.p95": 1,
+                  "stat.p99": 3,
+                  "stat.p9990": 4,
+                  "stat.p9999": 4,
+                  "stat.sum": 23,
+                  "stat.avg": 0.14465408805031446
+                },
+                "success": {
+                  "counter": 15145
+                },
+                "pending": {
+                  "gauge": 0.0
+                },
+                "requests": {
+                  "counter": 15145
+                }
+              }
+            },
+            "request_latency_ms": {
+              "stat.count": 159,
+              "stat.max": 4,
               "stat.min": 0,
               "stat.p50": 0,
               "stat.p90": 0,
               "stat.p95": 1,
               "stat.p99": 3,
-              "stat.p9990": 49,
-              "stat.p9999": 49,
-              "stat.sum": 66,
-              "stat.avg": 0.3905325443786982
-            }
-          },
-          "connection_received_bytes": {
-            "stat.count": 82,
-            "stat.max": 139,
-            "stat.min": 23,
-            "stat.p50": 46,
-            "stat.p90": 92,
-            "stat.p95": 115,
-            "stat.p99": 139,
-            "stat.p9990": 139,
-            "stat.p9999": 139,
-            "stat.sum": 3841,
-            "stat.avg": 46.84146341463415
-          },
-          "connection_duration": {
-            "stat.count": 82,
-            "stat.max": 2158,
-            "stat.min": 20,
-            "stat.p50": 46,
-            "stat.p90": 1421,
-            "stat.p95": 1585,
-            "stat.p99": 1877,
-            "stat.p9990": 2158,
-            "stat.p9999": 2158,
-            "stat.sum": 23936,
-            "stat.avg": 291.9024390243902
-          },
-          "failure_accrual": {
-            "removals": {
-              "counter": 0
+              "stat.p9990": 4,
+              "stat.p9999": 4,
+              "stat.sum": 23,
+              "stat.avg": 0.14465408805031446
             },
-            "probes": {
-              "counter": 0
-            },
-            "removed_for_ms": {
-              "counter": 0
-            },
-            "revivals": {
-              "counter": 0
-            }
-          },
-          "connects": {
-            "counter": 7853
-          },
-          "pool_num_waited": {
-            "counter": 0
-          },
-          "success": {
-            "counter": 14856
-          },
-          "service": {
-            "svc": {
-              "request_latency_ms": {
-                "stat.count": 169,
-                "stat.max": 1,
-                "stat.min": 0,
-                "stat.p50": 0,
-                "stat.p90": 0,
-                "stat.p95": 0,
-                "stat.p99": 1,
-                "stat.p9990": 1,
-                "stat.p9999": 1,
-                "stat.sum": 6,
-                "stat.avg": 0.03550295857988166
-              },
-              "success": {
-                "counter": 14856
-              },
-              "pending": {
-                "gauge": 0.0
-              },
-              "requests": {
-                "counter": 14856
-              }
-            }
-          },
-          "request_latency_ms": {
-            "stat.count": 169,
-            "stat.max": 1,
-            "stat.min": 0,
-            "stat.p50": 0,
-            "stat.p90": 0,
-            "stat.p95": 0,
-            "stat.p99": 1,
-            "stat.p9990": 1,
-            "stat.p9999": 1,
-            "stat.sum": 6,
-            "stat.avg": 0.03550295857988166
-          },
-          "pool_waiters": {
-            "gauge": 0.0
-          },
-          "retries": {
-            "requeues_per_request": {
-              "stat.count": 169,
-              "stat.max": 0,
-              "stat.min": 0,
-              "stat.p50": 0,
-              "stat.p90": 0,
-              "stat.p95": 0,
-              "stat.p99": 0,
-              "stat.p9990": 0,
-              "stat.p9999": 0,
-              "stat.sum": 0,
-              "stat.avg": 0.0
-            },
-            "request_limit": {
-              "counter": 0
-            },
-            "budget_exhausted": {
-              "counter": 0
-            },
-            "cannot_retry": {
-              "counter": 0
-            },
-            "not_open": {
-              "counter": 0
-            },
-            "budget": {
-              "gauge": 264.0
-            },
-            "requeues": {
-              "counter": 0
-            }
-          },
-          "received_bytes": {
-            "counter": 341688
-          },
-          "connection_sent_bytes": {
-            "stat.count": 82,
-            "stat.max": 180,
-            "stat.min": 30,
-            "stat.p50": 60,
-            "stat.p90": 121,
-            "stat.p95": 150,
-            "stat.p99": 180,
-            "stat.p9990": 180,
-            "stat.p9999": 180,
-            "stat.sum": 5010,
-            "stat.avg": 61.09756097560975
-          },
-          "connection_requests": {
-            "stat.count": 82,
-            "stat.max": 6,
-            "stat.min": 1,
-            "stat.p50": 2,
-            "stat.p90": 4,
-            "stat.p95": 5,
-            "stat.p99": 6,
-            "stat.p9990": 6,
-            "stat.p9999": 6,
-            "stat.sum": 167,
-            "stat.avg": 2.0365853658536586
-          },
-          "pool_num_too_many_waiters": {
-            "counter": 0
-          },
-          "socket_unwritable_ms": {
-            "counter": 0
-          },
-          "closes": {
-            "counter": 7852
-          },
-          "pool_cached": {
-            "gauge": 1.0
-          },
-          "pool_size": {
-            "gauge": 0.0
-          },
-          "available": {
-            "gauge": 1.0
-          },
-          "request_payload_bytes": {
-            "stat.count": 169,
-            "stat.max": 30,
-            "stat.min": 30,
-            "stat.p50": 30,
-            "stat.p90": 30,
-            "stat.p95": 30,
-            "stat.p99": 30,
-            "stat.p9990": 30,
-            "stat.p9999": 30,
-            "stat.sum": 5070,
-            "stat.avg": 30.0
-          },
-          "socket_writable_ms": {
-            "counter": 0
-          },
-          "cancelled_connects": {
-            "counter": 0
-          },
-          "response_payload_bytes": {
-            "stat.count": 169,
-            "stat.max": 23,
-            "stat.min": 23,
-            "stat.p50": 23,
-            "stat.p90": 23,
-            "stat.p95": 23,
-            "stat.p99": 23,
-            "stat.p9990": 23,
-            "stat.p9999": 23,
-            "stat.sum": 3887,
-            "stat.avg": 23.0
-          },
-          "dtab": {
-            "size": {
-              "stat.count": 0
-            }
-          },
-          "requests": {
-            "counter": 14856
-          },
-          "loadbalancer": {
-            "size": {
-              "gauge": 1.0
-            },
-            "rebuilds": {
-              "counter": 7869
-            },
-            "closed": {
+            "pool_waiters": {
               "gauge": 0.0
             },
-            "load": {
-              "gauge": 0.0
-            },
-            "meanweight": {
-              "gauge": 1.0
-            },
-            "adds": {
-              "counter": 7853
-            },
-            "p2c": {
-              "gauge": 26.0
-            },
-            "updates": {
-              "counter": 7869
-            },
-            "available": {
-              "gauge": 1.0
-            },
-            "max_effort_exhausted": {
-              "counter": 0
-            },
-            "busy": {
-              "gauge": 0.0
-            },
-            "removes": {
-              "counter": 7852
-            }
-          },
-          "pending": {
-            "gauge": 0.0
-          },
-          "dispatcher": {
-            "serial": {
-              "queue_size": {
-                "gauge": 0.0
-              }
-            }
-          },
-          "connections": {
-            "gauge": 1.0
-          }
-        },
-        "$/inet/127.1/9070": {
-          "connect_latency_ms": {
-            "stat.count": 85,
-            "stat.max": 3,
-            "stat.min": 0,
-            "stat.p50": 0,
-            "stat.p90": 0,
-            "stat.p95": 0,
-            "stat.p99": 1,
-            "stat.p9990": 3,
-            "stat.p9999": 3,
-            "stat.sum": 4,
-            "stat.avg": 0.047058823529411764
-          },
-          "failed_connect_latency_ms": {
-            "stat.count": 0
-          },
-          "sent_bytes": {
-            "counter": 448860
-          },
-          "service_creation": {
-            "service_acquisition_latency_ms": {
-              "stat.count": 183,
-              "stat.max": 3,
-              "stat.min": 0,
-              "stat.p50": 0,
-              "stat.p90": 0,
-              "stat.p95": 0,
-              "stat.p99": 1,
-              "stat.p9990": 3,
-              "stat.p9999": 3,
-              "stat.sum": 8,
-              "stat.avg": 0.04371584699453552
-            }
-          },
-          "connection_received_bytes": {
-            "stat.count": 85,
-            "stat.max": 161,
-            "stat.min": 23,
-            "stat.p50": 46,
-            "stat.p90": 92,
-            "stat.p95": 115,
-            "stat.p99": 139,
-            "stat.p9990": 161,
-            "stat.p9999": 161,
-            "stat.sum": 4209,
-            "stat.avg": 49.51764705882353
-          },
-          "connection_duration": {
-            "stat.count": 85,
-            "stat.max": 2313,
-            "stat.min": 17,
-            "stat.p50": 49,
-            "stat.p90": 1585,
-            "stat.p95": 1859,
-            "stat.p99": 2013,
-            "stat.p9990": 2313,
-            "stat.p9999": 2313,
-            "stat.sum": 35877,
-            "stat.avg": 422.08235294117645
-          },
-          "failure_accrual": {
-            "removals": {
-              "counter": 0
-            },
-            "probes": {
-              "counter": 0
-            },
-            "removed_for_ms": {
-              "counter": 0
-            },
-            "revivals": {
-              "counter": 0
-            }
-          },
-          "connects": {
-            "counter": 7832
-          },
-          "pool_num_waited": {
-            "counter": 0
-          },
-          "success": {
-            "counter": 14962
-          },
-          "service": {
-            "svc": {
-              "request_latency_ms": {
-                "stat.count": 183,
-                "stat.max": 53,
-                "stat.min": 0,
-                "stat.p50": 0,
-                "stat.p90": 0,
-                "stat.p95": 0,
-                "stat.p99": 1,
-                "stat.p9990": 53,
-                "stat.p9999": 53,
-                "stat.sum": 60,
-                "stat.avg": 0.32786885245901637
-              },
-              "success": {
-                "counter": 14962
-              },
-              "pending": {
-                "gauge": 0.0
-              },
-              "requests": {
-                "counter": 14962
-              }
-            }
-          },
-          "request_latency_ms": {
-            "stat.count": 183,
-            "stat.max": 53,
-            "stat.min": 0,
-            "stat.p50": 0,
-            "stat.p90": 0,
-            "stat.p95": 0,
-            "stat.p99": 1,
-            "stat.p9990": 53,
-            "stat.p9999": 53,
-            "stat.sum": 60,
-            "stat.avg": 0.32786885245901637
-          },
-          "pool_waiters": {
-            "gauge": 0.0
-          },
-          "retries": {
-            "requeues_per_request": {
-              "stat.count": 183,
-              "stat.max": 0,
-              "stat.min": 0,
-              "stat.p50": 0,
-              "stat.p90": 0,
-              "stat.p95": 0,
-              "stat.p99": 0,
-              "stat.p9990": 0,
-              "stat.p9999": 0,
-              "stat.sum": 0,
-              "stat.avg": 0.0
-            },
-            "request_limit": {
-              "counter": 0
-            },
-            "budget_exhausted": {
-              "counter": 0
-            },
-            "cannot_retry": {
-              "counter": 0
-            },
-            "not_open": {
-              "counter": 0
-            },
-            "budget": {
-              "gauge": 264.0
-            },
-            "requeues": {
-              "counter": 0
-            }
-          },
-          "received_bytes": {
-            "counter": 344126
-          },
-          "connection_sent_bytes": {
-            "stat.count": 85,
-            "stat.max": 211,
-            "stat.min": 30,
-            "stat.p50": 60,
-            "stat.p90": 121,
-            "stat.p95": 150,
-            "stat.p99": 180,
-            "stat.p9990": 211,
-            "stat.p9999": 211,
-            "stat.sum": 5490,
-            "stat.avg": 64.58823529411765
-          },
-          "connection_requests": {
-            "stat.count": 85,
-            "stat.max": 7,
-            "stat.min": 1,
-            "stat.p50": 2,
-            "stat.p90": 4,
-            "stat.p95": 5,
-            "stat.p99": 6,
-            "stat.p9990": 7,
-            "stat.p9999": 7,
-            "stat.sum": 183,
-            "stat.avg": 2.152941176470588
-          },
-          "pool_num_too_many_waiters": {
-            "counter": 0
-          },
-          "socket_unwritable_ms": {
-            "counter": 0
-          },
-          "closes": {
-            "counter": 7831
-          },
-          "pool_cached": {
-            "gauge": 1.0
-          },
-          "pool_size": {
-            "gauge": 0.0
-          },
-          "available": {
-            "gauge": 1.0
-          },
-          "request_payload_bytes": {
-            "stat.count": 183,
-            "stat.max": 30,
-            "stat.min": 30,
-            "stat.p50": 30,
-            "stat.p90": 30,
-            "stat.p95": 30,
-            "stat.p99": 30,
-            "stat.p9990": 30,
-            "stat.p9999": 30,
-            "stat.sum": 5490,
-            "stat.avg": 30.0
-          },
-          "socket_writable_ms": {
-            "counter": 0
-          },
-          "cancelled_connects": {
-            "counter": 0
-          },
-          "response_payload_bytes": {
-            "stat.count": 183,
-            "stat.max": 23,
-            "stat.min": 23,
-            "stat.p50": 23,
-            "stat.p90": 23,
-            "stat.p95": 23,
-            "stat.p99": 23,
-            "stat.p9990": 23,
-            "stat.p9999": 23,
-            "stat.sum": 4209,
-            "stat.avg": 23.0
-          },
-          "dtab": {
-            "size": {
-              "stat.count": 0
-            }
-          },
-          "requests": {
-            "counter": 14962
-          },
-          "loadbalancer": {
-            "size": {
-              "gauge": 1.0
-            },
-            "rebuilds": {
-              "counter": 7855
-            },
-            "closed": {
-              "gauge": 0.0
-            },
-            "load": {
-              "gauge": 0.0
-            },
-            "meanweight": {
-              "gauge": 1.0
-            },
-            "adds": {
-              "counter": 7832
-            },
-            "p2c": {
-              "gauge": 25.0
-            },
-            "updates": {
-              "counter": 7855
-            },
-            "available": {
-              "gauge": 1.0
-            },
-            "max_effort_exhausted": {
-              "counter": 0
-            },
-            "busy": {
-              "gauge": 0.0
-            },
-            "removes": {
-              "counter": 7831
-            }
-          },
-          "pending": {
-            "gauge": 0.0
-          },
-          "dispatcher": {
-            "serial": {
-              "queue_size": {
-                "gauge": 0.0
-              }
-            }
-          },
-          "connections": {
-            "gauge": 1.0
-          }
-        },
-        "$/inet/127.1/9080": {
-          "connect_latency_ms": {
-            "stat.count": 94,
-            "stat.max": 1,
-            "stat.min": 0,
-            "stat.p50": 0,
-            "stat.p90": 0,
-            "stat.p95": 0,
-            "stat.p99": 1,
-            "stat.p9990": 1,
-            "stat.p9999": 1,
-            "stat.sum": 3,
-            "stat.avg": 0.031914893617021274
-          },
-          "failed_connect_latency_ms": {
-            "stat.count": 0
-          },
-          "sent_bytes": {
-            "counter": 449130
-          },
-          "service_creation": {
-            "service_acquisition_latency_ms": {
-              "stat.count": 179,
-              "stat.max": 2,
-              "stat.min": 0,
-              "stat.p50": 0,
-              "stat.p90": 0,
-              "stat.p95": 0,
-              "stat.p99": 1,
-              "stat.p9990": 2,
-              "stat.p9999": 2,
-              "stat.sum": 11,
-              "stat.avg": 0.061452513966480445
-            }
-          },
-          "connection_received_bytes": {
-            "stat.count": 93,
-            "stat.max": 161,
-            "stat.min": 23,
-            "stat.p50": 23,
-            "stat.p90": 92,
-            "stat.p95": 92,
-            "stat.p99": 139,
-            "stat.p9990": 161,
-            "stat.p9999": 161,
-            "stat.sum": 4094,
-            "stat.avg": 44.02150537634409
-          },
-          "connection_duration": {
-            "stat.count": 93,
-            "stat.max": 2290,
-            "stat.min": 20,
-            "stat.p50": 43,
-            "stat.p90": 1379,
-            "stat.p95": 1478,
-            "stat.p99": 1859,
-            "stat.p9990": 2290,
-            "stat.p9999": 2290,
-            "stat.sum": 28546,
-            "stat.avg": 306.9462365591398
-          },
-          "failure_accrual": {
-            "removals": {
-              "counter": 0
-            },
-            "probes": {
-              "counter": 0
-            },
-            "removed_for_ms": {
-              "counter": 0
-            },
-            "revivals": {
-              "counter": 0
-            }
-          },
-          "connects": {
-            "counter": 7816
-          },
-          "pool_num_waited": {
-            "counter": 0
-          },
-          "success": {
-            "counter": 14971
-          },
-          "service": {
-            "svc": {
-              "request_latency_ms": {
-                "stat.count": 179,
-                "stat.max": 301,
-                "stat.min": 0,
-                "stat.p50": 0,
-                "stat.p90": 0,
-                "stat.p95": 0,
-                "stat.p99": 1,
-                "stat.p9990": 301,
-                "stat.p9999": 301,
-                "stat.sum": 309,
-                "stat.avg": 1.7262569832402235
-              },
-              "success": {
-                "counter": 14971
-              },
-              "pending": {
-                "gauge": 0.0
-              },
-              "requests": {
-                "counter": 14971
-              }
-            }
-          },
-          "request_latency_ms": {
-            "stat.count": 179,
-            "stat.max": 301,
-            "stat.min": 0,
-            "stat.p50": 0,
-            "stat.p90": 0,
-            "stat.p95": 0,
-            "stat.p99": 1,
-            "stat.p9990": 301,
-            "stat.p9999": 301,
-            "stat.sum": 308,
-            "stat.avg": 1.7206703910614525
-          },
-          "pool_waiters": {
-            "gauge": 0.0
-          },
-          "retries": {
-            "requeues_per_request": {
-              "stat.count": 179,
-              "stat.max": 0,
-              "stat.min": 0,
-              "stat.p50": 0,
-              "stat.p90": 0,
-              "stat.p95": 0,
-              "stat.p99": 0,
-              "stat.p9990": 0,
-              "stat.p9999": 0,
-              "stat.sum": 0,
-              "stat.avg": 0.0
-            },
-            "request_limit": {
-              "counter": 0
-            },
-            "budget_exhausted": {
-              "counter": 0
-            },
-            "cannot_retry": {
-              "counter": 0
-            },
-            "not_open": {
-              "counter": 0
-            },
-            "budget": {},
-            "requeues": {
-              "counter": 0
-            }
-          },
-          "received_bytes": {
-            "counter": 344333
-          },
-          "connection_sent_bytes": {
-            "stat.count": 93,
-            "stat.max": 211,
-            "stat.min": 30,
-            "stat.p50": 30,
-            "stat.p90": 121,
-            "stat.p95": 121,
-            "stat.p99": 180,
-            "stat.p9990": 211,
-            "stat.p9999": 211,
-            "stat.sum": 5340,
-            "stat.avg": 57.41935483870968
-          },
-          "connection_requests": {
-            "stat.count": 93,
-            "stat.max": 7,
-            "stat.min": 1,
-            "stat.p50": 1,
-            "stat.p90": 4,
-            "stat.p95": 4,
-            "stat.p99": 6,
-            "stat.p9990": 7,
-            "stat.p9999": 7,
-            "stat.sum": 178,
-            "stat.avg": 1.913978494623656
-          },
-          "pool_num_too_many_waiters": {
-            "counter": 0
-          },
-          "socket_unwritable_ms": {
-            "counter": 0
-          },
-          "closes": {
-            "counter": 7816
-          },
-          "pool_cached": {
-            "gauge": 0.0
-          },
-          "pool_size": {
-            "gauge": 0.0
-          },
-          "available": {
-            "gauge": 0.0
-          },
-          "request_payload_bytes": {
-            "stat.count": 179,
-            "stat.max": 30,
-            "stat.min": 30,
-            "stat.p50": 30,
-            "stat.p90": 30,
-            "stat.p95": 30,
-            "stat.p99": 30,
-            "stat.p9990": 30,
-            "stat.p9999": 30,
-            "stat.sum": 5370,
-            "stat.avg": 30.0
-          },
-          "socket_writable_ms": {
-            "counter": 0
-          },
-          "cancelled_connects": {
-            "counter": 0
-          },
-          "response_payload_bytes": {
-            "stat.count": 179,
-            "stat.max": 23,
-            "stat.min": 23,
-            "stat.p50": 23,
-            "stat.p90": 23,
-            "stat.p95": 23,
-            "stat.p99": 23,
-            "stat.p9990": 23,
-            "stat.p9999": 23,
-            "stat.sum": 4117,
-            "stat.avg": 23.0
-          },
-          "dtab": {
-            "size": {
-              "stat.count": 0
-            }
-          },
-          "requests": {
-            "counter": 14971
-          },
-          "loadbalancer": {
-            "size": {},
-            "rebuilds": {
-              "counter": 7840
-            },
-            "closed": {},
-            "load": {},
-            "meanweight": {},
-            "adds": {
-              "counter": 7816
-            },
-            "p2c": {
-              "gauge": 26.0
-            },
-            "updates": {
-              "counter": 7840
-            },
-            "available": {},
-            "max_effort_exhausted": {
-              "counter": 0
-            },
-            "busy": {},
-            "removes": {
-              "counter": 7816
-            }
-          },
-          "pending": {
-            "gauge": 0.0
-          },
-          "dispatcher": {
-            "serial": {
-              "queue_size": {
-                "gauge": 0.0
-              }
-            }
-          },
-          "connections": {
-            "gauge": 0.0
-          }
-        },
-        "$/inet/127.1/9085": {
-          "connect_latency_ms": {
-            "stat.count": 90,
-            "stat.max": 46,
-            "stat.min": 0,
-            "stat.p50": 0,
-            "stat.p90": 0,
-            "stat.p95": 1,
-            "stat.p99": 1,
-            "stat.p9990": 46,
-            "stat.p9999": 46,
-            "stat.sum": 50,
-            "stat.avg": 0.5555555555555556
-          },
-          "failed_connect_latency_ms": {
-            "stat.count": 0
-          },
-          "sent_bytes": {
-            "counter": 445650
-          },
-          "service_creation": {
-            "service_acquisition_latency_ms": {
-              "stat.count": 155,
-              "stat.max": 47,
-              "stat.min": 0,
-              "stat.p50": 0,
-              "stat.p90": 0,
-              "stat.p95": 0,
-              "stat.p99": 1,
-              "stat.p9990": 47,
-              "stat.p9999": 47,
-              "stat.sum": 56,
-              "stat.avg": 0.36129032258064514
-            }
-          },
-          "connection_received_bytes": {
-            "stat.count": 89,
-            "stat.max": 161,
-            "stat.min": 23,
-            "stat.p50": 23,
-            "stat.p90": 69,
-            "stat.p95": 92,
-            "stat.p99": 139,
-            "stat.p9990": 161,
-            "stat.p9999": 161,
-            "stat.sum": 3519,
-            "stat.avg": 39.53932584269663
-          },
-          "connection_duration": {
-            "stat.count": 89,
-            "stat.max": 2313,
-            "stat.min": 18,
-            "stat.p50": 37,
-            "stat.p90": 1352,
-            "stat.p95": 1493,
-            "stat.p99": 2013,
-            "stat.p9990": 2313,
-            "stat.p9999": 2313,
-            "stat.sum": 20765,
-            "stat.avg": 233.31460674157304
-          },
-          "failure_accrual": {
-            "removals": {
-              "counter": 0
-            },
-            "probes": {
-              "counter": 0
-            },
-            "removed_for_ms": {
-              "counter": 0
-            },
-            "revivals": {
-              "counter": 0
-            }
-          },
-          "connects": {
-            "counter": 7832
-          },
-          "pool_num_waited": {
-            "counter": 0
-          },
-          "success": {
-            "counter": 14855
-          },
-          "service": {
-            "svc": {
-              "request_latency_ms": {
-                "stat.count": 155,
-                "stat.max": 1,
-                "stat.min": 0,
-                "stat.p50": 0,
-                "stat.p90": 0,
-                "stat.p95": 0,
-                "stat.p99": 1,
-                "stat.p9990": 1,
-                "stat.p9999": 1,
-                "stat.sum": 4,
-                "stat.avg": 0.025806451612903226
-              },
-              "success": {
-                "counter": 14855
-              },
-              "pending": {
-                "gauge": 0.0
-              },
-              "requests": {
-                "counter": 14855
-              }
-            }
-          },
-          "request_latency_ms": {
-            "stat.count": 155,
-            "stat.max": 1,
-            "stat.min": 0,
-            "stat.p50": 0,
-            "stat.p90": 0,
-            "stat.p95": 0,
-            "stat.p99": 1,
-            "stat.p9990": 1,
-            "stat.p9999": 1,
-            "stat.sum": 4,
-            "stat.avg": 0.025806451612903226
-          },
-          "pool_waiters": {
-            "gauge": 0.0
-          },
-          "retries": {
-            "requeues_per_request": {
-              "stat.count": 155,
-              "stat.max": 0,
-              "stat.min": 0,
-              "stat.p50": 0,
-              "stat.p90": 0,
-              "stat.p95": 0,
-              "stat.p99": 0,
-              "stat.p9990": 0,
-              "stat.p9999": 0,
-              "stat.sum": 0,
-              "stat.avg": 0.0
-            },
-            "request_limit": {
-              "counter": 0
-            },
-            "budget_exhausted": {
-              "counter": 0
-            },
-            "cannot_retry": {
-              "counter": 0
-            },
-            "not_open": {
-              "counter": 0
-            },
-            "budget": {
-              "gauge": 264.0
-            },
-            "requeues": {
-              "counter": 0
-            }
-          },
-          "received_bytes": {
-            "counter": 341665
-          },
-          "connection_sent_bytes": {
-            "stat.count": 89,
-            "stat.max": 211,
-            "stat.min": 30,
-            "stat.p50": 30,
-            "stat.p90": 90,
-            "stat.p95": 121,
-            "stat.p99": 180,
-            "stat.p9990": 211,
-            "stat.p9999": 211,
-            "stat.sum": 4590,
-            "stat.avg": 51.57303370786517
-          },
-          "connection_requests": {
-            "stat.count": 89,
-            "stat.max": 7,
-            "stat.min": 1,
-            "stat.p50": 1,
-            "stat.p90": 3,
-            "stat.p95": 4,
-            "stat.p99": 6,
-            "stat.p9990": 7,
-            "stat.p9999": 7,
-            "stat.sum": 153,
-            "stat.avg": 1.7191011235955056
-          },
-          "pool_num_too_many_waiters": {
-            "counter": 0
-          },
-          "socket_unwritable_ms": {
-            "counter": 0
-          },
-          "closes": {
-            "counter": 7831
-          },
-          "pool_cached": {
-            "gauge": 1.0
-          },
-          "pool_size": {
-            "gauge": 0.0
-          },
-          "available": {
-            "gauge": 1.0
-          },
-          "request_payload_bytes": {
-            "stat.count": 155,
-            "stat.max": 30,
-            "stat.min": 30,
-            "stat.p50": 30,
-            "stat.p90": 30,
-            "stat.p95": 30,
-            "stat.p99": 30,
-            "stat.p9990": 30,
-            "stat.p9999": 30,
-            "stat.sum": 4650,
-            "stat.avg": 30.0
-          },
-          "socket_writable_ms": {
-            "counter": 0
-          },
-          "cancelled_connects": {
-            "counter": 0
-          },
-          "response_payload_bytes": {
-            "stat.count": 155,
-            "stat.max": 23,
-            "stat.min": 23,
-            "stat.p50": 23,
-            "stat.p90": 23,
-            "stat.p95": 23,
-            "stat.p99": 23,
-            "stat.p9990": 23,
-            "stat.p9999": 23,
-            "stat.sum": 3565,
-            "stat.avg": 23.0
-          },
-          "dtab": {
-            "size": {
-              "stat.count": 0
-            }
-          },
-          "requests": {
-            "counter": 14855
-          },
-          "loadbalancer": {
-            "size": {
-              "gauge": 1.0
-            },
-            "rebuilds": {
-              "counter": 7848
-            },
-            "closed": {
-              "gauge": 0.0
-            },
-            "load": {
-              "gauge": 0.0
-            },
-            "meanweight": {
-              "gauge": 1.0
-            },
-            "adds": {
-              "counter": 7832
-            },
-            "p2c": {
-              "gauge": 21.0
-            },
-            "updates": {
-              "counter": 7848
-            },
-            "available": {
-              "gauge": 1.0
-            },
-            "max_effort_exhausted": {
-              "counter": 0
-            },
-            "busy": {
-              "gauge": 0.0
-            },
-            "removes": {
-              "counter": 7831
-            }
-          },
-          "pending": {
-            "gauge": 0.0
-          },
-          "dispatcher": {
-            "serial": {
-              "queue_size": {
-                "gauge": 0.0
-              }
-            }
-          },
-          "connections": {
-            "gauge": 1.0
-          }
-        },
-        "$/inet/127.1/9089": {
-          "connect_latency_ms": {
-            "stat.count": 82,
-            "stat.max": 48,
-            "stat.min": 0,
-            "stat.p50": 0,
-            "stat.p90": 0,
-            "stat.p95": 1,
-            "stat.p99": 1,
-            "stat.p9990": 48,
-            "stat.p9999": 48,
-            "stat.sum": 52,
-            "stat.avg": 0.6341463414634146
-          },
-          "failed_connect_latency_ms": {
-            "stat.count": 0
-          },
-          "sent_bytes": {
-            "counter": 447300
-          },
-          "service_creation": {
-            "service_acquisition_latency_ms": {
-              "stat.count": 176,
-              "stat.max": 48,
-              "stat.min": 0,
-              "stat.p50": 0,
-              "stat.p90": 0,
-              "stat.p95": 1,
-              "stat.p99": 2,
-              "stat.p9990": 48,
-              "stat.p9999": 48,
-              "stat.sum": 63,
-              "stat.avg": 0.35795454545454547
-            }
-          },
-          "connection_received_bytes": {
-            "stat.count": 82,
-            "stat.max": 185,
-            "stat.min": 23,
-            "stat.p50": 46,
-            "stat.p90": 92,
-            "stat.p95": 115,
-            "stat.p99": 185,
-            "stat.p9990": 185,
-            "stat.p9999": 185,
-            "stat.sum": 4048,
-            "stat.avg": 49.36585365853659
-          },
-          "connection_duration": {
-            "stat.count": 82,
-            "stat.max": 2073,
-            "stat.min": 20,
-            "stat.p50": 46,
-            "stat.p90": 1569,
-            "stat.p95": 1633,
-            "stat.p99": 1877,
-            "stat.p9990": 2073,
-            "stat.p9999": 2073,
-            "stat.sum": 32237,
-            "stat.avg": 393.1341463414634
-          },
-          "failure_accrual": {
-            "removals": {
-              "counter": 0
-            },
-            "probes": {
-              "counter": 0
-            },
-            "removed_for_ms": {
-              "counter": 0
-            },
-            "revivals": {
-              "counter": 0
-            }
-          },
-          "connects": {
-            "counter": 7798
-          },
-          "pool_num_waited": {
-            "counter": 0
-          },
-          "success": {
-            "counter": 14910
-          },
-          "service": {
-            "svc": {
-              "request_latency_ms": {
-                "stat.count": 176,
-                "stat.max": 4,
-                "stat.min": 0,
-                "stat.p50": 0,
-                "stat.p90": 0,
-                "stat.p95": 0,
-                "stat.p99": 1,
-                "stat.p9990": 4,
-                "stat.p9999": 4,
-                "stat.sum": 11,
-                "stat.avg": 0.0625
-              },
-              "success": {
-                "counter": 14910
-              },
-              "pending": {
-                "gauge": 0.0
-              },
-              "requests": {
-                "counter": 14910
-              }
-            }
-          },
-          "request_latency_ms": {
-            "stat.count": 176,
-            "stat.max": 4,
-            "stat.min": 0,
-            "stat.p50": 0,
-            "stat.p90": 0,
-            "stat.p95": 0,
-            "stat.p99": 1,
-            "stat.p9990": 4,
-            "stat.p9999": 4,
-            "stat.sum": 11,
-            "stat.avg": 0.0625
-          },
-          "pool_waiters": {
-            "gauge": 0.0
-          },
-          "retries": {
-            "requeues_per_request": {
-              "stat.count": 176,
-              "stat.max": 0,
-              "stat.min": 0,
-              "stat.p50": 0,
-              "stat.p90": 0,
-              "stat.p95": 0,
-              "stat.p99": 0,
-              "stat.p9990": 0,
-              "stat.p9999": 0,
-              "stat.sum": 0,
-              "stat.avg": 0.0
-            },
-            "request_limit": {
-              "counter": 0
-            },
-            "budget_exhausted": {
-              "counter": 0
-            },
-            "cannot_retry": {
-              "counter": 0
-            },
-            "not_open": {
-              "counter": 0
-            },
-            "budget": {
-              "gauge": 264.0
-            },
-            "requeues": {
-              "counter": 0
-            }
-          },
-          "received_bytes": {
-            "counter": 342930
-          },
-          "connection_sent_bytes": {
-            "stat.count": 82,
-            "stat.max": 240,
-            "stat.min": 30,
-            "stat.p50": 60,
-            "stat.p90": 121,
-            "stat.p95": 150,
-            "stat.p99": 240,
-            "stat.p9990": 240,
-            "stat.p9999": 240,
-            "stat.sum": 5280,
-            "stat.avg": 64.39024390243902
-          },
-          "connection_requests": {
-            "stat.count": 82,
-            "stat.max": 8,
-            "stat.min": 1,
-            "stat.p50": 2,
-            "stat.p90": 4,
-            "stat.p95": 5,
-            "stat.p99": 8,
-            "stat.p9990": 8,
-            "stat.p9999": 8,
-            "stat.sum": 176,
-            "stat.avg": 2.1463414634146343
-          },
-          "pool_num_too_many_waiters": {
-            "counter": 0
-          },
-          "socket_unwritable_ms": {
-            "counter": 0
-          },
-          "closes": {
-            "counter": 7797
-          },
-          "pool_cached": {
-            "gauge": 1.0
-          },
-          "pool_size": {
-            "gauge": 0.0
-          },
-          "available": {
-            "gauge": 1.0
-          },
-          "request_payload_bytes": {
-            "stat.count": 176,
-            "stat.max": 30,
-            "stat.min": 30,
-            "stat.p50": 30,
-            "stat.p90": 30,
-            "stat.p95": 30,
-            "stat.p99": 30,
-            "stat.p9990": 30,
-            "stat.p9999": 30,
-            "stat.sum": 5280,
-            "stat.avg": 30.0
-          },
-          "socket_writable_ms": {
-            "counter": 0
-          },
-          "cancelled_connects": {
-            "counter": 0
-          },
-          "response_payload_bytes": {
-            "stat.count": 176,
-            "stat.max": 23,
-            "stat.min": 23,
-            "stat.p50": 23,
-            "stat.p90": 23,
-            "stat.p95": 23,
-            "stat.p99": 23,
-            "stat.p9990": 23,
-            "stat.p9999": 23,
-            "stat.sum": 4048,
-            "stat.avg": 23.0
-          },
-          "dtab": {
-            "size": {
-              "stat.count": 0
-            }
-          },
-          "requests": {
-            "counter": 14910
-          },
-          "loadbalancer": {
-            "size": {
-              "gauge": 1.0
-            },
-            "rebuilds": {
-              "counter": 7809
-            },
-            "closed": {
-              "gauge": 0.0
-            },
-            "load": {
-              "gauge": 0.0
-            },
-            "meanweight": {
-              "gauge": 1.0
-            },
-            "adds": {
-              "counter": 7798
-            },
-            "p2c": {
-              "gauge": 22.0
-            },
-            "updates": {
-              "counter": 7809
-            },
-            "available": {
-              "gauge": 1.0
-            },
-            "max_effort_exhausted": {
-              "counter": 0
-            },
-            "busy": {
-              "gauge": 0.0
-            },
-            "removes": {
-              "counter": 7797
-            }
-          },
-          "pending": {
-            "gauge": 0.0
-          },
-          "dispatcher": {
-            "serial": {
-              "queue_size": {
-                "gauge": 0.0
-              }
-            }
-          },
-          "connections": {
-            "gauge": 1.0
-          }
-        }
-      }
-    },
-    "bindcache": {
-      "path": {
-        "evicts": {
-          "counter": 0
-        },
-        "misses": {
-          "counter": 1
-        },
-        "oneshots": {
-          "counter": 0
-        }
-      },
-      "bound": {
-        "evicts": {
-          "counter": 0
-        },
-        "misses": {
-          "counter": 21
-        },
-        "oneshots": {
-          "counter": 0
-        }
-      },
-      "tree": {
-        "evicts": {
-          "counter": 0
-        },
-        "misses": {
-          "counter": 1
-        },
-        "oneshots": {
-          "counter": 0
-        }
-      },
-      "client": {
-        "evicts": {
-          "counter": 165251
-        },
-        "misses": {
-          "counter": 165261
-        },
-        "oneshots": {
-          "counter": 0
-        }
-      },
-      "srv": {
-        "0.0.0.0/4114": {
-          "sent_bytes": {
-            "counter": 7255005
-          },
-          "connection_received_bytes": {
-            "stat.count": 34,
-            "stat.max": 3026,
-            "stat.min": 3026,
-            "stat.p50": 3026,
-            "stat.p90": 3026,
-            "stat.p95": 3026,
-            "stat.p99": 3026,
-            "stat.p9990": 3026,
-            "stat.p9999": 3026,
-            "stat.sum": 103020,
-            "stat.avg": 3030.0
-          },
-          "connection_duration": {
-            "stat.count": 34,
-            "stat.max": 701,
-            "stat.min": 178,
-            "stat.p50": 228,
-            "stat.p90": 414,
-            "stat.p95": 435,
-            "stat.p99": 701,
-            "stat.p9990": 701,
-            "stat.p9999": 701,
-            "stat.sum": 9579,
-            "stat.avg": 281.7352941176471
-          },
-          "connects": {
-            "counter": 3124
-          },
-          "success": {
-            "counter": 315435
-          },
-          "request_latency_ms": {
-            "stat.count": 3434,
-            "stat.max": 316,
-            "stat.min": 0,
-            "stat.p50": 2,
-            "stat.p90": 3,
-            "stat.p95": 4,
-            "stat.p99": 9,
-            "stat.p9990": 55,
-            "stat.p9999": 316,
-            "stat.sum": 6237,
-            "stat.avg": 1.8162492719860222
-          },
-          "received_bytes": {
-            "counter": 9463080
-          },
-          "read_timeout": {
-            "counter": 0
-          },
-          "write_timeout": {
-            "counter": 0
-          },
-          "connection_sent_bytes": {
-            "stat.count": 34,
-            "stat.max": 2313,
-            "stat.min": 2313,
-            "stat.p50": 2313,
-            "stat.p90": 2313,
-            "stat.p95": 2313,
-            "stat.p99": 2313,
-            "stat.p9990": 2313,
-            "stat.p9999": 2313,
-            "stat.sum": 78982,
-            "stat.avg": 2323.0
-          },
-          "connection_requests": {
-            "stat.count": 34,
-            "stat.max": 101,
-            "stat.min": 101,
-            "stat.p50": 101,
-            "stat.p90": 101,
-            "stat.p95": 101,
-            "stat.p99": 101,
-            "stat.p9990": 101,
-            "stat.p9999": 101,
-            "stat.sum": 3434,
-            "stat.avg": 101.0
-          },
-          "transit_latency_ms": {
-            "stat.count": 0
-          },
-          "socket_unwritable_ms": {
-            "counter": 0
-          },
-          "closes": {
-            "counter": 0
-          },
-          "request_payload_bytes": {
-            "stat.count": 3434,
-            "stat.max": 30,
-            "stat.min": 30,
-            "stat.p50": 30,
-            "stat.p90": 30,
-            "stat.p95": 30,
-            "stat.p99": 30,
-            "stat.p9990": 30,
-            "stat.p9999": 30,
-            "stat.sum": 103020,
-            "stat.avg": 30.0
-          },
-          "socket_writable_ms": {
-            "counter": 0
-          },
-          "response_payload_bytes": {
-            "stat.count": 3434,
-            "stat.max": 23,
-            "stat.min": 23,
-            "stat.p50": 23,
-            "stat.p90": 23,
-            "stat.p95": 23,
-            "stat.p99": 23,
-            "stat.p9990": 23,
-            "stat.p9999": 23,
-            "stat.sum": 78982,
-            "stat.avg": 23.0
-          },
-          "dtab": {
-            "size": {
-              "stat.count": 0
-            }
-          },
-          "requests": {
-            "counter": 315435
-          },
-          "pending": {
-            "gauge": 1.0
-          },
-          "handletime_us": {
-            "stat.count": 3434,
-            "stat.max": 1352,
-            "stat.min": 4,
-            "stat.p50": 11,
-            "stat.p90": 24,
-            "stat.p95": 30,
-            "stat.p99": 65,
-            "stat.p9990": 453,
-            "stat.p9999": 1352,
-            "stat.sum": 52215,
-            "stat.avg": 15.205299941758883
-          },
-          "connections": {
-            "gauge": 1.0
-          }
-        }
-      }
-    },
-    "multiplier": {
-      "service": {
-        "svc": {
-          "success": {
-            "counter": 381
-          },
-          "request_latency_ms": {
-            "stat.count": 33,
-            "stat.max": 2,
-            "stat.min": 0,
-            "stat.p50": 0,
-            "stat.p90": 0,
-            "stat.p95": 1,
-            "stat.p99": 2,
-            "stat.p9990": 2,
-            "stat.p9999": 2,
-            "stat.sum": 4,
-            "stat.avg": 0.12121212121212122
-          },
-          "retries": {
-            "per_request": {
-              "stat.count": 33,
-              "stat.max": 0,
-              "stat.min": 0,
-              "stat.p50": 0,
-              "stat.p90": 0,
-              "stat.p95": 0,
-              "stat.p99": 0,
-              "stat.p9990": 0,
-              "stat.p9999": 0,
-              "stat.sum": 0,
-              "stat.avg": 0.0
-            },
-            "total": {
-              "counter": 0
-            },
-            "budget_exhausted": {
-              "counter": 0
-            }
-          },
-          "requests": {
-            "counter": 381
-          },
-          "pending": {
-            "gauge": 0.0
-          }
-        }
-      },
-      "client": {
-        "$/inet/127.1/9030": {
-          "connect_latency_ms": {
-            "stat.count": 0
-          },
-          "failed_connect_latency_ms": {
-            "stat.count": 0
-          },
-          "sent_bytes": {
-            "counter": 4760
-          },
-          "service_creation": {
-            "service_acquisition_latency_ms": {
-              "stat.count": 13,
-              "stat.max": 0,
-              "stat.min": 0,
-              "stat.p50": 0,
-              "stat.p90": 0,
-              "stat.p95": 0,
-              "stat.p99": 0,
-              "stat.p9990": 0,
-              "stat.p9999": 0,
-              "stat.sum": 0,
-              "stat.avg": 0.0
-            }
-          },
-          "connection_received_bytes": {
-            "stat.count": 0
-          },
-          "connection_duration": {
-            "stat.count": 0
-          },
-          "failure_accrual": {
-            "removals": {
-              "counter": 0
-            },
-            "probes": {
-              "counter": 0
-            },
-            "removed_for_ms": {
-              "counter": 0
-            },
-            "revivals": {
-              "counter": 0
-            }
-          },
-          "connects": {
-            "counter": 1
-          },
-          "pool_num_waited": {
-            "counter": 0
-          },
-          "success": {
-            "counter": 136
-          },
-          "service": {
-            "svc": {
-              "request_latency_ms": {
-                "stat.count": 13,
+            "retries": {
+              "requeues_per_request": {
+                "stat.count": 159,
                 "stat.max": 0,
                 "stat.min": 0,
                 "stat.p50": 0,
@@ -3045,679 +823,1909 @@ return {
                 "stat.sum": 0,
                 "stat.avg": 0.0
               },
-              "success": {
-                "counter": 136
+              "request_limit": {
+                "counter": 0
               },
-              "pending": {
-                "gauge": 0.0
+              "budget_exhausted": {
+                "counter": 0
               },
-              "requests": {
-                "counter": 136
+              "cannot_retry": {
+                "counter": 0
+              },
+              "not_open": {
+                "counter": 0
+              },
+              "budget": {},
+              "requeues": {
+                "counter": 0
               }
-            }
-          },
-          "request_latency_ms": {
-            "stat.count": 13,
-            "stat.max": 0,
-            "stat.min": 0,
-            "stat.p50": 0,
-            "stat.p90": 0,
-            "stat.p95": 0,
-            "stat.p99": 0,
-            "stat.p9990": 0,
-            "stat.p9999": 0,
-            "stat.sum": 0,
-            "stat.avg": 0.0
-          },
-          "pool_waiters": {
-            "gauge": 0.0
-          },
-          "retries": {
-            "requeues_per_request": {
-              "stat.count": 13,
-              "stat.max": 0,
-              "stat.min": 0,
-              "stat.p50": 0,
-              "stat.p90": 0,
-              "stat.p95": 0,
-              "stat.p99": 0,
-              "stat.p9990": 0,
-              "stat.p9999": 0,
-              "stat.sum": 0,
-              "stat.avg": 0.0
             },
-            "request_limit": {
+            "received_bytes": {
+              "counter": 348335
+            },
+            "connection_sent_bytes": {
+              "stat.count": 87,
+              "stat.max": 301,
+              "stat.min": 30,
+              "stat.p50": 30,
+              "stat.p90": 90,
+              "stat.p95": 121,
+              "stat.p99": 211,
+              "stat.p9990": 301,
+              "stat.p9999": 301,
+              "stat.sum": 4800,
+              "stat.avg": 55.172413793103445
+            },
+            "connection_requests": {
+              "stat.count": 87,
+              "stat.max": 10,
+              "stat.min": 1,
+              "stat.p50": 1,
+              "stat.p90": 3,
+              "stat.p95": 4,
+              "stat.p99": 7,
+              "stat.p9990": 10,
+              "stat.p9999": 10,
+              "stat.sum": 160,
+              "stat.avg": 1.839080459770115
+            },
+            "pool_num_too_many_waiters": {
               "counter": 0
             },
-            "budget_exhausted": {
+            "socket_unwritable_ms": {
               "counter": 0
             },
-            "cannot_retry": {
-              "counter": 0
+            "closes": {
+              "counter": 7887
             },
-            "not_open": {
-              "counter": 0
-            },
-            "budget": {
-              "gauge": 102.0
-            },
-            "requeues": {
-              "counter": 0
-            }
-          },
-          "received_bytes": {
-            "counter": 3808
-          },
-          "connection_sent_bytes": {
-            "stat.count": 0
-          },
-          "connection_requests": {
-            "stat.count": 0
-          },
-          "pool_num_too_many_waiters": {
-            "counter": 0
-          },
-          "socket_unwritable_ms": {
-            "counter": 0
-          },
-          "closes": {
-            "counter": 0
-          },
-          "pool_cached": {
-            "gauge": 1.0
-          },
-          "pool_size": {
-            "gauge": 0.0
-          },
-          "available": {
-            "gauge": 1.0
-          },
-          "request_payload_bytes": {
-            "stat.count": 13,
-            "stat.max": 35,
-            "stat.min": 35,
-            "stat.p50": 35,
-            "stat.p90": 35,
-            "stat.p95": 35,
-            "stat.p99": 35,
-            "stat.p9990": 35,
-            "stat.p9999": 35,
-            "stat.sum": 455,
-            "stat.avg": 35.0
-          },
-          "socket_writable_ms": {
-            "counter": 0
-          },
-          "cancelled_connects": {
-            "counter": 0
-          },
-          "response_payload_bytes": {
-            "stat.count": 13,
-            "stat.max": 28,
-            "stat.min": 28,
-            "stat.p50": 28,
-            "stat.p90": 28,
-            "stat.p95": 28,
-            "stat.p99": 28,
-            "stat.p9990": 28,
-            "stat.p9999": 28,
-            "stat.sum": 364,
-            "stat.avg": 28.0
-          },
-          "dtab": {
-            "size": {
-              "stat.count": 0
-            }
-          },
-          "requests": {
-            "counter": 136
-          },
-          "loadbalancer": {
-            "size": {
-              "gauge": 1.0
-            },
-            "rebuilds": {
-              "counter": 1
-            },
-            "closed": {
+            "pool_cached": {
               "gauge": 0.0
             },
-            "load": {
+            "pool_size": {
               "gauge": 0.0
-            },
-            "meanweight": {
-              "gauge": 1.0
-            },
-            "adds": {
-              "counter": 1
-            },
-            "p2c": {
-              "gauge": 1.0
-            },
-            "updates": {
-              "counter": 1
             },
             "available": {
-              "gauge": 1.0
-            },
-            "max_effort_exhausted": {
-              "counter": 0
-            },
-            "busy": {
               "gauge": 0.0
             },
-            "removes": {
+            "request_payload_bytes": {
+              "stat.count": 159,
+              "stat.max": 30,
+              "stat.min": 30,
+              "stat.p50": 30,
+              "stat.p90": 30,
+              "stat.p95": 30,
+              "stat.p99": 30,
+              "stat.p9990": 30,
+              "stat.p9999": 30,
+              "stat.sum": 4770,
+              "stat.avg": 30.0
+            },
+            "socket_writable_ms": {
               "counter": 0
-            }
-          },
-          "pending": {
-            "gauge": 0.0
-          },
-          "dispatcher": {
-            "serial": {
-              "queue_size": {
-                "gauge": 0.0
+            },
+            "cancelled_connects": {
+              "counter": 0
+            },
+            "response_payload_bytes": {
+              "stat.count": 159,
+              "stat.max": 23,
+              "stat.min": 23,
+              "stat.p50": 23,
+              "stat.p90": 23,
+              "stat.p95": 23,
+              "stat.p99": 23,
+              "stat.p9990": 23,
+              "stat.p9999": 23,
+              "stat.sum": 3657,
+              "stat.avg": 23.0
+            },
+            "dtab": {
+              "size": {
+                "stat.count": 0
               }
+            },
+            "requests": {
+              "counter": 15145
+            },
+            "loadbalancer": {
+              "size": {},
+              "rebuilds": {
+                "counter": 7912
+              },
+              "closed": {},
+              "load": {},
+              "meanweight": {},
+              "adds": {
+                "counter": 7887
+              },
+              "p2c": {
+                "gauge": 22.0
+              },
+              "updates": {
+                "counter": 7912
+              },
+              "available": {},
+              "max_effort_exhausted": {
+                "counter": 0
+              },
+              "busy": {},
+              "removes": {
+                "counter": 7887
+              }
+            },
+            "pending": {
+              "gauge": 0.0
+            },
+            "dispatcher": {
+              "serial": {
+                "queue_size": {
+                  "gauge": 0.0
+                }
+              }
+            },
+            "connections": {
+              "gauge": 0.0
             }
           },
-          "connections": {
-            "gauge": 1.0
-          }
-        },
-        "$/inet/127.1/9029": {
-          "connect_latency_ms": {
-            "stat.count": 0
-          },
-          "failed_connect_latency_ms": {
-            "stat.count": 0
-          },
-          "sent_bytes": {
-            "counter": 4165
-          },
-          "service_creation": {
-            "service_acquisition_latency_ms": {
-              "stat.count": 7,
-              "stat.max": 0,
+          "$/inet/127.1/9090": {
+            "connect_latency_ms": {
+              "stat.count": 92,
+              "stat.max": 31,
               "stat.min": 0,
               "stat.p50": 0,
               "stat.p90": 0,
               "stat.p95": 0,
-              "stat.p99": 0,
-              "stat.p9990": 0,
-              "stat.p9999": 0,
-              "stat.sum": 0,
-              "stat.avg": 0.0
-            }
-          },
-          "connection_received_bytes": {
-            "stat.count": 0
-          },
-          "connection_duration": {
-            "stat.count": 0
-          },
-          "failure_accrual": {
-            "removals": {
-              "counter": 0
+              "stat.p99": 3,
+              "stat.p9990": 31,
+              "stat.p9999": 31,
+              "stat.sum": 37,
+              "stat.avg": 0.40217391304347827
             },
-            "probes": {
-              "counter": 0
+            "failed_connect_latency_ms": {
+              "stat.count": 0
             },
-            "removed_for_ms": {
-              "counter": 0
+            "sent_bytes": {
+              "counter": 458460
             },
-            "revivals": {
-              "counter": 0
-            }
-          },
-          "connects": {
-            "counter": 1
-          },
-          "pool_num_waited": {
-            "counter": 0
-          },
-          "success": {
-            "counter": 119
-          },
-          "service": {
-            "svc": {
-              "request_latency_ms": {
-                "stat.count": 7,
-                "stat.max": 1,
+            "service_creation": {
+              "service_acquisition_latency_ms": {
+                "stat.count": 187,
+                "stat.max": 32,
                 "stat.min": 0,
                 "stat.p50": 0,
                 "stat.p90": 0,
                 "stat.p95": 1,
-                "stat.p99": 1,
-                "stat.p9990": 1,
-                "stat.p9999": 1,
-                "stat.sum": 1,
-                "stat.avg": 0.14285714285714285
-              },
-              "success": {
-                "counter": 119
-              },
-              "pending": {
-                "gauge": 0.0
-              },
-              "requests": {
-                "counter": 119
+                "stat.p99": 2,
+                "stat.p9990": 32,
+                "stat.p9999": 32,
+                "stat.sum": 46,
+                "stat.avg": 0.24598930481283424
               }
-            }
-          },
-          "request_latency_ms": {
-            "stat.count": 7,
-            "stat.max": 1,
-            "stat.min": 0,
-            "stat.p50": 0,
-            "stat.p90": 0,
-            "stat.p95": 1,
-            "stat.p99": 1,
-            "stat.p9990": 1,
-            "stat.p9999": 1,
-            "stat.sum": 1,
-            "stat.avg": 0.14285714285714285
-          },
-          "pool_waiters": {
-            "gauge": 0.0
-          },
-          "retries": {
-            "requeues_per_request": {
-              "stat.count": 7,
-              "stat.max": 0,
+            },
+            "connection_received_bytes": {
+              "stat.count": 91,
+              "stat.max": 230,
+              "stat.min": 23,
+              "stat.p50": 46,
+              "stat.p90": 92,
+              "stat.p95": 115,
+              "stat.p99": 207,
+              "stat.p9990": 230,
+              "stat.p9999": 230,
+              "stat.sum": 4278,
+              "stat.avg": 47.010989010989015
+            },
+            "connection_duration": {
+              "stat.count": 91,
+              "stat.max": 2290,
+              "stat.min": 18,
+              "stat.p50": 45,
+              "stat.p90": 1508,
+              "stat.p95": 1601,
+              "stat.p99": 2094,
+              "stat.p9990": 2290,
+              "stat.p9999": 2290,
+              "stat.sum": 31468,
+              "stat.avg": 345.8021978021978
+            },
+            "failure_accrual": {
+              "removals": {
+                "counter": 0
+              },
+              "probes": {
+                "counter": 0
+              },
+              "removed_for_ms": {
+                "counter": 0
+              },
+              "revivals": {
+                "counter": 0
+              }
+            },
+            "connects": {
+              "counter": 7937
+            },
+            "pool_num_waited": {
+              "counter": 0
+            },
+            "success": {
+              "counter": 15282
+            },
+            "service": {
+              "svc": {
+                "request_latency_ms": {
+                  "stat.count": 187,
+                  "stat.max": 55,
+                  "stat.min": 0,
+                  "stat.p50": 0,
+                  "stat.p90": 0,
+                  "stat.p95": 0,
+                  "stat.p99": 1,
+                  "stat.p9990": 55,
+                  "stat.p9999": 55,
+                  "stat.sum": 59,
+                  "stat.avg": 0.3155080213903743
+                },
+                "success": {
+                  "counter": 15282
+                },
+                "pending": {
+                  "gauge": 0.0
+                },
+                "requests": {
+                  "counter": 15282
+                }
+              }
+            },
+            "request_latency_ms": {
+              "stat.count": 187,
+              "stat.max": 55,
               "stat.min": 0,
               "stat.p50": 0,
               "stat.p90": 0,
               "stat.p95": 0,
-              "stat.p99": 0,
-              "stat.p9990": 0,
-              "stat.p9999": 0,
-              "stat.sum": 0,
-              "stat.avg": 0.0
+              "stat.p99": 1,
+              "stat.p9990": 55,
+              "stat.p9999": 55,
+              "stat.sum": 59,
+              "stat.avg": 0.3155080213903743
             },
-            "request_limit": {
+            "pool_waiters": {
+              "gauge": 0.0
+            },
+            "retries": {
+              "requeues_per_request": {
+                "stat.count": 187,
+                "stat.max": 0,
+                "stat.min": 0,
+                "stat.p50": 0,
+                "stat.p90": 0,
+                "stat.p95": 0,
+                "stat.p99": 0,
+                "stat.p9990": 0,
+                "stat.p9999": 0,
+                "stat.sum": 0,
+                "stat.avg": 0.0
+              },
+              "request_limit": {
+                "counter": 0
+              },
+              "budget_exhausted": {
+                "counter": 0
+              },
+              "cannot_retry": {
+                "counter": 0
+              },
+              "not_open": {
+                "counter": 0
+              },
+              "budget": {},
+              "requeues": {
+                "counter": 0
+              }
+            },
+            "received_bytes": {
+              "counter": 351486
+            },
+            "connection_sent_bytes": {
+              "stat.count": 91,
+              "stat.max": 301,
+              "stat.min": 30,
+              "stat.p50": 60,
+              "stat.p90": 121,
+              "stat.p95": 150,
+              "stat.p99": 270,
+              "stat.p9990": 301,
+              "stat.p9999": 301,
+              "stat.sum": 5580,
+              "stat.avg": 61.31868131868132
+            },
+            "connection_requests": {
+              "stat.count": 91,
+              "stat.max": 10,
+              "stat.min": 1,
+              "stat.p50": 2,
+              "stat.p90": 4,
+              "stat.p95": 5,
+              "stat.p99": 9,
+              "stat.p9990": 10,
+              "stat.p9999": 10,
+              "stat.sum": 186,
+              "stat.avg": 2.043956043956044
+            },
+            "pool_num_too_many_waiters": {
               "counter": 0
             },
-            "budget_exhausted": {
+            "socket_unwritable_ms": {
               "counter": 0
             },
-            "cannot_retry": {
+            "closes": {
+              "counter": 7937
+            },
+            "pool_cached": {
+              "gauge": 0.0
+            },
+            "pool_size": {
+              "gauge": 0.0
+            },
+            "available": {
+              "gauge": 0.0
+            },
+            "request_payload_bytes": {
+              "stat.count": 187,
+              "stat.max": 30,
+              "stat.min": 30,
+              "stat.p50": 30,
+              "stat.p90": 30,
+              "stat.p95": 30,
+              "stat.p99": 30,
+              "stat.p9990": 30,
+              "stat.p9999": 30,
+              "stat.sum": 5610,
+              "stat.avg": 30.0
+            },
+            "socket_writable_ms": {
               "counter": 0
             },
-            "not_open": {
+            "cancelled_connects": {
               "counter": 0
             },
-            "budget": {
-              "gauge": 102.0
+            "response_payload_bytes": {
+              "stat.count": 187,
+              "stat.max": 23,
+              "stat.min": 23,
+              "stat.p50": 23,
+              "stat.p90": 23,
+              "stat.p95": 23,
+              "stat.p99": 23,
+              "stat.p9990": 23,
+              "stat.p9999": 23,
+              "stat.sum": 4301,
+              "stat.avg": 23.0
             },
-            "requeues": {
-              "counter": 0
+            "dtab": {
+              "size": {
+                "stat.count": 0
+              }
+            },
+            "requests": {
+              "counter": 15282
+            },
+            "loadbalancer": {
+              "size": {},
+              "rebuilds": {
+                "counter": 7960
+              },
+              "closed": {},
+              "load": {},
+              "meanweight": {},
+              "adds": {
+                "counter": 7937
+              },
+              "p2c": {
+                "gauge": 27.0
+              },
+              "updates": {
+                "counter": 7960
+              },
+              "available": {},
+              "max_effort_exhausted": {
+                "counter": 0
+              },
+              "busy": {},
+              "removes": {
+                "counter": 7937
+              }
+            },
+            "pending": {
+              "gauge": 0.0
+            },
+            "dispatcher": {
+              "serial": {
+                "queue_size": {
+                  "gauge": 0.0
+                }
+              }
+            },
+            "connections": {
+              "gauge": 0.0
             }
           },
-          "received_bytes": {
-            "counter": 3332
-          },
-          "connection_sent_bytes": {
-            "stat.count": 0
-          },
-          "connection_requests": {
-            "stat.count": 0
-          },
-          "pool_num_too_many_waiters": {
-            "counter": 0
-          },
-          "socket_unwritable_ms": {
-            "counter": 0
-          },
-          "closes": {
-            "counter": 0
-          },
-          "pool_cached": {
-            "gauge": 1.0
-          },
-          "pool_size": {
-            "gauge": 0.0
-          },
-          "available": {
-            "gauge": 1.0
-          },
-          "request_payload_bytes": {
-            "stat.count": 7,
-            "stat.max": 35,
-            "stat.min": 35,
-            "stat.p50": 35,
-            "stat.p90": 35,
-            "stat.p95": 35,
-            "stat.p99": 35,
-            "stat.p9990": 35,
-            "stat.p9999": 35,
-            "stat.sum": 245,
-            "stat.avg": 35.0
-          },
-          "socket_writable_ms": {
-            "counter": 0
-          },
-          "cancelled_connects": {
-            "counter": 0
-          },
-          "response_payload_bytes": {
-            "stat.count": 7,
-            "stat.max": 28,
-            "stat.min": 28,
-            "stat.p50": 28,
-            "stat.p90": 28,
-            "stat.p95": 28,
-            "stat.p99": 28,
-            "stat.p9990": 28,
-            "stat.p9999": 28,
-            "stat.sum": 196,
-            "stat.avg": 28.0
-          },
-          "dtab": {
-            "size": {
+          "$/inet/127.1/9093": {
+            "connect_latency_ms": {
+              "stat.count": 82,
+              "stat.max": 49,
+              "stat.min": 0,
+              "stat.p50": 0,
+              "stat.p90": 0,
+              "stat.p95": 0,
+              "stat.p99": 2,
+              "stat.p9990": 49,
+              "stat.p9999": 49,
+              "stat.sum": 52,
+              "stat.avg": 0.6341463414634146
+            },
+            "failed_connect_latency_ms": {
               "stat.count": 0
-            }
-          },
-          "requests": {
-            "counter": 119
-          },
-          "loadbalancer": {
-            "size": {
-              "gauge": 1.0
             },
-            "rebuilds": {
-              "counter": 1
+            "sent_bytes": {
+              "counter": 445680
             },
-            "closed": {
+            "service_creation": {
+              "service_acquisition_latency_ms": {
+                "stat.count": 169,
+                "stat.max": 49,
+                "stat.min": 0,
+                "stat.p50": 0,
+                "stat.p90": 0,
+                "stat.p95": 1,
+                "stat.p99": 3,
+                "stat.p9990": 49,
+                "stat.p9999": 49,
+                "stat.sum": 66,
+                "stat.avg": 0.3905325443786982
+              }
+            },
+            "connection_received_bytes": {
+              "stat.count": 82,
+              "stat.max": 139,
+              "stat.min": 23,
+              "stat.p50": 46,
+              "stat.p90": 92,
+              "stat.p95": 115,
+              "stat.p99": 139,
+              "stat.p9990": 139,
+              "stat.p9999": 139,
+              "stat.sum": 3841,
+              "stat.avg": 46.84146341463415
+            },
+            "connection_duration": {
+              "stat.count": 82,
+              "stat.max": 2158,
+              "stat.min": 20,
+              "stat.p50": 46,
+              "stat.p90": 1421,
+              "stat.p95": 1585,
+              "stat.p99": 1877,
+              "stat.p9990": 2158,
+              "stat.p9999": 2158,
+              "stat.sum": 23936,
+              "stat.avg": 291.9024390243902
+            },
+            "failure_accrual": {
+              "removals": {
+                "counter": 0
+              },
+              "probes": {
+                "counter": 0
+              },
+              "removed_for_ms": {
+                "counter": 0
+              },
+              "revivals": {
+                "counter": 0
+              }
+            },
+            "connects": {
+              "counter": 7853
+            },
+            "pool_num_waited": {
+              "counter": 0
+            },
+            "success": {
+              "counter": 14856
+            },
+            "service": {
+              "svc": {
+                "request_latency_ms": {
+                  "stat.count": 169,
+                  "stat.max": 1,
+                  "stat.min": 0,
+                  "stat.p50": 0,
+                  "stat.p90": 0,
+                  "stat.p95": 0,
+                  "stat.p99": 1,
+                  "stat.p9990": 1,
+                  "stat.p9999": 1,
+                  "stat.sum": 6,
+                  "stat.avg": 0.03550295857988166
+                },
+                "success": {
+                  "counter": 14856
+                },
+                "pending": {
+                  "gauge": 0.0
+                },
+                "requests": {
+                  "counter": 14856
+                }
+              }
+            },
+            "request_latency_ms": {
+              "stat.count": 169,
+              "stat.max": 1,
+              "stat.min": 0,
+              "stat.p50": 0,
+              "stat.p90": 0,
+              "stat.p95": 0,
+              "stat.p99": 1,
+              "stat.p9990": 1,
+              "stat.p9999": 1,
+              "stat.sum": 6,
+              "stat.avg": 0.03550295857988166
+            },
+            "pool_waiters": {
               "gauge": 0.0
             },
-            "load": {
+            "retries": {
+              "requeues_per_request": {
+                "stat.count": 169,
+                "stat.max": 0,
+                "stat.min": 0,
+                "stat.p50": 0,
+                "stat.p90": 0,
+                "stat.p95": 0,
+                "stat.p99": 0,
+                "stat.p9990": 0,
+                "stat.p9999": 0,
+                "stat.sum": 0,
+                "stat.avg": 0.0
+              },
+              "request_limit": {
+                "counter": 0
+              },
+              "budget_exhausted": {
+                "counter": 0
+              },
+              "cannot_retry": {
+                "counter": 0
+              },
+              "not_open": {
+                "counter": 0
+              },
+              "budget": {
+                "gauge": 264.0
+              },
+              "requeues": {
+                "counter": 0
+              }
+            },
+            "received_bytes": {
+              "counter": 341688
+            },
+            "connection_sent_bytes": {
+              "stat.count": 82,
+              "stat.max": 180,
+              "stat.min": 30,
+              "stat.p50": 60,
+              "stat.p90": 121,
+              "stat.p95": 150,
+              "stat.p99": 180,
+              "stat.p9990": 180,
+              "stat.p9999": 180,
+              "stat.sum": 5010,
+              "stat.avg": 61.09756097560975
+            },
+            "connection_requests": {
+              "stat.count": 82,
+              "stat.max": 6,
+              "stat.min": 1,
+              "stat.p50": 2,
+              "stat.p90": 4,
+              "stat.p95": 5,
+              "stat.p99": 6,
+              "stat.p9990": 6,
+              "stat.p9999": 6,
+              "stat.sum": 167,
+              "stat.avg": 2.0365853658536586
+            },
+            "pool_num_too_many_waiters": {
+              "counter": 0
+            },
+            "socket_unwritable_ms": {
+              "counter": 0
+            },
+            "closes": {
+              "counter": 7852
+            },
+            "pool_cached": {
+              "gauge": 1.0
+            },
+            "pool_size": {
               "gauge": 0.0
-            },
-            "meanweight": {
-              "gauge": 1.0
-            },
-            "adds": {
-              "counter": 1
-            },
-            "p2c": {
-              "gauge": 1.0
-            },
-            "updates": {
-              "counter": 1
             },
             "available": {
               "gauge": 1.0
             },
-            "max_effort_exhausted": {
+            "request_payload_bytes": {
+              "stat.count": 169,
+              "stat.max": 30,
+              "stat.min": 30,
+              "stat.p50": 30,
+              "stat.p90": 30,
+              "stat.p95": 30,
+              "stat.p99": 30,
+              "stat.p9990": 30,
+              "stat.p9999": 30,
+              "stat.sum": 5070,
+              "stat.avg": 30.0
+            },
+            "socket_writable_ms": {
               "counter": 0
             },
-            "busy": {
+            "cancelled_connects": {
+              "counter": 0
+            },
+            "response_payload_bytes": {
+              "stat.count": 169,
+              "stat.max": 23,
+              "stat.min": 23,
+              "stat.p50": 23,
+              "stat.p90": 23,
+              "stat.p95": 23,
+              "stat.p99": 23,
+              "stat.p9990": 23,
+              "stat.p9999": 23,
+              "stat.sum": 3887,
+              "stat.avg": 23.0
+            },
+            "dtab": {
+              "size": {
+                "stat.count": 0
+              }
+            },
+            "requests": {
+              "counter": 14856
+            },
+            "loadbalancer": {
+              "size": {
+                "gauge": 1.0
+              },
+              "rebuilds": {
+                "counter": 7869
+              },
+              "closed": {
+                "gauge": 0.0
+              },
+              "load": {
+                "gauge": 0.0
+              },
+              "meanweight": {
+                "gauge": 1.0
+              },
+              "adds": {
+                "counter": 7853
+              },
+              "p2c": {
+                "gauge": 26.0
+              },
+              "updates": {
+                "counter": 7869
+              },
+              "available": {
+                "gauge": 1.0
+              },
+              "max_effort_exhausted": {
+                "counter": 0
+              },
+              "busy": {
+                "gauge": 0.0
+              },
+              "removes": {
+                "counter": 7852
+              }
+            },
+            "pending": {
               "gauge": 0.0
             },
-            "removes": {
-              "counter": 0
-            }
-          },
-          "pending": {
-            "gauge": 0.0
-          },
-          "dispatcher": {
-            "serial": {
-              "queue_size": {
-                "gauge": 0.0
+            "dispatcher": {
+              "serial": {
+                "queue_size": {
+                  "gauge": 0.0
+                }
               }
+            },
+            "connections": {
+              "gauge": 1.0
             }
           },
-          "connections": {
-            "gauge": 1.0
-          }
-        },
-        "$/inet/127.1/9092": {
-          "connect_latency_ms": {
-            "stat.count": 0
-          },
-          "failed_connect_latency_ms": {
-            "stat.count": 0
-          },
-          "sent_bytes": {
-            "counter": 4410
-          },
-          "service_creation": {
-            "service_acquisition_latency_ms": {
-              "stat.count": 13,
-              "stat.max": 0,
+          "$/inet/127.1/9070": {
+            "connect_latency_ms": {
+              "stat.count": 85,
+              "stat.max": 3,
               "stat.min": 0,
               "stat.p50": 0,
               "stat.p90": 0,
               "stat.p95": 0,
-              "stat.p99": 0,
-              "stat.p9990": 0,
-              "stat.p9999": 0,
-              "stat.sum": 0,
-              "stat.avg": 0.0
-            }
-          },
-          "connection_received_bytes": {
-            "stat.count": 0
-          },
-          "connection_duration": {
-            "stat.count": 0
-          },
-          "failure_accrual": {
-            "removals": {
-              "counter": 0
+              "stat.p99": 1,
+              "stat.p9990": 3,
+              "stat.p9999": 3,
+              "stat.sum": 4,
+              "stat.avg": 0.047058823529411764
             },
-            "probes": {
-              "counter": 0
+            "failed_connect_latency_ms": {
+              "stat.count": 0
             },
-            "removed_for_ms": {
-              "counter": 0
+            "sent_bytes": {
+              "counter": 448860
             },
-            "revivals": {
-              "counter": 0
-            }
-          },
-          "connects": {
-            "counter": 1
-          },
-          "pool_num_waited": {
-            "counter": 0
-          },
-          "success": {
-            "counter": 126
-          },
-          "service": {
-            "svc": {
-              "request_latency_ms": {
-                "stat.count": 13,
-                "stat.max": 1,
+            "service_creation": {
+              "service_acquisition_latency_ms": {
+                "stat.count": 183,
+                "stat.max": 3,
                 "stat.min": 0,
                 "stat.p50": 0,
                 "stat.p90": 0,
                 "stat.p95": 0,
                 "stat.p99": 1,
-                "stat.p9990": 1,
-                "stat.p9999": 1,
-                "stat.sum": 1,
-                "stat.avg": 0.07692307692307693
-              },
-              "success": {
-                "counter": 126
-              },
-              "pending": {
-                "gauge": 0.0
-              },
-              "requests": {
-                "counter": 126
+                "stat.p9990": 3,
+                "stat.p9999": 3,
+                "stat.sum": 8,
+                "stat.avg": 0.04371584699453552
               }
-            }
-          },
-          "request_latency_ms": {
-            "stat.count": 13,
-            "stat.max": 1,
-            "stat.min": 0,
-            "stat.p50": 0,
-            "stat.p90": 0,
-            "stat.p95": 0,
-            "stat.p99": 1,
-            "stat.p9990": 1,
-            "stat.p9999": 1,
-            "stat.sum": 1,
-            "stat.avg": 0.07692307692307693
-          },
-          "pool_waiters": {
-            "gauge": 0.0
-          },
-          "retries": {
-            "requeues_per_request": {
-              "stat.count": 13,
-              "stat.max": 0,
+            },
+            "connection_received_bytes": {
+              "stat.count": 85,
+              "stat.max": 161,
+              "stat.min": 23,
+              "stat.p50": 46,
+              "stat.p90": 92,
+              "stat.p95": 115,
+              "stat.p99": 139,
+              "stat.p9990": 161,
+              "stat.p9999": 161,
+              "stat.sum": 4209,
+              "stat.avg": 49.51764705882353
+            },
+            "connection_duration": {
+              "stat.count": 85,
+              "stat.max": 2313,
+              "stat.min": 17,
+              "stat.p50": 49,
+              "stat.p90": 1585,
+              "stat.p95": 1859,
+              "stat.p99": 2013,
+              "stat.p9990": 2313,
+              "stat.p9999": 2313,
+              "stat.sum": 35877,
+              "stat.avg": 422.08235294117645
+            },
+            "failure_accrual": {
+              "removals": {
+                "counter": 0
+              },
+              "probes": {
+                "counter": 0
+              },
+              "removed_for_ms": {
+                "counter": 0
+              },
+              "revivals": {
+                "counter": 0
+              }
+            },
+            "connects": {
+              "counter": 7832
+            },
+            "pool_num_waited": {
+              "counter": 0
+            },
+            "success": {
+              "counter": 14962
+            },
+            "service": {
+              "svc": {
+                "request_latency_ms": {
+                  "stat.count": 183,
+                  "stat.max": 53,
+                  "stat.min": 0,
+                  "stat.p50": 0,
+                  "stat.p90": 0,
+                  "stat.p95": 0,
+                  "stat.p99": 1,
+                  "stat.p9990": 53,
+                  "stat.p9999": 53,
+                  "stat.sum": 60,
+                  "stat.avg": 0.32786885245901637
+                },
+                "success": {
+                  "counter": 14962
+                },
+                "pending": {
+                  "gauge": 0.0
+                },
+                "requests": {
+                  "counter": 14962
+                }
+              }
+            },
+            "request_latency_ms": {
+              "stat.count": 183,
+              "stat.max": 53,
               "stat.min": 0,
               "stat.p50": 0,
               "stat.p90": 0,
               "stat.p95": 0,
-              "stat.p99": 0,
-              "stat.p9990": 0,
-              "stat.p9999": 0,
-              "stat.sum": 0,
-              "stat.avg": 0.0
+              "stat.p99": 1,
+              "stat.p9990": 53,
+              "stat.p9999": 53,
+              "stat.sum": 60,
+              "stat.avg": 0.32786885245901637
             },
-            "request_limit": {
-              "counter": 0
-            },
-            "budget_exhausted": {
-              "counter": 0
-            },
-            "cannot_retry": {
-              "counter": 0
-            },
-            "not_open": {
-              "counter": 0
-            },
-            "budget": {
-              "gauge": 102.0
-            },
-            "requeues": {
-              "counter": 0
-            }
-          },
-          "received_bytes": {
-            "counter": 3528
-          },
-          "connection_sent_bytes": {
-            "stat.count": 0
-          },
-          "connection_requests": {
-            "stat.count": 0
-          },
-          "pool_num_too_many_waiters": {
-            "counter": 0
-          },
-          "socket_unwritable_ms": {
-            "counter": 0
-          },
-          "closes": {
-            "counter": 0
-          },
-          "pool_cached": {
-            "gauge": 1.0
-          },
-          "pool_size": {
-            "gauge": 0.0
-          },
-          "available": {
-            "gauge": 1.0
-          },
-          "request_payload_bytes": {
-            "stat.count": 13,
-            "stat.max": 35,
-            "stat.min": 35,
-            "stat.p50": 35,
-            "stat.p90": 35,
-            "stat.p95": 35,
-            "stat.p99": 35,
-            "stat.p9990": 35,
-            "stat.p9999": 35,
-            "stat.sum": 455,
-            "stat.avg": 35.0
-          },
-          "socket_writable_ms": {
-            "counter": 0
-          },
-          "cancelled_connects": {
-            "counter": 0
-          },
-          "response_payload_bytes": {
-            "stat.count": 13,
-            "stat.max": 28,
-            "stat.min": 28,
-            "stat.p50": 28,
-            "stat.p90": 28,
-            "stat.p95": 28,
-            "stat.p99": 28,
-            "stat.p9990": 28,
-            "stat.p9999": 28,
-            "stat.sum": 364,
-            "stat.avg": 28.0
-          },
-          "dtab": {
-            "size": {
-              "stat.count": 0
-            }
-          },
-          "requests": {
-            "counter": 126
-          },
-          "loadbalancer": {
-            "size": {
-              "gauge": 1.0
-            },
-            "rebuilds": {
-              "counter": 1
-            },
-            "closed": {
+            "pool_waiters": {
               "gauge": 0.0
             },
-            "load": {
+            "retries": {
+              "requeues_per_request": {
+                "stat.count": 183,
+                "stat.max": 0,
+                "stat.min": 0,
+                "stat.p50": 0,
+                "stat.p90": 0,
+                "stat.p95": 0,
+                "stat.p99": 0,
+                "stat.p9990": 0,
+                "stat.p9999": 0,
+                "stat.sum": 0,
+                "stat.avg": 0.0
+              },
+              "request_limit": {
+                "counter": 0
+              },
+              "budget_exhausted": {
+                "counter": 0
+              },
+              "cannot_retry": {
+                "counter": 0
+              },
+              "not_open": {
+                "counter": 0
+              },
+              "budget": {
+                "gauge": 264.0
+              },
+              "requeues": {
+                "counter": 0
+              }
+            },
+            "received_bytes": {
+              "counter": 344126
+            },
+            "connection_sent_bytes": {
+              "stat.count": 85,
+              "stat.max": 211,
+              "stat.min": 30,
+              "stat.p50": 60,
+              "stat.p90": 121,
+              "stat.p95": 150,
+              "stat.p99": 180,
+              "stat.p9990": 211,
+              "stat.p9999": 211,
+              "stat.sum": 5490,
+              "stat.avg": 64.58823529411765
+            },
+            "connection_requests": {
+              "stat.count": 85,
+              "stat.max": 7,
+              "stat.min": 1,
+              "stat.p50": 2,
+              "stat.p90": 4,
+              "stat.p95": 5,
+              "stat.p99": 6,
+              "stat.p9990": 7,
+              "stat.p9999": 7,
+              "stat.sum": 183,
+              "stat.avg": 2.152941176470588
+            },
+            "pool_num_too_many_waiters": {
+              "counter": 0
+            },
+            "socket_unwritable_ms": {
+              "counter": 0
+            },
+            "closes": {
+              "counter": 7831
+            },
+            "pool_cached": {
+              "gauge": 1.0
+            },
+            "pool_size": {
               "gauge": 0.0
-            },
-            "meanweight": {
-              "gauge": 1.0
-            },
-            "adds": {
-              "counter": 1
-            },
-            "p2c": {
-              "gauge": 1.0
-            },
-            "updates": {
-              "counter": 1
             },
             "available": {
               "gauge": 1.0
             },
-            "max_effort_exhausted": {
+            "request_payload_bytes": {
+              "stat.count": 183,
+              "stat.max": 30,
+              "stat.min": 30,
+              "stat.p50": 30,
+              "stat.p90": 30,
+              "stat.p95": 30,
+              "stat.p99": 30,
+              "stat.p9990": 30,
+              "stat.p9999": 30,
+              "stat.sum": 5490,
+              "stat.avg": 30.0
+            },
+            "socket_writable_ms": {
               "counter": 0
             },
-            "busy": {
+            "cancelled_connects": {
+              "counter": 0
+            },
+            "response_payload_bytes": {
+              "stat.count": 183,
+              "stat.max": 23,
+              "stat.min": 23,
+              "stat.p50": 23,
+              "stat.p90": 23,
+              "stat.p95": 23,
+              "stat.p99": 23,
+              "stat.p9990": 23,
+              "stat.p9999": 23,
+              "stat.sum": 4209,
+              "stat.avg": 23.0
+            },
+            "dtab": {
+              "size": {
+                "stat.count": 0
+              }
+            },
+            "requests": {
+              "counter": 14962
+            },
+            "loadbalancer": {
+              "size": {
+                "gauge": 1.0
+              },
+              "rebuilds": {
+                "counter": 7855
+              },
+              "closed": {
+                "gauge": 0.0
+              },
+              "load": {
+                "gauge": 0.0
+              },
+              "meanweight": {
+                "gauge": 1.0
+              },
+              "adds": {
+                "counter": 7832
+              },
+              "p2c": {
+                "gauge": 25.0
+              },
+              "updates": {
+                "counter": 7855
+              },
+              "available": {
+                "gauge": 1.0
+              },
+              "max_effort_exhausted": {
+                "counter": 0
+              },
+              "busy": {
+                "gauge": 0.0
+              },
+              "removes": {
+                "counter": 7831
+              }
+            },
+            "pending": {
               "gauge": 0.0
             },
-            "removes": {
-              "counter": 0
-            }
-          },
-          "pending": {
-            "gauge": 0.0
-          },
-          "dispatcher": {
-            "serial": {
-              "queue_size": {
-                "gauge": 0.0
+            "dispatcher": {
+              "serial": {
+                "queue_size": {
+                  "gauge": 0.0
+                }
               }
+            },
+            "connections": {
+              "gauge": 1.0
             }
           },
-          "connections": {
-            "gauge": 1.0
+          "$/inet/127.1/9080": {
+            "connect_latency_ms": {
+              "stat.count": 94,
+              "stat.max": 1,
+              "stat.min": 0,
+              "stat.p50": 0,
+              "stat.p90": 0,
+              "stat.p95": 0,
+              "stat.p99": 1,
+              "stat.p9990": 1,
+              "stat.p9999": 1,
+              "stat.sum": 3,
+              "stat.avg": 0.031914893617021274
+            },
+            "failed_connect_latency_ms": {
+              "stat.count": 0
+            },
+            "sent_bytes": {
+              "counter": 449130
+            },
+            "service_creation": {
+              "service_acquisition_latency_ms": {
+                "stat.count": 179,
+                "stat.max": 2,
+                "stat.min": 0,
+                "stat.p50": 0,
+                "stat.p90": 0,
+                "stat.p95": 0,
+                "stat.p99": 1,
+                "stat.p9990": 2,
+                "stat.p9999": 2,
+                "stat.sum": 11,
+                "stat.avg": 0.061452513966480445
+              }
+            },
+            "connection_received_bytes": {
+              "stat.count": 93,
+              "stat.max": 161,
+              "stat.min": 23,
+              "stat.p50": 23,
+              "stat.p90": 92,
+              "stat.p95": 92,
+              "stat.p99": 139,
+              "stat.p9990": 161,
+              "stat.p9999": 161,
+              "stat.sum": 4094,
+              "stat.avg": 44.02150537634409
+            },
+            "connection_duration": {
+              "stat.count": 93,
+              "stat.max": 2290,
+              "stat.min": 20,
+              "stat.p50": 43,
+              "stat.p90": 1379,
+              "stat.p95": 1478,
+              "stat.p99": 1859,
+              "stat.p9990": 2290,
+              "stat.p9999": 2290,
+              "stat.sum": 28546,
+              "stat.avg": 306.9462365591398
+            },
+            "failure_accrual": {
+              "removals": {
+                "counter": 0
+              },
+              "probes": {
+                "counter": 0
+              },
+              "removed_for_ms": {
+                "counter": 0
+              },
+              "revivals": {
+                "counter": 0
+              }
+            },
+            "connects": {
+              "counter": 7816
+            },
+            "pool_num_waited": {
+              "counter": 0
+            },
+            "success": {
+              "counter": 14971
+            },
+            "service": {
+              "svc": {
+                "request_latency_ms": {
+                  "stat.count": 179,
+                  "stat.max": 301,
+                  "stat.min": 0,
+                  "stat.p50": 0,
+                  "stat.p90": 0,
+                  "stat.p95": 0,
+                  "stat.p99": 1,
+                  "stat.p9990": 301,
+                  "stat.p9999": 301,
+                  "stat.sum": 309,
+                  "stat.avg": 1.7262569832402235
+                },
+                "success": {
+                  "counter": 14971
+                },
+                "pending": {
+                  "gauge": 0.0
+                },
+                "requests": {
+                  "counter": 14971
+                }
+              }
+            },
+            "request_latency_ms": {
+              "stat.count": 179,
+              "stat.max": 301,
+              "stat.min": 0,
+              "stat.p50": 0,
+              "stat.p90": 0,
+              "stat.p95": 0,
+              "stat.p99": 1,
+              "stat.p9990": 301,
+              "stat.p9999": 301,
+              "stat.sum": 308,
+              "stat.avg": 1.7206703910614525
+            },
+            "pool_waiters": {
+              "gauge": 0.0
+            },
+            "retries": {
+              "requeues_per_request": {
+                "stat.count": 179,
+                "stat.max": 0,
+                "stat.min": 0,
+                "stat.p50": 0,
+                "stat.p90": 0,
+                "stat.p95": 0,
+                "stat.p99": 0,
+                "stat.p9990": 0,
+                "stat.p9999": 0,
+                "stat.sum": 0,
+                "stat.avg": 0.0
+              },
+              "request_limit": {
+                "counter": 0
+              },
+              "budget_exhausted": {
+                "counter": 0
+              },
+              "cannot_retry": {
+                "counter": 0
+              },
+              "not_open": {
+                "counter": 0
+              },
+              "budget": {},
+              "requeues": {
+                "counter": 0
+              }
+            },
+            "received_bytes": {
+              "counter": 344333
+            },
+            "connection_sent_bytes": {
+              "stat.count": 93,
+              "stat.max": 211,
+              "stat.min": 30,
+              "stat.p50": 30,
+              "stat.p90": 121,
+              "stat.p95": 121,
+              "stat.p99": 180,
+              "stat.p9990": 211,
+              "stat.p9999": 211,
+              "stat.sum": 5340,
+              "stat.avg": 57.41935483870968
+            },
+            "connection_requests": {
+              "stat.count": 93,
+              "stat.max": 7,
+              "stat.min": 1,
+              "stat.p50": 1,
+              "stat.p90": 4,
+              "stat.p95": 4,
+              "stat.p99": 6,
+              "stat.p9990": 7,
+              "stat.p9999": 7,
+              "stat.sum": 178,
+              "stat.avg": 1.913978494623656
+            },
+            "pool_num_too_many_waiters": {
+              "counter": 0
+            },
+            "socket_unwritable_ms": {
+              "counter": 0
+            },
+            "closes": {
+              "counter": 7816
+            },
+            "pool_cached": {
+              "gauge": 0.0
+            },
+            "pool_size": {
+              "gauge": 0.0
+            },
+            "available": {
+              "gauge": 0.0
+            },
+            "request_payload_bytes": {
+              "stat.count": 179,
+              "stat.max": 30,
+              "stat.min": 30,
+              "stat.p50": 30,
+              "stat.p90": 30,
+              "stat.p95": 30,
+              "stat.p99": 30,
+              "stat.p9990": 30,
+              "stat.p9999": 30,
+              "stat.sum": 5370,
+              "stat.avg": 30.0
+            },
+            "socket_writable_ms": {
+              "counter": 0
+            },
+            "cancelled_connects": {
+              "counter": 0
+            },
+            "response_payload_bytes": {
+              "stat.count": 179,
+              "stat.max": 23,
+              "stat.min": 23,
+              "stat.p50": 23,
+              "stat.p90": 23,
+              "stat.p95": 23,
+              "stat.p99": 23,
+              "stat.p9990": 23,
+              "stat.p9999": 23,
+              "stat.sum": 4117,
+              "stat.avg": 23.0
+            },
+            "dtab": {
+              "size": {
+                "stat.count": 0
+              }
+            },
+            "requests": {
+              "counter": 14971
+            },
+            "loadbalancer": {
+              "size": {},
+              "rebuilds": {
+                "counter": 7840
+              },
+              "closed": {},
+              "load": {},
+              "meanweight": {},
+              "adds": {
+                "counter": 7816
+              },
+              "p2c": {
+                "gauge": 26.0
+              },
+              "updates": {
+                "counter": 7840
+              },
+              "available": {},
+              "max_effort_exhausted": {
+                "counter": 0
+              },
+              "busy": {},
+              "removes": {
+                "counter": 7816
+              }
+            },
+            "pending": {
+              "gauge": 0.0
+            },
+            "dispatcher": {
+              "serial": {
+                "queue_size": {
+                  "gauge": 0.0
+                }
+              }
+            },
+            "connections": {
+              "gauge": 0.0
+            }
+          },
+          "$/inet/127.1/9085": {
+            "connect_latency_ms": {
+              "stat.count": 90,
+              "stat.max": 46,
+              "stat.min": 0,
+              "stat.p50": 0,
+              "stat.p90": 0,
+              "stat.p95": 1,
+              "stat.p99": 1,
+              "stat.p9990": 46,
+              "stat.p9999": 46,
+              "stat.sum": 50,
+              "stat.avg": 0.5555555555555556
+            },
+            "failed_connect_latency_ms": {
+              "stat.count": 0
+            },
+            "sent_bytes": {
+              "counter": 445650
+            },
+            "service_creation": {
+              "service_acquisition_latency_ms": {
+                "stat.count": 155,
+                "stat.max": 47,
+                "stat.min": 0,
+                "stat.p50": 0,
+                "stat.p90": 0,
+                "stat.p95": 0,
+                "stat.p99": 1,
+                "stat.p9990": 47,
+                "stat.p9999": 47,
+                "stat.sum": 56,
+                "stat.avg": 0.36129032258064514
+              }
+            },
+            "connection_received_bytes": {
+              "stat.count": 89,
+              "stat.max": 161,
+              "stat.min": 23,
+              "stat.p50": 23,
+              "stat.p90": 69,
+              "stat.p95": 92,
+              "stat.p99": 139,
+              "stat.p9990": 161,
+              "stat.p9999": 161,
+              "stat.sum": 3519,
+              "stat.avg": 39.53932584269663
+            },
+            "connection_duration": {
+              "stat.count": 89,
+              "stat.max": 2313,
+              "stat.min": 18,
+              "stat.p50": 37,
+              "stat.p90": 1352,
+              "stat.p95": 1493,
+              "stat.p99": 2013,
+              "stat.p9990": 2313,
+              "stat.p9999": 2313,
+              "stat.sum": 20765,
+              "stat.avg": 233.31460674157304
+            },
+            "failure_accrual": {
+              "removals": {
+                "counter": 0
+              },
+              "probes": {
+                "counter": 0
+              },
+              "removed_for_ms": {
+                "counter": 0
+              },
+              "revivals": {
+                "counter": 0
+              }
+            },
+            "connects": {
+              "counter": 7832
+            },
+            "pool_num_waited": {
+              "counter": 0
+            },
+            "success": {
+              "counter": 14855
+            },
+            "service": {
+              "svc": {
+                "request_latency_ms": {
+                  "stat.count": 155,
+                  "stat.max": 1,
+                  "stat.min": 0,
+                  "stat.p50": 0,
+                  "stat.p90": 0,
+                  "stat.p95": 0,
+                  "stat.p99": 1,
+                  "stat.p9990": 1,
+                  "stat.p9999": 1,
+                  "stat.sum": 4,
+                  "stat.avg": 0.025806451612903226
+                },
+                "success": {
+                  "counter": 14855
+                },
+                "pending": {
+                  "gauge": 0.0
+                },
+                "requests": {
+                  "counter": 14855
+                }
+              }
+            },
+            "request_latency_ms": {
+              "stat.count": 155,
+              "stat.max": 1,
+              "stat.min": 0,
+              "stat.p50": 0,
+              "stat.p90": 0,
+              "stat.p95": 0,
+              "stat.p99": 1,
+              "stat.p9990": 1,
+              "stat.p9999": 1,
+              "stat.sum": 4,
+              "stat.avg": 0.025806451612903226
+            },
+            "pool_waiters": {
+              "gauge": 0.0
+            },
+            "retries": {
+              "requeues_per_request": {
+                "stat.count": 155,
+                "stat.max": 0,
+                "stat.min": 0,
+                "stat.p50": 0,
+                "stat.p90": 0,
+                "stat.p95": 0,
+                "stat.p99": 0,
+                "stat.p9990": 0,
+                "stat.p9999": 0,
+                "stat.sum": 0,
+                "stat.avg": 0.0
+              },
+              "request_limit": {
+                "counter": 0
+              },
+              "budget_exhausted": {
+                "counter": 0
+              },
+              "cannot_retry": {
+                "counter": 0
+              },
+              "not_open": {
+                "counter": 0
+              },
+              "budget": {
+                "gauge": 264.0
+              },
+              "requeues": {
+                "counter": 0
+              }
+            },
+            "received_bytes": {
+              "counter": 341665
+            },
+            "connection_sent_bytes": {
+              "stat.count": 89,
+              "stat.max": 211,
+              "stat.min": 30,
+              "stat.p50": 30,
+              "stat.p90": 90,
+              "stat.p95": 121,
+              "stat.p99": 180,
+              "stat.p9990": 211,
+              "stat.p9999": 211,
+              "stat.sum": 4590,
+              "stat.avg": 51.57303370786517
+            },
+            "connection_requests": {
+              "stat.count": 89,
+              "stat.max": 7,
+              "stat.min": 1,
+              "stat.p50": 1,
+              "stat.p90": 3,
+              "stat.p95": 4,
+              "stat.p99": 6,
+              "stat.p9990": 7,
+              "stat.p9999": 7,
+              "stat.sum": 153,
+              "stat.avg": 1.7191011235955056
+            },
+            "pool_num_too_many_waiters": {
+              "counter": 0
+            },
+            "socket_unwritable_ms": {
+              "counter": 0
+            },
+            "closes": {
+              "counter": 7831
+            },
+            "pool_cached": {
+              "gauge": 1.0
+            },
+            "pool_size": {
+              "gauge": 0.0
+            },
+            "available": {
+              "gauge": 1.0
+            },
+            "request_payload_bytes": {
+              "stat.count": 155,
+              "stat.max": 30,
+              "stat.min": 30,
+              "stat.p50": 30,
+              "stat.p90": 30,
+              "stat.p95": 30,
+              "stat.p99": 30,
+              "stat.p9990": 30,
+              "stat.p9999": 30,
+              "stat.sum": 4650,
+              "stat.avg": 30.0
+            },
+            "socket_writable_ms": {
+              "counter": 0
+            },
+            "cancelled_connects": {
+              "counter": 0
+            },
+            "response_payload_bytes": {
+              "stat.count": 155,
+              "stat.max": 23,
+              "stat.min": 23,
+              "stat.p50": 23,
+              "stat.p90": 23,
+              "stat.p95": 23,
+              "stat.p99": 23,
+              "stat.p9990": 23,
+              "stat.p9999": 23,
+              "stat.sum": 3565,
+              "stat.avg": 23.0
+            },
+            "dtab": {
+              "size": {
+                "stat.count": 0
+              }
+            },
+            "requests": {
+              "counter": 14855
+            },
+            "loadbalancer": {
+              "size": {
+                "gauge": 1.0
+              },
+              "rebuilds": {
+                "counter": 7848
+              },
+              "closed": {
+                "gauge": 0.0
+              },
+              "load": {
+                "gauge": 0.0
+              },
+              "meanweight": {
+                "gauge": 1.0
+              },
+              "adds": {
+                "counter": 7832
+              },
+              "p2c": {
+                "gauge": 21.0
+              },
+              "updates": {
+                "counter": 7848
+              },
+              "available": {
+                "gauge": 1.0
+              },
+              "max_effort_exhausted": {
+                "counter": 0
+              },
+              "busy": {
+                "gauge": 0.0
+              },
+              "removes": {
+                "counter": 7831
+              }
+            },
+            "pending": {
+              "gauge": 0.0
+            },
+            "dispatcher": {
+              "serial": {
+                "queue_size": {
+                  "gauge": 0.0
+                }
+              }
+            },
+            "connections": {
+              "gauge": 1.0
+            }
+          },
+          "$/inet/127.1/9089": {
+            "connect_latency_ms": {
+              "stat.count": 82,
+              "stat.max": 48,
+              "stat.min": 0,
+              "stat.p50": 0,
+              "stat.p90": 0,
+              "stat.p95": 1,
+              "stat.p99": 1,
+              "stat.p9990": 48,
+              "stat.p9999": 48,
+              "stat.sum": 52,
+              "stat.avg": 0.6341463414634146
+            },
+            "failed_connect_latency_ms": {
+              "stat.count": 0
+            },
+            "sent_bytes": {
+              "counter": 447300
+            },
+            "service_creation": {
+              "service_acquisition_latency_ms": {
+                "stat.count": 176,
+                "stat.max": 48,
+                "stat.min": 0,
+                "stat.p50": 0,
+                "stat.p90": 0,
+                "stat.p95": 1,
+                "stat.p99": 2,
+                "stat.p9990": 48,
+                "stat.p9999": 48,
+                "stat.sum": 63,
+                "stat.avg": 0.35795454545454547
+              }
+            },
+            "connection_received_bytes": {
+              "stat.count": 82,
+              "stat.max": 185,
+              "stat.min": 23,
+              "stat.p50": 46,
+              "stat.p90": 92,
+              "stat.p95": 115,
+              "stat.p99": 185,
+              "stat.p9990": 185,
+              "stat.p9999": 185,
+              "stat.sum": 4048,
+              "stat.avg": 49.36585365853659
+            },
+            "connection_duration": {
+              "stat.count": 82,
+              "stat.max": 2073,
+              "stat.min": 20,
+              "stat.p50": 46,
+              "stat.p90": 1569,
+              "stat.p95": 1633,
+              "stat.p99": 1877,
+              "stat.p9990": 2073,
+              "stat.p9999": 2073,
+              "stat.sum": 32237,
+              "stat.avg": 393.1341463414634
+            },
+            "failure_accrual": {
+              "removals": {
+                "counter": 0
+              },
+              "probes": {
+                "counter": 0
+              },
+              "removed_for_ms": {
+                "counter": 0
+              },
+              "revivals": {
+                "counter": 0
+              }
+            },
+            "connects": {
+              "counter": 7798
+            },
+            "pool_num_waited": {
+              "counter": 0
+            },
+            "success": {
+              "counter": 14910
+            },
+            "service": {
+              "svc": {
+                "request_latency_ms": {
+                  "stat.count": 176,
+                  "stat.max": 4,
+                  "stat.min": 0,
+                  "stat.p50": 0,
+                  "stat.p90": 0,
+                  "stat.p95": 0,
+                  "stat.p99": 1,
+                  "stat.p9990": 4,
+                  "stat.p9999": 4,
+                  "stat.sum": 11,
+                  "stat.avg": 0.0625
+                },
+                "success": {
+                  "counter": 14910
+                },
+                "pending": {
+                  "gauge": 0.0
+                },
+                "requests": {
+                  "counter": 14910
+                }
+              }
+            },
+            "request_latency_ms": {
+              "stat.count": 176,
+              "stat.max": 4,
+              "stat.min": 0,
+              "stat.p50": 0,
+              "stat.p90": 0,
+              "stat.p95": 0,
+              "stat.p99": 1,
+              "stat.p9990": 4,
+              "stat.p9999": 4,
+              "stat.sum": 11,
+              "stat.avg": 0.0625
+            },
+            "pool_waiters": {
+              "gauge": 0.0
+            },
+            "retries": {
+              "requeues_per_request": {
+                "stat.count": 176,
+                "stat.max": 0,
+                "stat.min": 0,
+                "stat.p50": 0,
+                "stat.p90": 0,
+                "stat.p95": 0,
+                "stat.p99": 0,
+                "stat.p9990": 0,
+                "stat.p9999": 0,
+                "stat.sum": 0,
+                "stat.avg": 0.0
+              },
+              "request_limit": {
+                "counter": 0
+              },
+              "budget_exhausted": {
+                "counter": 0
+              },
+              "cannot_retry": {
+                "counter": 0
+              },
+              "not_open": {
+                "counter": 0
+              },
+              "budget": {
+                "gauge": 264.0
+              },
+              "requeues": {
+                "counter": 0
+              }
+            },
+            "received_bytes": {
+              "counter": 342930
+            },
+            "connection_sent_bytes": {
+              "stat.count": 82,
+              "stat.max": 240,
+              "stat.min": 30,
+              "stat.p50": 60,
+              "stat.p90": 121,
+              "stat.p95": 150,
+              "stat.p99": 240,
+              "stat.p9990": 240,
+              "stat.p9999": 240,
+              "stat.sum": 5280,
+              "stat.avg": 64.39024390243902
+            },
+            "connection_requests": {
+              "stat.count": 82,
+              "stat.max": 8,
+              "stat.min": 1,
+              "stat.p50": 2,
+              "stat.p90": 4,
+              "stat.p95": 5,
+              "stat.p99": 8,
+              "stat.p9990": 8,
+              "stat.p9999": 8,
+              "stat.sum": 176,
+              "stat.avg": 2.1463414634146343
+            },
+            "pool_num_too_many_waiters": {
+              "counter": 0
+            },
+            "socket_unwritable_ms": {
+              "counter": 0
+            },
+            "closes": {
+              "counter": 7797
+            },
+            "pool_cached": {
+              "gauge": 1.0
+            },
+            "pool_size": {
+              "gauge": 0.0
+            },
+            "available": {
+              "gauge": 1.0
+            },
+            "request_payload_bytes": {
+              "stat.count": 176,
+              "stat.max": 30,
+              "stat.min": 30,
+              "stat.p50": 30,
+              "stat.p90": 30,
+              "stat.p95": 30,
+              "stat.p99": 30,
+              "stat.p9990": 30,
+              "stat.p9999": 30,
+              "stat.sum": 5280,
+              "stat.avg": 30.0
+            },
+            "socket_writable_ms": {
+              "counter": 0
+            },
+            "cancelled_connects": {
+              "counter": 0
+            },
+            "response_payload_bytes": {
+              "stat.count": 176,
+              "stat.max": 23,
+              "stat.min": 23,
+              "stat.p50": 23,
+              "stat.p90": 23,
+              "stat.p95": 23,
+              "stat.p99": 23,
+              "stat.p9990": 23,
+              "stat.p9999": 23,
+              "stat.sum": 4048,
+              "stat.avg": 23.0
+            },
+            "dtab": {
+              "size": {
+                "stat.count": 0
+              }
+            },
+            "requests": {
+              "counter": 14910
+            },
+            "loadbalancer": {
+              "size": {
+                "gauge": 1.0
+              },
+              "rebuilds": {
+                "counter": 7809
+              },
+              "closed": {
+                "gauge": 0.0
+              },
+              "load": {
+                "gauge": 0.0
+              },
+              "meanweight": {
+                "gauge": 1.0
+              },
+              "adds": {
+                "counter": 7798
+              },
+              "p2c": {
+                "gauge": 22.0
+              },
+              "updates": {
+                "counter": 7809
+              },
+              "available": {
+                "gauge": 1.0
+              },
+              "max_effort_exhausted": {
+                "counter": 0
+              },
+              "busy": {
+                "gauge": 0.0
+              },
+              "removes": {
+                "counter": 7797
+              }
+            },
+            "pending": {
+              "gauge": 0.0
+            },
+            "dispatcher": {
+              "serial": {
+                "queue_size": {
+                  "gauge": 0.0
+                }
+              }
+            },
+            "connections": {
+              "gauge": 1.0
+            }
           }
         }
       },
@@ -3738,7 +2746,7 @@ return {
             "counter": 0
           },
           "misses": {
-            "counter": 3
+            "counter": 21
           },
           "oneshots": {
             "counter": 0
@@ -3757,466 +2765,1458 @@ return {
         },
         "client": {
           "evicts": {
-            "counter": 0
+            "counter": 165251
           },
           "misses": {
-            "counter": 3
+            "counter": 165261
           },
           "oneshots": {
             "counter": 0
           }
+        },
+        "srv": {
+          "0.0.0.0/4114": {
+            "sent_bytes": {
+              "counter": 7255005
+            },
+            "connection_received_bytes": {
+              "stat.count": 34,
+              "stat.max": 3026,
+              "stat.min": 3026,
+              "stat.p50": 3026,
+              "stat.p90": 3026,
+              "stat.p95": 3026,
+              "stat.p99": 3026,
+              "stat.p9990": 3026,
+              "stat.p9999": 3026,
+              "stat.sum": 103020,
+              "stat.avg": 3030.0
+            },
+            "connection_duration": {
+              "stat.count": 34,
+              "stat.max": 701,
+              "stat.min": 178,
+              "stat.p50": 228,
+              "stat.p90": 414,
+              "stat.p95": 435,
+              "stat.p99": 701,
+              "stat.p9990": 701,
+              "stat.p9999": 701,
+              "stat.sum": 9579,
+              "stat.avg": 281.7352941176471
+            },
+            "connects": {
+              "counter": 3124
+            },
+            "success": {
+              "counter": 315435
+            },
+            "request_latency_ms": {
+              "stat.count": 3434,
+              "stat.max": 316,
+              "stat.min": 0,
+              "stat.p50": 2,
+              "stat.p90": 3,
+              "stat.p95": 4,
+              "stat.p99": 9,
+              "stat.p9990": 55,
+              "stat.p9999": 316,
+              "stat.sum": 6237,
+              "stat.avg": 1.8162492719860222
+            },
+            "received_bytes": {
+              "counter": 9463080
+            },
+            "read_timeout": {
+              "counter": 0
+            },
+            "write_timeout": {
+              "counter": 0
+            },
+            "connection_sent_bytes": {
+              "stat.count": 34,
+              "stat.max": 2313,
+              "stat.min": 2313,
+              "stat.p50": 2313,
+              "stat.p90": 2313,
+              "stat.p95": 2313,
+              "stat.p99": 2313,
+              "stat.p9990": 2313,
+              "stat.p9999": 2313,
+              "stat.sum": 78982,
+              "stat.avg": 2323.0
+            },
+            "connection_requests": {
+              "stat.count": 34,
+              "stat.max": 101,
+              "stat.min": 101,
+              "stat.p50": 101,
+              "stat.p90": 101,
+              "stat.p95": 101,
+              "stat.p99": 101,
+              "stat.p9990": 101,
+              "stat.p9999": 101,
+              "stat.sum": 3434,
+              "stat.avg": 101.0
+            },
+            "transit_latency_ms": {
+              "stat.count": 0
+            },
+            "socket_unwritable_ms": {
+              "counter": 0
+            },
+            "closes": {
+              "counter": 0
+            },
+            "request_payload_bytes": {
+              "stat.count": 3434,
+              "stat.max": 30,
+              "stat.min": 30,
+              "stat.p50": 30,
+              "stat.p90": 30,
+              "stat.p95": 30,
+              "stat.p99": 30,
+              "stat.p9990": 30,
+              "stat.p9999": 30,
+              "stat.sum": 103020,
+              "stat.avg": 30.0
+            },
+            "socket_writable_ms": {
+              "counter": 0
+            },
+            "response_payload_bytes": {
+              "stat.count": 3434,
+              "stat.max": 23,
+              "stat.min": 23,
+              "stat.p50": 23,
+              "stat.p90": 23,
+              "stat.p95": 23,
+              "stat.p99": 23,
+              "stat.p9990": 23,
+              "stat.p9999": 23,
+              "stat.sum": 78982,
+              "stat.avg": 23.0
+            },
+            "dtab": {
+              "size": {
+                "stat.count": 0
+              }
+            },
+            "requests": {
+              "counter": 315435
+            },
+            "pending": {
+              "gauge": 1.0
+            },
+            "handletime_us": {
+              "stat.count": 3434,
+              "stat.max": 1352,
+              "stat.min": 4,
+              "stat.p50": 11,
+              "stat.p90": 24,
+              "stat.p95": 30,
+              "stat.p99": 65,
+              "stat.p9990": 453,
+              "stat.p9999": 1352,
+              "stat.sum": 52215,
+              "stat.avg": 15.205299941758883
+            },
+            "connections": {
+              "gauge": 1.0
+            }
+          }
         }
       },
-      "srv": {
-        "0.0.0.0/4116": {
-          "sent_bytes": {
-            "counter": 10668
-          },
-          "connection_received_bytes": {
-            "stat.count": 33,
-            "stat.max": 35,
-            "stat.min": 35,
-            "stat.p50": 35,
-            "stat.p90": 35,
-            "stat.p95": 35,
-            "stat.p99": 35,
-            "stat.p9990": 35,
-            "stat.p9999": 35,
-            "stat.sum": 1155,
-            "stat.avg": 35.0
-          },
-          "connection_duration": {
-            "stat.count": 33,
-            "stat.max": 3,
-            "stat.min": 0,
-            "stat.p50": 1,
-            "stat.p90": 3,
-            "stat.p95": 3,
-            "stat.p99": 3,
-            "stat.p9990": 3,
-            "stat.p9999": 3,
-            "stat.sum": 29,
-            "stat.avg": 0.8787878787878788
-          },
-          "connects": {
-            "counter": 381
-          },
-          "success": {
-            "counter": 381
-          },
-          "request_latency_ms": {
-            "stat.count": 33,
-            "stat.max": 2,
-            "stat.min": 0,
-            "stat.p50": 0,
-            "stat.p90": 0,
-            "stat.p95": 1,
-            "stat.p99": 2,
-            "stat.p9990": 2,
-            "stat.p9999": 2,
-            "stat.sum": 4,
-            "stat.avg": 0.12121212121212122
-          },
-          "received_bytes": {
-            "counter": 13335
-          },
-          "read_timeout": {
-            "counter": 0
-          },
-          "write_timeout": {
-            "counter": 0
-          },
-          "connection_sent_bytes": {
-            "stat.count": 33,
-            "stat.max": 28,
-            "stat.min": 28,
-            "stat.p50": 28,
-            "stat.p90": 28,
-            "stat.p95": 28,
-            "stat.p99": 28,
-            "stat.p9990": 28,
-            "stat.p9999": 28,
-            "stat.sum": 924,
-            "stat.avg": 28.0
-          },
-          "connection_requests": {
-            "stat.count": 33,
-            "stat.max": 1,
-            "stat.min": 1,
-            "stat.p50": 1,
-            "stat.p90": 1,
-            "stat.p95": 1,
-            "stat.p99": 1,
-            "stat.p9990": 1,
-            "stat.p9999": 1,
-            "stat.sum": 33,
-            "stat.avg": 1.0
-          },
-          "transit_latency_ms": {
-            "stat.count": 0
-          },
-          "socket_unwritable_ms": {
-            "counter": 0
-          },
-          "closes": {
-            "counter": 0
-          },
-          "request_payload_bytes": {
-            "stat.count": 33,
-            "stat.max": 35,
-            "stat.min": 35,
-            "stat.p50": 35,
-            "stat.p90": 35,
-            "stat.p95": 35,
-            "stat.p99": 35,
-            "stat.p9990": 35,
-            "stat.p9999": 35,
-            "stat.sum": 1155,
-            "stat.avg": 35.0
-          },
-          "socket_writable_ms": {
-            "counter": 0
-          },
-          "response_payload_bytes": {
-            "stat.count": 33,
-            "stat.max": 28,
-            "stat.min": 28,
-            "stat.p50": 28,
-            "stat.p90": 28,
-            "stat.p95": 28,
-            "stat.p99": 28,
-            "stat.p9990": 28,
-            "stat.p9999": 28,
-            "stat.sum": 924,
-            "stat.avg": 28.0
-          },
-          "dtab": {
-            "size": {
+      "multiplier": {
+        "service": {
+          "svc": {
+            "success": {
+              "counter": 381
+            },
+            "request_latency_ms": {
+              "stat.count": 33,
+              "stat.max": 2,
+              "stat.min": 0,
+              "stat.p50": 0,
+              "stat.p90": 0,
+              "stat.p95": 1,
+              "stat.p99": 2,
+              "stat.p9990": 2,
+              "stat.p9999": 2,
+              "stat.sum": 4,
+              "stat.avg": 0.12121212121212122
+            },
+            "retries": {
+              "per_request": {
+                "stat.count": 33,
+                "stat.max": 0,
+                "stat.min": 0,
+                "stat.p50": 0,
+                "stat.p90": 0,
+                "stat.p95": 0,
+                "stat.p99": 0,
+                "stat.p9990": 0,
+                "stat.p9999": 0,
+                "stat.sum": 0,
+                "stat.avg": 0.0
+              },
+              "total": {
+                "counter": 0
+              },
+              "budget_exhausted": {
+                "counter": 0
+              }
+            },
+            "requests": {
+              "counter": 381
+            },
+            "pending": {
+              "gauge": 0.0
+            }
+          }
+        },
+        "client": {
+          "$/inet/127.1/9030": {
+            "connect_latency_ms": {
               "stat.count": 0
+            },
+            "failed_connect_latency_ms": {
+              "stat.count": 0
+            },
+            "sent_bytes": {
+              "counter": 4760
+            },
+            "service_creation": {
+              "service_acquisition_latency_ms": {
+                "stat.count": 13,
+                "stat.max": 0,
+                "stat.min": 0,
+                "stat.p50": 0,
+                "stat.p90": 0,
+                "stat.p95": 0,
+                "stat.p99": 0,
+                "stat.p9990": 0,
+                "stat.p9999": 0,
+                "stat.sum": 0,
+                "stat.avg": 0.0
+              }
+            },
+            "connection_received_bytes": {
+              "stat.count": 0
+            },
+            "connection_duration": {
+              "stat.count": 0
+            },
+            "failure_accrual": {
+              "removals": {
+                "counter": 0
+              },
+              "probes": {
+                "counter": 0
+              },
+              "removed_for_ms": {
+                "counter": 0
+              },
+              "revivals": {
+                "counter": 0
+              }
+            },
+            "connects": {
+              "counter": 1
+            },
+            "pool_num_waited": {
+              "counter": 0
+            },
+            "success": {
+              "counter": 136
+            },
+            "service": {
+              "svc": {
+                "request_latency_ms": {
+                  "stat.count": 13,
+                  "stat.max": 0,
+                  "stat.min": 0,
+                  "stat.p50": 0,
+                  "stat.p90": 0,
+                  "stat.p95": 0,
+                  "stat.p99": 0,
+                  "stat.p9990": 0,
+                  "stat.p9999": 0,
+                  "stat.sum": 0,
+                  "stat.avg": 0.0
+                },
+                "success": {
+                  "counter": 136
+                },
+                "pending": {
+                  "gauge": 0.0
+                },
+                "requests": {
+                  "counter": 136
+                }
+              }
+            },
+            "request_latency_ms": {
+              "stat.count": 13,
+              "stat.max": 0,
+              "stat.min": 0,
+              "stat.p50": 0,
+              "stat.p90": 0,
+              "stat.p95": 0,
+              "stat.p99": 0,
+              "stat.p9990": 0,
+              "stat.p9999": 0,
+              "stat.sum": 0,
+              "stat.avg": 0.0
+            },
+            "pool_waiters": {
+              "gauge": 0.0
+            },
+            "retries": {
+              "requeues_per_request": {
+                "stat.count": 13,
+                "stat.max": 0,
+                "stat.min": 0,
+                "stat.p50": 0,
+                "stat.p90": 0,
+                "stat.p95": 0,
+                "stat.p99": 0,
+                "stat.p9990": 0,
+                "stat.p9999": 0,
+                "stat.sum": 0,
+                "stat.avg": 0.0
+              },
+              "request_limit": {
+                "counter": 0
+              },
+              "budget_exhausted": {
+                "counter": 0
+              },
+              "cannot_retry": {
+                "counter": 0
+              },
+              "not_open": {
+                "counter": 0
+              },
+              "budget": {
+                "gauge": 102.0
+              },
+              "requeues": {
+                "counter": 0
+              }
+            },
+            "received_bytes": {
+              "counter": 3808
+            },
+            "connection_sent_bytes": {
+              "stat.count": 0
+            },
+            "connection_requests": {
+              "stat.count": 0
+            },
+            "pool_num_too_many_waiters": {
+              "counter": 0
+            },
+            "socket_unwritable_ms": {
+              "counter": 0
+            },
+            "closes": {
+              "counter": 0
+            },
+            "pool_cached": {
+              "gauge": 1.0
+            },
+            "pool_size": {
+              "gauge": 0.0
+            },
+            "available": {
+              "gauge": 1.0
+            },
+            "request_payload_bytes": {
+              "stat.count": 13,
+              "stat.max": 35,
+              "stat.min": 35,
+              "stat.p50": 35,
+              "stat.p90": 35,
+              "stat.p95": 35,
+              "stat.p99": 35,
+              "stat.p9990": 35,
+              "stat.p9999": 35,
+              "stat.sum": 455,
+              "stat.avg": 35.0
+            },
+            "socket_writable_ms": {
+              "counter": 0
+            },
+            "cancelled_connects": {
+              "counter": 0
+            },
+            "response_payload_bytes": {
+              "stat.count": 13,
+              "stat.max": 28,
+              "stat.min": 28,
+              "stat.p50": 28,
+              "stat.p90": 28,
+              "stat.p95": 28,
+              "stat.p99": 28,
+              "stat.p9990": 28,
+              "stat.p9999": 28,
+              "stat.sum": 364,
+              "stat.avg": 28.0
+            },
+            "dtab": {
+              "size": {
+                "stat.count": 0
+              }
+            },
+            "requests": {
+              "counter": 136
+            },
+            "loadbalancer": {
+              "size": {
+                "gauge": 1.0
+              },
+              "rebuilds": {
+                "counter": 1
+              },
+              "closed": {
+                "gauge": 0.0
+              },
+              "load": {
+                "gauge": 0.0
+              },
+              "meanweight": {
+                "gauge": 1.0
+              },
+              "adds": {
+                "counter": 1
+              },
+              "p2c": {
+                "gauge": 1.0
+              },
+              "updates": {
+                "counter": 1
+              },
+              "available": {
+                "gauge": 1.0
+              },
+              "max_effort_exhausted": {
+                "counter": 0
+              },
+              "busy": {
+                "gauge": 0.0
+              },
+              "removes": {
+                "counter": 0
+              }
+            },
+            "pending": {
+              "gauge": 0.0
+            },
+            "dispatcher": {
+              "serial": {
+                "queue_size": {
+                  "gauge": 0.0
+                }
+              }
+            },
+            "connections": {
+              "gauge": 1.0
             }
           },
-          "requests": {
-            "counter": 381
+          "$/inet/127.1/9029": {
+            "connect_latency_ms": {
+              "stat.count": 0
+            },
+            "failed_connect_latency_ms": {
+              "stat.count": 0
+            },
+            "sent_bytes": {
+              "counter": 4165
+            },
+            "service_creation": {
+              "service_acquisition_latency_ms": {
+                "stat.count": 7,
+                "stat.max": 0,
+                "stat.min": 0,
+                "stat.p50": 0,
+                "stat.p90": 0,
+                "stat.p95": 0,
+                "stat.p99": 0,
+                "stat.p9990": 0,
+                "stat.p9999": 0,
+                "stat.sum": 0,
+                "stat.avg": 0.0
+              }
+            },
+            "connection_received_bytes": {
+              "stat.count": 0
+            },
+            "connection_duration": {
+              "stat.count": 0
+            },
+            "failure_accrual": {
+              "removals": {
+                "counter": 0
+              },
+              "probes": {
+                "counter": 0
+              },
+              "removed_for_ms": {
+                "counter": 0
+              },
+              "revivals": {
+                "counter": 0
+              }
+            },
+            "connects": {
+              "counter": 1
+            },
+            "pool_num_waited": {
+              "counter": 0
+            },
+            "success": {
+              "counter": 119
+            },
+            "service": {
+              "svc": {
+                "request_latency_ms": {
+                  "stat.count": 7,
+                  "stat.max": 1,
+                  "stat.min": 0,
+                  "stat.p50": 0,
+                  "stat.p90": 0,
+                  "stat.p95": 1,
+                  "stat.p99": 1,
+                  "stat.p9990": 1,
+                  "stat.p9999": 1,
+                  "stat.sum": 1,
+                  "stat.avg": 0.14285714285714285
+                },
+                "success": {
+                  "counter": 119
+                },
+                "pending": {
+                  "gauge": 0.0
+                },
+                "requests": {
+                  "counter": 119
+                }
+              }
+            },
+            "request_latency_ms": {
+              "stat.count": 7,
+              "stat.max": 1,
+              "stat.min": 0,
+              "stat.p50": 0,
+              "stat.p90": 0,
+              "stat.p95": 1,
+              "stat.p99": 1,
+              "stat.p9990": 1,
+              "stat.p9999": 1,
+              "stat.sum": 1,
+              "stat.avg": 0.14285714285714285
+            },
+            "pool_waiters": {
+              "gauge": 0.0
+            },
+            "retries": {
+              "requeues_per_request": {
+                "stat.count": 7,
+                "stat.max": 0,
+                "stat.min": 0,
+                "stat.p50": 0,
+                "stat.p90": 0,
+                "stat.p95": 0,
+                "stat.p99": 0,
+                "stat.p9990": 0,
+                "stat.p9999": 0,
+                "stat.sum": 0,
+                "stat.avg": 0.0
+              },
+              "request_limit": {
+                "counter": 0
+              },
+              "budget_exhausted": {
+                "counter": 0
+              },
+              "cannot_retry": {
+                "counter": 0
+              },
+              "not_open": {
+                "counter": 0
+              },
+              "budget": {
+                "gauge": 102.0
+              },
+              "requeues": {
+                "counter": 0
+              }
+            },
+            "received_bytes": {
+              "counter": 3332
+            },
+            "connection_sent_bytes": {
+              "stat.count": 0
+            },
+            "connection_requests": {
+              "stat.count": 0
+            },
+            "pool_num_too_many_waiters": {
+              "counter": 0
+            },
+            "socket_unwritable_ms": {
+              "counter": 0
+            },
+            "closes": {
+              "counter": 0
+            },
+            "pool_cached": {
+              "gauge": 1.0
+            },
+            "pool_size": {
+              "gauge": 0.0
+            },
+            "available": {
+              "gauge": 1.0
+            },
+            "request_payload_bytes": {
+              "stat.count": 7,
+              "stat.max": 35,
+              "stat.min": 35,
+              "stat.p50": 35,
+              "stat.p90": 35,
+              "stat.p95": 35,
+              "stat.p99": 35,
+              "stat.p9990": 35,
+              "stat.p9999": 35,
+              "stat.sum": 245,
+              "stat.avg": 35.0
+            },
+            "socket_writable_ms": {
+              "counter": 0
+            },
+            "cancelled_connects": {
+              "counter": 0
+            },
+            "response_payload_bytes": {
+              "stat.count": 7,
+              "stat.max": 28,
+              "stat.min": 28,
+              "stat.p50": 28,
+              "stat.p90": 28,
+              "stat.p95": 28,
+              "stat.p99": 28,
+              "stat.p9990": 28,
+              "stat.p9999": 28,
+              "stat.sum": 196,
+              "stat.avg": 28.0
+            },
+            "dtab": {
+              "size": {
+                "stat.count": 0
+              }
+            },
+            "requests": {
+              "counter": 119
+            },
+            "loadbalancer": {
+              "size": {
+                "gauge": 1.0
+              },
+              "rebuilds": {
+                "counter": 1
+              },
+              "closed": {
+                "gauge": 0.0
+              },
+              "load": {
+                "gauge": 0.0
+              },
+              "meanweight": {
+                "gauge": 1.0
+              },
+              "adds": {
+                "counter": 1
+              },
+              "p2c": {
+                "gauge": 1.0
+              },
+              "updates": {
+                "counter": 1
+              },
+              "available": {
+                "gauge": 1.0
+              },
+              "max_effort_exhausted": {
+                "counter": 0
+              },
+              "busy": {
+                "gauge": 0.0
+              },
+              "removes": {
+                "counter": 0
+              }
+            },
+            "pending": {
+              "gauge": 0.0
+            },
+            "dispatcher": {
+              "serial": {
+                "queue_size": {
+                  "gauge": 0.0
+                }
+              }
+            },
+            "connections": {
+              "gauge": 1.0
+            }
           },
-          "pending": {
-            "gauge": 0.0
+          "$/inet/127.1/9092": {
+            "connect_latency_ms": {
+              "stat.count": 0
+            },
+            "failed_connect_latency_ms": {
+              "stat.count": 0
+            },
+            "sent_bytes": {
+              "counter": 4410
+            },
+            "service_creation": {
+              "service_acquisition_latency_ms": {
+                "stat.count": 13,
+                "stat.max": 0,
+                "stat.min": 0,
+                "stat.p50": 0,
+                "stat.p90": 0,
+                "stat.p95": 0,
+                "stat.p99": 0,
+                "stat.p9990": 0,
+                "stat.p9999": 0,
+                "stat.sum": 0,
+                "stat.avg": 0.0
+              }
+            },
+            "connection_received_bytes": {
+              "stat.count": 0
+            },
+            "connection_duration": {
+              "stat.count": 0
+            },
+            "failure_accrual": {
+              "removals": {
+                "counter": 0
+              },
+              "probes": {
+                "counter": 0
+              },
+              "removed_for_ms": {
+                "counter": 0
+              },
+              "revivals": {
+                "counter": 0
+              }
+            },
+            "connects": {
+              "counter": 1
+            },
+            "pool_num_waited": {
+              "counter": 0
+            },
+            "success": {
+              "counter": 126
+            },
+            "service": {
+              "svc": {
+                "request_latency_ms": {
+                  "stat.count": 13,
+                  "stat.max": 1,
+                  "stat.min": 0,
+                  "stat.p50": 0,
+                  "stat.p90": 0,
+                  "stat.p95": 0,
+                  "stat.p99": 1,
+                  "stat.p9990": 1,
+                  "stat.p9999": 1,
+                  "stat.sum": 1,
+                  "stat.avg": 0.07692307692307693
+                },
+                "success": {
+                  "counter": 126
+                },
+                "pending": {
+                  "gauge": 0.0
+                },
+                "requests": {
+                  "counter": 126
+                }
+              }
+            },
+            "request_latency_ms": {
+              "stat.count": 13,
+              "stat.max": 1,
+              "stat.min": 0,
+              "stat.p50": 0,
+              "stat.p90": 0,
+              "stat.p95": 0,
+              "stat.p99": 1,
+              "stat.p9990": 1,
+              "stat.p9999": 1,
+              "stat.sum": 1,
+              "stat.avg": 0.07692307692307693
+            },
+            "pool_waiters": {
+              "gauge": 0.0
+            },
+            "retries": {
+              "requeues_per_request": {
+                "stat.count": 13,
+                "stat.max": 0,
+                "stat.min": 0,
+                "stat.p50": 0,
+                "stat.p90": 0,
+                "stat.p95": 0,
+                "stat.p99": 0,
+                "stat.p9990": 0,
+                "stat.p9999": 0,
+                "stat.sum": 0,
+                "stat.avg": 0.0
+              },
+              "request_limit": {
+                "counter": 0
+              },
+              "budget_exhausted": {
+                "counter": 0
+              },
+              "cannot_retry": {
+                "counter": 0
+              },
+              "not_open": {
+                "counter": 0
+              },
+              "budget": {
+                "gauge": 102.0
+              },
+              "requeues": {
+                "counter": 0
+              }
+            },
+            "received_bytes": {
+              "counter": 3528
+            },
+            "connection_sent_bytes": {
+              "stat.count": 0
+            },
+            "connection_requests": {
+              "stat.count": 0
+            },
+            "pool_num_too_many_waiters": {
+              "counter": 0
+            },
+            "socket_unwritable_ms": {
+              "counter": 0
+            },
+            "closes": {
+              "counter": 0
+            },
+            "pool_cached": {
+              "gauge": 1.0
+            },
+            "pool_size": {
+              "gauge": 0.0
+            },
+            "available": {
+              "gauge": 1.0
+            },
+            "request_payload_bytes": {
+              "stat.count": 13,
+              "stat.max": 35,
+              "stat.min": 35,
+              "stat.p50": 35,
+              "stat.p90": 35,
+              "stat.p95": 35,
+              "stat.p99": 35,
+              "stat.p9990": 35,
+              "stat.p9999": 35,
+              "stat.sum": 455,
+              "stat.avg": 35.0
+            },
+            "socket_writable_ms": {
+              "counter": 0
+            },
+            "cancelled_connects": {
+              "counter": 0
+            },
+            "response_payload_bytes": {
+              "stat.count": 13,
+              "stat.max": 28,
+              "stat.min": 28,
+              "stat.p50": 28,
+              "stat.p90": 28,
+              "stat.p95": 28,
+              "stat.p99": 28,
+              "stat.p9990": 28,
+              "stat.p9999": 28,
+              "stat.sum": 364,
+              "stat.avg": 28.0
+            },
+            "dtab": {
+              "size": {
+                "stat.count": 0
+              }
+            },
+            "requests": {
+              "counter": 126
+            },
+            "loadbalancer": {
+              "size": {
+                "gauge": 1.0
+              },
+              "rebuilds": {
+                "counter": 1
+              },
+              "closed": {
+                "gauge": 0.0
+              },
+              "load": {
+                "gauge": 0.0
+              },
+              "meanweight": {
+                "gauge": 1.0
+              },
+              "adds": {
+                "counter": 1
+              },
+              "p2c": {
+                "gauge": 1.0
+              },
+              "updates": {
+                "counter": 1
+              },
+              "available": {
+                "gauge": 1.0
+              },
+              "max_effort_exhausted": {
+                "counter": 0
+              },
+              "busy": {
+                "gauge": 0.0
+              },
+              "removes": {
+                "counter": 0
+              }
+            },
+            "pending": {
+              "gauge": 0.0
+            },
+            "dispatcher": {
+              "serial": {
+                "queue_size": {
+                  "gauge": 0.0
+                }
+              }
+            },
+            "connections": {
+              "gauge": 1.0
+            }
+          }
+        },
+        "bindcache": {
+          "path": {
+            "evicts": {
+              "counter": 0
+            },
+            "misses": {
+              "counter": 1
+            },
+            "oneshots": {
+              "counter": 0
+            }
           },
-          "handletime_us": {
-            "stat.count": 33,
-            "stat.max": 27,
-            "stat.min": 7,
-            "stat.p50": 11,
-            "stat.p90": 20,
-            "stat.p95": 20,
-            "stat.p99": 27,
-            "stat.p9990": 27,
-            "stat.p9999": 27,
-            "stat.sum": 407,
-            "stat.avg": 12.333333333333334
+          "bound": {
+            "evicts": {
+              "counter": 0
+            },
+            "misses": {
+              "counter": 3
+            },
+            "oneshots": {
+              "counter": 0
+            }
           },
-          "connections": {
-            "gauge": 0.0
+          "tree": {
+            "evicts": {
+              "counter": 0
+            },
+            "misses": {
+              "counter": 1
+            },
+            "oneshots": {
+              "counter": 0
+            }
+          },
+          "client": {
+            "evicts": {
+              "counter": 0
+            },
+            "misses": {
+              "counter": 3
+            },
+            "oneshots": {
+              "counter": 0
+            }
+          }
+        },
+        "srv": {
+          "0.0.0.0/4116": {
+            "sent_bytes": {
+              "counter": 10668
+            },
+            "connection_received_bytes": {
+              "stat.count": 33,
+              "stat.max": 35,
+              "stat.min": 35,
+              "stat.p50": 35,
+              "stat.p90": 35,
+              "stat.p95": 35,
+              "stat.p99": 35,
+              "stat.p9990": 35,
+              "stat.p9999": 35,
+              "stat.sum": 1155,
+              "stat.avg": 35.0
+            },
+            "connection_duration": {
+              "stat.count": 33,
+              "stat.max": 3,
+              "stat.min": 0,
+              "stat.p50": 1,
+              "stat.p90": 3,
+              "stat.p95": 3,
+              "stat.p99": 3,
+              "stat.p9990": 3,
+              "stat.p9999": 3,
+              "stat.sum": 29,
+              "stat.avg": 0.8787878787878788
+            },
+            "connects": {
+              "counter": 381
+            },
+            "success": {
+              "counter": 381
+            },
+            "request_latency_ms": {
+              "stat.count": 33,
+              "stat.max": 2,
+              "stat.min": 0,
+              "stat.p50": 0,
+              "stat.p90": 0,
+              "stat.p95": 1,
+              "stat.p99": 2,
+              "stat.p9990": 2,
+              "stat.p9999": 2,
+              "stat.sum": 4,
+              "stat.avg": 0.12121212121212122
+            },
+            "received_bytes": {
+              "counter": 13335
+            },
+            "read_timeout": {
+              "counter": 0
+            },
+            "write_timeout": {
+              "counter": 0
+            },
+            "connection_sent_bytes": {
+              "stat.count": 33,
+              "stat.max": 28,
+              "stat.min": 28,
+              "stat.p50": 28,
+              "stat.p90": 28,
+              "stat.p95": 28,
+              "stat.p99": 28,
+              "stat.p9990": 28,
+              "stat.p9999": 28,
+              "stat.sum": 924,
+              "stat.avg": 28.0
+            },
+            "connection_requests": {
+              "stat.count": 33,
+              "stat.max": 1,
+              "stat.min": 1,
+              "stat.p50": 1,
+              "stat.p90": 1,
+              "stat.p95": 1,
+              "stat.p99": 1,
+              "stat.p9990": 1,
+              "stat.p9999": 1,
+              "stat.sum": 33,
+              "stat.avg": 1.0
+            },
+            "transit_latency_ms": {
+              "stat.count": 0
+            },
+            "socket_unwritable_ms": {
+              "counter": 0
+            },
+            "closes": {
+              "counter": 0
+            },
+            "request_payload_bytes": {
+              "stat.count": 33,
+              "stat.max": 35,
+              "stat.min": 35,
+              "stat.p50": 35,
+              "stat.p90": 35,
+              "stat.p95": 35,
+              "stat.p99": 35,
+              "stat.p9990": 35,
+              "stat.p9999": 35,
+              "stat.sum": 1155,
+              "stat.avg": 35.0
+            },
+            "socket_writable_ms": {
+              "counter": 0
+            },
+            "response_payload_bytes": {
+              "stat.count": 33,
+              "stat.max": 28,
+              "stat.min": 28,
+              "stat.p50": 28,
+              "stat.p90": 28,
+              "stat.p95": 28,
+              "stat.p99": 28,
+              "stat.p9990": 28,
+              "stat.p9999": 28,
+              "stat.sum": 924,
+              "stat.avg": 28.0
+            },
+            "dtab": {
+              "size": {
+                "stat.count": 0
+              }
+            },
+            "requests": {
+              "counter": 381
+            },
+            "pending": {
+              "gauge": 0.0
+            },
+            "handletime_us": {
+              "stat.count": 33,
+              "stat.max": 27,
+              "stat.min": 7,
+              "stat.p50": 11,
+              "stat.p90": 20,
+              "stat.p95": 20,
+              "stat.p99": 27,
+              "stat.p9990": 27,
+              "stat.p9999": 27,
+              "stat.sum": 407,
+              "stat.avg": 12.333333333333334
+            },
+            "connections": {
+              "gauge": 0.0
+            }
           }
         }
-      }
-    },
-    "interpreter/io.buoyant.namerd.iface.NamerdInterpreterConfig": {
-      "connect_latency_ms": {
-        "stat.count": 0
       },
-      "failed_connect_latency_ms": {
-        "stat.count": 0
-      },
-      "sent_bytes": {
-        "counter": 3447
-      },
-      "service_creation": {
-        "service_acquisition_latency_ms": {
+      "interpreter/io.buoyant.namerd.iface.NamerdInterpreterConfig": {
+        "connect_latency_ms": {
           "stat.count": 0
-        }
-      },
-      "connection_received_bytes": {
-        "stat.count": 0
-      },
-      "connection_duration": {
-        "stat.count": 0
-      },
-      "connects": {
-        "counter": 1
-      },
-      "success": {
-        "counter": 4
-      },
-      "request_latency_ms": {
-        "stat.count": 0
-      },
-      "mux": {
-        "current_lease_ms": {
-          "gauge": 9.223372E+12
         },
-        "drained": {
-          "counter": 0
-        },
-        "failuredetector": {
-          "marked_busy": {
-            "counter": 0
-          },
-          "ping_latency_us": {
-            "stat.count": 12,
-            "stat.max": 6843,
-            "stat.min": 541,
-            "stat.p50": 752,
-            "stat.p90": 1299,
-            "stat.p95": 1299,
-            "stat.p99": 6843,
-            "stat.p9990": 6843,
-            "stat.p9999": 6843,
-            "stat.sum": 16097,
-            "stat.avg": 1341.4166666666667
-          },
-          "ping": {
-            "counter": 226
-          },
-          "revivals": {
-            "counter": 1
-          },
-          "close": {
-            "counter": 0
-          }
-        },
-        "leased": {
-          "counter": 0
-        },
-        "draining": {
-          "counter": 0
-        }
-      },
-      "retries": {
-        "stat.count": 0,
-        "budget_exhausted": {
-          "counter": 0
-        }
-      },
-      "received_bytes": {
-        "counter": 2413
-      },
-      "namer": {
-        "nametreecache": {
-          "evicts": {
-            "counter": 0
-          },
-          "misses": {
-            "counter": 1
-          },
-          "oneshots": {
-            "counter": 0
-          }
-        },
-        "dtabcache": {
-          "evicts": {
-            "counter": 0
-          },
-          "misses": {
-            "counter": 1
-          },
-          "oneshots": {
-            "counter": 0
-          }
-        },
-        "namecache": {
-          "evicts": {
-            "counter": 0
-          },
-          "misses": {
-            "counter": 1
-          },
-          "oneshots": {
-            "counter": 0
-          }
-        },
-        "bind_latency_us": {
+        "failed_connect_latency_ms": {
           "stat.count": 0
-        }
-      },
-      "bind": {
-        "failures": {
-          "counter": 0
         },
-        "success": {
-          "counter": 1
+        "sent_bytes": {
+          "counter": 3447
         },
-        "requests": {
-          "counter": 2
-        }
-      },
-      "connection_sent_bytes": {
-        "stat.count": 0
-      },
-      "connection_requests": {
-        "stat.count": 0
-      },
-      "addrcache.size": {
-        "gauge": 3.0
-      },
-      "socket_unwritable_ms": {
-        "counter": 0
-      },
-      "closes": {
-        "counter": 0
-      },
-      "addr": {
-        "failures": {
-          "counter": 0
+        "service_creation": {
+          "service_acquisition_latency_ms": {
+            "stat.count": 0
+          }
         },
-        "success": {
-          "counter": 3
+        "connection_received_bytes": {
+          "stat.count": 0
         },
-        "requests": {
-          "counter": 6
-        }
-      },
-      "srv": {},
-      "available": {
-        "gauge": 1.0
-      },
-      "singletonpool": {
+        "connection_duration": {
+          "stat.count": 0
+        },
         "connects": {
-          "fail": {
-            "counter": 0
-          },
-          "dead": {
-            "counter": 0
-          }
-        }
-      },
-      "bindcache.size": {
-        "gauge": 1.0
-      },
-      "request_payload_bytes": {
-        "stat.count": 0
-      },
-      "socket_writable_ms": {
-        "counter": 0
-      },
-      "cancelled_connects": {
-        "counter": 0
-      },
-      "response_payload_bytes": {
-        "stat.count": 0
-      },
-      "dtab": {
-        "size": {
-          "stat.count": 0
-        }
-      },
-      "requests": {
-        "counter": 4
-      },
-      "loadbalancer": {
-        "size": {
-          "gauge": 1.0
-        },
-        "rebuilds": {
-          "counter": 228
-        },
-        "closed": {
-          "gauge": 0.0
-        },
-        "load": {
-          "gauge": 4.0
-        },
-        "meanweight": {
-          "gauge": 1.0
-        },
-        "adds": {
           "counter": 1
         },
-        "p2c": {
-          "gauge": 1.0
+        "success": {
+          "counter": 4
         },
-        "updates": {
-          "counter": 226
+        "request_latency_ms": {
+          "stat.count": 0
         },
+        "mux": {
+          "current_lease_ms": {
+            "gauge": 9.223372E+12
+          },
+          "drained": {
+            "counter": 0
+          },
+          "failuredetector": {
+            "marked_busy": {
+              "counter": 0
+            },
+            "ping_latency_us": {
+              "stat.count": 12,
+              "stat.max": 6843,
+              "stat.min": 541,
+              "stat.p50": 752,
+              "stat.p90": 1299,
+              "stat.p95": 1299,
+              "stat.p99": 6843,
+              "stat.p9990": 6843,
+              "stat.p9999": 6843,
+              "stat.sum": 16097,
+              "stat.avg": 1341.4166666666667
+            },
+            "ping": {
+              "counter": 226
+            },
+            "revivals": {
+              "counter": 1
+            },
+            "close": {
+              "counter": 0
+            }
+          },
+          "leased": {
+            "counter": 0
+          },
+          "draining": {
+            "counter": 0
+          }
+        },
+        "retries": {
+          "stat.count": 0,
+          "budget_exhausted": {
+            "counter": 0
+          }
+        },
+        "received_bytes": {
+          "counter": 2413
+        },
+        "namer": {
+          "nametreecache": {
+            "evicts": {
+              "counter": 0
+            },
+            "misses": {
+              "counter": 1
+            },
+            "oneshots": {
+              "counter": 0
+            }
+          },
+          "dtabcache": {
+            "evicts": {
+              "counter": 0
+            },
+            "misses": {
+              "counter": 1
+            },
+            "oneshots": {
+              "counter": 0
+            }
+          },
+          "namecache": {
+            "evicts": {
+              "counter": 0
+            },
+            "misses": {
+              "counter": 1
+            },
+            "oneshots": {
+              "counter": 0
+            }
+          },
+          "bind_latency_us": {
+            "stat.count": 0
+          }
+        },
+        "bind": {
+          "failures": {
+            "counter": 0
+          },
+          "success": {
+            "counter": 1
+          },
+          "requests": {
+            "counter": 2
+          }
+        },
+        "connection_sent_bytes": {
+          "stat.count": 0
+        },
+        "connection_requests": {
+          "stat.count": 0
+        },
+        "addrcache.size": {
+          "gauge": 3.0
+        },
+        "socket_unwritable_ms": {
+          "counter": 0
+        },
+        "closes": {
+          "counter": 0
+        },
+        "addr": {
+          "failures": {
+            "counter": 0
+          },
+          "success": {
+            "counter": 3
+          },
+          "requests": {
+            "counter": 6
+          }
+        },
+        "srv": {},
         "available": {
           "gauge": 1.0
         },
-        "max_effort_exhausted": {
-          "counter": 2
+        "singletonpool": {
+          "connects": {
+            "fail": {
+              "counter": 0
+            },
+            "dead": {
+              "counter": 0
+            }
+          }
         },
-        "busy": {
-          "gauge": 0.0
+        "bindcache.size": {
+          "gauge": 1.0
         },
-        "removes": {
+        "request_payload_bytes": {
+          "stat.count": 0
+        },
+        "socket_writable_ms": {
           "counter": 0
-        }
-      },
-      "pending": {
-        "gauge": 4.0
-      },
-      "protocol": {
-        "thriftmux": {
+        },
+        "cancelled_connects": {
+          "counter": 0
+        },
+        "response_payload_bytes": {
+          "stat.count": 0
+        },
+        "dtab": {
+          "size": {
+            "stat.count": 0
+          }
+        },
+        "requests": {
+          "counter": 4
+        },
+        "loadbalancer": {
+          "size": {
+            "gauge": 1.0
+          },
+          "rebuilds": {
+            "counter": 228
+          },
+          "closed": {
+            "gauge": 0.0
+          },
+          "load": {
+            "gauge": 4.0
+          },
+          "meanweight": {
+            "gauge": 1.0
+          },
+          "adds": {
+            "counter": 1
+          },
+          "p2c": {
+            "gauge": 1.0
+          },
+          "updates": {
+            "counter": 226
+          },
+          "available": {
+            "gauge": 1.0
+          },
+          "max_effort_exhausted": {
+            "counter": 2
+          },
+          "busy": {
+            "gauge": 0.0
+          },
+          "removes": {
+            "counter": 0
+          }
+        },
+        "pending": {
+          "gauge": 4.0
+        },
+        "protocol": {
+          "thriftmux": {
+            "gauge": 1.0
+          }
+        },
+        "connections": {
           "gauge": 1.0
         }
-      },
-      "connections": {
-        "gauge": 1.0
-      }
-    }
-  },
-  "inet": {
-    "dns": {
-      "queue_size": {
-        "gauge": 0.0
-      },
-      "successes": {
-        "counter": 166676
-      },
-      "cache": {
-        "evicts": {
-          "gauge": 0.0
-        },
-        "size": {
-          "gauge": 0.0
-        },
-        "hit_rate": {
-          "gauge": 1.0
-        }
-      },
-      "dns_lookups": {
-        "counter": 165653
-      },
-      "failures": {
-        "counter": 0
-      },
-      "dns_lookup_failures": {
-        "counter": 0
-      },
-      "lookup_ms": {
-        "stat.count": 1792,
-        "stat.max": 23,
-        "stat.min": 0,
-        "stat.p50": 1,
-        "stat.p90": 2,
-        "stat.p95": 2,
-        "stat.p99": 4,
-        "stat.p9990": 21,
-        "stat.p9999": 23,
-        "stat.sum": 1745,
-        "stat.avg": 0.9737723214285714
-      }
-    }
-  },
-  "toggles": {
-    "com.twitter.finagle.mux": {
-      "checksum": {
-        "gauge": 1.65079066E+9
       }
     },
-    "com.twitter.finagle.thrift": {
-      "checksum": {
-        "gauge": 1.14950771E+9
+    "inet": {
+      "dns": {
+        "queue_size": {
+          "gauge": 0.0
+        },
+        "successes": {
+          "counter": 166676
+        },
+        "cache": {
+          "evicts": {
+            "gauge": 0.0
+          },
+          "size": {
+            "gauge": 0.0
+          },
+          "hit_rate": {
+            "gauge": 1.0
+          }
+        },
+        "dns_lookups": {
+          "counter": 165653
+        },
+        "failures": {
+          "counter": 0
+        },
+        "dns_lookup_failures": {
+          "counter": 0
+        },
+        "lookup_ms": {
+          "stat.count": 1792,
+          "stat.max": 23,
+          "stat.min": 0,
+          "stat.p50": 1,
+          "stat.p90": 2,
+          "stat.p95": 2,
+          "stat.p99": 4,
+          "stat.p9990": 21,
+          "stat.p9999": 23,
+          "stat.sum": 1745,
+          "stat.avg": 0.9737723214285714
+        }
+      }
+    },
+    "toggles": {
+      "com.twitter.finagle.mux": {
+        "checksum": {
+          "gauge": 1.65079066E+9
+        }
+      },
+      "com.twitter.finagle.thrift": {
+        "checksum": {
+          "gauge": 1.14950771E+9
+        }
       }
     }
   }
-}
-});
+}});

--- a/admin/src/main/resources/io/buoyant/admin/js/spec/fixtures/metrics.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/spec/fixtures/metrics.js
@@ -636,924 +636,942 @@ return {
       }
     },
     "adder": {
-      "dst": {
-        "path": {
-          "svc": {
-            "success": {
-              "counter": 315433
-            },
-            "request_latency_ms": {
+      "service": {
+        "svc": {
+          "success": {
+            "counter": 315433
+          },
+          "request_latency_ms": {
+            "stat.count": 3434,
+            "stat.max": 316,
+            "stat.min": 0,
+            "stat.p50": 2,
+            "stat.p90": 3,
+            "stat.p95": 4,
+            "stat.p99": 9,
+            "stat.p9990": 55,
+            "stat.p9999": 316,
+            "stat.sum": 6081,
+            "stat.avg": 1.7708211997670356
+          },
+          "retries": {
+            "per_request": {
               "stat.count": 3434,
-              "stat.max": 316,
-              "stat.min": 0,
-              "stat.p50": 2,
-              "stat.p90": 3,
-              "stat.p95": 4,
-              "stat.p99": 9,
-              "stat.p9990": 55,
-              "stat.p9999": 316,
-              "stat.sum": 6081,
-              "stat.avg": 1.7708211997670356
-            },
-            "retries": {
-              "per_request": {
-                "stat.count": 3434,
-                "stat.max": 0,
-                "stat.min": 0,
-                "stat.p50": 0,
-                "stat.p90": 0,
-                "stat.p95": 0,
-                "stat.p99": 0,
-                "stat.p9990": 0,
-                "stat.p9999": 0,
-                "stat.sum": 0,
-                "stat.avg": 0.0
-              },
-              "total": {
-                "counter": 0
-              },
-              "budget_exhausted": {
-                "counter": 0
-              }
-            },
-            "requests": {
-              "counter": 315433
-            },
-            "pending": {
-              "gauge": 0.0
-            }
-          }
-        },
-        "id": {
-          "$/inet/127.1/9091": {
-            "connect_latency_ms": {
-              "stat.count": 86,
-              "stat.max": 6,
+              "stat.max": 0,
               "stat.min": 0,
               "stat.p50": 0,
               "stat.p90": 0,
               "stat.p95": 0,
-              "stat.p99": 2,
-              "stat.p9990": 6,
-              "stat.p9999": 6,
-              "stat.sum": 8,
-              "stat.avg": 0.09302325581395349
+              "stat.p99": 0,
+              "stat.p9990": 0,
+              "stat.p9999": 0,
+              "stat.sum": 0,
+              "stat.avg": 0.0
             },
-            "failed_connect_latency_ms": {
-              "stat.count": 0
-            },
-            "sent_bytes": {
-              "counter": 454350
-            },
-            "service_creation": {
-              "service_acquisition_latency_ms": {
-                "stat.count": 159,
-                "stat.max": 7,
-                "stat.min": 0,
-                "stat.p50": 0,
-                "stat.p90": 0,
-                "stat.p95": 1,
-                "stat.p99": 1,
-                "stat.p9990": 7,
-                "stat.p9999": 7,
-                "stat.sum": 17,
-                "stat.avg": 0.1069182389937107
-              }
-            },
-            "connection_received_bytes": {
-              "stat.count": 87,
-              "stat.max": 230,
-              "stat.min": 23,
-              "stat.p50": 23,
-              "stat.p90": 69,
-              "stat.p95": 92,
-              "stat.p99": 161,
-              "stat.p9990": 230,
-              "stat.p9999": 230,
-              "stat.sum": 3680,
-              "stat.avg": 42.298850574712645
-            },
-            "connection_duration": {
-              "stat.count": 87,
-              "stat.max": 2268,
-              "stat.min": 20,
-              "stat.p50": 41,
-              "stat.p90": 1379,
-              "stat.p95": 1538,
-              "stat.p99": 1877,
-              "stat.p9990": 2268,
-              "stat.p9999": 2268,
-              "stat.sum": 27822,
-              "stat.avg": 319.7931034482759
-            },
-            "failure_accrual": {
-              "removals": {
-                "counter": 0
-              },
-              "probes": {
-                "counter": 0
-              },
-              "removed_for_ms": {
-                "counter": 0
-              },
-              "revivals": {
-                "counter": 0
-              }
-            },
-            "connects": {
-              "counter": 7887
-            },
-            "pool_num_waited": {
+            "total": {
               "counter": 0
             },
-            "success": {
-              "counter": 15145
-            },
-            "path": {
-              "svc": {
-                "request_latency_ms": {
-                  "stat.count": 159,
-                  "stat.max": 4,
-                  "stat.min": 0,
-                  "stat.p50": 0,
-                  "stat.p90": 0,
-                  "stat.p95": 1,
-                  "stat.p99": 3,
-                  "stat.p9990": 4,
-                  "stat.p9999": 4,
-                  "stat.sum": 23,
-                  "stat.avg": 0.14465408805031446
-                },
-                "success": {
-                  "counter": 15145
-                },
-                "pending": {
-                  "gauge": 0.0
-                },
-                "requests": {
-                  "counter": 15145
-                }
-              }
-            },
-            "request_latency_ms": {
+            "budget_exhausted": {
+              "counter": 0
+            }
+          },
+          "requests": {
+            "counter": 315433
+          },
+          "pending": {
+            "gauge": 0.0
+          }
+        },
+      "client": {
+        "$/inet/127.1/9091": {
+          "connect_latency_ms": {
+            "stat.count": 86,
+            "stat.max": 6,
+            "stat.min": 0,
+            "stat.p50": 0,
+            "stat.p90": 0,
+            "stat.p95": 0,
+            "stat.p99": 2,
+            "stat.p9990": 6,
+            "stat.p9999": 6,
+            "stat.sum": 8,
+            "stat.avg": 0.09302325581395349
+          },
+          "failed_connect_latency_ms": {
+            "stat.count": 0
+          },
+          "sent_bytes": {
+            "counter": 454350
+          },
+          "service_creation": {
+            "service_acquisition_latency_ms": {
               "stat.count": 159,
-              "stat.max": 4,
+              "stat.max": 7,
               "stat.min": 0,
               "stat.p50": 0,
               "stat.p90": 0,
               "stat.p95": 1,
-              "stat.p99": 3,
-              "stat.p9990": 4,
-              "stat.p9999": 4,
-              "stat.sum": 23,
-              "stat.avg": 0.14465408805031446
-            },
-            "pool_waiters": {
-              "gauge": 0.0
-            },
-            "retries": {
-              "requeues_per_request": {
-                "stat.count": 159,
-                "stat.max": 0,
-                "stat.min": 0,
-                "stat.p50": 0,
-                "stat.p90": 0,
-                "stat.p95": 0,
-                "stat.p99": 0,
-                "stat.p9990": 0,
-                "stat.p9999": 0,
-                "stat.sum": 0,
-                "stat.avg": 0.0
-              },
-              "request_limit": {
-                "counter": 0
-              },
-              "budget_exhausted": {
-                "counter": 0
-              },
-              "cannot_retry": {
-                "counter": 0
-              },
-              "not_open": {
-                "counter": 0
-              },
-              "budget": {},
-              "requeues": {
-                "counter": 0
-              }
-            },
-            "received_bytes": {
-              "counter": 348335
-            },
-            "connection_sent_bytes": {
-              "stat.count": 87,
-              "stat.max": 301,
-              "stat.min": 30,
-              "stat.p50": 30,
-              "stat.p90": 90,
-              "stat.p95": 121,
-              "stat.p99": 211,
-              "stat.p9990": 301,
-              "stat.p9999": 301,
-              "stat.sum": 4800,
-              "stat.avg": 55.172413793103445
-            },
-            "connection_requests": {
-              "stat.count": 87,
-              "stat.max": 10,
-              "stat.min": 1,
-              "stat.p50": 1,
-              "stat.p90": 3,
-              "stat.p95": 4,
-              "stat.p99": 7,
-              "stat.p9990": 10,
-              "stat.p9999": 10,
-              "stat.sum": 160,
-              "stat.avg": 1.839080459770115
-            },
-            "pool_num_too_many_waiters": {
-              "counter": 0
-            },
-            "socket_unwritable_ms": {
-              "counter": 0
-            },
-            "closes": {
-              "counter": 7887
-            },
-            "pool_cached": {
-              "gauge": 0.0
-            },
-            "pool_size": {
-              "gauge": 0.0
-            },
-            "available": {
-              "gauge": 0.0
-            },
-            "request_payload_bytes": {
-              "stat.count": 159,
-              "stat.max": 30,
-              "stat.min": 30,
-              "stat.p50": 30,
-              "stat.p90": 30,
-              "stat.p95": 30,
-              "stat.p99": 30,
-              "stat.p9990": 30,
-              "stat.p9999": 30,
-              "stat.sum": 4770,
-              "stat.avg": 30.0
-            },
-            "socket_writable_ms": {
-              "counter": 0
-            },
-            "cancelled_connects": {
-              "counter": 0
-            },
-            "response_payload_bytes": {
-              "stat.count": 159,
-              "stat.max": 23,
-              "stat.min": 23,
-              "stat.p50": 23,
-              "stat.p90": 23,
-              "stat.p95": 23,
-              "stat.p99": 23,
-              "stat.p9990": 23,
-              "stat.p9999": 23,
-              "stat.sum": 3657,
-              "stat.avg": 23.0
-            },
-            "dtab": {
-              "size": {
-                "stat.count": 0
-              }
-            },
-            "requests": {
-              "counter": 15145
-            },
-            "loadbalancer": {
-              "size": {},
-              "rebuilds": {
-                "counter": 7912
-              },
-              "closed": {},
-              "load": {},
-              "meanweight": {},
-              "adds": {
-                "counter": 7887
-              },
-              "p2c": {
-                "gauge": 22.0
-              },
-              "updates": {
-                "counter": 7912
-              },
-              "available": {},
-              "max_effort_exhausted": {
-                "counter": 0
-              },
-              "busy": {},
-              "removes": {
-                "counter": 7887
-              }
-            },
-            "pending": {
-              "gauge": 0.0
-            },
-            "dispatcher": {
-              "serial": {
-                "queue_size": {
-                  "gauge": 0.0
-                }
-              }
-            },
-            "connections": {
-              "gauge": 0.0
-            }
-          },
-          "$/inet/127.1/9090": {
-            "connect_latency_ms": {
-              "stat.count": 92,
-              "stat.max": 31,
-              "stat.min": 0,
-              "stat.p50": 0,
-              "stat.p90": 0,
-              "stat.p95": 0,
-              "stat.p99": 3,
-              "stat.p9990": 31,
-              "stat.p9999": 31,
-              "stat.sum": 37,
-              "stat.avg": 0.40217391304347827
-            },
-            "failed_connect_latency_ms": {
-              "stat.count": 0
-            },
-            "sent_bytes": {
-              "counter": 458460
-            },
-            "service_creation": {
-              "service_acquisition_latency_ms": {
-                "stat.count": 187,
-                "stat.max": 32,
-                "stat.min": 0,
-                "stat.p50": 0,
-                "stat.p90": 0,
-                "stat.p95": 1,
-                "stat.p99": 2,
-                "stat.p9990": 32,
-                "stat.p9999": 32,
-                "stat.sum": 46,
-                "stat.avg": 0.24598930481283424
-              }
-            },
-            "connection_received_bytes": {
-              "stat.count": 91,
-              "stat.max": 230,
-              "stat.min": 23,
-              "stat.p50": 46,
-              "stat.p90": 92,
-              "stat.p95": 115,
-              "stat.p99": 207,
-              "stat.p9990": 230,
-              "stat.p9999": 230,
-              "stat.sum": 4278,
-              "stat.avg": 47.010989010989015
-            },
-            "connection_duration": {
-              "stat.count": 91,
-              "stat.max": 2290,
-              "stat.min": 18,
-              "stat.p50": 45,
-              "stat.p90": 1508,
-              "stat.p95": 1601,
-              "stat.p99": 2094,
-              "stat.p9990": 2290,
-              "stat.p9999": 2290,
-              "stat.sum": 31468,
-              "stat.avg": 345.8021978021978
-            },
-            "failure_accrual": {
-              "removals": {
-                "counter": 0
-              },
-              "probes": {
-                "counter": 0
-              },
-              "removed_for_ms": {
-                "counter": 0
-              },
-              "revivals": {
-                "counter": 0
-              }
-            },
-            "connects": {
-              "counter": 7937
-            },
-            "pool_num_waited": {
-              "counter": 0
-            },
-            "success": {
-              "counter": 15282
-            },
-            "path": {
-              "svc": {
-                "request_latency_ms": {
-                  "stat.count": 187,
-                  "stat.max": 55,
-                  "stat.min": 0,
-                  "stat.p50": 0,
-                  "stat.p90": 0,
-                  "stat.p95": 0,
-                  "stat.p99": 1,
-                  "stat.p9990": 55,
-                  "stat.p9999": 55,
-                  "stat.sum": 59,
-                  "stat.avg": 0.3155080213903743
-                },
-                "success": {
-                  "counter": 15282
-                },
-                "pending": {
-                  "gauge": 0.0
-                },
-                "requests": {
-                  "counter": 15282
-                }
-              }
-            },
-            "request_latency_ms": {
-              "stat.count": 187,
-              "stat.max": 55,
-              "stat.min": 0,
-              "stat.p50": 0,
-              "stat.p90": 0,
-              "stat.p95": 0,
               "stat.p99": 1,
-              "stat.p9990": 55,
-              "stat.p9999": 55,
-              "stat.sum": 59,
-              "stat.avg": 0.3155080213903743
-            },
-            "pool_waiters": {
-              "gauge": 0.0
-            },
-            "retries": {
-              "requeues_per_request": {
-                "stat.count": 187,
-                "stat.max": 0,
-                "stat.min": 0,
-                "stat.p50": 0,
-                "stat.p90": 0,
-                "stat.p95": 0,
-                "stat.p99": 0,
-                "stat.p9990": 0,
-                "stat.p9999": 0,
-                "stat.sum": 0,
-                "stat.avg": 0.0
-              },
-              "request_limit": {
-                "counter": 0
-              },
-              "budget_exhausted": {
-                "counter": 0
-              },
-              "cannot_retry": {
-                "counter": 0
-              },
-              "not_open": {
-                "counter": 0
-              },
-              "budget": {},
-              "requeues": {
-                "counter": 0
-              }
-            },
-            "received_bytes": {
-              "counter": 351486
-            },
-            "connection_sent_bytes": {
-              "stat.count": 91,
-              "stat.max": 301,
-              "stat.min": 30,
-              "stat.p50": 60,
-              "stat.p90": 121,
-              "stat.p95": 150,
-              "stat.p99": 270,
-              "stat.p9990": 301,
-              "stat.p9999": 301,
-              "stat.sum": 5580,
-              "stat.avg": 61.31868131868132
-            },
-            "connection_requests": {
-              "stat.count": 91,
-              "stat.max": 10,
-              "stat.min": 1,
-              "stat.p50": 2,
-              "stat.p90": 4,
-              "stat.p95": 5,
-              "stat.p99": 9,
-              "stat.p9990": 10,
-              "stat.p9999": 10,
-              "stat.sum": 186,
-              "stat.avg": 2.043956043956044
-            },
-            "pool_num_too_many_waiters": {
-              "counter": 0
-            },
-            "socket_unwritable_ms": {
-              "counter": 0
-            },
-            "closes": {
-              "counter": 7937
-            },
-            "pool_cached": {
-              "gauge": 0.0
-            },
-            "pool_size": {
-              "gauge": 0.0
-            },
-            "available": {
-              "gauge": 0.0
-            },
-            "request_payload_bytes": {
-              "stat.count": 187,
-              "stat.max": 30,
-              "stat.min": 30,
-              "stat.p50": 30,
-              "stat.p90": 30,
-              "stat.p95": 30,
-              "stat.p99": 30,
-              "stat.p9990": 30,
-              "stat.p9999": 30,
-              "stat.sum": 5610,
-              "stat.avg": 30.0
-            },
-            "socket_writable_ms": {
-              "counter": 0
-            },
-            "cancelled_connects": {
-              "counter": 0
-            },
-            "response_payload_bytes": {
-              "stat.count": 187,
-              "stat.max": 23,
-              "stat.min": 23,
-              "stat.p50": 23,
-              "stat.p90": 23,
-              "stat.p95": 23,
-              "stat.p99": 23,
-              "stat.p9990": 23,
-              "stat.p9999": 23,
-              "stat.sum": 4301,
-              "stat.avg": 23.0
-            },
-            "dtab": {
-              "size": {
-                "stat.count": 0
-              }
-            },
-            "requests": {
-              "counter": 15282
-            },
-            "loadbalancer": {
-              "size": {},
-              "rebuilds": {
-                "counter": 7960
-              },
-              "closed": {},
-              "load": {},
-              "meanweight": {},
-              "adds": {
-                "counter": 7937
-              },
-              "p2c": {
-                "gauge": 27.0
-              },
-              "updates": {
-                "counter": 7960
-              },
-              "available": {},
-              "max_effort_exhausted": {
-                "counter": 0
-              },
-              "busy": {},
-              "removes": {
-                "counter": 7937
-              }
-            },
-            "pending": {
-              "gauge": 0.0
-            },
-            "dispatcher": {
-              "serial": {
-                "queue_size": {
-                  "gauge": 0.0
-                }
-              }
-            },
-            "connections": {
-              "gauge": 0.0
+              "stat.p9990": 7,
+              "stat.p9999": 7,
+              "stat.sum": 17,
+              "stat.avg": 0.1069182389937107
             }
           },
-          "$/inet/127.1/9093": {
-            "connect_latency_ms": {
-              "stat.count": 82,
-              "stat.max": 49,
-              "stat.min": 0,
-              "stat.p50": 0,
-              "stat.p90": 0,
-              "stat.p95": 0,
-              "stat.p99": 2,
-              "stat.p9990": 49,
-              "stat.p9999": 49,
-              "stat.sum": 52,
-              "stat.avg": 0.6341463414634146
+          "connection_received_bytes": {
+            "stat.count": 87,
+            "stat.max": 230,
+            "stat.min": 23,
+            "stat.p50": 23,
+            "stat.p90": 69,
+            "stat.p95": 92,
+            "stat.p99": 161,
+            "stat.p9990": 230,
+            "stat.p9999": 230,
+            "stat.sum": 3680,
+            "stat.avg": 42.298850574712645
+          },
+          "connection_duration": {
+            "stat.count": 87,
+            "stat.max": 2268,
+            "stat.min": 20,
+            "stat.p50": 41,
+            "stat.p90": 1379,
+            "stat.p95": 1538,
+            "stat.p99": 1877,
+            "stat.p9990": 2268,
+            "stat.p9999": 2268,
+            "stat.sum": 27822,
+            "stat.avg": 319.7931034482759
+          },
+          "failure_accrual": {
+            "removals": {
+              "counter": 0
             },
-            "failed_connect_latency_ms": {
-              "stat.count": 0
+            "probes": {
+              "counter": 0
             },
-            "sent_bytes": {
-              "counter": 445680
+            "removed_for_ms": {
+              "counter": 0
             },
-            "service_creation": {
-              "service_acquisition_latency_ms": {
-                "stat.count": 169,
-                "stat.max": 49,
+            "revivals": {
+              "counter": 0
+            }
+          },
+          "connects": {
+            "counter": 7887
+          },
+          "pool_num_waited": {
+            "counter": 0
+          },
+          "success": {
+            "counter": 15145
+          },
+          "service": {
+            "svc": {
+              "request_latency_ms": {
+                "stat.count": 159,
+                "stat.max": 4,
                 "stat.min": 0,
                 "stat.p50": 0,
                 "stat.p90": 0,
                 "stat.p95": 1,
                 "stat.p99": 3,
-                "stat.p9990": 49,
-                "stat.p9999": 49,
-                "stat.sum": 66,
-                "stat.avg": 0.3905325443786982
-              }
-            },
-            "connection_received_bytes": {
-              "stat.count": 82,
-              "stat.max": 139,
-              "stat.min": 23,
-              "stat.p50": 46,
-              "stat.p90": 92,
-              "stat.p95": 115,
-              "stat.p99": 139,
-              "stat.p9990": 139,
-              "stat.p9999": 139,
-              "stat.sum": 3841,
-              "stat.avg": 46.84146341463415
-            },
-            "connection_duration": {
-              "stat.count": 82,
-              "stat.max": 2158,
-              "stat.min": 20,
-              "stat.p50": 46,
-              "stat.p90": 1421,
-              "stat.p95": 1585,
-              "stat.p99": 1877,
-              "stat.p9990": 2158,
-              "stat.p9999": 2158,
-              "stat.sum": 23936,
-              "stat.avg": 291.9024390243902
-            },
-            "failure_accrual": {
-              "removals": {
-                "counter": 0
+                "stat.p9990": 4,
+                "stat.p9999": 4,
+                "stat.sum": 23,
+                "stat.avg": 0.14465408805031446
               },
-              "probes": {
-                "counter": 0
+              "success": {
+                "counter": 15145
               },
-              "removed_for_ms": {
-                "counter": 0
+              "pending": {
+                "gauge": 0.0
               },
-              "revivals": {
-                "counter": 0
+              "requests": {
+                "counter": 15145
               }
-            },
-            "connects": {
-              "counter": 7853
-            },
-            "pool_num_waited": {
-              "counter": 0
-            },
-            "success": {
-              "counter": 14856
-            },
-            "path": {
-              "svc": {
-                "request_latency_ms": {
-                  "stat.count": 169,
-                  "stat.max": 1,
-                  "stat.min": 0,
-                  "stat.p50": 0,
-                  "stat.p90": 0,
-                  "stat.p95": 0,
-                  "stat.p99": 1,
-                  "stat.p9990": 1,
-                  "stat.p9999": 1,
-                  "stat.sum": 6,
-                  "stat.avg": 0.03550295857988166
-                },
-                "success": {
-                  "counter": 14856
-                },
-                "pending": {
-                  "gauge": 0.0
-                },
-                "requests": {
-                  "counter": 14856
-                }
-              }
-            },
-            "request_latency_ms": {
-              "stat.count": 169,
-              "stat.max": 1,
+            }
+          },
+          "request_latency_ms": {
+            "stat.count": 159,
+            "stat.max": 4,
+            "stat.min": 0,
+            "stat.p50": 0,
+            "stat.p90": 0,
+            "stat.p95": 1,
+            "stat.p99": 3,
+            "stat.p9990": 4,
+            "stat.p9999": 4,
+            "stat.sum": 23,
+            "stat.avg": 0.14465408805031446
+          },
+          "pool_waiters": {
+            "gauge": 0.0
+          },
+          "retries": {
+            "requeues_per_request": {
+              "stat.count": 159,
+              "stat.max": 0,
               "stat.min": 0,
               "stat.p50": 0,
               "stat.p90": 0,
               "stat.p95": 0,
-              "stat.p99": 1,
-              "stat.p9990": 1,
-              "stat.p9999": 1,
-              "stat.sum": 6,
-              "stat.avg": 0.03550295857988166
+              "stat.p99": 0,
+              "stat.p9990": 0,
+              "stat.p9999": 0,
+              "stat.sum": 0,
+              "stat.avg": 0.0
             },
-            "pool_waiters": {
-              "gauge": 0.0
+            "request_limit": {
+              "counter": 0
             },
-            "retries": {
-              "requeues_per_request": {
-                "stat.count": 169,
-                "stat.max": 0,
+            "budget_exhausted": {
+              "counter": 0
+            },
+            "cannot_retry": {
+              "counter": 0
+            },
+            "not_open": {
+              "counter": 0
+            },
+            "budget": {},
+            "requeues": {
+              "counter": 0
+            }
+          },
+          "received_bytes": {
+            "counter": 348335
+          },
+          "connection_sent_bytes": {
+            "stat.count": 87,
+            "stat.max": 301,
+            "stat.min": 30,
+            "stat.p50": 30,
+            "stat.p90": 90,
+            "stat.p95": 121,
+            "stat.p99": 211,
+            "stat.p9990": 301,
+            "stat.p9999": 301,
+            "stat.sum": 4800,
+            "stat.avg": 55.172413793103445
+          },
+          "connection_requests": {
+            "stat.count": 87,
+            "stat.max": 10,
+            "stat.min": 1,
+            "stat.p50": 1,
+            "stat.p90": 3,
+            "stat.p95": 4,
+            "stat.p99": 7,
+            "stat.p9990": 10,
+            "stat.p9999": 10,
+            "stat.sum": 160,
+            "stat.avg": 1.839080459770115
+          },
+          "pool_num_too_many_waiters": {
+            "counter": 0
+          },
+          "socket_unwritable_ms": {
+            "counter": 0
+          },
+          "closes": {
+            "counter": 7887
+          },
+          "pool_cached": {
+            "gauge": 0.0
+          },
+          "pool_size": {
+            "gauge": 0.0
+          },
+          "available": {
+            "gauge": 0.0
+          },
+          "request_payload_bytes": {
+            "stat.count": 159,
+            "stat.max": 30,
+            "stat.min": 30,
+            "stat.p50": 30,
+            "stat.p90": 30,
+            "stat.p95": 30,
+            "stat.p99": 30,
+            "stat.p9990": 30,
+            "stat.p9999": 30,
+            "stat.sum": 4770,
+            "stat.avg": 30.0
+          },
+          "socket_writable_ms": {
+            "counter": 0
+          },
+          "cancelled_connects": {
+            "counter": 0
+          },
+          "response_payload_bytes": {
+            "stat.count": 159,
+            "stat.max": 23,
+            "stat.min": 23,
+            "stat.p50": 23,
+            "stat.p90": 23,
+            "stat.p95": 23,
+            "stat.p99": 23,
+            "stat.p9990": 23,
+            "stat.p9999": 23,
+            "stat.sum": 3657,
+            "stat.avg": 23.0
+          },
+          "dtab": {
+            "size": {
+              "stat.count": 0
+            }
+          },
+          "requests": {
+            "counter": 15145
+          },
+          "loadbalancer": {
+            "size": {},
+            "rebuilds": {
+              "counter": 7912
+            },
+            "closed": {},
+            "load": {},
+            "meanweight": {},
+            "adds": {
+              "counter": 7887
+            },
+            "p2c": {
+              "gauge": 22.0
+            },
+            "updates": {
+              "counter": 7912
+            },
+            "available": {},
+            "max_effort_exhausted": {
+              "counter": 0
+            },
+            "busy": {},
+            "removes": {
+              "counter": 7887
+            }
+          },
+          "pending": {
+            "gauge": 0.0
+          },
+          "dispatcher": {
+            "serial": {
+              "queue_size": {
+                "gauge": 0.0
+              }
+            }
+          },
+          "connections": {
+            "gauge": 0.0
+          }
+        },
+        "$/inet/127.1/9090": {
+          "connect_latency_ms": {
+            "stat.count": 92,
+            "stat.max": 31,
+            "stat.min": 0,
+            "stat.p50": 0,
+            "stat.p90": 0,
+            "stat.p95": 0,
+            "stat.p99": 3,
+            "stat.p9990": 31,
+            "stat.p9999": 31,
+            "stat.sum": 37,
+            "stat.avg": 0.40217391304347827
+          },
+          "failed_connect_latency_ms": {
+            "stat.count": 0
+          },
+          "sent_bytes": {
+            "counter": 458460
+          },
+          "service_creation": {
+            "service_acquisition_latency_ms": {
+              "stat.count": 187,
+              "stat.max": 32,
+              "stat.min": 0,
+              "stat.p50": 0,
+              "stat.p90": 0,
+              "stat.p95": 1,
+              "stat.p99": 2,
+              "stat.p9990": 32,
+              "stat.p9999": 32,
+              "stat.sum": 46,
+              "stat.avg": 0.24598930481283424
+            }
+          },
+          "connection_received_bytes": {
+            "stat.count": 91,
+            "stat.max": 230,
+            "stat.min": 23,
+            "stat.p50": 46,
+            "stat.p90": 92,
+            "stat.p95": 115,
+            "stat.p99": 207,
+            "stat.p9990": 230,
+            "stat.p9999": 230,
+            "stat.sum": 4278,
+            "stat.avg": 47.010989010989015
+          },
+          "connection_duration": {
+            "stat.count": 91,
+            "stat.max": 2290,
+            "stat.min": 18,
+            "stat.p50": 45,
+            "stat.p90": 1508,
+            "stat.p95": 1601,
+            "stat.p99": 2094,
+            "stat.p9990": 2290,
+            "stat.p9999": 2290,
+            "stat.sum": 31468,
+            "stat.avg": 345.8021978021978
+          },
+          "failure_accrual": {
+            "removals": {
+              "counter": 0
+            },
+            "probes": {
+              "counter": 0
+            },
+            "removed_for_ms": {
+              "counter": 0
+            },
+            "revivals": {
+              "counter": 0
+            }
+          },
+          "connects": {
+            "counter": 7937
+          },
+          "pool_num_waited": {
+            "counter": 0
+          },
+          "success": {
+            "counter": 15282
+          },
+          "service": {
+            "svc": {
+              "request_latency_ms": {
+                "stat.count": 187,
+                "stat.max": 55,
                 "stat.min": 0,
                 "stat.p50": 0,
                 "stat.p90": 0,
                 "stat.p95": 0,
-                "stat.p99": 0,
-                "stat.p9990": 0,
-                "stat.p9999": 0,
-                "stat.sum": 0,
-                "stat.avg": 0.0
+                "stat.p99": 1,
+                "stat.p9990": 55,
+                "stat.p9999": 55,
+                "stat.sum": 59,
+                "stat.avg": 0.3155080213903743
               },
-              "request_limit": {
-                "counter": 0
+              "success": {
+                "counter": 15282
               },
-              "budget_exhausted": {
-                "counter": 0
+              "pending": {
+                "gauge": 0.0
               },
-              "cannot_retry": {
-                "counter": 0
-              },
-              "not_open": {
-                "counter": 0
-              },
-              "budget": {
-                "gauge": 264.0
-              },
-              "requeues": {
-                "counter": 0
+              "requests": {
+                "counter": 15282
               }
+            }
+          },
+          "request_latency_ms": {
+            "stat.count": 187,
+            "stat.max": 55,
+            "stat.min": 0,
+            "stat.p50": 0,
+            "stat.p90": 0,
+            "stat.p95": 0,
+            "stat.p99": 1,
+            "stat.p9990": 55,
+            "stat.p9999": 55,
+            "stat.sum": 59,
+            "stat.avg": 0.3155080213903743
+          },
+          "pool_waiters": {
+            "gauge": 0.0
+          },
+          "retries": {
+            "requeues_per_request": {
+              "stat.count": 187,
+              "stat.max": 0,
+              "stat.min": 0,
+              "stat.p50": 0,
+              "stat.p90": 0,
+              "stat.p95": 0,
+              "stat.p99": 0,
+              "stat.p9990": 0,
+              "stat.p9999": 0,
+              "stat.sum": 0,
+              "stat.avg": 0.0
             },
-            "received_bytes": {
-              "counter": 341688
-            },
-            "connection_sent_bytes": {
-              "stat.count": 82,
-              "stat.max": 180,
-              "stat.min": 30,
-              "stat.p50": 60,
-              "stat.p90": 121,
-              "stat.p95": 150,
-              "stat.p99": 180,
-              "stat.p9990": 180,
-              "stat.p9999": 180,
-              "stat.sum": 5010,
-              "stat.avg": 61.09756097560975
-            },
-            "connection_requests": {
-              "stat.count": 82,
-              "stat.max": 6,
-              "stat.min": 1,
-              "stat.p50": 2,
-              "stat.p90": 4,
-              "stat.p95": 5,
-              "stat.p99": 6,
-              "stat.p9990": 6,
-              "stat.p9999": 6,
-              "stat.sum": 167,
-              "stat.avg": 2.0365853658536586
-            },
-            "pool_num_too_many_waiters": {
+            "request_limit": {
               "counter": 0
             },
-            "socket_unwritable_ms": {
+            "budget_exhausted": {
               "counter": 0
             },
-            "closes": {
-              "counter": 7852
+            "cannot_retry": {
+              "counter": 0
             },
-            "pool_cached": {
+            "not_open": {
+              "counter": 0
+            },
+            "budget": {},
+            "requeues": {
+              "counter": 0
+            }
+          },
+          "received_bytes": {
+            "counter": 351486
+          },
+          "connection_sent_bytes": {
+            "stat.count": 91,
+            "stat.max": 301,
+            "stat.min": 30,
+            "stat.p50": 60,
+            "stat.p90": 121,
+            "stat.p95": 150,
+            "stat.p99": 270,
+            "stat.p9990": 301,
+            "stat.p9999": 301,
+            "stat.sum": 5580,
+            "stat.avg": 61.31868131868132
+          },
+          "connection_requests": {
+            "stat.count": 91,
+            "stat.max": 10,
+            "stat.min": 1,
+            "stat.p50": 2,
+            "stat.p90": 4,
+            "stat.p95": 5,
+            "stat.p99": 9,
+            "stat.p9990": 10,
+            "stat.p9999": 10,
+            "stat.sum": 186,
+            "stat.avg": 2.043956043956044
+          },
+          "pool_num_too_many_waiters": {
+            "counter": 0
+          },
+          "socket_unwritable_ms": {
+            "counter": 0
+          },
+          "closes": {
+            "counter": 7937
+          },
+          "pool_cached": {
+            "gauge": 0.0
+          },
+          "pool_size": {
+            "gauge": 0.0
+          },
+          "available": {
+            "gauge": 0.0
+          },
+          "request_payload_bytes": {
+            "stat.count": 187,
+            "stat.max": 30,
+            "stat.min": 30,
+            "stat.p50": 30,
+            "stat.p90": 30,
+            "stat.p95": 30,
+            "stat.p99": 30,
+            "stat.p9990": 30,
+            "stat.p9999": 30,
+            "stat.sum": 5610,
+            "stat.avg": 30.0
+          },
+          "socket_writable_ms": {
+            "counter": 0
+          },
+          "cancelled_connects": {
+            "counter": 0
+          },
+          "response_payload_bytes": {
+            "stat.count": 187,
+            "stat.max": 23,
+            "stat.min": 23,
+            "stat.p50": 23,
+            "stat.p90": 23,
+            "stat.p95": 23,
+            "stat.p99": 23,
+            "stat.p9990": 23,
+            "stat.p9999": 23,
+            "stat.sum": 4301,
+            "stat.avg": 23.0
+          },
+          "dtab": {
+            "size": {
+              "stat.count": 0
+            }
+          },
+          "requests": {
+            "counter": 15282
+          },
+          "loadbalancer": {
+            "size": {},
+            "rebuilds": {
+              "counter": 7960
+            },
+            "closed": {},
+            "load": {},
+            "meanweight": {},
+            "adds": {
+              "counter": 7937
+            },
+            "p2c": {
+              "gauge": 27.0
+            },
+            "updates": {
+              "counter": 7960
+            },
+            "available": {},
+            "max_effort_exhausted": {
+              "counter": 0
+            },
+            "busy": {},
+            "removes": {
+              "counter": 7937
+            }
+          },
+          "pending": {
+            "gauge": 0.0
+          },
+          "dispatcher": {
+            "serial": {
+              "queue_size": {
+                "gauge": 0.0
+              }
+            }
+          },
+          "connections": {
+            "gauge": 0.0
+          }
+        },
+        "$/inet/127.1/9093": {
+          "connect_latency_ms": {
+            "stat.count": 82,
+            "stat.max": 49,
+            "stat.min": 0,
+            "stat.p50": 0,
+            "stat.p90": 0,
+            "stat.p95": 0,
+            "stat.p99": 2,
+            "stat.p9990": 49,
+            "stat.p9999": 49,
+            "stat.sum": 52,
+            "stat.avg": 0.6341463414634146
+          },
+          "failed_connect_latency_ms": {
+            "stat.count": 0
+          },
+          "sent_bytes": {
+            "counter": 445680
+          },
+          "service_creation": {
+            "service_acquisition_latency_ms": {
+              "stat.count": 169,
+              "stat.max": 49,
+              "stat.min": 0,
+              "stat.p50": 0,
+              "stat.p90": 0,
+              "stat.p95": 1,
+              "stat.p99": 3,
+              "stat.p9990": 49,
+              "stat.p9999": 49,
+              "stat.sum": 66,
+              "stat.avg": 0.3905325443786982
+            }
+          },
+          "connection_received_bytes": {
+            "stat.count": 82,
+            "stat.max": 139,
+            "stat.min": 23,
+            "stat.p50": 46,
+            "stat.p90": 92,
+            "stat.p95": 115,
+            "stat.p99": 139,
+            "stat.p9990": 139,
+            "stat.p9999": 139,
+            "stat.sum": 3841,
+            "stat.avg": 46.84146341463415
+          },
+          "connection_duration": {
+            "stat.count": 82,
+            "stat.max": 2158,
+            "stat.min": 20,
+            "stat.p50": 46,
+            "stat.p90": 1421,
+            "stat.p95": 1585,
+            "stat.p99": 1877,
+            "stat.p9990": 2158,
+            "stat.p9999": 2158,
+            "stat.sum": 23936,
+            "stat.avg": 291.9024390243902
+          },
+          "failure_accrual": {
+            "removals": {
+              "counter": 0
+            },
+            "probes": {
+              "counter": 0
+            },
+            "removed_for_ms": {
+              "counter": 0
+            },
+            "revivals": {
+              "counter": 0
+            }
+          },
+          "connects": {
+            "counter": 7853
+          },
+          "pool_num_waited": {
+            "counter": 0
+          },
+          "success": {
+            "counter": 14856
+          },
+          "service": {
+            "svc": {
+              "request_latency_ms": {
+                "stat.count": 169,
+                "stat.max": 1,
+                "stat.min": 0,
+                "stat.p50": 0,
+                "stat.p90": 0,
+                "stat.p95": 0,
+                "stat.p99": 1,
+                "stat.p9990": 1,
+                "stat.p9999": 1,
+                "stat.sum": 6,
+                "stat.avg": 0.03550295857988166
+              },
+              "success": {
+                "counter": 14856
+              },
+              "pending": {
+                "gauge": 0.0
+              },
+              "requests": {
+                "counter": 14856
+              }
+            }
+          },
+          "request_latency_ms": {
+            "stat.count": 169,
+            "stat.max": 1,
+            "stat.min": 0,
+            "stat.p50": 0,
+            "stat.p90": 0,
+            "stat.p95": 0,
+            "stat.p99": 1,
+            "stat.p9990": 1,
+            "stat.p9999": 1,
+            "stat.sum": 6,
+            "stat.avg": 0.03550295857988166
+          },
+          "pool_waiters": {
+            "gauge": 0.0
+          },
+          "retries": {
+            "requeues_per_request": {
+              "stat.count": 169,
+              "stat.max": 0,
+              "stat.min": 0,
+              "stat.p50": 0,
+              "stat.p90": 0,
+              "stat.p95": 0,
+              "stat.p99": 0,
+              "stat.p9990": 0,
+              "stat.p9999": 0,
+              "stat.sum": 0,
+              "stat.avg": 0.0
+            },
+            "request_limit": {
+              "counter": 0
+            },
+            "budget_exhausted": {
+              "counter": 0
+            },
+            "cannot_retry": {
+              "counter": 0
+            },
+            "not_open": {
+              "counter": 0
+            },
+            "budget": {
+              "gauge": 264.0
+            },
+            "requeues": {
+              "counter": 0
+            }
+          },
+          "received_bytes": {
+            "counter": 341688
+          },
+          "connection_sent_bytes": {
+            "stat.count": 82,
+            "stat.max": 180,
+            "stat.min": 30,
+            "stat.p50": 60,
+            "stat.p90": 121,
+            "stat.p95": 150,
+            "stat.p99": 180,
+            "stat.p9990": 180,
+            "stat.p9999": 180,
+            "stat.sum": 5010,
+            "stat.avg": 61.09756097560975
+          },
+          "connection_requests": {
+            "stat.count": 82,
+            "stat.max": 6,
+            "stat.min": 1,
+            "stat.p50": 2,
+            "stat.p90": 4,
+            "stat.p95": 5,
+            "stat.p99": 6,
+            "stat.p9990": 6,
+            "stat.p9999": 6,
+            "stat.sum": 167,
+            "stat.avg": 2.0365853658536586
+          },
+          "pool_num_too_many_waiters": {
+            "counter": 0
+          },
+          "socket_unwritable_ms": {
+            "counter": 0
+          },
+          "closes": {
+            "counter": 7852
+          },
+          "pool_cached": {
+            "gauge": 1.0
+          },
+          "pool_size": {
+            "gauge": 0.0
+          },
+          "available": {
+            "gauge": 1.0
+          },
+          "request_payload_bytes": {
+            "stat.count": 169,
+            "stat.max": 30,
+            "stat.min": 30,
+            "stat.p50": 30,
+            "stat.p90": 30,
+            "stat.p95": 30,
+            "stat.p99": 30,
+            "stat.p9990": 30,
+            "stat.p9999": 30,
+            "stat.sum": 5070,
+            "stat.avg": 30.0
+          },
+          "socket_writable_ms": {
+            "counter": 0
+          },
+          "cancelled_connects": {
+            "counter": 0
+          },
+          "response_payload_bytes": {
+            "stat.count": 169,
+            "stat.max": 23,
+            "stat.min": 23,
+            "stat.p50": 23,
+            "stat.p90": 23,
+            "stat.p95": 23,
+            "stat.p99": 23,
+            "stat.p9990": 23,
+            "stat.p9999": 23,
+            "stat.sum": 3887,
+            "stat.avg": 23.0
+          },
+          "dtab": {
+            "size": {
+              "stat.count": 0
+            }
+          },
+          "requests": {
+            "counter": 14856
+          },
+          "loadbalancer": {
+            "size": {
               "gauge": 1.0
             },
-            "pool_size": {
+            "rebuilds": {
+              "counter": 7869
+            },
+            "closed": {
               "gauge": 0.0
+            },
+            "load": {
+              "gauge": 0.0
+            },
+            "meanweight": {
+              "gauge": 1.0
+            },
+            "adds": {
+              "counter": 7853
+            },
+            "p2c": {
+              "gauge": 26.0
+            },
+            "updates": {
+              "counter": 7869
             },
             "available": {
               "gauge": 1.0
             },
-            "request_payload_bytes": {
-              "stat.count": 169,
-              "stat.max": 30,
-              "stat.min": 30,
-              "stat.p50": 30,
-              "stat.p90": 30,
-              "stat.p95": 30,
-              "stat.p99": 30,
-              "stat.p9990": 30,
-              "stat.p9999": 30,
-              "stat.sum": 5070,
-              "stat.avg": 30.0
-            },
-            "socket_writable_ms": {
+            "max_effort_exhausted": {
               "counter": 0
             },
-            "cancelled_connects": {
-              "counter": 0
-            },
-            "response_payload_bytes": {
-              "stat.count": 169,
-              "stat.max": 23,
-              "stat.min": 23,
-              "stat.p50": 23,
-              "stat.p90": 23,
-              "stat.p95": 23,
-              "stat.p99": 23,
-              "stat.p9990": 23,
-              "stat.p9999": 23,
-              "stat.sum": 3887,
-              "stat.avg": 23.0
-            },
-            "dtab": {
-              "size": {
-                "stat.count": 0
-              }
-            },
-            "requests": {
-              "counter": 14856
-            },
-            "loadbalancer": {
-              "size": {
-                "gauge": 1.0
-              },
-              "rebuilds": {
-                "counter": 7869
-              },
-              "closed": {
-                "gauge": 0.0
-              },
-              "load": {
-                "gauge": 0.0
-              },
-              "meanweight": {
-                "gauge": 1.0
-              },
-              "adds": {
-                "counter": 7853
-              },
-              "p2c": {
-                "gauge": 26.0
-              },
-              "updates": {
-                "counter": 7869
-              },
-              "available": {
-                "gauge": 1.0
-              },
-              "max_effort_exhausted": {
-                "counter": 0
-              },
-              "busy": {
-                "gauge": 0.0
-              },
-              "removes": {
-                "counter": 7852
-              }
-            },
-            "pending": {
+            "busy": {
               "gauge": 0.0
             },
-            "dispatcher": {
-              "serial": {
-                "queue_size": {
-                  "gauge": 0.0
-                }
-              }
-            },
-            "connections": {
-              "gauge": 1.0
+            "removes": {
+              "counter": 7852
             }
           },
-          "$/inet/127.1/9070": {
-            "connect_latency_ms": {
-              "stat.count": 85,
+          "pending": {
+            "gauge": 0.0
+          },
+          "dispatcher": {
+            "serial": {
+              "queue_size": {
+                "gauge": 0.0
+              }
+            }
+          },
+          "connections": {
+            "gauge": 1.0
+          }
+        },
+        "$/inet/127.1/9070": {
+          "connect_latency_ms": {
+            "stat.count": 85,
+            "stat.max": 3,
+            "stat.min": 0,
+            "stat.p50": 0,
+            "stat.p90": 0,
+            "stat.p95": 0,
+            "stat.p99": 1,
+            "stat.p9990": 3,
+            "stat.p9999": 3,
+            "stat.sum": 4,
+            "stat.avg": 0.047058823529411764
+          },
+          "failed_connect_latency_ms": {
+            "stat.count": 0
+          },
+          "sent_bytes": {
+            "counter": 448860
+          },
+          "service_creation": {
+            "service_acquisition_latency_ms": {
+              "stat.count": 183,
               "stat.max": 3,
               "stat.min": 0,
               "stat.p50": 0,
@@ -1562,1219 +1580,1198 @@ return {
               "stat.p99": 1,
               "stat.p9990": 3,
               "stat.p9999": 3,
-              "stat.sum": 4,
-              "stat.avg": 0.047058823529411764
+              "stat.sum": 8,
+              "stat.avg": 0.04371584699453552
+            }
+          },
+          "connection_received_bytes": {
+            "stat.count": 85,
+            "stat.max": 161,
+            "stat.min": 23,
+            "stat.p50": 46,
+            "stat.p90": 92,
+            "stat.p95": 115,
+            "stat.p99": 139,
+            "stat.p9990": 161,
+            "stat.p9999": 161,
+            "stat.sum": 4209,
+            "stat.avg": 49.51764705882353
+          },
+          "connection_duration": {
+            "stat.count": 85,
+            "stat.max": 2313,
+            "stat.min": 17,
+            "stat.p50": 49,
+            "stat.p90": 1585,
+            "stat.p95": 1859,
+            "stat.p99": 2013,
+            "stat.p9990": 2313,
+            "stat.p9999": 2313,
+            "stat.sum": 35877,
+            "stat.avg": 422.08235294117645
+          },
+          "failure_accrual": {
+            "removals": {
+              "counter": 0
             },
-            "failed_connect_latency_ms": {
-              "stat.count": 0
+            "probes": {
+              "counter": 0
             },
-            "sent_bytes": {
-              "counter": 448860
+            "removed_for_ms": {
+              "counter": 0
             },
-            "service_creation": {
-              "service_acquisition_latency_ms": {
+            "revivals": {
+              "counter": 0
+            }
+          },
+          "connects": {
+            "counter": 7832
+          },
+          "pool_num_waited": {
+            "counter": 0
+          },
+          "success": {
+            "counter": 14962
+          },
+          "service": {
+            "svc": {
+              "request_latency_ms": {
                 "stat.count": 183,
-                "stat.max": 3,
+                "stat.max": 53,
                 "stat.min": 0,
                 "stat.p50": 0,
                 "stat.p90": 0,
                 "stat.p95": 0,
                 "stat.p99": 1,
-                "stat.p9990": 3,
-                "stat.p9999": 3,
-                "stat.sum": 8,
-                "stat.avg": 0.04371584699453552
+                "stat.p9990": 53,
+                "stat.p9999": 53,
+                "stat.sum": 60,
+                "stat.avg": 0.32786885245901637
+              },
+              "success": {
+                "counter": 14962
+              },
+              "pending": {
+                "gauge": 0.0
+              },
+              "requests": {
+                "counter": 14962
               }
+            }
+          },
+          "request_latency_ms": {
+            "stat.count": 183,
+            "stat.max": 53,
+            "stat.min": 0,
+            "stat.p50": 0,
+            "stat.p90": 0,
+            "stat.p95": 0,
+            "stat.p99": 1,
+            "stat.p9990": 53,
+            "stat.p9999": 53,
+            "stat.sum": 60,
+            "stat.avg": 0.32786885245901637
+          },
+          "pool_waiters": {
+            "gauge": 0.0
+          },
+          "retries": {
+            "requeues_per_request": {
+              "stat.count": 183,
+              "stat.max": 0,
+              "stat.min": 0,
+              "stat.p50": 0,
+              "stat.p90": 0,
+              "stat.p95": 0,
+              "stat.p99": 0,
+              "stat.p9990": 0,
+              "stat.p9999": 0,
+              "stat.sum": 0,
+              "stat.avg": 0.0
             },
-            "connection_received_bytes": {
-              "stat.count": 85,
-              "stat.max": 161,
-              "stat.min": 23,
-              "stat.p50": 46,
-              "stat.p90": 92,
-              "stat.p95": 115,
-              "stat.p99": 139,
-              "stat.p9990": 161,
-              "stat.p9999": 161,
-              "stat.sum": 4209,
-              "stat.avg": 49.51764705882353
+            "request_limit": {
+              "counter": 0
             },
-            "connection_duration": {
-              "stat.count": 85,
-              "stat.max": 2313,
-              "stat.min": 17,
-              "stat.p50": 49,
-              "stat.p90": 1585,
-              "stat.p95": 1859,
-              "stat.p99": 2013,
-              "stat.p9990": 2313,
-              "stat.p9999": 2313,
-              "stat.sum": 35877,
-              "stat.avg": 422.08235294117645
+            "budget_exhausted": {
+              "counter": 0
             },
-            "failure_accrual": {
-              "removals": {
-                "counter": 0
-              },
-              "probes": {
-                "counter": 0
-              },
-              "removed_for_ms": {
-                "counter": 0
-              },
-              "revivals": {
-                "counter": 0
-              }
+            "cannot_retry": {
+              "counter": 0
             },
-            "connects": {
+            "not_open": {
+              "counter": 0
+            },
+            "budget": {
+              "gauge": 264.0
+            },
+            "requeues": {
+              "counter": 0
+            }
+          },
+          "received_bytes": {
+            "counter": 344126
+          },
+          "connection_sent_bytes": {
+            "stat.count": 85,
+            "stat.max": 211,
+            "stat.min": 30,
+            "stat.p50": 60,
+            "stat.p90": 121,
+            "stat.p95": 150,
+            "stat.p99": 180,
+            "stat.p9990": 211,
+            "stat.p9999": 211,
+            "stat.sum": 5490,
+            "stat.avg": 64.58823529411765
+          },
+          "connection_requests": {
+            "stat.count": 85,
+            "stat.max": 7,
+            "stat.min": 1,
+            "stat.p50": 2,
+            "stat.p90": 4,
+            "stat.p95": 5,
+            "stat.p99": 6,
+            "stat.p9990": 7,
+            "stat.p9999": 7,
+            "stat.sum": 183,
+            "stat.avg": 2.152941176470588
+          },
+          "pool_num_too_many_waiters": {
+            "counter": 0
+          },
+          "socket_unwritable_ms": {
+            "counter": 0
+          },
+          "closes": {
+            "counter": 7831
+          },
+          "pool_cached": {
+            "gauge": 1.0
+          },
+          "pool_size": {
+            "gauge": 0.0
+          },
+          "available": {
+            "gauge": 1.0
+          },
+          "request_payload_bytes": {
+            "stat.count": 183,
+            "stat.max": 30,
+            "stat.min": 30,
+            "stat.p50": 30,
+            "stat.p90": 30,
+            "stat.p95": 30,
+            "stat.p99": 30,
+            "stat.p9990": 30,
+            "stat.p9999": 30,
+            "stat.sum": 5490,
+            "stat.avg": 30.0
+          },
+          "socket_writable_ms": {
+            "counter": 0
+          },
+          "cancelled_connects": {
+            "counter": 0
+          },
+          "response_payload_bytes": {
+            "stat.count": 183,
+            "stat.max": 23,
+            "stat.min": 23,
+            "stat.p50": 23,
+            "stat.p90": 23,
+            "stat.p95": 23,
+            "stat.p99": 23,
+            "stat.p9990": 23,
+            "stat.p9999": 23,
+            "stat.sum": 4209,
+            "stat.avg": 23.0
+          },
+          "dtab": {
+            "size": {
+              "stat.count": 0
+            }
+          },
+          "requests": {
+            "counter": 14962
+          },
+          "loadbalancer": {
+            "size": {
+              "gauge": 1.0
+            },
+            "rebuilds": {
+              "counter": 7855
+            },
+            "closed": {
+              "gauge": 0.0
+            },
+            "load": {
+              "gauge": 0.0
+            },
+            "meanweight": {
+              "gauge": 1.0
+            },
+            "adds": {
               "counter": 7832
             },
-            "pool_num_waited": {
+            "p2c": {
+              "gauge": 25.0
+            },
+            "updates": {
+              "counter": 7855
+            },
+            "available": {
+              "gauge": 1.0
+            },
+            "max_effort_exhausted": {
               "counter": 0
             },
-            "success": {
-              "counter": 14962
-            },
-            "path": {
-              "svc": {
-                "request_latency_ms": {
-                  "stat.count": 183,
-                  "stat.max": 53,
-                  "stat.min": 0,
-                  "stat.p50": 0,
-                  "stat.p90": 0,
-                  "stat.p95": 0,
-                  "stat.p99": 1,
-                  "stat.p9990": 53,
-                  "stat.p9999": 53,
-                  "stat.sum": 60,
-                  "stat.avg": 0.32786885245901637
-                },
-                "success": {
-                  "counter": 14962
-                },
-                "pending": {
-                  "gauge": 0.0
-                },
-                "requests": {
-                  "counter": 14962
-                }
-              }
-            },
-            "request_latency_ms": {
-              "stat.count": 183,
-              "stat.max": 53,
-              "stat.min": 0,
-              "stat.p50": 0,
-              "stat.p90": 0,
-              "stat.p95": 0,
-              "stat.p99": 1,
-              "stat.p9990": 53,
-              "stat.p9999": 53,
-              "stat.sum": 60,
-              "stat.avg": 0.32786885245901637
-            },
-            "pool_waiters": {
+            "busy": {
               "gauge": 0.0
             },
-            "retries": {
-              "requeues_per_request": {
-                "stat.count": 183,
-                "stat.max": 0,
-                "stat.min": 0,
-                "stat.p50": 0,
-                "stat.p90": 0,
-                "stat.p95": 0,
-                "stat.p99": 0,
-                "stat.p9990": 0,
-                "stat.p9999": 0,
-                "stat.sum": 0,
-                "stat.avg": 0.0
-              },
-              "request_limit": {
-                "counter": 0
-              },
-              "budget_exhausted": {
-                "counter": 0
-              },
-              "cannot_retry": {
-                "counter": 0
-              },
-              "not_open": {
-                "counter": 0
-              },
-              "budget": {
-                "gauge": 264.0
-              },
-              "requeues": {
-                "counter": 0
-              }
-            },
-            "received_bytes": {
-              "counter": 344126
-            },
-            "connection_sent_bytes": {
-              "stat.count": 85,
-              "stat.max": 211,
-              "stat.min": 30,
-              "stat.p50": 60,
-              "stat.p90": 121,
-              "stat.p95": 150,
-              "stat.p99": 180,
-              "stat.p9990": 211,
-              "stat.p9999": 211,
-              "stat.sum": 5490,
-              "stat.avg": 64.58823529411765
-            },
-            "connection_requests": {
-              "stat.count": 85,
-              "stat.max": 7,
-              "stat.min": 1,
-              "stat.p50": 2,
-              "stat.p90": 4,
-              "stat.p95": 5,
-              "stat.p99": 6,
-              "stat.p9990": 7,
-              "stat.p9999": 7,
-              "stat.sum": 183,
-              "stat.avg": 2.152941176470588
-            },
-            "pool_num_too_many_waiters": {
-              "counter": 0
-            },
-            "socket_unwritable_ms": {
-              "counter": 0
-            },
-            "closes": {
+            "removes": {
               "counter": 7831
-            },
-            "pool_cached": {
-              "gauge": 1.0
-            },
-            "pool_size": {
-              "gauge": 0.0
-            },
-            "available": {
-              "gauge": 1.0
-            },
-            "request_payload_bytes": {
-              "stat.count": 183,
-              "stat.max": 30,
-              "stat.min": 30,
-              "stat.p50": 30,
-              "stat.p90": 30,
-              "stat.p95": 30,
-              "stat.p99": 30,
-              "stat.p9990": 30,
-              "stat.p9999": 30,
-              "stat.sum": 5490,
-              "stat.avg": 30.0
-            },
-            "socket_writable_ms": {
-              "counter": 0
-            },
-            "cancelled_connects": {
-              "counter": 0
-            },
-            "response_payload_bytes": {
-              "stat.count": 183,
-              "stat.max": 23,
-              "stat.min": 23,
-              "stat.p50": 23,
-              "stat.p90": 23,
-              "stat.p95": 23,
-              "stat.p99": 23,
-              "stat.p9990": 23,
-              "stat.p9999": 23,
-              "stat.sum": 4209,
-              "stat.avg": 23.0
-            },
-            "dtab": {
-              "size": {
-                "stat.count": 0
-              }
-            },
-            "requests": {
-              "counter": 14962
-            },
-            "loadbalancer": {
-              "size": {
-                "gauge": 1.0
-              },
-              "rebuilds": {
-                "counter": 7855
-              },
-              "closed": {
-                "gauge": 0.0
-              },
-              "load": {
-                "gauge": 0.0
-              },
-              "meanweight": {
-                "gauge": 1.0
-              },
-              "adds": {
-                "counter": 7832
-              },
-              "p2c": {
-                "gauge": 25.0
-              },
-              "updates": {
-                "counter": 7855
-              },
-              "available": {
-                "gauge": 1.0
-              },
-              "max_effort_exhausted": {
-                "counter": 0
-              },
-              "busy": {
-                "gauge": 0.0
-              },
-              "removes": {
-                "counter": 7831
-              }
-            },
-            "pending": {
-              "gauge": 0.0
-            },
-            "dispatcher": {
-              "serial": {
-                "queue_size": {
-                  "gauge": 0.0
-                }
-              }
-            },
-            "connections": {
-              "gauge": 1.0
             }
           },
-          "$/inet/127.1/9080": {
-            "connect_latency_ms": {
-              "stat.count": 94,
-              "stat.max": 1,
+          "pending": {
+            "gauge": 0.0
+          },
+          "dispatcher": {
+            "serial": {
+              "queue_size": {
+                "gauge": 0.0
+              }
+            }
+          },
+          "connections": {
+            "gauge": 1.0
+          }
+        },
+        "$/inet/127.1/9080": {
+          "connect_latency_ms": {
+            "stat.count": 94,
+            "stat.max": 1,
+            "stat.min": 0,
+            "stat.p50": 0,
+            "stat.p90": 0,
+            "stat.p95": 0,
+            "stat.p99": 1,
+            "stat.p9990": 1,
+            "stat.p9999": 1,
+            "stat.sum": 3,
+            "stat.avg": 0.031914893617021274
+          },
+          "failed_connect_latency_ms": {
+            "stat.count": 0
+          },
+          "sent_bytes": {
+            "counter": 449130
+          },
+          "service_creation": {
+            "service_acquisition_latency_ms": {
+              "stat.count": 179,
+              "stat.max": 2,
               "stat.min": 0,
               "stat.p50": 0,
               "stat.p90": 0,
               "stat.p95": 0,
               "stat.p99": 1,
-              "stat.p9990": 1,
-              "stat.p9999": 1,
-              "stat.sum": 3,
-              "stat.avg": 0.031914893617021274
+              "stat.p9990": 2,
+              "stat.p9999": 2,
+              "stat.sum": 11,
+              "stat.avg": 0.061452513966480445
+            }
+          },
+          "connection_received_bytes": {
+            "stat.count": 93,
+            "stat.max": 161,
+            "stat.min": 23,
+            "stat.p50": 23,
+            "stat.p90": 92,
+            "stat.p95": 92,
+            "stat.p99": 139,
+            "stat.p9990": 161,
+            "stat.p9999": 161,
+            "stat.sum": 4094,
+            "stat.avg": 44.02150537634409
+          },
+          "connection_duration": {
+            "stat.count": 93,
+            "stat.max": 2290,
+            "stat.min": 20,
+            "stat.p50": 43,
+            "stat.p90": 1379,
+            "stat.p95": 1478,
+            "stat.p99": 1859,
+            "stat.p9990": 2290,
+            "stat.p9999": 2290,
+            "stat.sum": 28546,
+            "stat.avg": 306.9462365591398
+          },
+          "failure_accrual": {
+            "removals": {
+              "counter": 0
             },
-            "failed_connect_latency_ms": {
-              "stat.count": 0
+            "probes": {
+              "counter": 0
             },
-            "sent_bytes": {
-              "counter": 449130
+            "removed_for_ms": {
+              "counter": 0
             },
-            "service_creation": {
-              "service_acquisition_latency_ms": {
+            "revivals": {
+              "counter": 0
+            }
+          },
+          "connects": {
+            "counter": 7816
+          },
+          "pool_num_waited": {
+            "counter": 0
+          },
+          "success": {
+            "counter": 14971
+          },
+          "service": {
+            "svc": {
+              "request_latency_ms": {
                 "stat.count": 179,
-                "stat.max": 2,
+                "stat.max": 301,
                 "stat.min": 0,
                 "stat.p50": 0,
                 "stat.p90": 0,
                 "stat.p95": 0,
                 "stat.p99": 1,
-                "stat.p9990": 2,
-                "stat.p9999": 2,
-                "stat.sum": 11,
-                "stat.avg": 0.061452513966480445
+                "stat.p9990": 301,
+                "stat.p9999": 301,
+                "stat.sum": 309,
+                "stat.avg": 1.7262569832402235
+              },
+              "success": {
+                "counter": 14971
+              },
+              "pending": {
+                "gauge": 0.0
+              },
+              "requests": {
+                "counter": 14971
               }
+            }
+          },
+          "request_latency_ms": {
+            "stat.count": 179,
+            "stat.max": 301,
+            "stat.min": 0,
+            "stat.p50": 0,
+            "stat.p90": 0,
+            "stat.p95": 0,
+            "stat.p99": 1,
+            "stat.p9990": 301,
+            "stat.p9999": 301,
+            "stat.sum": 308,
+            "stat.avg": 1.7206703910614525
+          },
+          "pool_waiters": {
+            "gauge": 0.0
+          },
+          "retries": {
+            "requeues_per_request": {
+              "stat.count": 179,
+              "stat.max": 0,
+              "stat.min": 0,
+              "stat.p50": 0,
+              "stat.p90": 0,
+              "stat.p95": 0,
+              "stat.p99": 0,
+              "stat.p9990": 0,
+              "stat.p9999": 0,
+              "stat.sum": 0,
+              "stat.avg": 0.0
             },
-            "connection_received_bytes": {
-              "stat.count": 93,
-              "stat.max": 161,
-              "stat.min": 23,
-              "stat.p50": 23,
-              "stat.p90": 92,
-              "stat.p95": 92,
-              "stat.p99": 139,
-              "stat.p9990": 161,
-              "stat.p9999": 161,
-              "stat.sum": 4094,
-              "stat.avg": 44.02150537634409
-            },
-            "connection_duration": {
-              "stat.count": 93,
-              "stat.max": 2290,
-              "stat.min": 20,
-              "stat.p50": 43,
-              "stat.p90": 1379,
-              "stat.p95": 1478,
-              "stat.p99": 1859,
-              "stat.p9990": 2290,
-              "stat.p9999": 2290,
-              "stat.sum": 28546,
-              "stat.avg": 306.9462365591398
-            },
-            "failure_accrual": {
-              "removals": {
-                "counter": 0
-              },
-              "probes": {
-                "counter": 0
-              },
-              "removed_for_ms": {
-                "counter": 0
-              },
-              "revivals": {
-                "counter": 0
-              }
-            },
-            "connects": {
-              "counter": 7816
-            },
-            "pool_num_waited": {
+            "request_limit": {
               "counter": 0
             },
-            "success": {
-              "counter": 14971
+            "budget_exhausted": {
+              "counter": 0
             },
-            "path": {
-              "svc": {
-                "request_latency_ms": {
-                  "stat.count": 179,
-                  "stat.max": 301,
-                  "stat.min": 0,
-                  "stat.p50": 0,
-                  "stat.p90": 0,
-                  "stat.p95": 0,
-                  "stat.p99": 1,
-                  "stat.p9990": 301,
-                  "stat.p9999": 301,
-                  "stat.sum": 309,
-                  "stat.avg": 1.7262569832402235
-                },
-                "success": {
-                  "counter": 14971
-                },
-                "pending": {
-                  "gauge": 0.0
-                },
-                "requests": {
-                  "counter": 14971
-                }
+            "cannot_retry": {
+              "counter": 0
+            },
+            "not_open": {
+              "counter": 0
+            },
+            "budget": {},
+            "requeues": {
+              "counter": 0
+            }
+          },
+          "received_bytes": {
+            "counter": 344333
+          },
+          "connection_sent_bytes": {
+            "stat.count": 93,
+            "stat.max": 211,
+            "stat.min": 30,
+            "stat.p50": 30,
+            "stat.p90": 121,
+            "stat.p95": 121,
+            "stat.p99": 180,
+            "stat.p9990": 211,
+            "stat.p9999": 211,
+            "stat.sum": 5340,
+            "stat.avg": 57.41935483870968
+          },
+          "connection_requests": {
+            "stat.count": 93,
+            "stat.max": 7,
+            "stat.min": 1,
+            "stat.p50": 1,
+            "stat.p90": 4,
+            "stat.p95": 4,
+            "stat.p99": 6,
+            "stat.p9990": 7,
+            "stat.p9999": 7,
+            "stat.sum": 178,
+            "stat.avg": 1.913978494623656
+          },
+          "pool_num_too_many_waiters": {
+            "counter": 0
+          },
+          "socket_unwritable_ms": {
+            "counter": 0
+          },
+          "closes": {
+            "counter": 7816
+          },
+          "pool_cached": {
+            "gauge": 0.0
+          },
+          "pool_size": {
+            "gauge": 0.0
+          },
+          "available": {
+            "gauge": 0.0
+          },
+          "request_payload_bytes": {
+            "stat.count": 179,
+            "stat.max": 30,
+            "stat.min": 30,
+            "stat.p50": 30,
+            "stat.p90": 30,
+            "stat.p95": 30,
+            "stat.p99": 30,
+            "stat.p9990": 30,
+            "stat.p9999": 30,
+            "stat.sum": 5370,
+            "stat.avg": 30.0
+          },
+          "socket_writable_ms": {
+            "counter": 0
+          },
+          "cancelled_connects": {
+            "counter": 0
+          },
+          "response_payload_bytes": {
+            "stat.count": 179,
+            "stat.max": 23,
+            "stat.min": 23,
+            "stat.p50": 23,
+            "stat.p90": 23,
+            "stat.p95": 23,
+            "stat.p99": 23,
+            "stat.p9990": 23,
+            "stat.p9999": 23,
+            "stat.sum": 4117,
+            "stat.avg": 23.0
+          },
+          "dtab": {
+            "size": {
+              "stat.count": 0
+            }
+          },
+          "requests": {
+            "counter": 14971
+          },
+          "loadbalancer": {
+            "size": {},
+            "rebuilds": {
+              "counter": 7840
+            },
+            "closed": {},
+            "load": {},
+            "meanweight": {},
+            "adds": {
+              "counter": 7816
+            },
+            "p2c": {
+              "gauge": 26.0
+            },
+            "updates": {
+              "counter": 7840
+            },
+            "available": {},
+            "max_effort_exhausted": {
+              "counter": 0
+            },
+            "busy": {},
+            "removes": {
+              "counter": 7816
+            }
+          },
+          "pending": {
+            "gauge": 0.0
+          },
+          "dispatcher": {
+            "serial": {
+              "queue_size": {
+                "gauge": 0.0
               }
-            },
-            "request_latency_ms": {
-              "stat.count": 179,
-              "stat.max": 301,
+            }
+          },
+          "connections": {
+            "gauge": 0.0
+          }
+        },
+        "$/inet/127.1/9085": {
+          "connect_latency_ms": {
+            "stat.count": 90,
+            "stat.max": 46,
+            "stat.min": 0,
+            "stat.p50": 0,
+            "stat.p90": 0,
+            "stat.p95": 1,
+            "stat.p99": 1,
+            "stat.p9990": 46,
+            "stat.p9999": 46,
+            "stat.sum": 50,
+            "stat.avg": 0.5555555555555556
+          },
+          "failed_connect_latency_ms": {
+            "stat.count": 0
+          },
+          "sent_bytes": {
+            "counter": 445650
+          },
+          "service_creation": {
+            "service_acquisition_latency_ms": {
+              "stat.count": 155,
+              "stat.max": 47,
               "stat.min": 0,
               "stat.p50": 0,
               "stat.p90": 0,
               "stat.p95": 0,
               "stat.p99": 1,
-              "stat.p9990": 301,
-              "stat.p9999": 301,
-              "stat.sum": 308,
-              "stat.avg": 1.7206703910614525
-            },
-            "pool_waiters": {
-              "gauge": 0.0
-            },
-            "retries": {
-              "requeues_per_request": {
-                "stat.count": 179,
-                "stat.max": 0,
-                "stat.min": 0,
-                "stat.p50": 0,
-                "stat.p90": 0,
-                "stat.p95": 0,
-                "stat.p99": 0,
-                "stat.p9990": 0,
-                "stat.p9999": 0,
-                "stat.sum": 0,
-                "stat.avg": 0.0
-              },
-              "request_limit": {
-                "counter": 0
-              },
-              "budget_exhausted": {
-                "counter": 0
-              },
-              "cannot_retry": {
-                "counter": 0
-              },
-              "not_open": {
-                "counter": 0
-              },
-              "budget": {},
-              "requeues": {
-                "counter": 0
-              }
-            },
-            "received_bytes": {
-              "counter": 344333
-            },
-            "connection_sent_bytes": {
-              "stat.count": 93,
-              "stat.max": 211,
-              "stat.min": 30,
-              "stat.p50": 30,
-              "stat.p90": 121,
-              "stat.p95": 121,
-              "stat.p99": 180,
-              "stat.p9990": 211,
-              "stat.p9999": 211,
-              "stat.sum": 5340,
-              "stat.avg": 57.41935483870968
-            },
-            "connection_requests": {
-              "stat.count": 93,
-              "stat.max": 7,
-              "stat.min": 1,
-              "stat.p50": 1,
-              "stat.p90": 4,
-              "stat.p95": 4,
-              "stat.p99": 6,
-              "stat.p9990": 7,
-              "stat.p9999": 7,
-              "stat.sum": 178,
-              "stat.avg": 1.913978494623656
-            },
-            "pool_num_too_many_waiters": {
-              "counter": 0
-            },
-            "socket_unwritable_ms": {
-              "counter": 0
-            },
-            "closes": {
-              "counter": 7816
-            },
-            "pool_cached": {
-              "gauge": 0.0
-            },
-            "pool_size": {
-              "gauge": 0.0
-            },
-            "available": {
-              "gauge": 0.0
-            },
-            "request_payload_bytes": {
-              "stat.count": 179,
-              "stat.max": 30,
-              "stat.min": 30,
-              "stat.p50": 30,
-              "stat.p90": 30,
-              "stat.p95": 30,
-              "stat.p99": 30,
-              "stat.p9990": 30,
-              "stat.p9999": 30,
-              "stat.sum": 5370,
-              "stat.avg": 30.0
-            },
-            "socket_writable_ms": {
-              "counter": 0
-            },
-            "cancelled_connects": {
-              "counter": 0
-            },
-            "response_payload_bytes": {
-              "stat.count": 179,
-              "stat.max": 23,
-              "stat.min": 23,
-              "stat.p50": 23,
-              "stat.p90": 23,
-              "stat.p95": 23,
-              "stat.p99": 23,
-              "stat.p9990": 23,
-              "stat.p9999": 23,
-              "stat.sum": 4117,
-              "stat.avg": 23.0
-            },
-            "dtab": {
-              "size": {
-                "stat.count": 0
-              }
-            },
-            "requests": {
-              "counter": 14971
-            },
-            "loadbalancer": {
-              "size": {},
-              "rebuilds": {
-                "counter": 7840
-              },
-              "closed": {},
-              "load": {},
-              "meanweight": {},
-              "adds": {
-                "counter": 7816
-              },
-              "p2c": {
-                "gauge": 26.0
-              },
-              "updates": {
-                "counter": 7840
-              },
-              "available": {},
-              "max_effort_exhausted": {
-                "counter": 0
-              },
-              "busy": {},
-              "removes": {
-                "counter": 7816
-              }
-            },
-            "pending": {
-              "gauge": 0.0
-            },
-            "dispatcher": {
-              "serial": {
-                "queue_size": {
-                  "gauge": 0.0
-                }
-              }
-            },
-            "connections": {
-              "gauge": 0.0
+              "stat.p9990": 47,
+              "stat.p9999": 47,
+              "stat.sum": 56,
+              "stat.avg": 0.36129032258064514
             }
           },
-          "$/inet/127.1/9085": {
-            "connect_latency_ms": {
-              "stat.count": 90,
-              "stat.max": 46,
-              "stat.min": 0,
-              "stat.p50": 0,
-              "stat.p90": 0,
-              "stat.p95": 1,
-              "stat.p99": 1,
-              "stat.p9990": 46,
-              "stat.p9999": 46,
-              "stat.sum": 50,
-              "stat.avg": 0.5555555555555556
+          "connection_received_bytes": {
+            "stat.count": 89,
+            "stat.max": 161,
+            "stat.min": 23,
+            "stat.p50": 23,
+            "stat.p90": 69,
+            "stat.p95": 92,
+            "stat.p99": 139,
+            "stat.p9990": 161,
+            "stat.p9999": 161,
+            "stat.sum": 3519,
+            "stat.avg": 39.53932584269663
+          },
+          "connection_duration": {
+            "stat.count": 89,
+            "stat.max": 2313,
+            "stat.min": 18,
+            "stat.p50": 37,
+            "stat.p90": 1352,
+            "stat.p95": 1493,
+            "stat.p99": 2013,
+            "stat.p9990": 2313,
+            "stat.p9999": 2313,
+            "stat.sum": 20765,
+            "stat.avg": 233.31460674157304
+          },
+          "failure_accrual": {
+            "removals": {
+              "counter": 0
             },
-            "failed_connect_latency_ms": {
-              "stat.count": 0
+            "probes": {
+              "counter": 0
             },
-            "sent_bytes": {
-              "counter": 445650
+            "removed_for_ms": {
+              "counter": 0
             },
-            "service_creation": {
-              "service_acquisition_latency_ms": {
+            "revivals": {
+              "counter": 0
+            }
+          },
+          "connects": {
+            "counter": 7832
+          },
+          "pool_num_waited": {
+            "counter": 0
+          },
+          "success": {
+            "counter": 14855
+          },
+          "service": {
+            "svc": {
+              "request_latency_ms": {
                 "stat.count": 155,
-                "stat.max": 47,
+                "stat.max": 1,
                 "stat.min": 0,
                 "stat.p50": 0,
                 "stat.p90": 0,
                 "stat.p95": 0,
                 "stat.p99": 1,
-                "stat.p9990": 47,
-                "stat.p9999": 47,
-                "stat.sum": 56,
-                "stat.avg": 0.36129032258064514
+                "stat.p9990": 1,
+                "stat.p9999": 1,
+                "stat.sum": 4,
+                "stat.avg": 0.025806451612903226
+              },
+              "success": {
+                "counter": 14855
+              },
+              "pending": {
+                "gauge": 0.0
+              },
+              "requests": {
+                "counter": 14855
               }
+            }
+          },
+          "request_latency_ms": {
+            "stat.count": 155,
+            "stat.max": 1,
+            "stat.min": 0,
+            "stat.p50": 0,
+            "stat.p90": 0,
+            "stat.p95": 0,
+            "stat.p99": 1,
+            "stat.p9990": 1,
+            "stat.p9999": 1,
+            "stat.sum": 4,
+            "stat.avg": 0.025806451612903226
+          },
+          "pool_waiters": {
+            "gauge": 0.0
+          },
+          "retries": {
+            "requeues_per_request": {
+              "stat.count": 155,
+              "stat.max": 0,
+              "stat.min": 0,
+              "stat.p50": 0,
+              "stat.p90": 0,
+              "stat.p95": 0,
+              "stat.p99": 0,
+              "stat.p9990": 0,
+              "stat.p9999": 0,
+              "stat.sum": 0,
+              "stat.avg": 0.0
             },
-            "connection_received_bytes": {
-              "stat.count": 89,
-              "stat.max": 161,
-              "stat.min": 23,
-              "stat.p50": 23,
-              "stat.p90": 69,
-              "stat.p95": 92,
-              "stat.p99": 139,
-              "stat.p9990": 161,
-              "stat.p9999": 161,
-              "stat.sum": 3519,
-              "stat.avg": 39.53932584269663
+            "request_limit": {
+              "counter": 0
             },
-            "connection_duration": {
-              "stat.count": 89,
-              "stat.max": 2313,
-              "stat.min": 18,
-              "stat.p50": 37,
-              "stat.p90": 1352,
-              "stat.p95": 1493,
-              "stat.p99": 2013,
-              "stat.p9990": 2313,
-              "stat.p9999": 2313,
-              "stat.sum": 20765,
-              "stat.avg": 233.31460674157304
+            "budget_exhausted": {
+              "counter": 0
             },
-            "failure_accrual": {
-              "removals": {
-                "counter": 0
-              },
-              "probes": {
-                "counter": 0
-              },
-              "removed_for_ms": {
-                "counter": 0
-              },
-              "revivals": {
-                "counter": 0
-              }
+            "cannot_retry": {
+              "counter": 0
             },
-            "connects": {
+            "not_open": {
+              "counter": 0
+            },
+            "budget": {
+              "gauge": 264.0
+            },
+            "requeues": {
+              "counter": 0
+            }
+          },
+          "received_bytes": {
+            "counter": 341665
+          },
+          "connection_sent_bytes": {
+            "stat.count": 89,
+            "stat.max": 211,
+            "stat.min": 30,
+            "stat.p50": 30,
+            "stat.p90": 90,
+            "stat.p95": 121,
+            "stat.p99": 180,
+            "stat.p9990": 211,
+            "stat.p9999": 211,
+            "stat.sum": 4590,
+            "stat.avg": 51.57303370786517
+          },
+          "connection_requests": {
+            "stat.count": 89,
+            "stat.max": 7,
+            "stat.min": 1,
+            "stat.p50": 1,
+            "stat.p90": 3,
+            "stat.p95": 4,
+            "stat.p99": 6,
+            "stat.p9990": 7,
+            "stat.p9999": 7,
+            "stat.sum": 153,
+            "stat.avg": 1.7191011235955056
+          },
+          "pool_num_too_many_waiters": {
+            "counter": 0
+          },
+          "socket_unwritable_ms": {
+            "counter": 0
+          },
+          "closes": {
+            "counter": 7831
+          },
+          "pool_cached": {
+            "gauge": 1.0
+          },
+          "pool_size": {
+            "gauge": 0.0
+          },
+          "available": {
+            "gauge": 1.0
+          },
+          "request_payload_bytes": {
+            "stat.count": 155,
+            "stat.max": 30,
+            "stat.min": 30,
+            "stat.p50": 30,
+            "stat.p90": 30,
+            "stat.p95": 30,
+            "stat.p99": 30,
+            "stat.p9990": 30,
+            "stat.p9999": 30,
+            "stat.sum": 4650,
+            "stat.avg": 30.0
+          },
+          "socket_writable_ms": {
+            "counter": 0
+          },
+          "cancelled_connects": {
+            "counter": 0
+          },
+          "response_payload_bytes": {
+            "stat.count": 155,
+            "stat.max": 23,
+            "stat.min": 23,
+            "stat.p50": 23,
+            "stat.p90": 23,
+            "stat.p95": 23,
+            "stat.p99": 23,
+            "stat.p9990": 23,
+            "stat.p9999": 23,
+            "stat.sum": 3565,
+            "stat.avg": 23.0
+          },
+          "dtab": {
+            "size": {
+              "stat.count": 0
+            }
+          },
+          "requests": {
+            "counter": 14855
+          },
+          "loadbalancer": {
+            "size": {
+              "gauge": 1.0
+            },
+            "rebuilds": {
+              "counter": 7848
+            },
+            "closed": {
+              "gauge": 0.0
+            },
+            "load": {
+              "gauge": 0.0
+            },
+            "meanweight": {
+              "gauge": 1.0
+            },
+            "adds": {
               "counter": 7832
             },
-            "pool_num_waited": {
-              "counter": 0
+            "p2c": {
+              "gauge": 21.0
             },
-            "success": {
-              "counter": 14855
-            },
-            "path": {
-              "svc": {
-                "request_latency_ms": {
-                  "stat.count": 155,
-                  "stat.max": 1,
-                  "stat.min": 0,
-                  "stat.p50": 0,
-                  "stat.p90": 0,
-                  "stat.p95": 0,
-                  "stat.p99": 1,
-                  "stat.p9990": 1,
-                  "stat.p9999": 1,
-                  "stat.sum": 4,
-                  "stat.avg": 0.025806451612903226
-                },
-                "success": {
-                  "counter": 14855
-                },
-                "pending": {
-                  "gauge": 0.0
-                },
-                "requests": {
-                  "counter": 14855
-                }
-              }
-            },
-            "request_latency_ms": {
-              "stat.count": 155,
-              "stat.max": 1,
-              "stat.min": 0,
-              "stat.p50": 0,
-              "stat.p90": 0,
-              "stat.p95": 0,
-              "stat.p99": 1,
-              "stat.p9990": 1,
-              "stat.p9999": 1,
-              "stat.sum": 4,
-              "stat.avg": 0.025806451612903226
-            },
-            "pool_waiters": {
-              "gauge": 0.0
-            },
-            "retries": {
-              "requeues_per_request": {
-                "stat.count": 155,
-                "stat.max": 0,
-                "stat.min": 0,
-                "stat.p50": 0,
-                "stat.p90": 0,
-                "stat.p95": 0,
-                "stat.p99": 0,
-                "stat.p9990": 0,
-                "stat.p9999": 0,
-                "stat.sum": 0,
-                "stat.avg": 0.0
-              },
-              "request_limit": {
-                "counter": 0
-              },
-              "budget_exhausted": {
-                "counter": 0
-              },
-              "cannot_retry": {
-                "counter": 0
-              },
-              "not_open": {
-                "counter": 0
-              },
-              "budget": {
-                "gauge": 264.0
-              },
-              "requeues": {
-                "counter": 0
-              }
-            },
-            "received_bytes": {
-              "counter": 341665
-            },
-            "connection_sent_bytes": {
-              "stat.count": 89,
-              "stat.max": 211,
-              "stat.min": 30,
-              "stat.p50": 30,
-              "stat.p90": 90,
-              "stat.p95": 121,
-              "stat.p99": 180,
-              "stat.p9990": 211,
-              "stat.p9999": 211,
-              "stat.sum": 4590,
-              "stat.avg": 51.57303370786517
-            },
-            "connection_requests": {
-              "stat.count": 89,
-              "stat.max": 7,
-              "stat.min": 1,
-              "stat.p50": 1,
-              "stat.p90": 3,
-              "stat.p95": 4,
-              "stat.p99": 6,
-              "stat.p9990": 7,
-              "stat.p9999": 7,
-              "stat.sum": 153,
-              "stat.avg": 1.7191011235955056
-            },
-            "pool_num_too_many_waiters": {
-              "counter": 0
-            },
-            "socket_unwritable_ms": {
-              "counter": 0
-            },
-            "closes": {
-              "counter": 7831
-            },
-            "pool_cached": {
-              "gauge": 1.0
-            },
-            "pool_size": {
-              "gauge": 0.0
+            "updates": {
+              "counter": 7848
             },
             "available": {
               "gauge": 1.0
             },
-            "request_payload_bytes": {
-              "stat.count": 155,
-              "stat.max": 30,
-              "stat.min": 30,
-              "stat.p50": 30,
-              "stat.p90": 30,
-              "stat.p95": 30,
-              "stat.p99": 30,
-              "stat.p9990": 30,
-              "stat.p9999": 30,
-              "stat.sum": 4650,
-              "stat.avg": 30.0
-            },
-            "socket_writable_ms": {
+            "max_effort_exhausted": {
               "counter": 0
             },
-            "cancelled_connects": {
-              "counter": 0
-            },
-            "response_payload_bytes": {
-              "stat.count": 155,
-              "stat.max": 23,
-              "stat.min": 23,
-              "stat.p50": 23,
-              "stat.p90": 23,
-              "stat.p95": 23,
-              "stat.p99": 23,
-              "stat.p9990": 23,
-              "stat.p9999": 23,
-              "stat.sum": 3565,
-              "stat.avg": 23.0
-            },
-            "dtab": {
-              "size": {
-                "stat.count": 0
-              }
-            },
-            "requests": {
-              "counter": 14855
-            },
-            "loadbalancer": {
-              "size": {
-                "gauge": 1.0
-              },
-              "rebuilds": {
-                "counter": 7848
-              },
-              "closed": {
-                "gauge": 0.0
-              },
-              "load": {
-                "gauge": 0.0
-              },
-              "meanweight": {
-                "gauge": 1.0
-              },
-              "adds": {
-                "counter": 7832
-              },
-              "p2c": {
-                "gauge": 21.0
-              },
-              "updates": {
-                "counter": 7848
-              },
-              "available": {
-                "gauge": 1.0
-              },
-              "max_effort_exhausted": {
-                "counter": 0
-              },
-              "busy": {
-                "gauge": 0.0
-              },
-              "removes": {
-                "counter": 7831
-              }
-            },
-            "pending": {
+            "busy": {
               "gauge": 0.0
             },
-            "dispatcher": {
-              "serial": {
-                "queue_size": {
-                  "gauge": 0.0
-                }
-              }
-            },
-            "connections": {
-              "gauge": 1.0
+            "removes": {
+              "counter": 7831
             }
           },
-          "$/inet/127.1/9089": {
-            "connect_latency_ms": {
-              "stat.count": 82,
+          "pending": {
+            "gauge": 0.0
+          },
+          "dispatcher": {
+            "serial": {
+              "queue_size": {
+                "gauge": 0.0
+              }
+            }
+          },
+          "connections": {
+            "gauge": 1.0
+          }
+        },
+        "$/inet/127.1/9089": {
+          "connect_latency_ms": {
+            "stat.count": 82,
+            "stat.max": 48,
+            "stat.min": 0,
+            "stat.p50": 0,
+            "stat.p90": 0,
+            "stat.p95": 1,
+            "stat.p99": 1,
+            "stat.p9990": 48,
+            "stat.p9999": 48,
+            "stat.sum": 52,
+            "stat.avg": 0.6341463414634146
+          },
+          "failed_connect_latency_ms": {
+            "stat.count": 0
+          },
+          "sent_bytes": {
+            "counter": 447300
+          },
+          "service_creation": {
+            "service_acquisition_latency_ms": {
+              "stat.count": 176,
               "stat.max": 48,
               "stat.min": 0,
               "stat.p50": 0,
               "stat.p90": 0,
               "stat.p95": 1,
-              "stat.p99": 1,
+              "stat.p99": 2,
               "stat.p9990": 48,
               "stat.p9999": 48,
-              "stat.sum": 52,
-              "stat.avg": 0.6341463414634146
-            },
-            "failed_connect_latency_ms": {
-              "stat.count": 0
-            },
-            "sent_bytes": {
-              "counter": 447300
-            },
-            "service_creation": {
-              "service_acquisition_latency_ms": {
-                "stat.count": 176,
-                "stat.max": 48,
-                "stat.min": 0,
-                "stat.p50": 0,
-                "stat.p90": 0,
-                "stat.p95": 1,
-                "stat.p99": 2,
-                "stat.p9990": 48,
-                "stat.p9999": 48,
-                "stat.sum": 63,
-                "stat.avg": 0.35795454545454547
-              }
-            },
-            "connection_received_bytes": {
-              "stat.count": 82,
-              "stat.max": 185,
-              "stat.min": 23,
-              "stat.p50": 46,
-              "stat.p90": 92,
-              "stat.p95": 115,
-              "stat.p99": 185,
-              "stat.p9990": 185,
-              "stat.p9999": 185,
-              "stat.sum": 4048,
-              "stat.avg": 49.36585365853659
-            },
-            "connection_duration": {
-              "stat.count": 82,
-              "stat.max": 2073,
-              "stat.min": 20,
-              "stat.p50": 46,
-              "stat.p90": 1569,
-              "stat.p95": 1633,
-              "stat.p99": 1877,
-              "stat.p9990": 2073,
-              "stat.p9999": 2073,
-              "stat.sum": 32237,
-              "stat.avg": 393.1341463414634
-            },
-            "failure_accrual": {
-              "removals": {
-                "counter": 0
-              },
-              "probes": {
-                "counter": 0
-              },
-              "removed_for_ms": {
-                "counter": 0
-              },
-              "revivals": {
-                "counter": 0
-              }
-            },
-            "connects": {
-              "counter": 7798
-            },
-            "pool_num_waited": {
+              "stat.sum": 63,
+              "stat.avg": 0.35795454545454547
+            }
+          },
+          "connection_received_bytes": {
+            "stat.count": 82,
+            "stat.max": 185,
+            "stat.min": 23,
+            "stat.p50": 46,
+            "stat.p90": 92,
+            "stat.p95": 115,
+            "stat.p99": 185,
+            "stat.p9990": 185,
+            "stat.p9999": 185,
+            "stat.sum": 4048,
+            "stat.avg": 49.36585365853659
+          },
+          "connection_duration": {
+            "stat.count": 82,
+            "stat.max": 2073,
+            "stat.min": 20,
+            "stat.p50": 46,
+            "stat.p90": 1569,
+            "stat.p95": 1633,
+            "stat.p99": 1877,
+            "stat.p9990": 2073,
+            "stat.p9999": 2073,
+            "stat.sum": 32237,
+            "stat.avg": 393.1341463414634
+          },
+          "failure_accrual": {
+            "removals": {
               "counter": 0
             },
-            "success": {
-              "counter": 14910
+            "probes": {
+              "counter": 0
             },
-            "path": {
-              "svc": {
-                "request_latency_ms": {
-                  "stat.count": 176,
-                  "stat.max": 4,
-                  "stat.min": 0,
-                  "stat.p50": 0,
-                  "stat.p90": 0,
-                  "stat.p95": 0,
-                  "stat.p99": 1,
-                  "stat.p9990": 4,
-                  "stat.p9999": 4,
-                  "stat.sum": 11,
-                  "stat.avg": 0.0625
-                },
-                "success": {
-                  "counter": 14910
-                },
-                "pending": {
-                  "gauge": 0.0
-                },
-                "requests": {
-                  "counter": 14910
-                }
-              }
+            "removed_for_ms": {
+              "counter": 0
             },
-            "request_latency_ms": {
-              "stat.count": 176,
-              "stat.max": 4,
-              "stat.min": 0,
-              "stat.p50": 0,
-              "stat.p90": 0,
-              "stat.p95": 0,
-              "stat.p99": 1,
-              "stat.p9990": 4,
-              "stat.p9999": 4,
-              "stat.sum": 11,
-              "stat.avg": 0.0625
-            },
-            "pool_waiters": {
-              "gauge": 0.0
-            },
-            "retries": {
-              "requeues_per_request": {
+            "revivals": {
+              "counter": 0
+            }
+          },
+          "connects": {
+            "counter": 7798
+          },
+          "pool_num_waited": {
+            "counter": 0
+          },
+          "success": {
+            "counter": 14910
+          },
+          "service": {
+            "svc": {
+              "request_latency_ms": {
                 "stat.count": 176,
-                "stat.max": 0,
+                "stat.max": 4,
                 "stat.min": 0,
                 "stat.p50": 0,
                 "stat.p90": 0,
                 "stat.p95": 0,
-                "stat.p99": 0,
-                "stat.p9990": 0,
-                "stat.p9999": 0,
-                "stat.sum": 0,
-                "stat.avg": 0.0
+                "stat.p99": 1,
+                "stat.p9990": 4,
+                "stat.p9999": 4,
+                "stat.sum": 11,
+                "stat.avg": 0.0625
               },
-              "request_limit": {
-                "counter": 0
+              "success": {
+                "counter": 14910
               },
-              "budget_exhausted": {
-                "counter": 0
+              "pending": {
+                "gauge": 0.0
               },
-              "cannot_retry": {
-                "counter": 0
-              },
-              "not_open": {
-                "counter": 0
-              },
-              "budget": {
-                "gauge": 264.0
-              },
-              "requeues": {
-                "counter": 0
+              "requests": {
+                "counter": 14910
               }
+            }
+          },
+          "request_latency_ms": {
+            "stat.count": 176,
+            "stat.max": 4,
+            "stat.min": 0,
+            "stat.p50": 0,
+            "stat.p90": 0,
+            "stat.p95": 0,
+            "stat.p99": 1,
+            "stat.p9990": 4,
+            "stat.p9999": 4,
+            "stat.sum": 11,
+            "stat.avg": 0.0625
+          },
+          "pool_waiters": {
+            "gauge": 0.0
+          },
+          "retries": {
+            "requeues_per_request": {
+              "stat.count": 176,
+              "stat.max": 0,
+              "stat.min": 0,
+              "stat.p50": 0,
+              "stat.p90": 0,
+              "stat.p95": 0,
+              "stat.p99": 0,
+              "stat.p9990": 0,
+              "stat.p9999": 0,
+              "stat.sum": 0,
+              "stat.avg": 0.0
             },
-            "received_bytes": {
-              "counter": 342930
-            },
-            "connection_sent_bytes": {
-              "stat.count": 82,
-              "stat.max": 240,
-              "stat.min": 30,
-              "stat.p50": 60,
-              "stat.p90": 121,
-              "stat.p95": 150,
-              "stat.p99": 240,
-              "stat.p9990": 240,
-              "stat.p9999": 240,
-              "stat.sum": 5280,
-              "stat.avg": 64.39024390243902
-            },
-            "connection_requests": {
-              "stat.count": 82,
-              "stat.max": 8,
-              "stat.min": 1,
-              "stat.p50": 2,
-              "stat.p90": 4,
-              "stat.p95": 5,
-              "stat.p99": 8,
-              "stat.p9990": 8,
-              "stat.p9999": 8,
-              "stat.sum": 176,
-              "stat.avg": 2.1463414634146343
-            },
-            "pool_num_too_many_waiters": {
+            "request_limit": {
               "counter": 0
             },
-            "socket_unwritable_ms": {
+            "budget_exhausted": {
               "counter": 0
             },
-            "closes": {
-              "counter": 7797
+            "cannot_retry": {
+              "counter": 0
             },
-            "pool_cached": {
+            "not_open": {
+              "counter": 0
+            },
+            "budget": {
+              "gauge": 264.0
+            },
+            "requeues": {
+              "counter": 0
+            }
+          },
+          "received_bytes": {
+            "counter": 342930
+          },
+          "connection_sent_bytes": {
+            "stat.count": 82,
+            "stat.max": 240,
+            "stat.min": 30,
+            "stat.p50": 60,
+            "stat.p90": 121,
+            "stat.p95": 150,
+            "stat.p99": 240,
+            "stat.p9990": 240,
+            "stat.p9999": 240,
+            "stat.sum": 5280,
+            "stat.avg": 64.39024390243902
+          },
+          "connection_requests": {
+            "stat.count": 82,
+            "stat.max": 8,
+            "stat.min": 1,
+            "stat.p50": 2,
+            "stat.p90": 4,
+            "stat.p95": 5,
+            "stat.p99": 8,
+            "stat.p9990": 8,
+            "stat.p9999": 8,
+            "stat.sum": 176,
+            "stat.avg": 2.1463414634146343
+          },
+          "pool_num_too_many_waiters": {
+            "counter": 0
+          },
+          "socket_unwritable_ms": {
+            "counter": 0
+          },
+          "closes": {
+            "counter": 7797
+          },
+          "pool_cached": {
+            "gauge": 1.0
+          },
+          "pool_size": {
+            "gauge": 0.0
+          },
+          "available": {
+            "gauge": 1.0
+          },
+          "request_payload_bytes": {
+            "stat.count": 176,
+            "stat.max": 30,
+            "stat.min": 30,
+            "stat.p50": 30,
+            "stat.p90": 30,
+            "stat.p95": 30,
+            "stat.p99": 30,
+            "stat.p9990": 30,
+            "stat.p9999": 30,
+            "stat.sum": 5280,
+            "stat.avg": 30.0
+          },
+          "socket_writable_ms": {
+            "counter": 0
+          },
+          "cancelled_connects": {
+            "counter": 0
+          },
+          "response_payload_bytes": {
+            "stat.count": 176,
+            "stat.max": 23,
+            "stat.min": 23,
+            "stat.p50": 23,
+            "stat.p90": 23,
+            "stat.p95": 23,
+            "stat.p99": 23,
+            "stat.p9990": 23,
+            "stat.p9999": 23,
+            "stat.sum": 4048,
+            "stat.avg": 23.0
+          },
+          "dtab": {
+            "size": {
+              "stat.count": 0
+            }
+          },
+          "requests": {
+            "counter": 14910
+          },
+          "loadbalancer": {
+            "size": {
               "gauge": 1.0
             },
-            "pool_size": {
+            "rebuilds": {
+              "counter": 7809
+            },
+            "closed": {
               "gauge": 0.0
+            },
+            "load": {
+              "gauge": 0.0
+            },
+            "meanweight": {
+              "gauge": 1.0
+            },
+            "adds": {
+              "counter": 7798
+            },
+            "p2c": {
+              "gauge": 22.0
+            },
+            "updates": {
+              "counter": 7809
             },
             "available": {
               "gauge": 1.0
             },
-            "request_payload_bytes": {
-              "stat.count": 176,
-              "stat.max": 30,
-              "stat.min": 30,
-              "stat.p50": 30,
-              "stat.p90": 30,
-              "stat.p95": 30,
-              "stat.p99": 30,
-              "stat.p9990": 30,
-              "stat.p9999": 30,
-              "stat.sum": 5280,
-              "stat.avg": 30.0
-            },
-            "socket_writable_ms": {
+            "max_effort_exhausted": {
               "counter": 0
             },
-            "cancelled_connects": {
-              "counter": 0
-            },
-            "response_payload_bytes": {
-              "stat.count": 176,
-              "stat.max": 23,
-              "stat.min": 23,
-              "stat.p50": 23,
-              "stat.p90": 23,
-              "stat.p95": 23,
-              "stat.p99": 23,
-              "stat.p9990": 23,
-              "stat.p9999": 23,
-              "stat.sum": 4048,
-              "stat.avg": 23.0
-            },
-            "dtab": {
-              "size": {
-                "stat.count": 0
-              }
-            },
-            "requests": {
-              "counter": 14910
-            },
-            "loadbalancer": {
-              "size": {
-                "gauge": 1.0
-              },
-              "rebuilds": {
-                "counter": 7809
-              },
-              "closed": {
-                "gauge": 0.0
-              },
-              "load": {
-                "gauge": 0.0
-              },
-              "meanweight": {
-                "gauge": 1.0
-              },
-              "adds": {
-                "counter": 7798
-              },
-              "p2c": {
-                "gauge": 22.0
-              },
-              "updates": {
-                "counter": 7809
-              },
-              "available": {
-                "gauge": 1.0
-              },
-              "max_effort_exhausted": {
-                "counter": 0
-              },
-              "busy": {
-                "gauge": 0.0
-              },
-              "removes": {
-                "counter": 7797
-              }
-            },
-            "pending": {
+            "busy": {
               "gauge": 0.0
             },
-            "dispatcher": {
-              "serial": {
-                "queue_size": {
-                  "gauge": 0.0
-                }
-              }
-            },
-            "connections": {
-              "gauge": 1.0
+            "removes": {
+              "counter": 7797
             }
+          },
+          "pending": {
+            "gauge": 0.0
+          },
+          "dispatcher": {
+            "serial": {
+              "queue_size": {
+                "gauge": 0.0
+              }
+            }
+          },
+          "connections": {
+            "gauge": 1.0
           }
         }
+      }
+    },
+    "bindcache": {
+      "path": {
+        "evicts": {
+          "counter": 0
+        },
+        "misses": {
+          "counter": 1
+        },
+        "oneshots": {
+          "counter": 0
+        }
       },
-      "bindcache": {
-        "path": {
-          "evicts": {
-            "counter": 0
-          },
-          "misses": {
-            "counter": 1
-          },
-          "oneshots": {
-            "counter": 0
-          }
+      "bound": {
+        "evicts": {
+          "counter": 0
         },
-        "bound": {
-          "evicts": {
-            "counter": 0
-          },
-          "misses": {
-            "counter": 21
-          },
-          "oneshots": {
-            "counter": 0
-          }
+        "misses": {
+          "counter": 21
         },
-        "tree": {
-          "evicts": {
-            "counter": 0
-          },
-          "misses": {
-            "counter": 1
-          },
-          "oneshots": {
-            "counter": 0
-          }
+        "oneshots": {
+          "counter": 0
+        }
+      },
+      "tree": {
+        "evicts": {
+          "counter": 0
         },
-        "client": {
-          "evicts": {
-            "counter": 165251
-          },
-          "misses": {
-            "counter": 165261
-          },
-          "oneshots": {
-            "counter": 0
-          }
+        "misses": {
+          "counter": 1
+        },
+        "oneshots": {
+          "counter": 0
+        }
+      },
+      "client": {
+        "evicts": {
+          "counter": 165251
+        },
+        "misses": {
+          "counter": 165261
+        },
+        "oneshots": {
+          "counter": 0
         }
       },
       "srv": {
@@ -2931,67 +2928,111 @@ return {
       }
     },
     "multiplier": {
-      "dst": {
-        "path": {
-          "svc": {
-            "success": {
-              "counter": 381
-            },
-            "request_latency_ms": {
+      "service": {
+        "svc": {
+          "success": {
+            "counter": 381
+          },
+          "request_latency_ms": {
+            "stat.count": 33,
+            "stat.max": 2,
+            "stat.min": 0,
+            "stat.p50": 0,
+            "stat.p90": 0,
+            "stat.p95": 1,
+            "stat.p99": 2,
+            "stat.p9990": 2,
+            "stat.p9999": 2,
+            "stat.sum": 4,
+            "stat.avg": 0.12121212121212122
+          },
+          "retries": {
+            "per_request": {
               "stat.count": 33,
-              "stat.max": 2,
+              "stat.max": 0,
               "stat.min": 0,
               "stat.p50": 0,
               "stat.p90": 0,
-              "stat.p95": 1,
-              "stat.p99": 2,
-              "stat.p9990": 2,
-              "stat.p9999": 2,
-              "stat.sum": 4,
-              "stat.avg": 0.12121212121212122
+              "stat.p95": 0,
+              "stat.p99": 0,
+              "stat.p9990": 0,
+              "stat.p9999": 0,
+              "stat.sum": 0,
+              "stat.avg": 0.0
             },
-            "retries": {
-              "per_request": {
-                "stat.count": 33,
-                "stat.max": 0,
-                "stat.min": 0,
-                "stat.p50": 0,
-                "stat.p90": 0,
-                "stat.p95": 0,
-                "stat.p99": 0,
-                "stat.p9990": 0,
-                "stat.p9999": 0,
-                "stat.sum": 0,
-                "stat.avg": 0.0
-              },
-              "total": {
-                "counter": 0
-              },
-              "budget_exhausted": {
-                "counter": 0
-              }
+            "total": {
+              "counter": 0
             },
-            "requests": {
-              "counter": 381
-            },
-            "pending": {
-              "gauge": 0.0
+            "budget_exhausted": {
+              "counter": 0
             }
+          },
+          "requests": {
+            "counter": 381
+          },
+          "pending": {
+            "gauge": 0.0
           }
-        },
-        "id": {
-          "$/inet/127.1/9030": {
-            "connect_latency_ms": {
-              "stat.count": 0
+        }
+      },
+      "client": {
+        "$/inet/127.1/9030": {
+          "connect_latency_ms": {
+            "stat.count": 0
+          },
+          "failed_connect_latency_ms": {
+            "stat.count": 0
+          },
+          "sent_bytes": {
+            "counter": 4760
+          },
+          "service_creation": {
+            "service_acquisition_latency_ms": {
+              "stat.count": 13,
+              "stat.max": 0,
+              "stat.min": 0,
+              "stat.p50": 0,
+              "stat.p90": 0,
+              "stat.p95": 0,
+              "stat.p99": 0,
+              "stat.p9990": 0,
+              "stat.p9999": 0,
+              "stat.sum": 0,
+              "stat.avg": 0.0
+            }
+          },
+          "connection_received_bytes": {
+            "stat.count": 0
+          },
+          "connection_duration": {
+            "stat.count": 0
+          },
+          "failure_accrual": {
+            "removals": {
+              "counter": 0
             },
-            "failed_connect_latency_ms": {
-              "stat.count": 0
+            "probes": {
+              "counter": 0
             },
-            "sent_bytes": {
-              "counter": 4760
+            "removed_for_ms": {
+              "counter": 0
             },
-            "service_creation": {
-              "service_acquisition_latency_ms": {
+            "revivals": {
+              "counter": 0
+            }
+          },
+          "connects": {
+            "counter": 1
+          },
+          "pool_num_waited": {
+            "counter": 0
+          },
+          "success": {
+            "counter": 136
+          },
+          "service": {
+            "svc": {
+              "request_latency_ms": {
                 "stat.count": 13,
                 "stat.max": 0,
                 "stat.min": 0,
@@ -3003,64 +3044,36 @@ return {
                 "stat.p9999": 0,
                 "stat.sum": 0,
                 "stat.avg": 0.0
-              }
-            },
-            "connection_received_bytes": {
-              "stat.count": 0
-            },
-            "connection_duration": {
-              "stat.count": 0
-            },
-            "failure_accrual": {
-              "removals": {
-                "counter": 0
               },
-              "probes": {
-                "counter": 0
+              "success": {
+                "counter": 136
               },
-              "removed_for_ms": {
-                "counter": 0
+              "pending": {
+                "gauge": 0.0
               },
-              "revivals": {
-                "counter": 0
+              "requests": {
+                "counter": 136
               }
-            },
-            "connects": {
-              "counter": 1
-            },
-            "pool_num_waited": {
-              "counter": 0
-            },
-            "success": {
-              "counter": 136
-            },
-            "path": {
-              "svc": {
-                "request_latency_ms": {
-                  "stat.count": 13,
-                  "stat.max": 0,
-                  "stat.min": 0,
-                  "stat.p50": 0,
-                  "stat.p90": 0,
-                  "stat.p95": 0,
-                  "stat.p99": 0,
-                  "stat.p9990": 0,
-                  "stat.p9999": 0,
-                  "stat.sum": 0,
-                  "stat.avg": 0.0
-                },
-                "success": {
-                  "counter": 136
-                },
-                "pending": {
-                  "gauge": 0.0
-                },
-                "requests": {
-                  "counter": 136
-                }
-              }
-            },
-            "request_latency_ms": {
+            }
+          },
+          "request_latency_ms": {
+            "stat.count": 13,
+            "stat.max": 0,
+            "stat.min": 0,
+            "stat.p50": 0,
+            "stat.p90": 0,
+            "stat.p95": 0,
+            "stat.p99": 0,
+            "stat.p9990": 0,
+            "stat.p9999": 0,
+            "stat.sum": 0,
+            "stat.avg": 0.0
+          },
+          "pool_waiters": {
+            "gauge": 0.0
+          },
+          "retries": {
+            "requeues_per_request": {
               "stat.count": 13,
               "stat.max": 0,
               "stat.min": 0,
@@ -3073,656 +3086,638 @@ return {
               "stat.sum": 0,
               "stat.avg": 0.0
             },
-            "pool_waiters": {
-              "gauge": 0.0
+            "request_limit": {
+              "counter": 0
             },
-            "retries": {
-              "requeues_per_request": {
-                "stat.count": 13,
-                "stat.max": 0,
-                "stat.min": 0,
-                "stat.p50": 0,
-                "stat.p90": 0,
-                "stat.p95": 0,
-                "stat.p99": 0,
-                "stat.p9990": 0,
-                "stat.p9999": 0,
-                "stat.sum": 0,
-                "stat.avg": 0.0
-              },
-              "request_limit": {
-                "counter": 0
-              },
-              "budget_exhausted": {
-                "counter": 0
-              },
-              "cannot_retry": {
-                "counter": 0
-              },
-              "not_open": {
-                "counter": 0
-              },
-              "budget": {
-                "gauge": 102.0
-              },
-              "requeues": {
-                "counter": 0
-              }
+            "budget_exhausted": {
+              "counter": 0
             },
-            "received_bytes": {
-              "counter": 3808
+            "cannot_retry": {
+              "counter": 0
             },
-            "connection_sent_bytes": {
+            "not_open": {
+              "counter": 0
+            },
+            "budget": {
+              "gauge": 102.0
+            },
+            "requeues": {
+              "counter": 0
+            }
+          },
+          "received_bytes": {
+            "counter": 3808
+          },
+          "connection_sent_bytes": {
+            "stat.count": 0
+          },
+          "connection_requests": {
+            "stat.count": 0
+          },
+          "pool_num_too_many_waiters": {
+            "counter": 0
+          },
+          "socket_unwritable_ms": {
+            "counter": 0
+          },
+          "closes": {
+            "counter": 0
+          },
+          "pool_cached": {
+            "gauge": 1.0
+          },
+          "pool_size": {
+            "gauge": 0.0
+          },
+          "available": {
+            "gauge": 1.0
+          },
+          "request_payload_bytes": {
+            "stat.count": 13,
+            "stat.max": 35,
+            "stat.min": 35,
+            "stat.p50": 35,
+            "stat.p90": 35,
+            "stat.p95": 35,
+            "stat.p99": 35,
+            "stat.p9990": 35,
+            "stat.p9999": 35,
+            "stat.sum": 455,
+            "stat.avg": 35.0
+          },
+          "socket_writable_ms": {
+            "counter": 0
+          },
+          "cancelled_connects": {
+            "counter": 0
+          },
+          "response_payload_bytes": {
+            "stat.count": 13,
+            "stat.max": 28,
+            "stat.min": 28,
+            "stat.p50": 28,
+            "stat.p90": 28,
+            "stat.p95": 28,
+            "stat.p99": 28,
+            "stat.p9990": 28,
+            "stat.p9999": 28,
+            "stat.sum": 364,
+            "stat.avg": 28.0
+          },
+          "dtab": {
+            "size": {
               "stat.count": 0
-            },
-            "connection_requests": {
-              "stat.count": 0
-            },
-            "pool_num_too_many_waiters": {
-              "counter": 0
-            },
-            "socket_unwritable_ms": {
-              "counter": 0
-            },
-            "closes": {
-              "counter": 0
-            },
-            "pool_cached": {
+            }
+          },
+          "requests": {
+            "counter": 136
+          },
+          "loadbalancer": {
+            "size": {
               "gauge": 1.0
             },
-            "pool_size": {
+            "rebuilds": {
+              "counter": 1
+            },
+            "closed": {
               "gauge": 0.0
+            },
+            "load": {
+              "gauge": 0.0
+            },
+            "meanweight": {
+              "gauge": 1.0
+            },
+            "adds": {
+              "counter": 1
+            },
+            "p2c": {
+              "gauge": 1.0
+            },
+            "updates": {
+              "counter": 1
             },
             "available": {
               "gauge": 1.0
             },
-            "request_payload_bytes": {
-              "stat.count": 13,
-              "stat.max": 35,
-              "stat.min": 35,
-              "stat.p50": 35,
-              "stat.p90": 35,
-              "stat.p95": 35,
-              "stat.p99": 35,
-              "stat.p9990": 35,
-              "stat.p9999": 35,
-              "stat.sum": 455,
-              "stat.avg": 35.0
-            },
-            "socket_writable_ms": {
+            "max_effort_exhausted": {
               "counter": 0
             },
-            "cancelled_connects": {
-              "counter": 0
-            },
-            "response_payload_bytes": {
-              "stat.count": 13,
-              "stat.max": 28,
-              "stat.min": 28,
-              "stat.p50": 28,
-              "stat.p90": 28,
-              "stat.p95": 28,
-              "stat.p99": 28,
-              "stat.p9990": 28,
-              "stat.p9999": 28,
-              "stat.sum": 364,
-              "stat.avg": 28.0
-            },
-            "dtab": {
-              "size": {
-                "stat.count": 0
-              }
-            },
-            "requests": {
-              "counter": 136
-            },
-            "loadbalancer": {
-              "size": {
-                "gauge": 1.0
-              },
-              "rebuilds": {
-                "counter": 1
-              },
-              "closed": {
-                "gauge": 0.0
-              },
-              "load": {
-                "gauge": 0.0
-              },
-              "meanweight": {
-                "gauge": 1.0
-              },
-              "adds": {
-                "counter": 1
-              },
-              "p2c": {
-                "gauge": 1.0
-              },
-              "updates": {
-                "counter": 1
-              },
-              "available": {
-                "gauge": 1.0
-              },
-              "max_effort_exhausted": {
-                "counter": 0
-              },
-              "busy": {
-                "gauge": 0.0
-              },
-              "removes": {
-                "counter": 0
-              }
-            },
-            "pending": {
+            "busy": {
               "gauge": 0.0
             },
-            "dispatcher": {
-              "serial": {
-                "queue_size": {
-                  "gauge": 0.0
-                }
-              }
-            },
-            "connections": {
-              "gauge": 1.0
+            "removes": {
+              "counter": 0
             }
           },
-          "$/inet/127.1/9029": {
-            "connect_latency_ms": {
-              "stat.count": 0
-            },
-            "failed_connect_latency_ms": {
-              "stat.count": 0
-            },
-            "sent_bytes": {
-              "counter": 4165
-            },
-            "service_creation": {
-              "service_acquisition_latency_ms": {
-                "stat.count": 7,
-                "stat.max": 0,
-                "stat.min": 0,
-                "stat.p50": 0,
-                "stat.p90": 0,
-                "stat.p95": 0,
-                "stat.p99": 0,
-                "stat.p9990": 0,
-                "stat.p9999": 0,
-                "stat.sum": 0,
-                "stat.avg": 0.0
-              }
-            },
-            "connection_received_bytes": {
-              "stat.count": 0
-            },
-            "connection_duration": {
-              "stat.count": 0
-            },
-            "failure_accrual": {
-              "removals": {
-                "counter": 0
-              },
-              "probes": {
-                "counter": 0
-              },
-              "removed_for_ms": {
-                "counter": 0
-              },
-              "revivals": {
-                "counter": 0
-              }
-            },
-            "connects": {
-              "counter": 1
-            },
-            "pool_num_waited": {
-              "counter": 0
-            },
-            "success": {
-              "counter": 119
-            },
-            "path": {
-              "svc": {
-                "request_latency_ms": {
-                  "stat.count": 7,
-                  "stat.max": 1,
-                  "stat.min": 0,
-                  "stat.p50": 0,
-                  "stat.p90": 0,
-                  "stat.p95": 1,
-                  "stat.p99": 1,
-                  "stat.p9990": 1,
-                  "stat.p9999": 1,
-                  "stat.sum": 1,
-                  "stat.avg": 0.14285714285714285
-                },
-                "success": {
-                  "counter": 119
-                },
-                "pending": {
-                  "gauge": 0.0
-                },
-                "requests": {
-                  "counter": 119
-                }
-              }
-            },
-            "request_latency_ms": {
-              "stat.count": 7,
-              "stat.max": 1,
-              "stat.min": 0,
-              "stat.p50": 0,
-              "stat.p90": 0,
-              "stat.p95": 1,
-              "stat.p99": 1,
-              "stat.p9990": 1,
-              "stat.p9999": 1,
-              "stat.sum": 1,
-              "stat.avg": 0.14285714285714285
-            },
-            "pool_waiters": {
-              "gauge": 0.0
-            },
-            "retries": {
-              "requeues_per_request": {
-                "stat.count": 7,
-                "stat.max": 0,
-                "stat.min": 0,
-                "stat.p50": 0,
-                "stat.p90": 0,
-                "stat.p95": 0,
-                "stat.p99": 0,
-                "stat.p9990": 0,
-                "stat.p9999": 0,
-                "stat.sum": 0,
-                "stat.avg": 0.0
-              },
-              "request_limit": {
-                "counter": 0
-              },
-              "budget_exhausted": {
-                "counter": 0
-              },
-              "cannot_retry": {
-                "counter": 0
-              },
-              "not_open": {
-                "counter": 0
-              },
-              "budget": {
-                "gauge": 102.0
-              },
-              "requeues": {
-                "counter": 0
-              }
-            },
-            "received_bytes": {
-              "counter": 3332
-            },
-            "connection_sent_bytes": {
-              "stat.count": 0
-            },
-            "connection_requests": {
-              "stat.count": 0
-            },
-            "pool_num_too_many_waiters": {
-              "counter": 0
-            },
-            "socket_unwritable_ms": {
-              "counter": 0
-            },
-            "closes": {
-              "counter": 0
-            },
-            "pool_cached": {
-              "gauge": 1.0
-            },
-            "pool_size": {
-              "gauge": 0.0
-            },
-            "available": {
-              "gauge": 1.0
-            },
-            "request_payload_bytes": {
-              "stat.count": 7,
-              "stat.max": 35,
-              "stat.min": 35,
-              "stat.p50": 35,
-              "stat.p90": 35,
-              "stat.p95": 35,
-              "stat.p99": 35,
-              "stat.p9990": 35,
-              "stat.p9999": 35,
-              "stat.sum": 245,
-              "stat.avg": 35.0
-            },
-            "socket_writable_ms": {
-              "counter": 0
-            },
-            "cancelled_connects": {
-              "counter": 0
-            },
-            "response_payload_bytes": {
-              "stat.count": 7,
-              "stat.max": 28,
-              "stat.min": 28,
-              "stat.p50": 28,
-              "stat.p90": 28,
-              "stat.p95": 28,
-              "stat.p99": 28,
-              "stat.p9990": 28,
-              "stat.p9999": 28,
-              "stat.sum": 196,
-              "stat.avg": 28.0
-            },
-            "dtab": {
-              "size": {
-                "stat.count": 0
-              }
-            },
-            "requests": {
-              "counter": 119
-            },
-            "loadbalancer": {
-              "size": {
-                "gauge": 1.0
-              },
-              "rebuilds": {
-                "counter": 1
-              },
-              "closed": {
+          "pending": {
+            "gauge": 0.0
+          },
+          "dispatcher": {
+            "serial": {
+              "queue_size": {
                 "gauge": 0.0
-              },
-              "load": {
-                "gauge": 0.0
-              },
-              "meanweight": {
-                "gauge": 1.0
-              },
-              "adds": {
-                "counter": 1
-              },
-              "p2c": {
-                "gauge": 1.0
-              },
-              "updates": {
-                "counter": 1
-              },
-              "available": {
-                "gauge": 1.0
-              },
-              "max_effort_exhausted": {
-                "counter": 0
-              },
-              "busy": {
-                "gauge": 0.0
-              },
-              "removes": {
-                "counter": 0
               }
-            },
-            "pending": {
-              "gauge": 0.0
-            },
-            "dispatcher": {
-              "serial": {
-                "queue_size": {
-                  "gauge": 0.0
-                }
-              }
-            },
-            "connections": {
-              "gauge": 1.0
             }
           },
-          "$/inet/127.1/9092": {
-            "connect_latency_ms": {
-              "stat.count": 0
-            },
-            "failed_connect_latency_ms": {
-              "stat.count": 0
-            },
-            "sent_bytes": {
-              "counter": 4410
-            },
-            "service_creation": {
-              "service_acquisition_latency_ms": {
-                "stat.count": 13,
-                "stat.max": 0,
-                "stat.min": 0,
-                "stat.p50": 0,
-                "stat.p90": 0,
-                "stat.p95": 0,
-                "stat.p99": 0,
-                "stat.p9990": 0,
-                "stat.p9999": 0,
-                "stat.sum": 0,
-                "stat.avg": 0.0
-              }
-            },
-            "connection_received_bytes": {
-              "stat.count": 0
-            },
-            "connection_duration": {
-              "stat.count": 0
-            },
-            "failure_accrual": {
-              "removals": {
-                "counter": 0
-              },
-              "probes": {
-                "counter": 0
-              },
-              "removed_for_ms": {
-                "counter": 0
-              },
-              "revivals": {
-                "counter": 0
-              }
-            },
-            "connects": {
-              "counter": 1
-            },
-            "pool_num_waited": {
-              "counter": 0
-            },
-            "success": {
-              "counter": 126
-            },
-            "path": {
-              "svc": {
-                "request_latency_ms": {
-                  "stat.count": 13,
-                  "stat.max": 1,
-                  "stat.min": 0,
-                  "stat.p50": 0,
-                  "stat.p90": 0,
-                  "stat.p95": 0,
-                  "stat.p99": 1,
-                  "stat.p9990": 1,
-                  "stat.p9999": 1,
-                  "stat.sum": 1,
-                  "stat.avg": 0.07692307692307693
-                },
-                "success": {
-                  "counter": 126
-                },
-                "pending": {
-                  "gauge": 0.0
-                },
-                "requests": {
-                  "counter": 126
-                }
-              }
-            },
-            "request_latency_ms": {
-              "stat.count": 13,
-              "stat.max": 1,
+          "connections": {
+            "gauge": 1.0
+          }
+        },
+        "$/inet/127.1/9029": {
+          "connect_latency_ms": {
+            "stat.count": 0
+          },
+          "failed_connect_latency_ms": {
+            "stat.count": 0
+          },
+          "sent_bytes": {
+            "counter": 4165
+          },
+          "service_creation": {
+            "service_acquisition_latency_ms": {
+              "stat.count": 7,
+              "stat.max": 0,
               "stat.min": 0,
               "stat.p50": 0,
               "stat.p90": 0,
               "stat.p95": 0,
-              "stat.p99": 1,
-              "stat.p9990": 1,
-              "stat.p9999": 1,
-              "stat.sum": 1,
-              "stat.avg": 0.07692307692307693
+              "stat.p99": 0,
+              "stat.p9990": 0,
+              "stat.p9999": 0,
+              "stat.sum": 0,
+              "stat.avg": 0.0
+            }
+          },
+          "connection_received_bytes": {
+            "stat.count": 0
+          },
+          "connection_duration": {
+            "stat.count": 0
+          },
+          "failure_accrual": {
+            "removals": {
+              "counter": 0
             },
-            "pool_waiters": {
-              "gauge": 0.0
+            "probes": {
+              "counter": 0
             },
-            "retries": {
-              "requeues_per_request": {
-                "stat.count": 13,
-                "stat.max": 0,
+            "removed_for_ms": {
+              "counter": 0
+            },
+            "revivals": {
+              "counter": 0
+            }
+          },
+          "connects": {
+            "counter": 1
+          },
+          "pool_num_waited": {
+            "counter": 0
+          },
+          "success": {
+            "counter": 119
+          },
+          "service": {
+            "svc": {
+              "request_latency_ms": {
+                "stat.count": 7,
+                "stat.max": 1,
                 "stat.min": 0,
                 "stat.p50": 0,
                 "stat.p90": 0,
-                "stat.p95": 0,
-                "stat.p99": 0,
-                "stat.p9990": 0,
-                "stat.p9999": 0,
-                "stat.sum": 0,
-                "stat.avg": 0.0
+                "stat.p95": 1,
+                "stat.p99": 1,
+                "stat.p9990": 1,
+                "stat.p9999": 1,
+                "stat.sum": 1,
+                "stat.avg": 0.14285714285714285
               },
-              "request_limit": {
-                "counter": 0
+              "success": {
+                "counter": 119
               },
-              "budget_exhausted": {
-                "counter": 0
+              "pending": {
+                "gauge": 0.0
               },
-              "cannot_retry": {
-                "counter": 0
-              },
-              "not_open": {
-                "counter": 0
-              },
-              "budget": {
-                "gauge": 102.0
-              },
-              "requeues": {
-                "counter": 0
+              "requests": {
+                "counter": 119
               }
+            }
+          },
+          "request_latency_ms": {
+            "stat.count": 7,
+            "stat.max": 1,
+            "stat.min": 0,
+            "stat.p50": 0,
+            "stat.p90": 0,
+            "stat.p95": 1,
+            "stat.p99": 1,
+            "stat.p9990": 1,
+            "stat.p9999": 1,
+            "stat.sum": 1,
+            "stat.avg": 0.14285714285714285
+          },
+          "pool_waiters": {
+            "gauge": 0.0
+          },
+          "retries": {
+            "requeues_per_request": {
+              "stat.count": 7,
+              "stat.max": 0,
+              "stat.min": 0,
+              "stat.p50": 0,
+              "stat.p90": 0,
+              "stat.p95": 0,
+              "stat.p99": 0,
+              "stat.p9990": 0,
+              "stat.p9999": 0,
+              "stat.sum": 0,
+              "stat.avg": 0.0
             },
-            "received_bytes": {
-              "counter": 3528
+            "request_limit": {
+              "counter": 0
             },
-            "connection_sent_bytes": {
+            "budget_exhausted": {
+              "counter": 0
+            },
+            "cannot_retry": {
+              "counter": 0
+            },
+            "not_open": {
+              "counter": 0
+            },
+            "budget": {
+              "gauge": 102.0
+            },
+            "requeues": {
+              "counter": 0
+            }
+          },
+          "received_bytes": {
+            "counter": 3332
+          },
+          "connection_sent_bytes": {
+            "stat.count": 0
+          },
+          "connection_requests": {
+            "stat.count": 0
+          },
+          "pool_num_too_many_waiters": {
+            "counter": 0
+          },
+          "socket_unwritable_ms": {
+            "counter": 0
+          },
+          "closes": {
+            "counter": 0
+          },
+          "pool_cached": {
+            "gauge": 1.0
+          },
+          "pool_size": {
+            "gauge": 0.0
+          },
+          "available": {
+            "gauge": 1.0
+          },
+          "request_payload_bytes": {
+            "stat.count": 7,
+            "stat.max": 35,
+            "stat.min": 35,
+            "stat.p50": 35,
+            "stat.p90": 35,
+            "stat.p95": 35,
+            "stat.p99": 35,
+            "stat.p9990": 35,
+            "stat.p9999": 35,
+            "stat.sum": 245,
+            "stat.avg": 35.0
+          },
+          "socket_writable_ms": {
+            "counter": 0
+          },
+          "cancelled_connects": {
+            "counter": 0
+          },
+          "response_payload_bytes": {
+            "stat.count": 7,
+            "stat.max": 28,
+            "stat.min": 28,
+            "stat.p50": 28,
+            "stat.p90": 28,
+            "stat.p95": 28,
+            "stat.p99": 28,
+            "stat.p9990": 28,
+            "stat.p9999": 28,
+            "stat.sum": 196,
+            "stat.avg": 28.0
+          },
+          "dtab": {
+            "size": {
               "stat.count": 0
-            },
-            "connection_requests": {
-              "stat.count": 0
-            },
-            "pool_num_too_many_waiters": {
-              "counter": 0
-            },
-            "socket_unwritable_ms": {
-              "counter": 0
-            },
-            "closes": {
-              "counter": 0
-            },
-            "pool_cached": {
+            }
+          },
+          "requests": {
+            "counter": 119
+          },
+          "loadbalancer": {
+            "size": {
               "gauge": 1.0
             },
-            "pool_size": {
+            "rebuilds": {
+              "counter": 1
+            },
+            "closed": {
               "gauge": 0.0
+            },
+            "load": {
+              "gauge": 0.0
+            },
+            "meanweight": {
+              "gauge": 1.0
+            },
+            "adds": {
+              "counter": 1
+            },
+            "p2c": {
+              "gauge": 1.0
+            },
+            "updates": {
+              "counter": 1
             },
             "available": {
               "gauge": 1.0
             },
-            "request_payload_bytes": {
-              "stat.count": 13,
-              "stat.max": 35,
-              "stat.min": 35,
-              "stat.p50": 35,
-              "stat.p90": 35,
-              "stat.p95": 35,
-              "stat.p99": 35,
-              "stat.p9990": 35,
-              "stat.p9999": 35,
-              "stat.sum": 455,
-              "stat.avg": 35.0
-            },
-            "socket_writable_ms": {
+            "max_effort_exhausted": {
               "counter": 0
             },
-            "cancelled_connects": {
-              "counter": 0
-            },
-            "response_payload_bytes": {
-              "stat.count": 13,
-              "stat.max": 28,
-              "stat.min": 28,
-              "stat.p50": 28,
-              "stat.p90": 28,
-              "stat.p95": 28,
-              "stat.p99": 28,
-              "stat.p9990": 28,
-              "stat.p9999": 28,
-              "stat.sum": 364,
-              "stat.avg": 28.0
-            },
-            "dtab": {
-              "size": {
-                "stat.count": 0
-              }
-            },
-            "requests": {
-              "counter": 126
-            },
-            "loadbalancer": {
-              "size": {
-                "gauge": 1.0
-              },
-              "rebuilds": {
-                "counter": 1
-              },
-              "closed": {
-                "gauge": 0.0
-              },
-              "load": {
-                "gauge": 0.0
-              },
-              "meanweight": {
-                "gauge": 1.0
-              },
-              "adds": {
-                "counter": 1
-              },
-              "p2c": {
-                "gauge": 1.0
-              },
-              "updates": {
-                "counter": 1
-              },
-              "available": {
-                "gauge": 1.0
-              },
-              "max_effort_exhausted": {
-                "counter": 0
-              },
-              "busy": {
-                "gauge": 0.0
-              },
-              "removes": {
-                "counter": 0
-              }
-            },
-            "pending": {
+            "busy": {
               "gauge": 0.0
             },
-            "dispatcher": {
-              "serial": {
-                "queue_size": {
-                  "gauge": 0.0
-                }
-              }
-            },
-            "connections": {
-              "gauge": 1.0
+            "removes": {
+              "counter": 0
             }
+          },
+          "pending": {
+            "gauge": 0.0
+          },
+          "dispatcher": {
+            "serial": {
+              "queue_size": {
+                "gauge": 0.0
+              }
+            }
+          },
+          "connections": {
+            "gauge": 1.0
+          }
+        },
+        "$/inet/127.1/9092": {
+          "connect_latency_ms": {
+            "stat.count": 0
+          },
+          "failed_connect_latency_ms": {
+            "stat.count": 0
+          },
+          "sent_bytes": {
+            "counter": 4410
+          },
+          "service_creation": {
+            "service_acquisition_latency_ms": {
+              "stat.count": 13,
+              "stat.max": 0,
+              "stat.min": 0,
+              "stat.p50": 0,
+              "stat.p90": 0,
+              "stat.p95": 0,
+              "stat.p99": 0,
+              "stat.p9990": 0,
+              "stat.p9999": 0,
+              "stat.sum": 0,
+              "stat.avg": 0.0
+            }
+          },
+          "connection_received_bytes": {
+            "stat.count": 0
+          },
+          "connection_duration": {
+            "stat.count": 0
+          },
+          "failure_accrual": {
+            "removals": {
+              "counter": 0
+            },
+            "probes": {
+              "counter": 0
+            },
+            "removed_for_ms": {
+              "counter": 0
+            },
+            "revivals": {
+              "counter": 0
+            }
+          },
+          "connects": {
+            "counter": 1
+          },
+          "pool_num_waited": {
+            "counter": 0
+          },
+          "success": {
+            "counter": 126
+          },
+          "service": {
+            "svc": {
+              "request_latency_ms": {
+                "stat.count": 13,
+                "stat.max": 1,
+                "stat.min": 0,
+                "stat.p50": 0,
+                "stat.p90": 0,
+                "stat.p95": 0,
+                "stat.p99": 1,
+                "stat.p9990": 1,
+                "stat.p9999": 1,
+                "stat.sum": 1,
+                "stat.avg": 0.07692307692307693
+              },
+              "success": {
+                "counter": 126
+              },
+              "pending": {
+                "gauge": 0.0
+              },
+              "requests": {
+                "counter": 126
+              }
+            }
+          },
+          "request_latency_ms": {
+            "stat.count": 13,
+            "stat.max": 1,
+            "stat.min": 0,
+            "stat.p50": 0,
+            "stat.p90": 0,
+            "stat.p95": 0,
+            "stat.p99": 1,
+            "stat.p9990": 1,
+            "stat.p9999": 1,
+            "stat.sum": 1,
+            "stat.avg": 0.07692307692307693
+          },
+          "pool_waiters": {
+            "gauge": 0.0
+          },
+          "retries": {
+            "requeues_per_request": {
+              "stat.count": 13,
+              "stat.max": 0,
+              "stat.min": 0,
+              "stat.p50": 0,
+              "stat.p90": 0,
+              "stat.p95": 0,
+              "stat.p99": 0,
+              "stat.p9990": 0,
+              "stat.p9999": 0,
+              "stat.sum": 0,
+              "stat.avg": 0.0
+            },
+            "request_limit": {
+              "counter": 0
+            },
+            "budget_exhausted": {
+              "counter": 0
+            },
+            "cannot_retry": {
+              "counter": 0
+            },
+            "not_open": {
+              "counter": 0
+            },
+            "budget": {
+              "gauge": 102.0
+            },
+            "requeues": {
+              "counter": 0
+            }
+          },
+          "received_bytes": {
+            "counter": 3528
+          },
+          "connection_sent_bytes": {
+            "stat.count": 0
+          },
+          "connection_requests": {
+            "stat.count": 0
+          },
+          "pool_num_too_many_waiters": {
+            "counter": 0
+          },
+          "socket_unwritable_ms": {
+            "counter": 0
+          },
+          "closes": {
+            "counter": 0
+          },
+          "pool_cached": {
+            "gauge": 1.0
+          },
+          "pool_size": {
+            "gauge": 0.0
+          },
+          "available": {
+            "gauge": 1.0
+          },
+          "request_payload_bytes": {
+            "stat.count": 13,
+            "stat.max": 35,
+            "stat.min": 35,
+            "stat.p50": 35,
+            "stat.p90": 35,
+            "stat.p95": 35,
+            "stat.p99": 35,
+            "stat.p9990": 35,
+            "stat.p9999": 35,
+            "stat.sum": 455,
+            "stat.avg": 35.0
+          },
+          "socket_writable_ms": {
+            "counter": 0
+          },
+          "cancelled_connects": {
+            "counter": 0
+          },
+          "response_payload_bytes": {
+            "stat.count": 13,
+            "stat.max": 28,
+            "stat.min": 28,
+            "stat.p50": 28,
+            "stat.p90": 28,
+            "stat.p95": 28,
+            "stat.p99": 28,
+            "stat.p9990": 28,
+            "stat.p9999": 28,
+            "stat.sum": 364,
+            "stat.avg": 28.0
+          },
+          "dtab": {
+            "size": {
+              "stat.count": 0
+            }
+          },
+          "requests": {
+            "counter": 126
+          },
+          "loadbalancer": {
+            "size": {
+              "gauge": 1.0
+            },
+            "rebuilds": {
+              "counter": 1
+            },
+            "closed": {
+              "gauge": 0.0
+            },
+            "load": {
+              "gauge": 0.0
+            },
+            "meanweight": {
+              "gauge": 1.0
+            },
+            "adds": {
+              "counter": 1
+            },
+            "p2c": {
+              "gauge": 1.0
+            },
+            "updates": {
+              "counter": 1
+            },
+            "available": {
+              "gauge": 1.0
+            },
+            "max_effort_exhausted": {
+              "counter": 0
+            },
+            "busy": {
+              "gauge": 0.0
+            },
+            "removes": {
+              "counter": 0
+            }
+          },
+          "pending": {
+            "gauge": 0.0
+          },
+          "dispatcher": {
+            "serial": {
+              "queue_size": {
+                "gauge": 0.0
+              }
+            }
+          },
+          "connections": {
+            "gauge": 1.0
           }
         }
       },

--- a/admin/src/main/resources/io/buoyant/admin/js/src/combined_client_graph.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/combined_client_graph.js
@@ -60,7 +60,7 @@ define([
       chart.setMetrics(desiredMetrics);
 
       var metricsListener = function(data) {
-        var clientData = _.get(data, ["rt", routerName, "dst", "id"]);
+        var clientData = _.get(data, ["rt", routerName, "client"]);
         var clientsToDisplay = getClientsToDisplay(clientData, routerName);
 
         var dataToDisplay = _.map(clientsToDisplay, function(client) {

--- a/admin/src/main/resources/io/buoyant/admin/js/src/dashboard.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/dashboard.js
@@ -26,7 +26,7 @@ define([
       var initialData = _.reduce(initialRouters, function(mem, data, router) {
         mem[router] = {};
         mem[router]["servers"] = _.keys(data.srv);
-        mem[router]["clients"] = _.keys(_.get(data, "dst.id"));
+        mem[router]["clients"] = _.keys(_.get(data, "client"));
         return mem;
       }, {});
 

--- a/admin/src/main/resources/io/buoyant/admin/js/src/metrics_collector.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/metrics_collector.js
@@ -43,7 +43,7 @@ define(['jQuery'], function($) {
     function getAddedClients(resp) {
       var addedClients = {};
       _.each(resp.rt, function(routerData, router) {
-        _.each(_.get(routerData, "dst.id"), function(clientData, client) {
+        _.each(_.get(routerData, "client"), function(clientData, client) {
           clients[router] = clients[router] || {};
           if(!clients[router][client]) {
             addedClients[router] = addedClients[router] || {};

--- a/admin/src/main/resources/io/buoyant/admin/js/src/request_totals.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/request_totals.js
@@ -40,7 +40,7 @@ define([
         getMetrics: function(data) {
           return sumMetric(data, "connections", true, this.prefix);
         },
-        prefix: "dst.id",
+        prefix: "client",
         metric: "connections",
         isGauge: true
       }

--- a/admin/src/main/resources/io/buoyant/admin/js/src/router_client.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/router_client.js
@@ -75,7 +75,7 @@ define([
         {suffix: "loadbalancer/size", label: "Load balancer pool size", isGauge: true},
         {suffix: "loadbalancer/available", label: "Load balancers available", isGauge: true}
       ], function(metric) {
-        var treeKeyRoot = ["rt", routerName, "dst", "id", clientName].concat(metric.suffix.split("/"));
+        var treeKeyRoot = ["rt", routerName, "client", clientName].concat(metric.suffix.split("/"));
 
         return {
           metricSuffix: metric.suffix,
@@ -98,7 +98,7 @@ define([
     }
 
     function getLatencyData(data, routerName, clientName, chartLegend) {
-      var latencyData = _.get(data, ["rt", routerName, "dst", "id", clientName, "request_latency_ms"]);
+      var latencyData = _.get(data, ["rt", routerName, "client", clientName, "request_latency_ms"]);
 
       return _.map(latencyKeys, function(key) {
         return {

--- a/admin/src/main/resources/io/buoyant/admin/js/src/router_summary.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/router_summary.js
@@ -51,8 +51,8 @@ define([
 
     function getMetrics(routerName) {
       var serverAccessor = ["rt", routerName, "srv"];
-      var clientAccessor = ["rt", routerName, "dst", "id"];
-      var pathAccessor = ["rt", routerName, "dst", "path", "svc"];
+      var clientAccessor = ["rt", routerName, "client"];
+      var pathAccessor = ["rt", routerName, "service", "svc"];
 
       return _.each({
         load: {

--- a/linkerd/docs/protocol-h2.md
+++ b/linkerd/docs/protocol-h2.md
@@ -325,8 +325,8 @@ The informational headers linkerd emits on outgoing requests.
 
 Header | Description
 ------ | -----------
-`l5d-dst-logical` | The logical name of the request as identified by linkerd.
-`l5d-dst-concrete` | The concrete client name after delegation.
+`l5d-dst-service` | The logical service name of the request as identified by linkerd.
+`l5d-dst-client` | The concrete client name after delegation.
 `l5d-dst-residual` | An optional residual path remaining after delegation.
 `l5d-reqid` | A token that may be used to correlate requests in a callgraph across services and linkerd instances.
 

--- a/linkerd/docs/protocol-http.md
+++ b/linkerd/docs/protocol-http.md
@@ -475,8 +475,8 @@ The informational headers linkerd emits on outgoing requests.
 
 Header | Description
 ------ | -----------
-`l5d-dst-logical` | The logical name of the request as identified by linkerd.
-`l5d-dst-concrete` | The concrete client name after delegation.
+`l5d-dst-service` | The logical service name of the request as identified by linkerd.
+`l5d-dst-client` | The concrete client name after delegation.
 `l5d-dst-residual` | An optional residual path remaining after delegation.
 `l5d-reqid` | A token that may be used to correlate requests in a callgraph across services and linkerd instances.
 

--- a/linkerd/protocol/h2/src/main/scala/com/twitter/finagle/buoyant/h2/LinkerdHeaders.scala
+++ b/linkerd/protocol/h2/src/main/scala/com/twitter/finagle/buoyant/h2/LinkerdHeaders.scala
@@ -379,11 +379,11 @@ object LinkerdHeaders {
    * next hop.
    */
   object Dst {
-    val Path = Prefix + "dst-logical"
-    val Bound = Prefix + "dst-concrete"
+    val Path = Prefix + "dst-service"
+    val Bound = Prefix + "dst-client"
     val Residual = Prefix + "dst-residual"
 
-    /** Encodes `l5d-dst-path` on outgoing requests. */
+    /** Encodes `l5d-dst-service` on outgoing requests. */
     class PathFilter(path: Path) extends SimpleFilter[Request, Response] {
       private[this] val pathShow = path.show
       def apply(req: Request, service: Service[Request, Response]) = {

--- a/linkerd/protocol/http/src/e2e/scala/io/buoyant/linkerd/protocol/HttpEndToEndTest.scala
+++ b/linkerd/protocol/http/src/e2e/scala/io/buoyant/linkerd/protocol/HttpEndToEndTest.scala
@@ -117,9 +117,9 @@ class HttpEndToEndTest extends FunSuite with Awaits {
         val bound = s"/$$/inet/127.1/${cat.port}"
         withAnnotations { anns =>
           assert(annotationKeys(anns) == Seq("sr", "cs", "ws", "wr", "l5d.success", "cr", "ss"))
-          assert(anns.contains(Annotation.BinaryAnnotation("namer.path", path)))
-          assert(anns.contains(Annotation.BinaryAnnotation("dst.id", bound)))
-          assert(anns.contains(Annotation.BinaryAnnotation("dst.path", "/")))
+          assert(anns.contains(Annotation.BinaryAnnotation("service", path)))
+          assert(anns.contains(Annotation.BinaryAnnotation("client", bound)))
+          assert(anns.contains(Annotation.BinaryAnnotation("residual", "/")))
         }
       }
 
@@ -178,9 +178,9 @@ class HttpEndToEndTest extends FunSuite with Awaits {
       assert(stats.counters.get(Seq("http", "srv", "127.0.0.1/0", "requests")) == Some(1))
       assert(stats.counters.get(Seq("http", "srv", "127.0.0.1/0", "success")) == Some(1))
       assert(stats.counters.get(Seq("http", "srv", "127.0.0.1/0", "failures")) == None)
-      assert(stats.counters.get(Seq("http", "dst", "id", label, "requests")) == Some(1))
-      assert(stats.counters.get(Seq("http", "dst", "id", label, "success")) == Some(1))
-      assert(stats.counters.get(Seq("http", "dst", "id", label, "failures")) == None)
+      assert(stats.counters.get(Seq("http", "client", label, "requests")) == Some(1))
+      assert(stats.counters.get(Seq("http", "client", label, "success")) == Some(1))
+      assert(stats.counters.get(Seq("http", "client", label, "failures")) == None)
 
       val errreq = Request()
       errreq.host = "dog"
@@ -189,9 +189,9 @@ class HttpEndToEndTest extends FunSuite with Awaits {
       assert(stats.counters.get(Seq("http", "srv", "127.0.0.1/0", "requests")) == Some(2))
       assert(stats.counters.get(Seq("http", "srv", "127.0.0.1/0", "success")) == Some(1))
       assert(stats.counters.get(Seq("http", "srv", "127.0.0.1/0", "failures")) == Some(1))
-      assert(stats.counters.get(Seq("http", "dst", "id", label, "requests")) == Some(2))
-      assert(stats.counters.get(Seq("http", "dst", "id", label, "success")) == Some(1))
-      assert(stats.counters.get(Seq("http", "dst", "id", label, "failures")) == Some(1))
+      assert(stats.counters.get(Seq("http", "client", label, "requests")) == Some(2))
+      assert(stats.counters.get(Seq("http", "client", label, "success")) == Some(1))
+      assert(stats.counters.get(Seq("http", "client", label, "failures")) == Some(1))
 
     } finally {
       await(client.close())
@@ -252,17 +252,17 @@ class HttpEndToEndTest extends FunSuite with Awaits {
         assert(stats.counters.get(Seq("http", "srv", "127.0.0.1/0", "requests")) == Some(1))
         assert(stats.counters.get(Seq("http", "srv", "127.0.0.1/0", "success")) == Some(1))
         assert(stats.counters.get(Seq("http", "srv", "127.0.0.1/0", "failures")) == None)
-        assert(stats.counters.get(Seq("http", "dst", "id", label, "requests")) == Some(2))
-        assert(stats.counters.get(Seq("http", "dst", "id", label, "success")) == Some(1))
-        assert(stats.counters.get(Seq("http", "dst", "id", label, "failures")) == Some(1))
-        assert(stats.counters.get(Seq("http", "dst", "id", label, "status", "200")) == Some(1))
-        assert(stats.counters.get(Seq("http", "dst", "id", label, "status", "500")) == Some(1))
+        assert(stats.counters.get(Seq("http", "client", label, "requests")) == Some(2))
+        assert(stats.counters.get(Seq("http", "client", label, "success")) == Some(1))
+        assert(stats.counters.get(Seq("http", "client", label, "failures")) == Some(1))
+        assert(stats.counters.get(Seq("http", "client", label, "status", "200")) == Some(1))
+        assert(stats.counters.get(Seq("http", "client", label, "status", "500")) == Some(1))
         val name = "svc/dog"
-        assert(stats.counters.get(Seq("http", "dst", "path", name, "requests")) == Some(1))
-        assert(stats.counters.get(Seq("http", "dst", "path", name, "success")) == Some(1))
-        assert(stats.counters.get(Seq("http", "dst", "path", name, "failures")) == None)
-        assert(stats.stats.get(Seq("http", "dst", "path", name, "retries", "per_request")) == Some(Seq(1.0)))
-        assert(stats.counters.get(Seq("http", "dst", "path", name, "retries", "total")) == Some(1))
+        assert(stats.counters.get(Seq("http", "service", name, "requests")) == Some(1))
+        assert(stats.counters.get(Seq("http", "service", name, "success")) == Some(1))
+        assert(stats.counters.get(Seq("http", "service", name, "failures")) == None)
+        assert(stats.stats.get(Seq("http", "service", name, "retries", "per_request")) == Some(Seq(1.0)))
+        assert(stats.counters.get(Seq("http", "service", name, "retries", "total")) == Some(1))
         withAnnotations { anns =>
           assert(annotationKeys(anns) == Seq("sr", "cs", "ws", "wr", "l5d.retryable", "cr", "cs", "ws", "wr", "l5d.success", "cr", "ss"))
         }
@@ -280,17 +280,17 @@ class HttpEndToEndTest extends FunSuite with Awaits {
         assert(stats.counters.get(Seq("http", "srv", "127.0.0.1/0", "requests")) == Some(1))
         assert(stats.counters.get(Seq("http", "srv", "127.0.0.1/0", "success")) == None)
         assert(stats.counters.get(Seq("http", "srv", "127.0.0.1/0", "failures")) == Some(1))
-        assert(stats.counters.get(Seq("http", "dst", "id", label, "requests")) == Some(1))
-        assert(stats.counters.get(Seq("http", "dst", "id", label, "success")) == None)
-        assert(stats.counters.get(Seq("http", "dst", "id", label, "failures")) == Some(1))
-        assert(stats.counters.get(Seq("http", "dst", "id", label, "status", "200")) == None)
-        assert(stats.counters.get(Seq("http", "dst", "id", label, "status", "500")) == Some(1))
+        assert(stats.counters.get(Seq("http", "client", label, "requests")) == Some(1))
+        assert(stats.counters.get(Seq("http", "client", label, "success")) == None)
+        assert(stats.counters.get(Seq("http", "client", label, "failures")) == Some(1))
+        assert(stats.counters.get(Seq("http", "client", label, "status", "200")) == None)
+        assert(stats.counters.get(Seq("http", "client", label, "status", "500")) == Some(1))
         val name = s"svc/dog"
-        assert(stats.counters.get(Seq("http", "dst", "path", name, "requests")) == Some(1))
-        assert(stats.counters.get(Seq("http", "dst", "path", name, "success")) == None)
-        assert(stats.counters.get(Seq("http", "dst", "path", name, "failures")) == Some(1))
-        assert(stats.stats.get(Seq("http", "dst", "path", name, "retries", "per_request")) == Some(Seq(0.0)))
-        assert(!stats.counters.contains(Seq("http", "dst", "path", name, "retries", "total")))
+        assert(stats.counters.get(Seq("http", "service", name, "requests")) == Some(1))
+        assert(stats.counters.get(Seq("http", "service", name, "success")) == None)
+        assert(stats.counters.get(Seq("http", "service", name, "failures")) == Some(1))
+        assert(stats.stats.get(Seq("http", "service", name, "retries", "per_request")) == Some(Seq(0.0)))
+        assert(!stats.counters.contains(Seq("http", "service", name, "retries", "total")))
         withAnnotations { anns =>
           assert(annotationKeys(anns) == Seq("sr", "cs", "ws", "wr", "l5d.failure", "cr", "ss"))
         }
@@ -419,8 +419,8 @@ class HttpEndToEndTest extends FunSuite with Awaits {
         k -> v
       }.toMap
     assert(headers.keySet == Set(
-      "l5d-dst-logical",
-      "l5d-dst-concrete",
+      "l5d-dst-service",
+      "l5d-dst-client",
       "l5d-reqid",
       "l5d-ctx-trace"
     ))
@@ -463,8 +463,8 @@ class HttpEndToEndTest extends FunSuite with Awaits {
         k -> v
       }.toMap
     assert(headers.keySet == Set(
-      "l5d-dst-logical",
-      "l5d-dst-concrete",
+      "l5d-dst-service",
+      "l5d-dst-client",
       "l5d-reqid",
       "l5d-ctx-dtab",
       "l5d-ctx-trace",

--- a/linkerd/protocol/http/src/e2e/scala/io/buoyant/linkerd/protocol/ResponseClassificationEndToEndTest.scala
+++ b/linkerd/protocol/http/src/e2e/scala/io/buoyant/linkerd/protocol/ResponseClassificationEndToEndTest.scala
@@ -55,8 +55,8 @@ class ResponseClassificationEndToEndTest extends FunSuite {
     req.host = "foo"
     await(client(req))
 
-    assert(stats.counters(Seq("http", "dst", "id", s"$$/inet/127.1/${downstream.port}", "path", "svc/foo", "success")) == 1)
-    assert(stats.counters(Seq("http", "dst", "path", "svc/foo", "success")) == 1)
+    assert(stats.counters(Seq("http", "client", s"$$/inet/127.1/${downstream.port}", "service", "svc/foo", "success")) == 1)
+    assert(stats.counters(Seq("http", "service", "svc/foo", "success")) == 1)
     assert(stats.counters(Seq("http", "srv", "127.0.0.1/0", "success")) == 1)
   }
 
@@ -89,8 +89,8 @@ class ResponseClassificationEndToEndTest extends FunSuite {
     req.host = "foo"
     await(client(req))
 
-    assert(stats.counters(Seq("http", "dst", "id", s"$$/inet/127.1/${downstream.port}", "path", "svc/foo", "failures")) == 1)
-    assert(stats.counters(Seq("http", "dst", "path", "svc/foo", "failures")) == 1)
+    assert(stats.counters(Seq("http", "client", s"$$/inet/127.1/${downstream.port}", "service", "svc/foo", "failures")) == 1)
+    assert(stats.counters(Seq("http", "service", "svc/foo", "failures")) == 1)
     assert(stats.counters(Seq("http", "srv", "127.0.0.1/0", "failures")) == 1)
   }
 
@@ -130,10 +130,10 @@ class ResponseClassificationEndToEndTest extends FunSuite {
 
     assert(stats.counters(Seq("http", "srv", "127.0.0.1/0", "success")) == 1)
     assert(stats.counters.get(Seq("http", "srv", "127.0.0.1/0", "failures")) == None)
-    assert(stats.counters(Seq("http", "dst", "path", "svc/foo", "success")) == 1)
-    assert(stats.counters.get(Seq("http", "dst", "path", "svc/foo", "failures")) == None)
-    assert(stats.counters(Seq("http", "dst", "id", s"$$/inet/127.1/${downstream.port}", "path", "svc/foo", "success")) == 1)
-    assert(stats.counters(Seq("http", "dst", "id", s"$$/inet/127.1/${downstream.port}", "path", "svc/foo", "failures")) == 1)
+    assert(stats.counters(Seq("http", "service", "svc/foo", "success")) == 1)
+    assert(stats.counters.get(Seq("http", "service", "svc/foo", "failures")) == None)
+    assert(stats.counters(Seq("http", "client", s"$$/inet/127.1/${downstream.port}", "service", "svc/foo", "success")) == 1)
+    assert(stats.counters(Seq("http", "client", s"$$/inet/127.1/${downstream.port}", "service", "svc/foo", "failures")) == 1)
   }
 
   test("per service classification") {
@@ -180,10 +180,10 @@ class ResponseClassificationEndToEndTest extends FunSuite {
 
     assert(stats.counters(Seq("http", "srv", "127.0.0.1/0", "success")) == 1)
     assert(stats.counters.get(Seq("http", "srv", "127.0.0.1/0", "failures")) == None)
-    assert(stats.counters(Seq("http", "dst", "path", "svc/a", "success")) == 1)
-    assert(stats.counters.get(Seq("http", "dst", "path", "svc/a", "failures")) == None)
-    assert(stats.counters(Seq("http", "dst", "id", s"$$/inet/127.1/${downstream.port}", "path", "svc/a", "success")) == 1)
-    assert(stats.counters(Seq("http", "dst", "id", s"$$/inet/127.1/${downstream.port}", "path", "svc/a", "failures")) == 1)
+    assert(stats.counters(Seq("http", "service", "svc/a", "success")) == 1)
+    assert(stats.counters.get(Seq("http", "service", "svc/a", "failures")) == None)
+    assert(stats.counters(Seq("http", "client", s"$$/inet/127.1/${downstream.port}", "service", "svc/a", "success")) == 1)
+    assert(stats.counters(Seq("http", "client", s"$$/inet/127.1/${downstream.port}", "service", "svc/a", "failures")) == 1)
 
     // Request to "b" is non-retryable
     // fails and doesn't retry
@@ -192,9 +192,9 @@ class ResponseClassificationEndToEndTest extends FunSuite {
 
     assert(stats.counters(Seq("http", "srv", "127.0.0.1/0", "success")) == 1)
     assert(stats.counters(Seq("http", "srv", "127.0.0.1/0", "failures")) == 1)
-    assert(stats.counters.get(Seq("http", "dst", "path", "svc/b", "success")) == None)
-    assert(stats.counters(Seq("http", "dst", "path", "svc/b", "failures")) == 1)
-    assert(stats.counters.get(Seq("http", "dst", "id", s"$$/inet/127.1/${downstream.port}", "path", "svc/b", "success")) == None)
-    assert(stats.counters(Seq("http", "dst", "id", s"$$/inet/127.1/${downstream.port}", "path", "svc/b", "failures")) == 1)
+    assert(stats.counters.get(Seq("http", "service", "svc/b", "success")) == None)
+    assert(stats.counters(Seq("http", "service", "svc/b", "failures")) == 1)
+    assert(stats.counters.get(Seq("http", "client", s"$$/inet/127.1/${downstream.port}", "service", "svc/b", "success")) == None)
+    assert(stats.counters(Seq("http", "client", s"$$/inet/127.1/${downstream.port}", "service", "svc/b", "failures")) == 1)
   }
 }

--- a/linkerd/protocol/http/src/e2e/scala/io/buoyant/linkerd/protocol/RetriesEndToEndTest.scala
+++ b/linkerd/protocol/http/src/e2e/scala/io/buoyant/linkerd/protocol/RetriesEndToEndTest.scala
@@ -79,13 +79,13 @@ class RetriesEndToEndTest extends FunSuite {
       Time.withCurrentTimeFrozen { tc =>
 
 
-        def budget = stats.gauges(Seq("http", "dst", "id", s"$$/inet/127.1/${downstream.port}", "retries", "budget"))
+        def budget = stats.gauges(Seq("http", "client", s"$$/inet/127.1/${downstream.port}", "retries", "budget"))
         def requeues = stats.counters.getOrElse(
-          Seq("http", "dst", "id", s"$$/inet/127.1/${downstream.port}", "retries", "requeues"),
+          Seq("http", "client", s"$$/inet/127.1/${downstream.port}", "retries", "requeues"),
           0
         )
         def requestLimit = stats.counters.getOrElse(
-          Seq("http", "dst", "id", s"$$/inet/127.1/${downstream.port}", "retries", "request_limit"),
+          Seq("http", "client", s"$$/inet/127.1/${downstream.port}", "retries", "request_limit"),
           0
         )
 
@@ -178,13 +178,13 @@ class RetriesEndToEndTest extends FunSuite {
 
 
         def budget(ds: Downstream) = 
-          stats.gauges(Seq("http", "dst", "id", s"$$/inet/127.1/${ds.port}", "retries", "budget"))
+          stats.gauges(Seq("http", "client", s"$$/inet/127.1/${ds.port}", "retries", "budget"))
         def requeues(ds: Downstream) = stats.counters.getOrElse(
-          Seq("http", "dst", "id", s"$$/inet/127.1/${ds.port}", "retries", "requeues"),
+          Seq("http", "client", s"$$/inet/127.1/${ds.port}", "retries", "requeues"),
           0
         )
         def requestLimit(ds: Downstream) = stats.counters.getOrElse(
-          Seq("http", "dst", "id", s"$$/inet/127.1/${ds.port}", "retries", "request_limit"),
+          Seq("http", "client", s"$$/inet/127.1/${ds.port}", "retries", "request_limit"),
           0
         )
 
@@ -289,13 +289,13 @@ class RetriesEndToEndTest extends FunSuite {
       Time.withCurrentTimeFrozen { tc =>
 
 
-        def budget = stats.gauges(Seq("http", "dst", "path", "svc/foo", "retries", "budget"))
+        def budget = stats.gauges(Seq("http", "service", "svc/foo", "retries", "budget"))
         def retries = stats.counters.getOrElse(
-          Seq("http", "dst", "path", "svc/foo", "retries", "total"),
+          Seq("http", "service", "svc/foo", "retries", "total"),
           0
         )
         def budgetExhausted = stats.counters.getOrElse(
-          Seq("http", "dst", "path", "svc/foo", "retries", "budget_exhausted"),
+          Seq("http", "service", "svc/foo", "retries", "budget_exhausted"),
           0
         )
 
@@ -390,13 +390,13 @@ class RetriesEndToEndTest extends FunSuite {
 
 
         def budget(ds: Downstream) = 
-          stats.gauges(Seq("http", "dst", "path", s"svc/${ds.name}", "retries", "budget"))
+          stats.gauges(Seq("http", "service", s"svc/${ds.name}", "retries", "budget"))
         def retries(ds: Downstream) = stats.counters.getOrElse(
-          Seq("http", "dst", "path", s"svc/${ds.name}", "retries", "total"),
+          Seq("http", "service", s"svc/${ds.name}", "retries", "total"),
           0
         )
         def budgetExhausted(ds: Downstream) = stats.counters.getOrElse(
-          Seq("http", "dst", "path", s"svc/${ds.name}", "retries", "budget_exhausted"),
+          Seq("http", "service", s"svc/${ds.name}", "retries", "budget_exhausted"),
           0
         )
 
@@ -483,9 +483,9 @@ class RetriesEndToEndTest extends FunSuite {
         // Each budget starts with a balance of 100 from minRetriesPerSec
         // we subtract that off to see just the deposits
         def retryBudget(svc: String): Int =
-          stats.gauges.get(Seq("http", "dst", "path", svc, "retries", "budget")).map(_() - 100).getOrElse(0.0f).toInt
+          stats.gauges.get(Seq("http", "service", svc, "retries", "budget")).map(_() - 100).getOrElse(0.0f).toInt
         def requeueBudget(clnt: String): Int = 
-          stats.gauges.get(Seq("http", "dst", "id", clnt, "retries", "budget")).map(_() - 100).getOrElse(0.0f).toInt
+          stats.gauges.get(Seq("http", "client", clnt, "retries", "budget")).map(_() - 100).getOrElse(0.0f).toInt
 
         // 20% budget
         assert(retryBudget("svc/a") == 2)

--- a/linkerd/protocol/http/src/main/scala/com/twitter/finagle/buoyant/linkerd/LinkerdHeaders.scala
+++ b/linkerd/protocol/http/src/main/scala/com/twitter/finagle/buoyant/linkerd/LinkerdHeaders.scala
@@ -383,11 +383,11 @@ object Headers {
    * next hop.
    */
   object Dst {
-    val Path = Prefix + "dst-logical"
-    val Bound = Prefix + "dst-concrete"
+    val Path = Prefix + "dst-service"
+    val Bound = Prefix + "dst-client"
     val Residual = Prefix + "dst-residual"
 
-    /** Encodes `l5d-dst-path` on outgoing requests. */
+    /** Encodes `l5d-dst-service` on outgoing requests. */
     class PathFilter(path: Path) extends SimpleFilter[Request, Response] {
       private[this] val pathShow = path.show
       def apply(req: Request, service: Service[Request, Response]) = {

--- a/router/core/src/e2e/scala/io/buoyant/router/EchoEndToEndTest.scala
+++ b/router/core/src/e2e/scala/io/buoyant/router/EchoEndToEndTest.scala
@@ -88,21 +88,21 @@ class EchoEndToEndTest extends FunSuite with Awaits {
 
     assert(await(client("cat")) == "cat")
     withAnnotations { anns =>
-      assert(anns.exists(_ == Annotation.BinaryAnnotation("namer.path", "/svc/cat")))
-      assert(anns.exists(_ == Annotation.BinaryAnnotation("dst.id", s"/${echoDst}")))
-      assert(anns.exists(_ == Annotation.BinaryAnnotation("dst.path", "/cat")))
+      assert(anns.exists(_ == Annotation.BinaryAnnotation("service", "/svc/cat")))
+      assert(anns.exists(_ == Annotation.BinaryAnnotation("client", s"/${echoDst}")))
+      assert(anns.exists(_ == Annotation.BinaryAnnotation("residual", "/cat")))
     }
 
     assert(await(client("dog/bark")) == "krab/god")
     withAnnotations { anns =>
-      assert(anns.exists(_ == Annotation.BinaryAnnotation("namer.path", "/svc/dog/bark")))
-      assert(anns.exists(_ == Annotation.BinaryAnnotation("dst.id", s"/${ohceDst}")))
-      assert(anns.exists(_ == Annotation.BinaryAnnotation("dst.path", "/bark")))
+      assert(anns.exists(_ == Annotation.BinaryAnnotation("service", "/svc/dog/bark")))
+      assert(anns.exists(_ == Annotation.BinaryAnnotation("client", s"/${ohceDst}")))
+      assert(anns.exists(_ == Annotation.BinaryAnnotation("residual", "/bark")))
     }
 
     assert(await(client("idk")) == "NOBROKERS")
     withAnnotations { anns =>
-      assert(anns.exists(_ == Annotation.BinaryAnnotation("namer.path", "/svc/idk")))
+      assert(anns.exists(_ == Annotation.BinaryAnnotation("service", "/svc/idk")))
       assert(anns.exists(_ == Annotation.BinaryAnnotation(
         RoutingFactory.Annotations.Failure.key,
         RoutingFactory.Annotations.Failure.ClientAcquisition.name
@@ -111,30 +111,30 @@ class EchoEndToEndTest extends FunSuite with Awaits {
 
     assert(await(client("")) == "ERROR empty request")
     withAnnotations { anns =>
-      assert(anns.exists(_ == Annotation.BinaryAnnotation("namer.path", "/svc")))
+      assert(anns.exists(_ == Annotation.BinaryAnnotation("service", "/svc")))
       assert(anns.exists(_ == Annotation.BinaryAnnotation(
         RoutingFactory.Annotations.Failure.key,
         RoutingFactory.Annotations.Failure.Service.name
       )))
     }
 
-    assert(stats.counters(Seq("echo", "dst", "id", echoDst, "requests")) == 1)
-    assert(stats.counters(Seq("echo", "dst", "id", echoDst, "success")) == 1)
-    assert(stats.counters(Seq("echo", "dst", "id", echoDst, "path", "svc/cat", "requests")) == 1)
-    assert(stats.counters(Seq("echo", "dst", "id", echoDst, "path", "svc/cat", "success")) == 1)
-    assert(stats.counters(Seq("echo", "dst", "id", ohceDst, "requests")) == 1)
-    assert(stats.counters(Seq("echo", "dst", "id", ohceDst, "success")) == 1)
-    assert(stats.counters(Seq("echo", "dst", "id", ohceDst, "path", "svc/dog/bark", "requests")) == 1)
-    assert(stats.counters(Seq("echo", "dst", "id", ohceDst, "path", "svc/dog/bark", "success")) == 1)
+    assert(stats.counters(Seq("echo", "client", echoDst, "requests")) == 1)
+    assert(stats.counters(Seq("echo", "client", echoDst, "success")) == 1)
+    assert(stats.counters(Seq("echo", "client", echoDst, "service", "svc/cat", "requests")) == 1)
+    assert(stats.counters(Seq("echo", "client", echoDst, "service", "svc/cat", "success")) == 1)
+    assert(stats.counters(Seq("echo", "client", ohceDst, "requests")) == 1)
+    assert(stats.counters(Seq("echo", "client", ohceDst, "success")) == 1)
+    assert(stats.counters(Seq("echo", "client", ohceDst, "service", "svc/dog/bark", "requests")) == 1)
+    assert(stats.counters(Seq("echo", "client", ohceDst, "service", "svc/dog/bark", "success")) == 1)
 
-    assert(stats.counters(Seq("echo", "dst", "path", "svc/cat", "requests")) == 1)
-    assert(stats.counters(Seq("echo", "dst", "path", "svc/cat", "success")) == 1)
-    assert(stats.counters(Seq("echo", "dst", "path", "svc/dog/bark", "requests")) == 1)
-    assert(stats.counters(Seq("echo", "dst", "path", "svc/dog/bark", "success")) == 1)
-    assert(stats.counters(Seq("echo", "dst", "path", "svc/idk", "requests")) == 1)
-    assert(stats.counters(Seq("echo", "dst", "path", "svc/idk", "failures")) == 1)
-    assert(stats.counters(Seq("echo", "dst", "path", "svc", "requests")) == 1)
-    assert(stats.counters(Seq("echo", "dst", "path", "svc", "failures")) == 1)
+    assert(stats.counters(Seq("echo", "service", "svc/cat", "requests")) == 1)
+    assert(stats.counters(Seq("echo", "service", "svc/cat", "success")) == 1)
+    assert(stats.counters(Seq("echo", "service", "svc/dog/bark", "requests")) == 1)
+    assert(stats.counters(Seq("echo", "service", "svc/dog/bark", "success")) == 1)
+    assert(stats.counters(Seq("echo", "service", "svc/idk", "requests")) == 1)
+    assert(stats.counters(Seq("echo", "service", "svc/idk", "failures")) == 1)
+    assert(stats.counters(Seq("echo", "service", "svc", "requests")) == 1)
+    assert(stats.counters(Seq("echo", "service", "svc", "failures")) == 1)
 
     assert(stats.gauges(Seq("echo", "originator"))() == 1f)
 

--- a/router/core/src/main/scala/com/twitter/finagle/buoyant/DstTracing.scala
+++ b/router/core/src/main/scala/com/twitter/finagle/buoyant/DstTracing.scala
@@ -24,9 +24,9 @@ object DstTracing {
       override def apply(conn: ClientConnection) = {
         if (Trace.isActivelyTracing) {
           Trace.recordRpc(s"$label $pathShow")
-          Trace.recordBinary("namer.dtab.base", baseDtabShow)
-          Trace.recordBinary("namer.dtab.local", localDtabShow)
-          Trace.recordBinary("namer.path", pathShow)
+          Trace.recordBinary("dtab.base", baseDtabShow)
+          Trace.recordBinary("dtab.local", localDtabShow)
+          Trace.recordBinary("service", pathShow)
         }
         self(conn)
       }
@@ -49,8 +49,8 @@ object DstTracing {
       private[this] val path = dst.path.show
       override def apply(conn: ClientConnection) = {
         if (Trace.isActivelyTracing) {
-          Trace.recordBinary("dst.id", idStr)
-          Trace.recordBinary("dst.path", path)
+          Trace.recordBinary("client", idStr)
+          Trace.recordBinary("residual", path)
         }
         self(conn)
       }

--- a/router/core/src/main/scala/io/buoyant/router/PerDstPathStatsFilter.scala
+++ b/router/core/src/main/scala/io/buoyant/router/PerDstPathStatsFilter.scala
@@ -27,7 +27,7 @@ object PerDstPathStatsFilter {
 
           def mkScopedStatsFilter(path: Path): Filter[Req, Rsp, Req, Rsp] = {
             val name = path.show.stripPrefix("/")
-            val sr = statsReceiver.scope("path", name)
+            val sr = statsReceiver.scope("service", name)
             new StatsFilter(sr, classifier, handler, unit)
           }
 

--- a/router/core/src/main/scala/io/buoyant/router/Router.scala
+++ b/router/core/src/main/scala/io/buoyant/router/Router.scala
@@ -198,7 +198,7 @@ trait StdStackRouter[Req, Rsp, This <: StdStackRouter[Req, Rsp, This]]
         }
         val param.Stats(stats0) = params[param.Stats]
         val stats = stats0.scope(label)
-        val clientStats = param.Stats(stats.scope("dst", "id"))
+        val clientStats = param.Stats(stats.scope("client"))
 
         // if this router has been configured as an originator, add a
         // gauge to reflect that in the router's stats
@@ -206,7 +206,7 @@ trait StdStackRouter[Req, Rsp, This <: StdStackRouter[Req, Rsp, This]]
         if (originator) { stats.provideGauge("originator")(1f) }
 
         def pathMk(dst: Dst.Path, sf: ServiceFactory[Req, Rsp]) = {
-          val sr = stats.scope("dst", "path", dst.path.show.stripPrefix("/"))
+          val sr = stats.scope("service", dst.path.show.stripPrefix("/"))
           val stk = pathStack ++ Stack.Leaf(Endpoint, sf)
 
           val pathParams = params[StackRouter.Client.PerPathParams].paramsFor(dst.path)

--- a/router/core/src/test/scala/io/buoyant/router/PerDstPathStatsFilterTest.scala
+++ b/router/core/src/test/scala/io/buoyant/router/PerDstPathStatsFilterTest.scala
@@ -44,7 +44,7 @@ class PerDstPathStatsFilterTest extends FunSuite {
     assert(await(service("cat").liftToTry).isThrow)
     await(service("dog"))
 
-    val pfx = Seq("pfx", "path")
+    val pfx = Seq("pfx", "service")
     val catPfx = pfx :+ "req/cat"
     val dogPfx = pfx :+ "req/dog"
     assert(stats.counters == Map(
@@ -60,8 +60,8 @@ class PerDstPathStatsFilterTest extends FunSuite {
       (dogPfx :+ "pending")
     ))
     assert(stats.histogramDetails.keys == Set(
-      "pfx/path/req/cat/request_latency_ms",
-      "pfx/path/req/dog/request_latency_ms"
+      "pfx/service/req/cat/request_latency_ms",
+      "pfx/service/req/dog/request_latency_ms"
     ))
   }
 

--- a/router/http/src/e2e/scala/io/buoyant/router/HttpEndToEndTest.scala
+++ b/router/http/src/e2e/scala/io/buoyant/router/HttpEndToEndTest.scala
@@ -158,7 +158,7 @@ class HttpEndToEndTest extends FunSuite with Awaits {
 
     val stats = new InMemoryStatsReceiver
     def downstreamCounter(name: String) = {
-      val k = Seq("http", "dst", "id", s"$$/inet/127.1/${downstream.port}", name)
+      val k = Seq("http", "client", s"$$/inet/127.1/${downstream.port}", name)
       stats.counters.get(k)
     }
 
@@ -239,7 +239,7 @@ class HttpEndToEndTest extends FunSuite with Awaits {
 
     val stats = new InMemoryStatsReceiver
     def downstreamCounter(name: String) = {
-      val k = Seq("http", "dst", "id", s"$$/inet/127.1/${downstream.port}", name)
+      val k = Seq("http", "client", s"$$/inet/127.1/${downstream.port}", name)
       stats.counters.get(k)
     }
     def serverCounter(name: String) = {

--- a/router/thrift/src/e2e/scala/io/buoyant/router/ThriftEndToEndTest.scala
+++ b/router/thrift/src/e2e/scala/io/buoyant/router/ThriftEndToEndTest.scala
@@ -89,9 +89,9 @@ class ThriftEndToEndTest extends FunSuite with Awaits {
         val path = "/thrift"
         val bound = s"/$$/inet/127.1/${cat.port}"
         withAnnotations { anns =>
-          assert(anns.contains(Annotation.BinaryAnnotation("namer.path", path)))
-          assert(anns.contains(Annotation.BinaryAnnotation("dst.id", bound)))
-          assert(anns.contains(Annotation.BinaryAnnotation("dst.path", "/")))
+          assert(anns.contains(Annotation.BinaryAnnotation("service", path)))
+          assert(anns.contains(Annotation.BinaryAnnotation("client", bound)))
+          assert(anns.contains(Annotation.BinaryAnnotation("residual", "/")))
         }
       }
 

--- a/router/thriftmux/src/e2e/scala/io/buoyant/router/ThriftMuxEndToEndTest.scala
+++ b/router/thriftmux/src/e2e/scala/io/buoyant/router/ThriftMuxEndToEndTest.scala
@@ -104,18 +104,18 @@ class ThriftMuxEndToEndTest extends FunSuite with Awaits {
       Upstream.pingWithClient(clientThrift, "felix") { rsp =>
         assert(rsp == "meow")
         withAnnotations(tracer) { anns =>
-          assert(anns.contains(Annotation.BinaryAnnotation("namer.path", path)))
-          assert(anns.contains(Annotation.BinaryAnnotation("dst.id", bound)))
-          assert(anns.contains(Annotation.BinaryAnnotation("dst.path", "/")))
+          assert(anns.contains(Annotation.BinaryAnnotation("service", path)))
+          assert(anns.contains(Annotation.BinaryAnnotation("client", bound)))
+          assert(anns.contains(Annotation.BinaryAnnotation("residual", "/")))
         }
       }
 
       Upstream.pingWithClient(clientThriftMux, "felix") { rsp =>
         assert(rsp == "meow")
         withAnnotations(tracer) { anns =>
-          assert(anns.contains(Annotation.BinaryAnnotation("namer.path", path)))
-          assert(anns.contains(Annotation.BinaryAnnotation("dst.id", bound)))
-          assert(anns.contains(Annotation.BinaryAnnotation("dst.path", "/")))
+          assert(anns.contains(Annotation.BinaryAnnotation("service", path)))
+          assert(anns.contains(Annotation.BinaryAnnotation("client", bound)))
+          assert(anns.contains(Annotation.BinaryAnnotation("residual", "/")))
         }
       }
     } finally {
@@ -160,18 +160,18 @@ class ThriftMuxEndToEndTest extends FunSuite with Awaits {
       Upstream.pingWithClient(clientThrift, "dog") { rsp =>
         assert(rsp == "woof")
         withAnnotations(tracer) { anns =>
-          assert(anns.contains(Annotation.BinaryAnnotation("namer.path", path)))
-          assert(anns.contains(Annotation.BinaryAnnotation("dst.id", bound)))
-          assert(anns.contains(Annotation.BinaryAnnotation("dst.path", "/")))
+          assert(anns.contains(Annotation.BinaryAnnotation("service", path)))
+          assert(anns.contains(Annotation.BinaryAnnotation("client", bound)))
+          assert(anns.contains(Annotation.BinaryAnnotation("residual", "/")))
         }
       }
 
       Upstream.pingWithClient(clientThriftMux, "dog") { rsp =>
         assert(rsp == "woof")
         withAnnotations(tracer) { anns =>
-          assert(anns.contains(Annotation.BinaryAnnotation("namer.path", path)))
-          assert(anns.contains(Annotation.BinaryAnnotation("dst.id", bound)))
-          assert(anns.contains(Annotation.BinaryAnnotation("dst.path", "/")))
+          assert(anns.contains(Annotation.BinaryAnnotation("service", path)))
+          assert(anns.contains(Annotation.BinaryAnnotation("client", bound)))
+          assert(anns.contains(Annotation.BinaryAnnotation("residual", "/")))
         }
       }
     } finally {

--- a/telemetry/influxdb/src/main/scala/io/buoyant/telemetry/influxdb/InfluxDbTelemeter.scala
+++ b/telemetry/influxdb/src/main/scala/io/buoyant/telemetry/influxdb/InfluxDbTelemeter.scala
@@ -59,12 +59,12 @@ class InfluxDbTelemeter(metrics: MetricsTree) extends Telemeter with Admin.WithH
     val (prefix1, tags1) = prefix0 match {
       case Seq("rt", router) if !labelExists(tags0, "rt") =>
         (Seq("rt"), tags0 :+ ("rt" -> router))
-      case Seq("rt", "dst", "path", path) if !labelExists(tags0, "dst_path") =>
-        (Seq("rt", "dst_path"), tags0 :+ ("dst_path" -> path))
-      case Seq("rt", "dst", "id", id) if !labelExists(tags0, "dst_id") =>
-        (Seq("rt", "dst_id"), tags0 :+ ("dst_id" -> id))
-      case Seq("rt", "dst_id", "path", path) if !labelExists(tags0, "dst_path") =>
-        (Seq("rt", "dst_id", "dst_path"), tags0 :+ ("dst_path" -> path))
+      case Seq("rt", "dst", "service", path) if !labelExists(tags0, "service") =>
+        (Seq("rt", "service"), tags0 :+ ("service" -> path))
+      case Seq("rt", "dst", "id", id) if !labelExists(tags0, "client") =>
+        (Seq("rt", "client"), tags0 :+ ("client" -> id))
+      case Seq("rt", "client", "service", path) if !labelExists(tags0, "service") =>
+        (Seq("rt", "client", "service"), tags0 :+ ("service" -> path))
       case Seq("rt", "srv", srv) if !labelExists(tags0, "srv") =>
         (Seq("rt", "srv"), tags0 :+ ("srv" -> srv))
       case _ => (prefix0, tags0)

--- a/telemetry/influxdb/src/main/scala/io/buoyant/telemetry/influxdb/InfluxDbTelemeter.scala
+++ b/telemetry/influxdb/src/main/scala/io/buoyant/telemetry/influxdb/InfluxDbTelemeter.scala
@@ -59,9 +59,9 @@ class InfluxDbTelemeter(metrics: MetricsTree) extends Telemeter with Admin.WithH
     val (prefix1, tags1) = prefix0 match {
       case Seq("rt", router) if !labelExists(tags0, "rt") =>
         (Seq("rt"), tags0 :+ ("rt" -> router))
-      case Seq("rt", "dst", "service", path) if !labelExists(tags0, "service") =>
+      case Seq("rt", "service", path) if !labelExists(tags0, "service") =>
         (Seq("rt", "service"), tags0 :+ ("service" -> path))
-      case Seq("rt", "dst", "id", id) if !labelExists(tags0, "client") =>
+      case Seq("rt", "client", id) if !labelExists(tags0, "client") =>
         (Seq("rt", "client"), tags0 :+ ("client" -> id))
       case Seq("rt", "client", "service", path) if !labelExists(tags0, "service") =>
         (Seq("rt", "client", "service"), tags0 :+ ("service" -> path))

--- a/telemetry/influxdb/src/test/scala/io/buoyant/telemetry/influxdb/InfluxDbTelemeterTest.scala
+++ b/telemetry/influxdb/src/test/scala/io/buoyant/telemetry/influxdb/InfluxDbTelemeterTest.scala
@@ -66,26 +66,26 @@ class InfluxDbTelemeterTest extends FunSuite {
 
   test("path stats are labelled") {
     val (stats, handler) = statsAndHandler
-    val counter = stats.scope("rt", "incoming", "dst", "path", "/svc/foo").counter("requests")
+    val counter = stats.scope("rt", "incoming", "service", "/svc/foo").counter("requests")
     counter.incr()
     val rsp = await(handler(Request("/admin/metrics/influxdb"))).contentString
-    assert(rsp == "rt:dst_path,dst_path=/svc/foo,host=none,rt=incoming requests=1\n")
+    assert(rsp == "rt:service,service=/svc/foo,host=none,rt=incoming requests=1\n")
   }
 
   test("bound stats are labelled") {
     val (stats, handler) = statsAndHandler
-    stats.scope("rt", "incoming", "dst", "id", "/#/bar").counter("requests").incr()
+    stats.scope("rt", "incoming", "client", "/#/bar").counter("requests").incr()
     val rsp = await(handler(Request("/admin/metrics/influxdb"))).contentString
     assert(rsp ==
-      "rt:dst_id,dst_id=/#/bar,host=none,rt=incoming requests=1\n")
+      "rt:client,client=/#/bar,host=none,rt=incoming requests=1\n")
   }
 
   test("bound stats with path scope are labelled") {
     val (stats, handler) = statsAndHandler
-    stats.scope("rt", "incoming", "dst", "id", "/#/bar", "path", "/svc/foo").counter("requests").incr()
+    stats.scope("rt", "incoming", "client", "/#/bar", "path", "/svc/foo").counter("requests").incr()
     val rsp = await(handler(Request("/admin/metrics/influxdb"))).contentString
     assert(rsp ==
-      "rt:dst_id:dst_path,dst_id=/#/bar,dst_path=/svc/foo,host=none,rt=incoming requests=1\n")
+      "rt:client:service,client=/#/bar,service=/svc/foo,host=none,rt=incoming requests=1\n")
   }
 
   test("server stats are labelled") {

--- a/telemetry/influxdb/src/test/scala/io/buoyant/telemetry/influxdb/InfluxDbTelemeterTest.scala
+++ b/telemetry/influxdb/src/test/scala/io/buoyant/telemetry/influxdb/InfluxDbTelemeterTest.scala
@@ -69,7 +69,7 @@ class InfluxDbTelemeterTest extends FunSuite {
     val counter = stats.scope("rt", "incoming", "service", "/svc/foo").counter("requests")
     counter.incr()
     val rsp = await(handler(Request("/admin/metrics/influxdb"))).contentString
-    assert(rsp == "rt:service,service=/svc/foo,host=none,rt=incoming requests=1\n")
+    assert(rsp == "rt:service,host=none,rt=incoming,service=/svc/foo requests=1\n")
   }
 
   test("bound stats are labelled") {
@@ -82,10 +82,10 @@ class InfluxDbTelemeterTest extends FunSuite {
 
   test("bound stats with path scope are labelled") {
     val (stats, handler) = statsAndHandler
-    stats.scope("rt", "incoming", "client", "/#/bar", "path", "/svc/foo").counter("requests").incr()
+    stats.scope("rt", "incoming", "client", "/#/bar", "service", "/svc/foo").counter("requests").incr()
     val rsp = await(handler(Request("/admin/metrics/influxdb"))).contentString
     assert(rsp ==
-      "rt:client:service,client=/#/bar,service=/svc/foo,host=none,rt=incoming requests=1\n")
+      "rt:client:service,client=/#/bar,host=none,rt=incoming,service=/svc/foo requests=1\n")
   }
 
   test("server stats are labelled") {

--- a/telemetry/prometheus/src/main/scala/io/buoyant/telemetry/prometheus/PrometheusTelemeter.scala
+++ b/telemetry/prometheus/src/main/scala/io/buoyant/telemetry/prometheus/PrometheusTelemeter.scala
@@ -62,12 +62,12 @@ class PrometheusTelemeter(metrics: MetricsTree) extends Telemeter with Admin.Wit
     val (prefix1, labels1) = prefix0 match {
       case Seq("rt", router) if !labelExists(labels0, "rt") =>
         (Seq("rt"), labels0 :+ ("rt" -> router))
-      case Seq("rt", "dst", "path", path) if !labelExists(labels0, "dst_path") =>
-        (Seq("rt", "dst_path"), labels0 :+ ("dst_path" -> path))
-      case Seq("rt", "dst", "id", id) if !labelExists(labels0, "dst_id") =>
-        (Seq("rt", "dst_id"), labels0 :+ ("dst_id" -> id))
-      case Seq("rt", "dst_id", "path", path) if !labelExists(labels0, "dst_path") =>
-        (Seq("rt", "dst_id", "dst_path"), labels0 :+ ("dst_path" -> path))
+      case Seq("rt", "service", path) if !labelExists(labels0, "service") =>
+        (Seq("rt", "service"), labels0 :+ ("service" -> path))
+      case Seq("rt", "client", id) if !labelExists(labels0, "client") =>
+        (Seq("rt", "client"), labels0 :+ ("client" -> id))
+      case Seq("rt", "client", "service", path) if !labelExists(labels0, "service") =>
+        (Seq("rt", "client", "service"), labels0 :+ ("service" -> path))
       case Seq("rt", "srv", srv) if !labelExists(labels0, "srv") =>
         (Seq("rt", "srv"), labels0 :+ ("srv" -> srv))
       case _ => (prefix0, labels0)

--- a/telemetry/prometheus/src/test/scala/io/buoyant/telemetry/prometheus/PrometheusTelemeterTest.scala
+++ b/telemetry/prometheus/src/test/scala/io/buoyant/telemetry/prometheus/PrometheusTelemeterTest.scala
@@ -88,26 +88,26 @@ class PrometheusTelemeterTest extends FunSuite {
 
   test("path stats are labelled") {
     val (stats, handler) = statsAndHandler
-    val counter = stats.scope("rt", "incoming", "dst", "path", "/svc/foo").counter("requests")
+    val counter = stats.scope("rt", "incoming", "service", "/svc/foo").counter("requests")
     counter.incr()
     val rsp = await(handler(Request("/admin/metrics/prometheus"))).contentString
-    assert(rsp == "rt:dst_path:requests{rt=\"incoming\", dst_path=\"/svc/foo\"} 1\n")
+    assert(rsp == "rt:service:requests{rt=\"incoming\", service=\"/svc/foo\"} 1\n")
   }
 
   test("bound stats are labelled") {
     val (stats, handler) = statsAndHandler
-    stats.scope("rt", "incoming", "dst", "id", "/#/bar").counter("requests").incr()
+    stats.scope("rt", "incoming", "client", "/#/bar").counter("requests").incr()
     val rsp = await(handler(Request("/admin/metrics/prometheus"))).contentString
     assert(rsp ==
-      "rt:dst_id:requests{rt=\"incoming\", dst_id=\"/#/bar\"} 1\n")
+      "rt:client:requests{rt=\"incoming\", client=\"/#/bar\"} 1\n")
   }
 
   test("bound stats with path scope are labelled") {
     val (stats, handler) = statsAndHandler
-    stats.scope("rt", "incoming", "dst", "id", "/#/bar", "path", "/svc/foo").counter("requests").incr()
+    stats.scope("rt", "incoming", "client", "/#/bar", "service", "/svc/foo").counter("requests").incr()
     val rsp = await(handler(Request("/admin/metrics/prometheus"))).contentString
     assert(rsp ==
-      "rt:dst_id:dst_path:requests{rt=\"incoming\", dst_id=\"/#/bar\", dst_path=\"/svc/foo\"} 1\n")
+      "rt:client:service:requests{rt=\"incoming\", client=\"/#/bar\", service=\"/svc/foo\"} 1\n")
   }
 
   test("server stats are labelled") {

--- a/telemetry/recent-requests/src/main/scala/io/buoyant/telemetry/recentRequests/RecentRequetsTracer.scala
+++ b/telemetry/recent-requests/src/main/scala/io/buoyant/telemetry/recentRequests/RecentRequetsTracer.scala
@@ -37,8 +37,8 @@ class RecentRequetsTracer(sampleRate: Double, capacity: Int) extends Tracer {
     case Annotation.ServerAddr(_) => true
     case Annotation.ClientAddr(_) => true
     case Annotation.BinaryAnnotation("router.label", _) => true
-    case Annotation.BinaryAnnotation("namer.path", _) => true
-    case Annotation.BinaryAnnotation("dst.id", _) => true
+    case Annotation.BinaryAnnotation("service", _) => true
+    case Annotation.BinaryAnnotation("client", _) => true
     case _ => false
   }
 
@@ -86,8 +86,8 @@ class RecentRequetsTracer(sampleRate: Double, capacity: Int) extends Tracer {
           (serverId, srv) <- serverAddr
           (destinationId, dst) <- destAddr
           router <- annotationNamed(annotations, "router.label")
-          logicalName <- annotationNamed(annotations, "namer.path")
-          concreteName <- annotationNamed(annotations, "dst.id")
+          logicalName <- annotationNamed(annotations, "service")
+          concreteName <- annotationNamed(annotations, "client")
         } yield {
           val timestamp = recs.map(_.timestamp).minBy(_.inMillis)
           RequestMetadata(timestamp, src.toString, srv.toString, router, logicalName, concreteName, dst.toString)

--- a/telemetry/statsd/src/test/scala/io/buoyant/telemetry/statsd/StatsDStatsReceiverTest.scala
+++ b/telemetry/statsd/src/test/scala/io/buoyant/telemetry/statsd/StatsDStatsReceiverTest.scala
@@ -22,13 +22,13 @@ class StatsDStatsReceiverTest extends FunSuite {
     val names = Seq(
       Seq("foo", "$", "", "bar/baz.stuff#word?who//what^when*where\\why", "#/^//\\huh?@$%^&"),
       Seq("clnt", "zipkin-tracer", "service_creation", "service_acquisition_latency_ms"),
-      Seq("rt", "http", "dst", "id", "#/io.l5d.fs/default/path/http/1.1/GET/default", "request_latency_ms")
+      Seq("rt", "http", "client", "#/io.l5d.fs/default/path/http/1.1/GET/default", "request_latency_ms")
     )
     val newNames = names.map { StatsDStatsReceiver.mkName(_) }
     val expected = Seq(
       "foo._.bar.baz_stuff_word_who.what_when_where_why._._._huh______",
       "clnt.zipkin_tracer.service_creation.service_acquisition_latency_ms",
-      "rt.http.dst.id._.io_l5d_fs.default.path.http.1_1.GET.default.request_latency_ms"
+      "rt.http.client._.io_l5d_fs.default.path.http.1_1.GET.default.request_latency_ms"
     )
 
     assert(newNames == expected)


### PR DESCRIPTION
The names dst_id and dst_path which occur in linkerd's metrics, trace annotions
and headers are arcane, unintuitive, and not consistently used.

Rename dst_id to client and dst_path to service in metrics keys, trace
annotation keys, and header names.