### PR TITLE
Fix handling of failure accrual default

### DIFF
--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/ClientConfig.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/ClientConfig.scala
@@ -35,8 +35,8 @@ trait ClientConfig {
     .maybeWith(hostConnectionPool.map(_.param))
     .maybeWith(requestAttemptTimeoutMs.map(timeout => TimeoutFilter.Param(timeout.millis)))
     .maybeWith(failFast.map(FailFastFactory.FailFast(_)))
-    .maybeWith(requeueBudget) +
-    FailureAccrualConfig.param(failureAccrual)
+    .maybeWith(requeueBudget)
+    .maybeWith(failureAccrual.map(FailureAccrualConfig.param(_)))
 }
 
 case class TlsClientConfig(

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/FailureAccrualInitializer.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/FailureAccrualInitializer.scala
@@ -31,6 +31,8 @@ object FailureAccrualConfig {
   private val defaultPolicy =
     () => FailureAccrualPolicy.consecutiveFailures(defaultConsecutiveFailures, defaultBackoff)
 
-  def param(config: Option[FailureAccrualConfig]): FailureAccrualFactory.Param =
-    FailureAccrualFactory.Param(config.map(_.policy).getOrElse(defaultPolicy))
+  def default: FailureAccrualFactory.Param = FailureAccrualFactory.Param(defaultPolicy)
+
+  def param(config: FailureAccrualConfig): FailureAccrualFactory.Param =
+    FailureAccrualFactory.Param(config.policy)
 }

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/Router.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/Router.scala
@@ -153,7 +153,9 @@ trait RouterConfig {
   def disabled = protocol.experimentalRequired && !_experimentalEnabled.contains(true)
 
   @JsonIgnore
-  def routerParams = (Stack.Params.empty + param.ResponseClassifier(defaultResponseClassifier))
+  def routerParams = (Stack.Params.empty +
+    param.ResponseClassifier(defaultResponseClassifier) +
+    FailureAccrualConfig.default)
     .maybeWith(dtab.map(dtab => RoutingFactory.BaseDtab(() => dtab)))
     .maybeWith(originator.map(Originator.Param(_)))
     .maybeWith(dstPrefix.map(pfx => RoutingFactory.DstPrefix(Path.read(pfx))))


### PR DESCRIPTION
If a client config section does not include a failureAccrual property, the
default failure accrual policy will be applied, overriding any failure accrual
policy set in previous matching client configs.

We refactor slightly to use .maybeWith so that the failureAccrual param will
only be added if the property is defined.  A default value is supplied as a
router config that can be overwritten.

A test case in ClientTest validates this.