### PR TITLE
Fix broken tests

### DIFF
--- a/linkerd/protocol/http/src/e2e/scala/io/buoyant/linkerd/protocol/HttpEndToEndTest.scala
+++ b/linkerd/protocol/http/src/e2e/scala/io/buoyant/linkerd/protocol/HttpEndToEndTest.scala
@@ -228,9 +228,9 @@ class HttpEndToEndTest extends FunSuite with Awaits {
       assert(stats.counters.get(Seq("http", "srv", "127.0.0.1/0", "requests")) == Some(1))
       assert(stats.counters.get(Seq("http", "srv", "127.0.0.1/0", "success")) == None)
       assert(stats.counters.get(Seq("http", "srv", "127.0.0.1/0", "failures")) == Some(1))
-      assert(stats.counters.get(Seq("http", "dst", "path", "svc/dog", "requests")) == Some(1))
-      assert(stats.counters.get(Seq("http", "dst", "path", "svc/dog", "success")) == None)
-      assert(stats.counters.get(Seq("http", "dst", "path", "svc/dog", "failures")) == Some(1))
+      assert(stats.counters.get(Seq("http", "service", "svc/dog", "requests")) == Some(1))
+      assert(stats.counters.get(Seq("http", "service", "svc/dog", "success")) == None)
+      assert(stats.counters.get(Seq("http", "service", "svc/dog", "failures")) == Some(1))
     } finally {
       await(client.close())
       await(downstream.server.close())

--- a/linkerd/protocol/http/src/e2e/scala/io/buoyant/linkerd/protocol/RetriesEndToEndTest.scala
+++ b/linkerd/protocol/http/src/e2e/scala/io/buoyant/linkerd/protocol/RetriesEndToEndTest.scala
@@ -545,7 +545,7 @@ class RetriesEndToEndTest extends FunSuite {
       Time.withCurrentTimeFrozen { tc =>
 
         def retries = stats.counters.getOrElse(
-          Seq("http", "dst", "path", "svc/foo", "retries", "total"),
+          Seq("http", "service", "svc/foo", "retries", "total"),
           0
         )
 
@@ -600,7 +600,7 @@ class RetriesEndToEndTest extends FunSuite {
       Time.withCurrentTimeFrozen { tc =>
 
         def retries = stats.counters.getOrElse(
-          Seq("http", "dst", "path", "svc/foo", "retries", "total"),
+          Seq("http", "service", "svc/foo", "retries", "total"),
           0
         )
 


### PR DESCRIPTION
Due to merge conflicts, some tests still reference outdated metrics that no
longer exist.  This causes those tests to fail.

Update the tests to reference the new metrics.

Tests pass.