### PR TITLE
Use java:openjdk-8-jre base image for namerd (#1239)

### DIFF
--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -311,6 +311,7 @@ object LinkerdBuild extends Base {
       mainClass := Some("io.buoyant.namerd.Main"),
       assemblyExecScript := execScript.split("\n").toSeq,
       dockerEnvPrefix := "NAMERD_",
+      dockerJavaImage := "library/java:openjdk-8-jre",
       unmanagedBase := baseDirectory.value / "plugins",
       assemblyJarName in assembly := s"${name.value}-${version.value}-exec",
       dockerTag := version.value


### PR DESCRIPTION
## Problem

The based image for namerd was recently updated (#1214) to a different docker base image that does not include openssl, and openssl is still required for serving namerd's thrift interface over tls, since that interface is still implemented with netty 3.

## Solution

Revert the namerd base image back to the previously used image. In the longer term, we should also move namerd's thrift interface to using netty4 (#1240). Fixes #1239.