### PR TITLE
Revert "Use the openjdk:8-jre-alpine base docker image (#1214)"

### DIFF
--- a/project/Base.scala
+++ b/project/Base.scala
@@ -137,7 +137,7 @@ class Base extends Build {
     assemblyJarName in assembly := s"${name.value}-${version.value}-${configuration.value}-exec",
     docker <<= docker dependsOn (assembly in configuration),
     dockerEnvPrefix := "",
-    dockerJavaImage <<= (dockerJavaImage in Global).?(_.getOrElse("library/openjdk:8-jre-alpine")),
+    dockerJavaImage <<= (dockerJavaImage in Global).?(_.getOrElse("library/java:openjdk-8-jre")),
     dockerfile in docker := new Dockerfile {
       val envPrefix = dockerEnvPrefix.value.toUpperCase
       val home = s"/${organization.value}/${name.value}/${version.value}"

--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -311,7 +311,6 @@ object LinkerdBuild extends Base {
       mainClass := Some("io.buoyant.namerd.Main"),
       assemblyExecScript := execScript.split("\n").toSeq,
       dockerEnvPrefix := "NAMERD_",
-      dockerJavaImage := "library/java:openjdk-8-jre",
       unmanagedBase := baseDirectory.value / "plugins",
       assemblyJarName in assembly := s"${name.value}-${version.value}-exec",
       dockerTag := version.value


### PR DESCRIPTION
## Problem

With the buoyantio/linkerd:1.0.0 docker image, it's not possible to configure a netty3 router to serve with tls. It fails with the following error:

```
W 0425 21:16:20.761 UTC THREAD29 org.jboss.netty.channel.socket.nio.AbstractNioSelector: Failed to initialize an accepted socket.
java.io.IOException: Cannot run program "openssl": error=2, No such file or directory
```

## Solution

Revert to the java base image that we previously used pre-1.0.0. Relates to #1240. As part of this change, I'm also going to republish the buoyantio/linkerd:1.0.0 image to docker hub.