### PR TITLE
Discard responses when retrying

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## In the next release...
+
+* Fix connection leak when retrying on responses with chunked bodies.
+
 ## 1.0.0 2017-04-24
 
 * Configuration:

--- a/router/core/src/main/scala/com/twitter/finagle/buoyant/RetryFilter.scala
+++ b/router/core/src/main/scala/com/twitter/finagle/buoyant/RetryFilter.scala
@@ -17,7 +17,8 @@ class RetryFilter[Req, Rep](
   retryPolicy: RetryPolicy[(Req, Try[Rep])],
   timer: Timer,
   statsReceiver: StatsReceiver,
-  retryBudget: RetryBudget
+  retryBudget: RetryBudget,
+  discard: Rep => Unit
 )
   extends Filter[Req, Rep, Req, Rep] {
 
@@ -29,7 +30,8 @@ class RetryFilter[Req, Rep](
     retryPolicy,
     timer,
     statsReceiver,
-    RetryBudget()
+    RetryBudget(),
+    RetryFilter.noopDiscard[Rep]
   )
 
   private[this] val retriesStat = statsReceiver.scope("retries").stat("per_request")
@@ -63,6 +65,8 @@ class RetryFilter[Req, Rep](
       policy((req, rep)) match {
         case Some((howlong, nextPolicy)) =>
           if (retryBudget.tryWithdraw()) {
+            // we will retry, discard the current response (if there is one)
+            rep.foreach(discard)
             schedule(howlong) {
               Trace.record("finagle.retry")
               totalRetries.incr()
@@ -84,4 +88,8 @@ class RetryFilter[Req, Rep](
     retryBudget.deposit()
     dispatch(request, service, retryPolicy)
   }
+}
+
+object RetryFilter {
+  def noopDiscard[Rep]: Rep => Unit = _ => ()
 }

--- a/router/core/src/main/scala/io/buoyant/router/ClassifiedRetries.scala
+++ b/router/core/src/main/scala/io/buoyant/router/ClassifiedRetries.scala
@@ -51,12 +51,22 @@ object ClassifiedRetries {
     }
   }
 
+  case class ResponseDiscarder[Rsp](discard: Rsp => Unit)
+  object ResponseDiscarder {
+    private val _param = new Stack.Param[ResponseDiscarder[Any]] {
+      val default = ResponseDiscarder(RetryFilter.noopDiscard[Any])
+    }
+    // Ah... the illusion of type safety
+    def param[Rsp] = _param.asInstanceOf[Stack.Param[ResponseDiscarder[Rsp]]]
+  }
+
   /**
    * A stack module that installs a RetryFilter that uses the stack's
    * ResponseClassifier.
    */
-  def module[Req, Rsp]: Stackable[ServiceFactory[Req, Rsp]] =
-    new Stack.Module5[Backoffs, param.ResponseClassifier, Retries.Budget, param.HighResTimer, param.Stats, ServiceFactory[Req, Rsp]] {
+  def module[Req, Rsp]: Stackable[ServiceFactory[Req, Rsp]] = {
+    implicit val discarderParam = ResponseDiscarder.param[Rsp]
+    new Stack.Module6[Backoffs, param.ResponseClassifier, Retries.Budget, param.HighResTimer, param.Stats, ResponseDiscarder[Rsp], ServiceFactory[Req, Rsp]] {
       val role = ClassifiedRetries.role
       val description = "Retries requests that are classified to be retryable"
       def make(
@@ -65,6 +75,7 @@ object ClassifiedRetries {
         _budget: Retries.Budget,
         _timer: param.HighResTimer,
         _stats: param.Stats,
+        _discard: ResponseDiscarder[Rsp],
         next: ServiceFactory[Req, Rsp]
       ): ServiceFactory[Req, Rsp] = {
         val Backoffs(backoff) = _backoffs
@@ -72,9 +83,11 @@ object ClassifiedRetries {
         val Retries.Budget(budget, _) = _budget
         val param.HighResTimer(timer) = _timer
         val param.Stats(stats) = _stats
+        val ResponseDiscarder(discard) = _discard
         val policy = new ClassifiedPolicy[Req, Rsp](backoff, classifier)
-        val filter = new RetryFilter[Req, Rsp](policy, timer, stats, budget)
+        val filter = new RetryFilter[Req, Rsp](policy, timer, stats, budget, discard)
         filter andThen next
       }
     }
+  }
 }

--- a/router/http/src/main/scala/io/buoyant/router/Http.scala
+++ b/router/http/src/main/scala/io/buoyant/router/Http.scala
@@ -7,6 +7,7 @@ import com.twitter.finagle.param.{ProtocolLibrary, ResponseClassifier}
 import com.twitter.finagle.server.StackServer
 import com.twitter.finagle.service.StatsFilter
 import com.twitter.finagle.{Http => FinagleHttp, Server => FinagleServer, http => fhttp, _}
+import io.buoyant.router.ClassifiedRetries.ResponseDiscarder
 import io.buoyant.router.Http.param.HttpIdentifier
 import io.buoyant.router.http._
 import java.net.SocketAddress
@@ -38,10 +39,18 @@ object Http extends Router[Request, Response] with FinagleServer[Request, Respon
       .transformed(_.replace(http.TracingFilter.role, http.TracingFilter.module))
       .transformed(_.remove(TlsFilter.role))
 
+    val responseDiscarder = ResponseDiscarder[Response] { rsp =>
+      if (rsp.isChunked) {
+        rsp.reader.discard()
+      }
+    }
+    implicit val discarderParam = ResponseDiscarder.param[Response]
+
     val defaultParams: Stack.Params =
       StackRouter.defaultParams +
         fhttp.param.Streaming(true) +
         fhttp.param.Decompression(false) +
+        responseDiscarder +
         ProtocolLibrary("http")
   }
 


### PR DESCRIPTION
Fixes #1178

When an HTTP response with a chunked body is classified as a retryable failure
and is retried, the chunked body is never read and the request is discarded.
The connection is never released because the response has unread chunks.  This
results in a connection leak.

Introduce a ResponseDiscarder stack param which is invoked on responses when
the RetryFilter decides to retry and thus discard the response.  For HTTP we
supply a ResponseDiscarder that explicitly discards chunked bodies.

Tested manually against a node.js server that returns chuncked 500s and added
an e2e test.  Shout out to @taer for providing the node.js server and @fantayeneh
for providing the test case.