### PR TITLE
Try to reconnect to consul after ConnectionFailedException

### DIFF
--- a/namer/consul/src/main/scala/io/buoyant/namer/consul/ConsulInitializer.scala
+++ b/namer/consul/src/main/scala/io/buoyant/namer/consul/ConsulInitializer.scala
@@ -2,6 +2,7 @@ package io.buoyant.namer.consul
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.twitter.finagle._
+import com.twitter.finagle.service.Retries
 import com.twitter.finagle.tracing.NullTracer
 import io.buoyant.config.types.Port
 import io.buoyant.consul.utils.RichConsulClient
@@ -60,6 +61,9 @@ case class ConsulConfig(
   @JsonIgnore
   def newNamer(params: Stack.Params): Namer = {
     val service = Http.client
+      // Removes the default client requeues module,
+      // (retries are handled in BaseApi.infiniteRetryFilter)
+      .withStack(Http.client.stack.remove(Retries.Role))
       .withParams(Http.client.params ++ params)
       .withLabel(prefix.show.stripPrefix("/"))
       .interceptInterrupts


### PR DESCRIPTION
Problem:
Sometimes on consul restart linkerd stops talking to consul, causing a stale lookup cache.
As consul is starting up, linkerd tries to connect and fails. Then never tries again.

Solution:
Remove the RequeueFilter from the client stack so that connection failures are no longer flagged as NonRetryable. Fixes #1230 