### PR TITLE
Add path stack registry

### DIFF
--- a/finagle/buoyant/src/main/scala/com/twitter/finagle/buoyant/TlsClientPrep.scala
+++ b/finagle/buoyant/src/main/scala/com/twitter/finagle/buoyant/TlsClientPrep.scala
@@ -45,8 +45,8 @@ object TlsClientPrep {
   implicit object Trust extends Stack.Param[Trust] {
     sealed trait Config
     case class Verified(name: String, certs: Seq[X509Certificate]) extends Config
-    object UnsafeNotVerified extends Config
-    object NotConfigured extends Config
+    case object UnsafeNotVerified extends Config
+    case object NotConfigured extends Config
 
     val default = Trust(NotConfigured)
   }

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/SvcConfig.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/SvcConfig.scala
@@ -41,7 +41,9 @@ trait SvcConfig {
 
   @JsonIgnore
   def responseClassifier: Option[ResponseClassifier] =
-    _responseClassifier.map(_.mk orElse baseResponseClassifier)
+    _responseClassifier.map { classifier =>
+      ClassifiedRetries.orElse(classifier.mk, baseResponseClassifier)
+    }
 }
 
 case class RetriesConfig(

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/H2Config.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/H2Config.scala
@@ -86,7 +86,10 @@ class H2Config extends RouterConfig {
 
   @JsonIgnore
   override val defaultResponseClassifier = ResponseClassifiers.NonRetryableStream(
-    ResponseClassifiers.NonRetryableServerFailures orElse ClassifiedRetries.Default
+    ClassifiedRetries.orElse(
+      ResponseClassifiers.NonRetryableServerFailures,
+      ClassifiedRetries.Default
+    )
   )
 
   @JsonIgnore
@@ -168,9 +171,10 @@ class H2SvcPrefixConfig(prefix: PathMatcher) extends SvcPrefixConfig(prefix) wit
 trait H2SvcConfig extends SvcConfig {
 
   @JsonIgnore
-  override def baseResponseClassifier =
-    ResponseClassifiers.NonRetryableServerFailures
-      .orElse(super.baseResponseClassifier)
+  override def baseResponseClassifier = ClassifiedRetries.orElse(
+    ResponseClassifiers.NonRetryableServerFailures,
+    super.baseResponseClassifier
+  )
 
   // TODO: gRPC (trailers-aware)
   @JsonIgnore

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpConfig.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpConfig.scala
@@ -136,8 +136,10 @@ class HttpSvcPrefixConfig(prefix: PathMatcher) extends SvcPrefixConfig(prefix) w
 trait HttpSvcConfig extends SvcConfig {
 
   @JsonIgnore
-  override def baseResponseClassifier =
-    ResponseClassifiers.NonRetryableServerFailures orElse super.baseResponseClassifier
+  override def baseResponseClassifier = ClassifiedRetries.orElse(
+    ResponseClassifiers.NonRetryableServerFailures,
+    super.baseResponseClassifier
+  )
 
   @JsonIgnore
   override def responseClassifier =
@@ -199,7 +201,10 @@ case class HttpConfig(
   @JsonIgnore
   override val defaultResponseClassifier = ResponseClassifiers.NonRetryableChunked(
     ResponseClassifiers.HeaderRetryable(
-      ResponseClassifiers.NonRetryableServerFailures orElse ClassifiedRetries.Default
+      ClassifiedRetries.orElse(
+        ResponseClassifiers.NonRetryableServerFailures,
+        ClassifiedRetries.Default
+      )
     )
   )
 

--- a/router/core/src/main/scala/io/buoyant/router/ClassifiedRetries.scala
+++ b/router/core/src/main/scala/io/buoyant/router/ClassifiedRetries.scala
@@ -35,7 +35,7 @@ object ClassifiedRetries {
     private[this] val underlying = a orElse b
     def isDefinedAt(reqRep: ReqRep): Boolean = underlying.isDefinedAt(reqRep)
     def apply(reqRep: ReqRep): ResponseClass = underlying(reqRep)
-    override def toString: String = s"$a; $b"
+    override def toString: String = s"$a orElse $b"
   }
 
   /**

--- a/router/core/src/main/scala/io/buoyant/router/ClassifiedRetries.scala
+++ b/router/core/src/main/scala/io/buoyant/router/ClassifiedRetries.scala
@@ -29,6 +29,16 @@ object ClassifiedRetries {
   }
 
   /**
+   * A replacement for ResponseClassifier's orElse that gives a nice toString.
+   */
+  def orElse(a: ResponseClassifier, b: ResponseClassifier): ResponseClassifier = new ResponseClassifier {
+    private[this] val underlying = a orElse b
+    def isDefinedAt(reqRep: ReqRep): Boolean = underlying.isDefinedAt(reqRep)
+    def apply(reqRep: ReqRep): ResponseClass = underlying(reqRep)
+    override def toString: String = s"$a; $b"
+  }
+
+  /**
    * A RetryPolicy that uses a ResponseClassifier.
    */
   private class ClassifiedPolicy[Req, Rsp](backoff: Stream[Duration], classifier: ResponseClassifier)

--- a/router/core/src/main/scala/io/buoyant/router/PathRegistry.scala
+++ b/router/core/src/main/scala/io/buoyant/router/PathRegistry.scala
@@ -1,0 +1,40 @@
+package io.buoyant.router
+
+import com.twitter.finagle._
+import com.twitter.finagle.buoyant.Dst
+import com.twitter.finagle.util.StackRegistry
+import com.twitter.util.{Closable, Future, Time}
+
+object PathRegistry extends StackRegistry {
+  val registryName: String = "path"
+
+  val role = Stack.Role("PathRegistryLifecycle")
+
+  def module[Req, Rep]: Stackable[ServiceFactory[Req, Rep]] = new Stack.Module[ServiceFactory[Req, Rep]] {
+    val role: Stack.Role = PathRegistry.role
+
+    val description: String = "Maintains the PathRegistry for the stack"
+    def parameters: Seq[Stack.Param[_]] = Seq(
+      implicitly[Stack.Param[Dst.Path]]
+    )
+
+    def make(
+      params: Stack.Params,
+      next: Stack[ServiceFactory[Req, Rep]]
+    ): Stack[ServiceFactory[Req, Rep]] = {
+      val Dst.Path(path, dtabBase, dtabLocal) = params[Dst.Path]
+
+      val shown = path.show
+      PathRegistry.register(path.show, next, params)
+
+      CanStackFrom.fromFun[ServiceFactory[Req, Rep]].toStackable(role, { factory: ServiceFactory[Req, Rep] =>
+        new ServiceFactoryProxy[Req, Rep](factory) {
+          override def close(deadline: Time): Future[Unit] = {
+            PathRegistry.unregister(shown, next, params)
+            self.close(deadline)
+          }
+        }
+      }) +: next
+    }
+  }
+}

--- a/router/core/src/main/scala/io/buoyant/router/Router.scala
+++ b/router/core/src/main/scala/io/buoyant/router/Router.scala
@@ -359,6 +359,7 @@ object StackRouter {
     stk.push(StatsFilter.module)
     stk.push(DstTracing.Path.module)
     stk.push(DstPathCtx.Setter.module)
+    stk.push(PathRegistry.module)
     stk.result
   }
 

--- a/router/h2/src/main/scala/io/buoyant/router/H2.scala
+++ b/router/h2/src/main/scala/io/buoyant/router/H2.scala
@@ -80,8 +80,10 @@ object H2 extends Router[Request, Response]
     val newStack: Stack[ServiceFactory[Request, Response]] = FinagleH2.Server.newStack
       .insertAfter(StackServer.Role.protoTracing, h2.ProxyRewriteFilter.module)
 
-    private val serverResponseClassifier =
-      h2.ClassifierFilter.successClassClassifier orElse ResponseClassifiers.NonRetryableServerFailures
+    private val serverResponseClassifier = ClassifiedRetries.orElse(
+      h2.ClassifierFilter.successClassClassifier,
+      ResponseClassifiers.NonRetryableServerFailures
+    )
     val defaultParams = StackServer.defaultParams + param.ResponseClassifier(serverResponseClassifier)
   }
 

--- a/router/http/src/main/scala/io/buoyant/router/Http.scala
+++ b/router/http/src/main/scala/io/buoyant/router/Http.scala
@@ -75,8 +75,10 @@ object Http extends Router[Request, Response] with FinagleServer[Request, Respon
       (AddForwardedHeader.module +: FinagleHttp.Server.stack)
         .insertBefore(http.TracingFilter.role, ProxyRewriteFilter.module)
 
-    private val serverResponseClassifier =
-      ClassifierFilter.successClassClassifier orElse HttpResponseClassifier.ServerErrorsAsFailures
+    private val serverResponseClassifier = ClassifiedRetries.orElse(
+      ClassifierFilter.successClassClassifier,
+      HttpResponseClassifier.ServerErrorsAsFailures
+    )
 
     val defaultParams: Stack.Params =
       StackServer.defaultParams +


### PR DESCRIPTION
There is little visibility into what path stacks have been created and how they
have been configured.

Add a path stack registry that exposes information about the modules in each
path stack and the params that configure them.  This information is exposed
in the global registry which can be viewed at /admin/registry.json on the
admin site.  Also improve the readability of the ResponseClassifier and
Trust.Config params.

<img width="1047" alt="screen shot 2017-05-02 at 10 54 51 am" src="https://cloud.githubusercontent.com/assets/3979810/25632180/8ea75e90-2f27-11e7-8e9f-ed2cd082f827.png">
