### PR TITLE
Fail on duplicate config properties

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 * Upgrade to scala 2.12.
 * Fix connection leak when retrying on responses with chunked bodies.
+* Fail on duplicate config file properties instead of silently taking the last
+  value.
 
 ## 1.0.0 2017-04-24
 

--- a/config/src/main/scala/io/buoyant/config/Parser.scala
+++ b/config/src/main/scala/io/buoyant/config/Parser.scala
@@ -3,7 +3,7 @@ package io.buoyant.config
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility
 import com.fasterxml.jackson.annotation.JsonInclude.Include
 import com.fasterxml.jackson.annotation.PropertyAccessor
-import com.fasterxml.jackson.core.JsonFactory
+import com.fasterxml.jackson.core.{JsonFactory, JsonParser}
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer
 import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.databind.ser.std.StdSerializer
@@ -81,6 +81,7 @@ object Parser {
     mapper.registerModule(customTypes)
     mapper.setSerializationInclusion(Include.NON_ABSENT)
     mapper.setVisibility(PropertyAccessor.ALL, Visibility.PUBLIC_ONLY)
+    mapper.enable(JsonParser.Feature.STRICT_DUPLICATE_DETECTION)
 
     // Subtypes with the same config deserializer parent must not conflict
     for (kinds <- configInitializers) {

--- a/config/src/test/scala/io/buoyant/config/ParserTest.scala
+++ b/config/src/test/scala/io/buoyant/config/ParserTest.scala
@@ -1,6 +1,7 @@
 package io.buoyant.config
 
 import io.buoyant.test.FunSuite
+import com.fasterxml.jackson.core.JsonParseException
 
 class ParserTest extends FunSuite {
 
@@ -42,4 +43,14 @@ class ParserTest extends FunSuite {
   test("allows same id for different initializers") {
     val _ = Parser.objectMapper("{}", Seq(Seq(new A1()), Seq(new A1())))
   }
+
+  test("errors on duplicated properties") {
+
+    val mapper = Parser.objectMapper("{}", Nil)
+    assertThrows[JsonParseException] {
+      val foo = mapper.readValue[Foo]("""{"a": 5, "a": 7}""")
+    }
+  }
 }
+
+case class Foo(a: Int)


### PR DESCRIPTION
If a property is defined more than once in a linkerd config, no error is raised
and the last value is used.  This can lead to subtle and difficult to debug
behaviors.

Use STRICT_DUPLICATE_DETECTION to immediately fail if duplicate properties are
detected.