### PR TITLE
Namespaced Kubernetes Namer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 * Fail on duplicate config file properties instead of silently taking the last
   value.
 * Port numbers in k8s names will now have the service's port mapping applied.
+* Add `io.l5d.k8s.ns` namer.
 
 ## 1.0.0 2017-04-24
 

--- a/interpreter/k8s/src/main/scala/io/buoyant/transformer/k8s/DaemonSetTransformerInitializer.scala
+++ b/interpreter/k8s/src/main/scala/io/buoyant/transformer/k8s/DaemonSetTransformerInitializer.scala
@@ -7,7 +7,7 @@ import com.twitter.finagle.param.Label
 import com.twitter.finagle.{NameTree, Path}
 import io.buoyant.config.types.Port
 import io.buoyant.k8s.v1.Api
-import io.buoyant.k8s.{ClientConfig, EndpointsNamer}
+import io.buoyant.k8s.{MultiNsNamer, ClientConfig, EndpointsNamer}
 import io.buoyant.namer.{Metadata, NameTreeTransformer, TransformerConfig, TransformerInitializer}
 import java.net.InetAddress
 
@@ -44,7 +44,7 @@ case class DaemonSetTransformerConfig(
   override def mk(): NameTreeTransformer = {
     val client = mkClient(Params.empty).configured(Label("daemonsetTransformer"))
     def mkNs(ns: String) = Api(client.newService(dst)).withNamespace(ns)
-    val namer = new EndpointsNamer(Path.empty, None, mkNs)
+    val namer = new MultiNsNamer(Path.empty, None, mkNs)
     val daemonSet = namer.bind(NameTree.Leaf(Path.Utf8(namespace, port, service)))
     if (hostNetwork.getOrElse(false))
       new MetadataGatewayTransformer(prefix, daemonSet, Metadata.nodeName)

--- a/k8s/src/main/scala/io/buoyant/k8s/EndpointsNamer.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/EndpointsNamer.scala
@@ -22,7 +22,7 @@ class MultiNsNamer(
 
   /**
    * Accepts names in the form:
-   *   /<namespace>/<port-name>/<svc-name>/residual/path
+   *   /<namespace>/<port-name>/<svc-name>[/<label-value>]/residual/path
    *
    * and attempts to bind an Addr by resolving named endpoint from the
    * kubernetes master.
@@ -65,7 +65,7 @@ class SingleNsNamer(
 
   /**
    * Accepts names in the form:
-   *   /<port-name>/<svc-name>/residual/path
+   *   /<port-name>/<svc-name>[/<label-value>]/residual/path
    *
    * and attempts to bind an Addr by resolving named endpoint from the
    * kubernetes master.

--- a/k8s/src/test/scala/io/buoyant/k8s/EndpointsNamerTest.scala
+++ b/k8s/src/test/scala/io/buoyant/k8s/EndpointsNamerTest.scala
@@ -107,7 +107,7 @@ class EndpointsNamerTest extends FunSuite with Awaits {
     val namer = new SingleNsNamer(Path.read("/test"), None, "srv", api.withNamespace, Stream.continually(1.millis))
     namer.lookup(Path.read("/thrift/sessions/d3adb33f"))
 
-    assert(req.uri == "/api/v1/namespaces/srv/endpoints?watch=true&resourceVersion=5319481")
+    assert(req.uri == "/api/v1/namespaces/srv/services?watch=true&resourceVersion=5319481")
   }
 
   test("watches a namespace and receives updates") {

--- a/k8s/src/test/scala/io/buoyant/k8s/EndpointsNamerTest.scala
+++ b/k8s/src/test/scala/io/buoyant/k8s/EndpointsNamerTest.scala
@@ -53,7 +53,7 @@ class EndpointsNamerTest extends FunSuite with Awaits {
     }
     val api = v1.Api(service)
     val timer = new MockTimer
-    val namer = new EndpointsNamer(Path.read("/test"), None, api.withNamespace, Stream.continually(1.millis))(timer)
+    val namer = new MultiNsNamer(Path.read("/test"), None, api.withNamespace, Stream.continually(1.millis))(timer)
 
     def name = "/srv/http/sessions"
 
@@ -78,6 +78,24 @@ class EndpointsNamerTest extends FunSuite with Awaits {
 
     def assertHas(n: Int) =
       assert(addrs.size == n)
+  }
+
+  test("single ns namer uses passed in namespace") {
+    @volatile var req: Request = null
+
+    val service = Service.mk[Request, Response] {
+      case r =>
+        req = r
+        val rsp = Response()
+        rsp.content = Rsps.Init
+        Future.value(rsp)
+    }
+
+    val api = v1.Api(service)
+    val namer = new SingleNsNamer(Path.read("/test"), None, "srv", api.withNamespace, Stream.continually(1.millis))
+    namer.lookup(Path.read("/thrift/sessions/d3adb33f"))
+
+    assert(req.uri == "/api/v1/namespaces/srv/endpoints?watch=true&resourceVersion=5319481")
   }
 
   test("watches a namespace and receives updates") {
@@ -127,7 +145,7 @@ class EndpointsNamerTest extends FunSuite with Awaits {
         fail(s"unexpected request: $req")
     }
     val api = v1.Api(service)
-    val namer = new EndpointsNamer(Path.read("/test"), None, api.withNamespace)
+    val namer = new MultiNsNamer(Path.read("/test"), None, api.withNamespace)
 
     @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
     val _ = namer.lookup(Path.read("/srv/thrift/sessions")).states respond { s =>
@@ -167,7 +185,7 @@ class EndpointsNamerTest extends FunSuite with Awaits {
     }
 
     val api = v1.Api(service)
-    val namer = new EndpointsNamer(Path.read("/test"), Some("versionLabel"), api.withNamespace)
+    val namer = new MultiNsNamer(Path.read("/test"), Some("versionLabel"), api.withNamespace)
     namer.lookup(Path.read("/srv/thrift/sessions/d3adb33f"))
 
     assert(req.uri == "/api/v1/namespaces/srv/endpoints?watch=true&labelSelector=versionLabel%3Dd3adb33f&resourceVersion=5319481")

--- a/linkerd/docs/namer.md
+++ b/linkerd/docs/namer.md
@@ -362,7 +362,7 @@ spec:
           name: "l5d-config"
       containers:
       - name: l5d
-        image: buoyantio/linkerd:1.0.0-SNAPSHOT
+        image: buoyantio/linkerd:latest
         # Use the downward api to populate an environment variable
         env:
         - name: MY_POD_NAMESPACE

--- a/linkerd/docs/namer.md
+++ b/linkerd/docs/namer.md
@@ -318,6 +318,123 @@ port-name | yes | The port name.
 svc-name | yes | The name of the service.
 label-value | yes if `labelSelector` is defined | The label value used to filter services.
 
+### K8s Namespaced Configuration
+
+> Example usage of the namespaced namer that routes traffic to services within the current namespace
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: l5d-config
+data:
+  config.yaml: |-
+    namers:
+    - kind: io.l5d.k8s.ns
+      host: localhost
+      port: 8001
+      envVar: MY_POD_NAMESPACE
+
+    routers:
+    - protocol: http
+      dtab: |
+        /svc => /#/io.l5d.k8s.ns/admin;
+      servers:
+      - port: 4140
+        ip: 0.0.0.0
+
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: l5d
+  name: l5d
+spec:
+  template:
+    metadata:
+      labels:
+        app: l5d
+    spec:
+      volumes:
+      - name: l5d-config
+        configMap:
+          name: "l5d-config"
+      containers:
+      - name: l5d
+        image: buoyantio/linkerd:1.0.0-SNAPSHOT
+        # Use the downward api to populate an environment variable
+        env:
+        - name: MY_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        args:
+        - /io.buoyant/linkerd/config/config.yaml
+        ports:
+        - name: http
+          containerPort: 4140
+        - name: admin
+          containerPort: 9990
+        volumeMounts:
+        - name: "l5d-config"
+          mountPath: "/io.buoyant/linkerd/config"
+          readOnly: true
+
+      - name: kubectl
+        image: buoyantio/kubectl:v1.6.2
+        args: ["proxy", "-p", "8001"]
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: l5d
+spec:
+  selector:
+    app: l5d
+  type: LoadBalancer
+  ports:
+  - name: http
+    port: 4140
+  - name: admin
+    port: 9990
+
+```
+
+
+The [Kubernetes](https://k8s.io/) Namespaced namer scopes service discovery to
+the current namespace, as provided by the
+[Kubernetes downward api](https://kubernetes.io/docs/tasks/configure-pod-container/environment-variable-expose-pod-information/#the-downward-api).
+
+Key | Default Value | Description
+--- | ------------- | -----------
+prefix | `io.l5d.k8s.ns` | Resolves names with `/#/<prefix>`.
+envVar | `POD_NAMESPACE` | Environment variable that contains the namespace name.
+host | `localhost` | The Kubernetes master host.
+port | `8001` | The Kubernetes master port.
+labelSelector | none | The key of the label to filter services.
+
+<aside class="notice">
+The Kubernetes namer does not support TLS.  Instead, you should run `kubectl proxy` on each host
+which will create a local proxy for securely talking to the Kubernetes cluster API. See (the k8s guide)[https://linkerd.io/doc/latest/k8s/] for more information.
+</aside>
+
+### K8s Namespaced Path Parameters
+
+> Dtab Path Format
+
+```yaml
+/#/<prefix>/<port-name>/<svc-name>[/<label-value>]
+```
+
+Key | Required | Description
+--- | -------- | -----------
+prefix | yes | Tells linkerd to resolve the request path using the k8s external namer.
+port-name | yes | The port name.
+svc-name | yes | The name of the service.
+label-value | yes if `labelSelector` is defined | The label value used to filter services.
+
+
 
 <a name="marathon"></a>
 ## Marathon service discovery

--- a/namer/fs/src/test/scala/io/buoyant/namer/fs/FsTest.scala
+++ b/namer/fs/src/test/scala/io/buoyant/namer/fs/FsTest.scala
@@ -95,9 +95,10 @@ class FsTest extends FunSuite with NamerTestUtil with Eventually with Integratio
         val bound = lookupBound(namer, path.drop(fs.prefix.size))
         assert(bound.size == 1)
         assert(bound.head.addr.sample() == Addr.Bound(
-            Address("127.0.0.1", 8080),
-            WeightedAddress(Address("127.0.0.1", 8081), 0.23)))
-        }
+          Address("127.0.0.1", 8080),
+          WeightedAddress(Address("127.0.0.1", 8081), 0.23)
+        ))
+      }
     } finally {
       val _ = Seq("rm", "-rf", dir.getPath).!
     }

--- a/namer/k8s/src/main/resources/META-INF/services/io.buoyant.namer.NamerInitializer
+++ b/namer/k8s/src/main/resources/META-INF/services/io.buoyant.namer.NamerInitializer
@@ -1,2 +1,3 @@
 io.buoyant.namer.k8s.K8sExternalInitializer
 io.buoyant.namer.k8s.K8sInitializer
+io.buoyant.namer.k8s.K8sNamespacedInitializer

--- a/namer/k8s/src/main/scala/io/buoyant/namer/k8s/K8sExternalInitializer.scala
+++ b/namer/k8s/src/main/scala/io/buoyant/namer/k8s/K8sExternalInitializer.scala
@@ -13,7 +13,7 @@ import io.buoyant.namer.{NamerConfig, NamerInitializer}
  * <pre>
  * namers:
  * - kind: io.l5d.k8s.external
- *   exerimental: true
+ *   experimental: true
  *   host: localhost
  *   port: 8001
  * </pre>

--- a/namer/k8s/src/main/scala/io/buoyant/namer/k8s/K8sNamespacedInitializer.scala
+++ b/namer/k8s/src/main/scala/io/buoyant/namer/k8s/K8sNamespacedInitializer.scala
@@ -1,51 +1,44 @@
 package io.buoyant.namer.k8s
 
 import com.fasterxml.jackson.annotation.JsonIgnore
-import com.twitter.finagle._
+import com.twitter.finagle.{param, Namer, Stack, Path}
 import io.buoyant.config.types.Port
-import io.buoyant.k8s._
+import io.buoyant.k8s.{SingleNsNamer, ClientConfig}
 import io.buoyant.k8s.v1.Api
 import io.buoyant.namer.{NamerConfig, NamerInitializer}
 
-/**
- * Supports namer configurations in the form:
- *
- * <pre>
- * namers:
- * - kind: io.l5d.k8s
- *   host: localhost
- *   port: 8001
- * </pre>
- */
-class K8sInitializer extends NamerInitializer {
-  val configClass = classOf[K8sConfig]
-  override def configId = "io.l5d.k8s"
+class K8sNamespacedInitializer extends NamerInitializer {
+  val configClass = classOf[K8sNamespacedConfig]
+  override def configId = "io.l5d.k8s.ns"
 }
 
-object K8sInitializer extends K8sInitializer
+object K8sNamespacedInitializer extends K8sNamespacedInitializer
 
-case class K8sConfig(
+case class K8sNamespacedConfig(
   host: Option[String],
   port: Option[Port],
+  envVar: Option[String],
   labelSelector: Option[String]
 ) extends NamerConfig with ClientConfig {
 
   @JsonIgnore
-  override def defaultPrefix: Path = Path.read("/io.l5d.k8s")
+  override def defaultPrefix: Path = Path.read("/io.l5d.k8s.ns")
 
   @JsonIgnore
   def portNum = port.map(_.port)
 
-  /**
-   * Construct a namer.
-   */
+  @JsonIgnore
+  def nsName = sys.env.get(envVar.getOrElse("POD_NAMESPACE"))
+
   @JsonIgnore
   override def newNamer(params: Stack.Params): Namer = {
+    assert(nsName.isDefined, "could not find namespace for envVar")
+
     val client = mkClient(params)
     def mkNs(ns: String) = {
       val label = param.Label(s"namer${prefix.show}/$ns")
       Api(client.configured(label).newService(dst)).withNamespace(ns)
     }
-    new MultiNsNamer(prefix, labelSelector, mkNs)
+    new SingleNsNamer(prefix, labelSelector, nsName.get, mkNs)
   }
 }


### PR DESCRIPTION
Problem:
Users have requested a version of the k8s namer that is restricted
to only route to services in the namespace where linkerd is currently
running.

Solution:
This version of the k8s namer reads the namespace name from the
downward api and uses that namespace instead of specifying the
namespace in the dtab. Fixes #1199