### PR TITLE
Ensure h2 streams are fully received before closing (#1245)

### DIFF
--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/ConnectionHeaders.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/ConnectionHeaders.scala
@@ -1,5 +1,4 @@
 package com.twitter.finagle.buoyant.h2
-package netty4
 
 /**
  * Detect connection-headers in accordance with RFC 7540 §8.1.2.2:

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/Stream.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/Stream.scala
@@ -1,8 +1,7 @@
 package com.twitter.finagle.buoyant.h2
 
-import com.twitter.io.Buf
 import com.twitter.concurrent.AsyncQueue
-import com.twitter.finagle.Failure
+import com.twitter.io.Buf
 import com.twitter.util.{Future, Promise, Return, Throw, Try}
 
 /**

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4ClientDispatcher.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4ClientDispatcher.scala
@@ -2,15 +2,11 @@ package com.twitter.finagle.buoyant.h2
 package netty4
 
 import com.twitter.finagle.{Service, Status => SvcStatus}
-import com.twitter.finagle.stats.{StatsReceiver => FStatsReceiver}
 import com.twitter.finagle.transport.Transport
 import com.twitter.logging.Logger
 import com.twitter.util._
 import io.netty.handler.codec.http2._
-import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
-import scala.collection.JavaConverters._
-import scala.util.control.NoStackTrace
+import java.util.concurrent.atomic.AtomicInteger
 
 object Netty4ClientDispatcher {
   private val log = Logger.get(getClass.getName)

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4H2Writer.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4H2Writer.scala
@@ -2,17 +2,15 @@ package com.twitter.finagle.buoyant.h2
 package netty4
 
 import com.twitter.finagle.WriteException
-import com.twitter.finagle.netty4.{BufAsByteBuf, ByteBufAsBuf}
-import com.twitter.finagle.stats.{StatsReceiver, NullStatsReceiver}
+import com.twitter.finagle.netty4.BufAsByteBuf
 import com.twitter.finagle.transport.Transport
 import com.twitter.io.Buf
 import com.twitter.logging.Logger
-import com.twitter.util.{Future, NonFatal, Stopwatch, Time}
+import com.twitter.util.{Future, Time}
 import io.netty.handler.codec.http2._
 import java.net.SocketAddress
 
 private[netty4] trait Netty4H2Writer extends H2Transport.Writer {
-  import Netty4H2Writer.log
 
   protected[this] def write(f: Http2Frame): Future[Unit]
   protected[this] def close(deadline: Time): Future[Unit]

--- a/linkerd/docs/routers.md
+++ b/linkerd/docs/routers.md
@@ -104,7 +104,7 @@ kind | `io.l5d.global` | Either [io.l5d.global](#global-service-config) or [io.l
 - protocol: http
   service:
     kind: io.l5d.global
-    totalTimeoutMs: 500ms
+    totalTimeoutMs: 500
     retries:
       budget:
         minRetriesPerSec: 5
@@ -137,9 +137,9 @@ which will be applied to all services.
           minMs: 10
           maxMs: 10000
     - prefix: /svc/foo
-      totalTimeoutMs: 500ms
+      totalTimeoutMs: 500
     - prefix: /svc/bar
-      totalTimeoutMs: 200ms
+      totalTimeoutMs: 200
 
 ```
 


### PR DESCRIPTION
## Problem

A race condition existed that would cause a stream to be closed by the remote sender before the local receiver had fully received all frames in an h2 stream. This would result in the final frame of an h2 response never being sent back to the caller, causing the caller's connection to hang indefinitely.

## Solution

Make the receiver fully responsible for closing streams, to ensure that they are fully received before closing.

## Validation

I've deployed this branch to a test environment and it has successfully served gRPC traffic for the past 48 hours, whereas without this fix the connection hangs within about 20 minutes.

As part of this change I've included some small refactors for readability in the Netty4StreamTransport. Will also try to add a unit test in a follow-up commit. Fixes #1245.