### PR TITLE
Minor docs fixes

### DIFF
--- a/linkerd/docs/load_balancer.md
+++ b/linkerd/docs/load_balancer.md
@@ -19,7 +19,7 @@ These parameters are available to the loadbalancer regardless of kind. The loadb
 Key | Default Value | Description
 --- | ------------- | -----------
 kind | `p2c` | Either [`p2c`](#power-of-two-choices-least-loaded), [`ewma`](#power-of-two-choices-peak-ewma), [`aperture`](#aperture-least-loaded), [`heap`](#heap-least-loaded), or [`roundRobin`](#round-robin).
-enableProbation | `false` | If `true`, endpoints are eagerly evicted from service discovery. See Finagle's [LoadBalancerFactory.EnableProbation](https://github.com/twitter/finagle/blob/develop/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/LoadBalancerFactory.scala#L28).
+enableProbation | `false` | If `true`, removals from service discovery are treated as advisory and the removed endpoints will remain in the load balancer pool as long as they remain healthy. See Finagle's [LoadBalancerFactory.EnableProbation](https://github.com/twitter/finagle/blob/develop/finagle-core/src/main/scala/com/twitter/finagle/loadbalancer/LoadBalancerFactory.scala#L28).
 
 [p2c]: https://twitter.github.io/finagle/guide/Clients.html#power-of-two-choices-p2c-least-loaded
 [ewma]: https://twitter.github.io/finagle/guide/Clients.html#power-of-two-choices-p2c-peak-ewma

--- a/linkerd/docs/namer.md
+++ b/linkerd/docs/namer.md
@@ -58,6 +58,11 @@ $ cat config/web
 192.0.2.210 8080 * 2.0
 ```
 
+<aside class="warning">
+Due to the implmentation of file watches in Java, this namer consumes a high
+amount of CPU and is not suitable for production use.
+</aside>
+
 linkerd ships with a simple file-based service discovery mechanism, called the
 *file-based namer*. This system is intended to act as a structured form of
 basic host lists.

--- a/linkerd/docs/protocol-http.md
+++ b/linkerd/docs/protocol-http.md
@@ -37,6 +37,7 @@ maxInitialLineKB | 4 | The maximum size of an initial HTTP message line.
 maxRequestKB | 5120 | The maximum size of a non-chunked HTTP request payload.
 maxResponseKB | 5120 | The maximum size of a non-chunked HTTP response payload.
 compressionLevel | `-1`, automatically compresses textual content types with compression level 6 | The compression level to use (on 0-9).
+streamingEnabled | `true` | Streaming allows linkerd to work with HTTP messages that have large (or infinite) content bodies using chunked encoding.  Disabling this is highly discouraged.
 
 <aside class="warning">
 These memory constraints are selected to allow reliable


### PR DESCRIPTION
Fixes #1206 
Fixes #661 
Fixes #1070

Some docs were missing or incorrect:
* Add warning about io.l5d.fs CPU usage.
* Add docs for streamingEnabled property.
* Fix docs for enableProbation property.