### PR TITLE
Add error messages to namerd's http iface BadRequest responses

### DIFF
--- a/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/DtabHandler.scala
+++ b/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/DtabHandler.scala
@@ -117,11 +117,19 @@ class DtabHandler(storage: DtabStore) extends Service[Request, Response] {
             }
 
           // invalid dtab
-          case Throw(_) => Future.value(Response(Status.BadRequest))
+          case Throw(e: IllegalArgumentException) =>
+            val rsp = Response(Status.BadRequest)
+            rsp.setContentString(e.getMessage)
+            Future.value(rsp)
+          case Throw(_) =>
+            Future.value(Response(Status.BadRequest))
         }
 
       // invalid content type
-      case None => Future.value(Response(Status.BadRequest))
+      case None =>
+        val rsp = Response(Status.BadRequest)
+        rsp.setContentString(s"""Invalid Content-Type "${req.contentType.getOrElse("")}". """)
+        Future.value(rsp)
     }
 
   private[this] def post(ns: String, req: Request): Future[Response] =


### PR DESCRIPTION
It can be hard to debug dtab syntax. This change shows the illegal argument exception message to the caller. eg:

```bash
$ curl -v -X PUT -d"/foo ==> /bar" -H "Content-Type: application/dtab" $NAMERD_URL/api/1/dtabs/baz
...
< HTTP/1.1 400 Bad Request
< Content-Length: 47

'>' expected but '=' found at '/foo =[=]> /bar'
```