### PR TITLE
Fix deprecated eta-expansion of zero-argument method values

### DIFF
--- a/validator/src/main/scala/io/buoyant/namerd/Validator.scala
+++ b/validator/src/main/scala/io/buoyant/namerd/Validator.scala
@@ -298,6 +298,6 @@ object Validator extends TwitterServer {
       }
     }
 
-    try f(kill) finally kill()
+    try f(() => kill()) finally kill()
   }
 }


### PR DESCRIPTION
As per [SI-7187](https://issues.scala-lang.org/browse/SI-7187), eta-expansion is deprecated in Scala 2.12.

This was shown as an error in Eclipse Scala IDE 4.6.0-rc2.