### PR TITLE
Escape metrics labels in the Prometheus Telemeter

### DIFF
--- a/telemetry/prometheus/src/main/scala/io/buoyant/telemetry/prometheus/PrometheusTelemeter.scala
+++ b/telemetry/prometheus/src/main/scala/io/buoyant/telemetry/prometheus/PrometheusTelemeter.scala
@@ -34,14 +34,20 @@ class PrometheusTelemeter(metrics: MetricsTree) extends Telemeter with Admin.Wit
   def tracer = NullTracer
   def run(): Closable with Awaitable[Unit] = Telemeter.nopRun
 
-  private[this] val disallowedChars = "[^a-zA-Z0-9:]".r
-  private[this] def escapeKey(key: String) = disallowedChars.replaceAllIn(key, "_")
+  private[this] val metricNameDisallowedChars = "[^a-zA-Z0-9:]".r
+  private[this] def escapeKey(key: String) = metricNameDisallowedChars.replaceAllIn(key, "_")
+
+  private[this] val labelKeyDisallowedChars = """[^a-zA-Z0-9_]""".r
+  private[this] def escapeLabelKey(key: String) = labelKeyDisallowedChars.replaceAllIn(key, "_")
+
+  private[this] val labelValDisallowedChars = "(\\\\+|\"|\n)".r
+  private[this] def escapeLabelVal(key: String) = labelValDisallowedChars.replaceAllIn(key, "\\\\\\\\")
 
   private[this] def formatLabels(labels: Seq[(String, String)]): String =
     if (labels.nonEmpty) {
       labels.map {
         case (k, v) =>
-          s"""$k="$v""""
+          s"""${escapeLabelKey(k)}="${escapeLabelVal(v)}""""
       }.mkString("{", ", ", "}")
     } else {
       ""

--- a/telemetry/prometheus/src/main/scala/io/buoyant/telemetry/prometheus/PrometheusTelemeter.scala
+++ b/telemetry/prometheus/src/main/scala/io/buoyant/telemetry/prometheus/PrometheusTelemeter.scala
@@ -37,11 +37,12 @@ class PrometheusTelemeter(metrics: MetricsTree) extends Telemeter with Admin.Wit
   private[this] val metricNameDisallowedChars = "[^a-zA-Z0-9:]".r
   private[this] def escapeKey(key: String) = metricNameDisallowedChars.replaceAllIn(key, "_")
 
-  private[this] val labelKeyDisallowedChars = """[^a-zA-Z0-9_]""".r
+  private[this] val labelKeyDisallowedChars = "[^a-zA-Z0-9_]".r
   private[this] def escapeLabelKey(key: String) = labelKeyDisallowedChars.replaceAllIn(key, "_")
 
-  private[this] val labelValDisallowedChars = "(\\\\+|\"|\n)".r
-  private[this] def escapeLabelVal(key: String) = labelValDisallowedChars.replaceAllIn(key, "\\\\\\\\")
+  // https://prometheus.io/docs/instrumenting/exposition_formats/#text-format-details
+  private[this] val labelValDisallowedChars = """(\\|\"|\n)""".r
+  private[this] def escapeLabelVal(key: String) = labelValDisallowedChars.replaceAllIn(key, """\\\\""")
 
   private[this] def formatLabels(labels: Seq[(String, String)]): String =
     if (labels.nonEmpty) {

--- a/telemetry/prometheus/src/test/scala/io/buoyant/telemetry/prometheus/PrometheusTelemeterTest.scala
+++ b/telemetry/prometheus/src/test/scala/io/buoyant/telemetry/prometheus/PrometheusTelemeterTest.scala
@@ -86,6 +86,14 @@ class PrometheusTelemeterTest extends FunSuite {
                      |""".stripMargin)
   }
 
+  test("metric labels are escaped") {
+    val (stats, handler) = statsAndHandler
+    val counter = stats.scope("rt", "incoming", "service", """\x5b\x31\x32\x33\x2e\x31\x32\x33\x2e\x31\x32\x33\x2e\x31\x32\x33\x5dun"esc""").counter("requests")
+    counter.incr()
+    val rsp = await(handler(Request("/admin/metrics/prometheus"))).contentString
+    assert(rsp == "rt:service:requests{rt=\"incoming\", service=\"\\\\x5b\\\\x31\\\\x32\\\\x33\\\\x2e\\\\x31\\\\x32\\\\x33\\\\x2e\\\\x31\\\\x32\\\\x33\\\\x2e\\\\x31\\\\x32\\\\x33\\\\x5dun\\\\esc\"} 1\n")
+  }
+
   test("path stats are labelled") {
     val (stats, handler) = statsAndHandler
     val counter = stats.scope("rt", "incoming", "service", "/svc/foo").counter("requests")

--- a/telemetry/prometheus/src/test/scala/io/buoyant/telemetry/prometheus/PrometheusTelemeterTest.scala
+++ b/telemetry/prometheus/src/test/scala/io/buoyant/telemetry/prometheus/PrometheusTelemeterTest.scala
@@ -91,7 +91,8 @@ class PrometheusTelemeterTest extends FunSuite {
     val counter = stats.scope("rt", "incoming", "service", """\x5b\x31\x32\x33\x2e\x31\x32\x33\x2e\x31\x32\x33\x2e\x31\x32\x33\x5dun"esc""").counter("requests")
     counter.incr()
     val rsp = await(handler(Request("/admin/metrics/prometheus"))).contentString
-    assert(rsp == """rt:service:requests{rt="incoming", service="\\x5b\\x31\\x32\\x33\\x2e\\x31\\x32\\x33\\x2e\\x31\\x32\\x33\\x2e\\x31\\x32\\x33\\x5dun\\esc"} 1\n""")
+    assert(rsp == """rt:service:requests{rt="incoming", service="\\x5b\\x31\\x32\\x33\\x2e\\x31\\x32\\x33\\x2e\\x31\\x32\\x33\\x2e\\x31\\x32\\x33\\x5dun\\esc"} 1
+""")
   }
 
   test("path stats are labelled") {

--- a/telemetry/prometheus/src/test/scala/io/buoyant/telemetry/prometheus/PrometheusTelemeterTest.scala
+++ b/telemetry/prometheus/src/test/scala/io/buoyant/telemetry/prometheus/PrometheusTelemeterTest.scala
@@ -91,7 +91,7 @@ class PrometheusTelemeterTest extends FunSuite {
     val counter = stats.scope("rt", "incoming", "service", """\x5b\x31\x32\x33\x2e\x31\x32\x33\x2e\x31\x32\x33\x2e\x31\x32\x33\x5dun"esc""").counter("requests")
     counter.incr()
     val rsp = await(handler(Request("/admin/metrics/prometheus"))).contentString
-    assert(rsp == "rt:service:requests{rt=\"incoming\", service=\"\\\\x5b\\\\x31\\\\x32\\\\x33\\\\x2e\\\\x31\\\\x32\\\\x33\\\\x2e\\\\x31\\\\x32\\\\x33\\\\x2e\\\\x31\\\\x32\\\\x33\\\\x5dun\\\\esc\"} 1\n")
+    assert(rsp == """rt:service:requests{rt="incoming", service="\\x5b\\x31\\x32\\x33\\x2e\\x31\\x32\\x33\\x2e\\x31\\x32\\x33\\x2e\\x31\\x32\\x33\\x5dun\\esc"} 1\n""")
   }
 
   test("path stats are labelled") {


### PR DESCRIPTION
Problem:
if someone names their labels with unicode hex characters, or single quotes,
prometheus chokes because we don't escape them in the prometheus telemeter

Solution:
Escape these characters in the telemeter

Validation:
Wrote a test, ran prometheus and checked for errors

Fixes #1236