### PR TITLE
Namerd support for telemeters (#740)

### DIFF
--- a/namerd/core/src/main/scala/io/buoyant/namerd/NamerdConfig.scala
+++ b/namerd/core/src/main/scala/io/buoyant/namerd/NamerdConfig.scala
@@ -1,14 +1,14 @@
 package io.buoyant.namerd
 
-import com.twitter.conversions.time._
-import com.twitter.finagle.stats.{LoadedStatsReceiver, StatsReceiver}
+import com.twitter.finagle.stats.{BroadcastStatsReceiver, LoadedStatsReceiver, StatsReceiver}
 import com.twitter.finagle.util.{DefaultTimer, LoadService}
-import com.twitter.finagle.{Namer, Path, param, Stack}
+import com.twitter.finagle.{Namer, Path, Stack, param}
+import com.twitter.logging.Logger
 import com.twitter.server.util.JvmStats
 import io.buoyant.admin.AdminConfig
 import io.buoyant.config.{ConfigError, ConfigInitializer, Parser}
 import io.buoyant.namer.{NamerConfig, NamerInitializer, TransformerInitializer}
-import io.buoyant.telemetry.{MetricsTree, MetricsTreeStatsReceiver, Telemeter}
+import io.buoyant.telemetry._
 import io.buoyant.telemetry.admin.{AdminMetricsExportTelemeter, histogramSnapshotInterval}
 import java.net.InetSocketAddress
 import scala.util.control.NoStackTrace
@@ -17,7 +17,8 @@ private[namerd] case class NamerdConfig(
   admin: Option[AdminConfig],
   storage: DtabStoreConfig,
   namers: Seq[NamerConfig],
-  interfaces: Seq[InterfaceConfig]
+  interfaces: Seq[InterfaceConfig],
+  telemetry: Option[Seq[TelemeterConfig]]
 ) {
   require(namers != null, "'namers' field is required")
   require(interfaces != null, "'interfaces' field is required")
@@ -33,9 +34,18 @@ private[namerd] case class NamerdConfig(
 
     val metrics = MetricsTree()
 
-    val telemeter = new AdminMetricsExportTelemeter(metrics, histogramSnapshotInterval(), DefaultTimer.twitter)
+    val telemeterParams = Stack.Params.empty + metrics
+    val adminTelemeter = new AdminMetricsExportTelemeter(metrics, histogramSnapshotInterval(), DefaultTimer.twitter)
+    val telemeters = telemetry.toSeq.flatten.map {
+      case t if t.disabled =>
+        val msg = s"The ${t.getClass.getCanonicalName} telemeter is experimental and must be " +
+          "explicitly enabled by setting the `experimental' parameter to `true'."
+        throw new IllegalArgumentException(msg) with NoStackTrace
+      case t => t.mk(telemeterParams)
+    } :+ adminTelemeter
 
-    val stats = new MetricsTreeStatsReceiver(metrics)
+    // Telemeters may provide StatsReceivers.
+    val stats = mkStats(metrics, telemeters)
     JvmStats.register(stats)
     LoadedStatsReceiver.self = stats
 
@@ -43,8 +53,14 @@ private[namerd] case class NamerdConfig(
     val namersByPfx = mkNamers(Stack.Params.empty + param.Stats(stats))
     val ifaces = mkInterfaces(dtabStore, namersByPfx, stats)
     val adminImpl = admin.getOrElse(DefaultAdminConfig).mk(DefaultAdminAddress)
-    val telemeters = Seq(telemeter)
+
     new Namerd(ifaces, dtabStore, namersByPfx, adminImpl, telemeters)
+  }
+
+  private[this] def mkStats(metrics: MetricsTree, telemeters: Seq[Telemeter]) = {
+    val receivers = telemeters.collect { case t if !t.stats.isNull => t.stats } :+ new MetricsTreeStatsReceiver(metrics)
+    for (r <- receivers) log.debug("stats: %s", r)
+    BroadcastStatsReceiver(receivers)
   }
 
   private[this] def mkNamers(params: Stack.Params): Map[Path, Namer] =
@@ -69,6 +85,7 @@ private[namerd] case class NamerdConfig(
 }
 
 private[namerd] object NamerdConfig {
+  private val log = Logger()
 
   private def DefaultAdminAddress = new InetSocketAddress(9991)
   private def DefaultAdminConfig = AdminConfig()
@@ -86,17 +103,19 @@ private[namerd] object NamerdConfig {
     namer: Seq[NamerInitializer] = Nil,
     dtabStore: Seq[DtabStoreInitializer] = Nil,
     iface: Seq[InterfaceInitializer] = Nil,
-    transformers: Seq[TransformerInitializer] = Nil
+    transformers: Seq[TransformerInitializer] = Nil,
+    telemeters: Seq[TelemeterInitializer] = Nil
   ) {
     def iter: Iterable[Seq[ConfigInitializer]] =
-      Seq(namer, dtabStore, iface, transformers)
+      Seq(namer, dtabStore, iface, transformers, telemeters)
   }
 
   private[namerd] lazy val LoadedInitializers = Initializers(
     LoadService[NamerInitializer],
     LoadService[DtabStoreInitializer],
     LoadService[InterfaceInitializer],
-    LoadService[TransformerInitializer]
+    LoadService[TransformerInitializer],
+    LoadService[TelemeterInitializer]
   )
 
   def loadNamerd(configText: String, initializers: Initializers): NamerdConfig = {

--- a/namerd/docs/config.md
+++ b/namerd/docs/config.md
@@ -38,7 +38,7 @@ Key | Required | Description
 [interfaces](#interfaces) | no | Configures namerd's published network interfaces.
 [storage](#storage) | yes | Configures namerd's storage backend.
 [namers](https://linkerd.io/config/head/linkerd#namers) | no | Configures namerd's integration with various service discovery backends. namerd uses the same namers as linkerd.
-[telemetry](https://linkerd.io/config/head/linkerd#telemetry) | no | Configures namerd's metrics instrumentation.
+[telemetry](https://linkerd.io/config/head/linkerd#telemetry) | no | Configures namerd's metrics instrumentation. Namerd does not support tracing, so tracers provided by telemeters are ignored.
 
 ### Administrative interface
 

--- a/namerd/docs/config.md
+++ b/namerd/docs/config.md
@@ -38,6 +38,7 @@ Key | Required | Description
 [interfaces](#interfaces) | no | Configures namerd's published network interfaces.
 [storage](#storage) | yes | Configures namerd's storage backend.
 [namers](https://linkerd.io/config/head/linkerd#namers) | no | Configures namerd's integration with various service discovery backends. namerd uses the same namers as linkerd.
+[telemetry](https://linkerd.io/config/head/linkerd#telemetry) | no | Configures namerd's metrics instrumentation.
 
 ### Administrative interface
 

--- a/namerd/examples/basic.yaml
+++ b/namerd/examples/basic.yaml
@@ -11,3 +11,6 @@ namers:
 interfaces:
 - kind: io.l5d.thriftNameInterpreter
 - kind: io.l5d.httpController
+telemetry:
+- kind: io.l5d.prometheus
+- kind: io.l5d.influxdb

--- a/namerd/main/src/main/scala/io/buoyant/namerd/Main.scala
+++ b/namerd/main/src/main/scala/io/buoyant/namerd/Main.scala
@@ -28,6 +28,7 @@ object Main extends App {
 
         closeOnExit(Closable.sequence(
           Closable.all(servers: _*),
+          Closable.all(telemeters: _*),
           admin
         ))
         Await.all(servers: _*)

--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -324,7 +324,7 @@ object LinkerdBuild extends Base {
       Iface.mesh,
       Interpreter.perHost, Interpreter.k8s,
       Storage.etcd, Storage.inMemory, Storage.k8s, Storage.zk, Storage.consul,
-      Telemetry.adminMetricsExport
+      Telemetry.adminMetricsExport, Telemetry.core, Telemetry.influxdb, Telemetry.prometheus, Telemetry.recentRequests, Telemetry.statsd, Telemetry.tracelog, Telemetry.zipkin
     )
 
     val LowMemSettings = BundleSettings ++ Seq(


### PR DESCRIPTION
This cl adds a "telemetry" section to the namerd config that behaves the same way
as linkerd's telemetry section. Fixes #740