### PR TITLE
Stop tracking all closed streams in h2 dispatchers (#1215)

### DIFF
--- a/finagle/h2/src/test/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4ServerDispatcherTest.scala
+++ b/finagle/h2/src/test/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4ServerDispatcherTest.scala
@@ -3,7 +3,6 @@ package netty4
 
 import com.twitter.concurrent.AsyncQueue
 import com.twitter.finagle.Service
-import com.twitter.finagle.netty4.BufAsByteBuf
 import com.twitter.finagle.stats.InMemoryStatsReceiver
 import com.twitter.finagle.transport.Transport
 import com.twitter.io.Buf
@@ -14,7 +13,7 @@ import java.net.SocketAddress
 import java.util.concurrent.atomic.AtomicBoolean
 import scala.collection.immutable.Queue
 
-class Netty4ServerDispatchTest extends FunSuite {
+class Netty4ServerDispatcherTest extends FunSuite {
   setLogLevel(com.twitter.logging.Level.OFF)
 
   test("serves multiple concurrent requests ") {


### PR DESCRIPTION
## Problem

Netty4DispatcherBase maintains a ConcurrentHashMap with all known stream states, including closed streams. This map grows unbounded as the number of closed streams increase over the lifetime of a connection, causing a memory leak.

## Solution

Remove closed streams from the map, and store the highest closed stream id. Streams with an id <= to the max and not found in the map are assumed to be closed.

## Validation

Tested locally and verified that the memory leak does not happen.

Fixes #1215.