### PR TITLE
Accept private keys in PKCS#1 format

### DIFF
--- a/project/Base.scala
+++ b/project/Base.scala
@@ -59,6 +59,8 @@ class Base extends Build {
       Resolver.mavenLocal,
       "typesafe" at "https://repo.typesafe.com/typesafe/releases"
     ),
+    libraryDependencies += compilerPlugin("com.github.ghik" %% "silencer-plugin" % "0.5"),
+    libraryDependencies += "com.github.ghik" %% "silencer-lib" % "0.5",
     aggregate in assembly := false,
     (developTwitterDeps in Global) := { sys.env.get("TWITTER_DEVELOP") == Some("1") },
 


### PR DESCRIPTION
As of finagle 6.43, private keys are expected to explicitly be PKCS#8
PEM-encoded keys.  This means that PKCS#1 keys that were previously accepted
no longer work.

We use the deprecated LegacyKeyServerEngineFactory in order to continue
accepting PKCS#1 keys.  This has the added benefit that PKCS#1 keys can now
be used for both the Netty3 and Netty4 HTTP engines.

Manually tested client and server TLS with both netty3 and netty4 all using
PKCS#1 keys.