### PR TITLE
Fix shutdown documentation

### DIFF
--- a/linkerd/README.md
+++ b/linkerd/README.md
@@ -15,7 +15,7 @@ I 0201 21:17:41.992 THREAD52: serving http on localhost/127.0.0.1:4140
 ```
 
 Then, you may browse to http://localhost:9990 to see an admin
-dashboard. Running `curl http://localhost:9990/admin/shutdown` will
+dashboard. Running `curl -X POST http://localhost:9990/admin/shutdown` will
 initiate a graceful shutdown of a running router.
 
 


### PR DESCRIPTION
This is a pretty trivial fix:

```
$ curl localhost:9990/admin/shutdown
ignoring [/admin/shutdown] from 127.0.0.1, because it is a GET, not a POST
$ curl -X POST localhost:9990/admin/shutdown
[/admin/shutdown] from 127.0.0.1 quitting
```

happy to follow the rest of the guidelines, but wasn't sure it was necessary for something this trivial