### PR TITLE
Update h2 headers API with method for fetching single header value

### DIFF
--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/ConnectionHeaders.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/ConnectionHeaders.scala
@@ -53,5 +53,5 @@ object ConnectionHeaders {
   }
 
   private def detectTE(headers: Headers): Boolean =
-    headers.contains(Te) && (headers.get(Te) != TeTrailers)
+    headers.contains(Te) && (headers.getAll(Te) != TeTrailers)
 }

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/Message.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/Message.scala
@@ -61,8 +61,8 @@ object Headers {
     def toSeq = synchronized(current)
     override def toString = s"""Headers(${toSeq.mkString(", ")})"""
     def contains(key: String) = toSeq.exists { case (k, _) => key == k }
-    def get(key: String) = toSeq.collectFirst { case (k, v) if key == k => v }
-    def getAll(key: String) = toSeq.collect { case (k, v) if key == k => v }
+    def get(key: String) = toSeq.find(_._1 == key).map(_._2)
+    def getAll(key: String) = toSeq.filter(_._1 == key).map(_._2)
     def add(key: String, value: String) = synchronized {
       current = current :+ (key -> value)
     }

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/Message.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/Message.scala
@@ -62,7 +62,7 @@ object Headers {
     override def toString = s"""Headers(${toSeq.mkString(", ")})"""
     def contains(key: String) = toSeq.exists { case (k, _) => key == k }
     def get(key: String) = toSeq.find(_._1 == key).map(_._2)
-    def getAll(key: String) = toSeq.filter(_._1 == key).map(_._2)
+    def getAll(key: String) = toSeq.collect { case (k, v) if key == k => v }
     def add(key: String, value: String) = synchronized {
       current = current :+ (key -> value)
     }

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/Message.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/Message.scala
@@ -27,7 +27,8 @@ sealed trait Message {
 trait Headers {
   def toSeq: Seq[(String, String)]
   def contains(k: String): Boolean
-  def get(k: String): Seq[String]
+  def get(k: String): Option[String]
+  def getAll(k: String): Seq[String]
   def add(k: String, v: String): Unit
   def set(k: String, v: String): Unit
   def remove(key: String): Seq[String]
@@ -60,7 +61,8 @@ object Headers {
     def toSeq = synchronized(current)
     override def toString = s"""Headers(${toSeq.mkString(", ")})"""
     def contains(key: String) = toSeq.exists { case (k, _) => key == k }
-    def get(key: String) = toSeq.collect { case (k, v) if key == k => v }
+    def get(key: String) = toSeq.collectFirst { case (k, v) if key == k => v }
+    def getAll(key: String) = toSeq.collect { case (k, v) if key == k => v }
     def add(key: String, value: String) = synchronized {
       current = current :+ (key -> value)
     }
@@ -113,13 +115,13 @@ object Request {
   private case class Impl(headers: Headers, stream: Stream) extends Request {
     override def toString = s"Request($scheme, $method, $authority, $path, $stream)"
     override def dup() = copy(headers = headers.dup())
-    override def scheme = headers.get(Headers.Scheme).headOption.getOrElse("")
-    override def method = headers.get(Headers.Method).headOption match {
+    override def scheme = headers.get(Headers.Scheme).getOrElse("")
+    override def method = headers.get(Headers.Method) match {
       case Some(name) => Method(name)
       case None => throw new IllegalArgumentException("missing :method header")
     }
-    override def authority = headers.get(Headers.Authority).headOption.getOrElse("")
-    override def path = headers.get(Headers.Path).headOption.getOrElse("/")
+    override def authority = headers.get(Headers.Authority).getOrElse("")
+    override def path = headers.get(Headers.Path).getOrElse("/")
   }
 }
 

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4Message.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4Message.scala
@@ -24,7 +24,13 @@ private[h2] object Netty4Message {
       buf.result
     }
 
-    override def get(key: String): Seq[String] =
+    override def get(key: String): Option[String] =
+      underlying.get(key) match {
+        case null => None
+        case str => Some(str.toString)
+      }
+
+    override def getAll(key: String): Seq[String] =
       underlying.getAll(key).asScala.map(_.toString)
 
     override def contains(key: String): Boolean =
@@ -39,7 +45,7 @@ private[h2] object Netty4Message {
     }
 
     override def remove(key: String): Seq[String] = {
-      val removed = get(key)
+      val removed = getAll(key)
       underlying.remove(key)
       removed
     }

--- a/grpc/runtime/src/main/scala/io/buoyant/grpc/runtime/GrpcStatus.scala
+++ b/grpc/runtime/src/main/scala/io/buoyant/grpc/runtime/GrpcStatus.scala
@@ -73,9 +73,9 @@ object GrpcStatus {
   }
 
   def fromTrailers(tlrs: h2.Frame.Trailers): GrpcStatus = {
-    val msg = tlrs.get("grpc-message").headOption.getOrElse("")
+    val msg = tlrs.get("grpc-message").getOrElse("")
     tlrs.get("grpc-status") match {
-      case Seq(code, _*) =>
+      case Some(code) =>
         try GrpcStatus(code.toInt, msg)
         catch { case _: NumberFormatException => GrpcStatus.Unknown(s"bad status code: '$code'") }
       case _ => GrpcStatus.Unknown(msg)

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/HeaderPathIdentifier.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/HeaderPathIdentifier.scala
@@ -45,7 +45,7 @@ class HeaderPathIdentifier(
     }
 
   private[this] def reqPath(req: Request): Path =
-    req.headers.get(header).lastOption match {
+    req.headers.get(header) match {
       case Some(UriPath(p)) if p.nonEmpty => Path.read(p)
       case _ => Path.empty
     }

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/HeaderTokenIdentifier.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/HeaderTokenIdentifier.scala
@@ -34,7 +34,7 @@ class HeaderTokenIdentifier(header: String, pfx: Path, baseDtab: () => Dtab)
     new UnidentifiedRequest(s"missing header: '$header'")
 
   override def apply(req: Request): Future[RequestIdentification[Request]] =
-    req.headers.get(header).lastOption match {
+    req.headers.get(header) match {
       case None | Some("") => Future.value(unidentified)
       case Some(token) =>
         val path = pfx ++ Path.Utf8(token)

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/IngressIdentifier.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/IngressIdentifier.scala
@@ -1,7 +1,6 @@
 package io.buoyant.linkerd.protocol.h2
 
 import com.fasterxml.jackson.annotation.JsonIgnore
-import com.twitter.finagle.Stack.Params
 import com.twitter.finagle._
 import com.twitter.finagle.buoyant.Dst
 import com.twitter.finagle.buoyant.h2.{Headers, Request}
@@ -26,7 +25,7 @@ class IngressIdentifier(
   private[this] val ingressCache = new IngressCache(namespace, apiClient)
 
   override def apply(req: Request): Future[RequestIdentification[Request]] = {
-    val headerToMatch = req.headers.get(Headers.Authority).lastOption
+    val headerToMatch = req.headers.get(Headers.Authority)
     val matchingPath = ingressCache.matchPath(headerToMatch, req.path)
     matchingPath.flatMap {
       case None => Future.value(unidentified)

--- a/router/h2/src/main/scala/io/buoyant/router/h2/ClassifierFilter.scala
+++ b/router/h2/src/main/scala/io/buoyant/router/h2/ClassifierFilter.scala
@@ -23,7 +23,6 @@ object ClassifierFilter {
   val successClassClassifier: ResponseClassifier = {
     case ReqRep(req, Return(rep: Response)) if rep.headers.contains(SuccessClassHeader) =>
       val success = rep.headers.get(SuccessClassHeader)
-        .headOption
         .flatMap { value =>
           Try(value.toDouble).toOption
         }.getOrElse(0.0)

--- a/router/h2/src/main/scala/io/buoyant/router/h2/ViaHeaderFilter.scala
+++ b/router/h2/src/main/scala/io/buoyant/router/h2/ViaHeaderFilter.scala
@@ -23,7 +23,7 @@ object ViaHeaderFilter {
       svc(setRequest(req)).map(setResponse)
 
     private[this] def setMessage[T <: Message]: T => T = { msg =>
-      val updated = msg.headers.get(Key) match {
+      val updated = msg.headers.getAll(Key) match {
         case Nil => via
         case vals => vals.mkString("", ", ", s", $via")
       }


### PR DESCRIPTION
## Problem

In a local CPU profile, `Netty4Message.Headers.get` showed up as a minor hotspot (0.1%). The method returns all values for a header, but in many of the places where we call it, we immediately follow the call with a `headOption` or `lastOption` call.

## Solution

Rename the existing method to `getAll`, and add a new `get` method that returns a single option value.

## Validation

With this change, neither `get` nor `getAll` show up as hotspots, but this could also just be a result of splitting 1 method into 2. That said, I think the new API is cleaner and would like to keep it.