### PR TITLE
Namerd should accept private keys in PKCS#1 format

### DIFF
--- a/linkerd/examples/namerd-tls.yaml
+++ b/linkerd/examples/namerd-tls.yaml
@@ -6,7 +6,7 @@ routers:
     dst: /$/inet/localhost/4100
     namespace: default
     tls:
-      commonName: namerdee
+      commonName: namerd
       caCert: namerd/examples/certs/namerd-cacert.pem
   servers:
   - port: 4140


### PR DESCRIPTION
When configured with TLS, namerd's thrift interface no longer accepts PKCS#1
private keys due to the finagle 6.43 upgrade.

Use the deprecated LegacyKeyServerEngineFactory in order to continue accepting
PKCS#1 keys.

Manually tested with the namerd tls.yaml example and the linkerd
namerd-tls.yaml example which use PKCS#1 keys.