### PR TITLE
Don't use legacy key ssl server engine for h2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## In the next release...
+
+* Fix issue where TLS could not be used with H2.
+
 ## 1.0.1 2017-05-12
 
 * Upgrade to scala 2.12.

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/Server.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/Server.scala
@@ -121,20 +121,23 @@ class ServerConfig { config =>
       case Some(ps) => ApplicationProtocols.Supported(ps)
       case None => ApplicationProtocols.Unspecified
     }
-    // The deprecated LegacyKeyServerEngineFactory allows us to accept PKCS#1 formatted keys.
-    // We should remove this and replace it with Netty4ServerEngineFactory once we no longer allow
-    // PKCS#1 keys.
-    @silent val sslServerEngine = SslServerEngineFactory.Param(LegacyKeyServerEngineFactory)
     Stack.Params.empty + Transport.ServerSsl(Some(SslServerConfiguration(
       keyCredentials = KeyCredentials.CertAndKey(new File(c.certPath), new File(c.keyPath)),
       trustCredentials = trust,
       cipherSuites = ciphers,
       applicationProtocols = appProtocols
-    ))) + sslServerEngine
+    ))) + SslServerEngineFactory.Param(sslServerEngine)
   }
 
   @JsonIgnore
   def alpnProtocols: Option[Seq[String]] = None
+
+  // The deprecated LegacyKeyServerEngineFactory allows us to accept PKCS#1 formatted keys.
+  // We should remove this and replace it with Netty4ServerEngineFactory once we no longer allow
+  // PKCS#1 keys.
+  @JsonIgnore
+  @silent
+  val sslServerEngine: SslServerEngineFactory = LegacyKeyServerEngineFactory
 
   @JsonIgnore
   def mk(pi: ProtocolInitializer, routerLabel: String) = Server.Impl(

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/H2Config.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/H2Config.scala
@@ -10,6 +10,8 @@ import com.twitter.finagle.buoyant.PathMatcher
 import com.twitter.finagle.buoyant.h2.{LinkerdHeaders, Request, Response, ResponseClassifiers}
 import com.twitter.finagle.buoyant.h2.param._
 import com.twitter.finagle.client.StackClient
+import com.twitter.finagle.netty4.ssl.server.Netty4ServerEngineFactory
+import com.twitter.finagle.ssl.server.SslServerEngineFactory
 import com.twitter.finagle.{Path, Stack, param}
 import com.twitter.util.Monitor
 import io.buoyant.config.PolymorphicConfig
@@ -189,6 +191,9 @@ class H2ServerConfig extends ServerConfig with H2EndpointConfig {
   @JsonIgnore
   override val alpnProtocols: Option[Seq[String]] =
     Some(Seq(ApplicationProtocolNames.HTTP_2))
+
+  @JsonIgnore
+  override val sslServerEngine = Netty4ServerEngineFactory()
 
   override def withEndpointParams(params: Stack.Params): Stack.Params = super.withEndpointParams(params)
     .maybeWith(maxConcurrentStreamsPerConnection.map(c => Settings.MaxConcurrentStreams(Some(c.toLong))))


### PR DESCRIPTION
TLS cannot be used with the H2 protocol because the LegacyKeyServerEngineFactory is not compatible with ApplicationProtocols.

Use the Netty4ServerEngineFactory instead of the LegacyKeyServerEngineFactory for H2.  This is fine to do because H2 already requires pkcs#8 formatted private keys.

Verified manually that TLS can be used with H2.