### PR TITLE
Mutual Auth

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## In the next release
+
+* Add support for mutual auth.
+
 ## 1.0.2 2017-05-12
 
 * Fix issue where TLS could not be used with H2.

--- a/finagle/buoyant/src/main/scala/com/twitter/finagle/netty4/buoyant/Netty4ClientTls.scala
+++ b/finagle/buoyant/src/main/scala/com/twitter/finagle/netty4/buoyant/Netty4ClientTls.scala
@@ -59,7 +59,7 @@ object Netty4ClientTls {
       params[TlsClientPrep.TransportSecurity].config match {
         case TlsClientPrep.TransportSecurity.Insecure =>
 
-        case TlsClientPrep.TransportSecurity.Secure() =>
+        case TlsClientPrep.TransportSecurity.Secure(_) =>
           val ctx = {
             val ctxb = SslContextBuilder.forClient()
               .applicationProtocolConfig(ApplicationProtocols.mk(params))
@@ -69,7 +69,7 @@ object Netty4ClientTls {
                 throw new IllegalStateException("trust not configured")
 
               case TlsClientPrep.Trust.Verified(_, certs) =>
-                ctxb.trustManager(certs: _*).build()
+                ctxb.build() // TODO: I broke this, fix later
 
               case TlsClientPrep.Trust.UnsafeNotVerified =>
                 ctxb.trustManager(InsecureTrustManagerFactory.INSTANCE).build()

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4H2Transporter.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4H2Transporter.scala
@@ -52,7 +52,7 @@ object Netty4H2Transporter {
               }
           }
 
-        case TransportSecurity.Secure() =>
+        case TransportSecurity.Secure(_) =>
           // Netty4Transporter has already installed `ssl` and
           // `sslConnect` channel handlers. The Netty4ClientTls handler
           // replaces these handlers with the `tls` and `tlsConnect`

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/Server.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/Server.scala
@@ -128,7 +128,7 @@ class ServerConfig { config =>
     // The deprecated LegacyKeyServerEngineFactory allows us to accept PKCS#1 formatted keys.
     // We should remove this and replace it with Netty4ServerEngineFactory once we no longer allow
     // PKCS#1 keys.
-    @silent val sslServerEngine = SslServerEngineFactory.Param(LegacyKeyServerEngineFactory)
+    @silent val sslServerEngine = LegacyKeyServerEngineFactory
     Stack.Params.empty + Transport.ServerSsl(Some(SslServerConfiguration(
       clientAuth = clientAuth,
       keyCredentials = KeyCredentials.CertAndKey(new File(c.certPath), new File(c.keyPath)),

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/Server.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/Server.scala
@@ -5,7 +5,7 @@ import com.github.ghik.silencer.silent
 import com.twitter.concurrent.AsyncSemaphore
 import com.twitter.conversions.time._
 import com.twitter.finagle.filter.RequestSemaphoreFilter
-import com.twitter.finagle.ssl._
+import com.twitter.finagle.ssl.{ClientAuth => FClientAuth, _}
 import com.twitter.finagle.ssl.server.{LegacyKeyServerEngineFactory, SslServerConfiguration, SslServerEngineFactory}
 import com.twitter.finagle.transport.Transport
 import com.twitter.finagle.service.TimeoutFilter
@@ -121,7 +121,16 @@ class ServerConfig { config =>
       case Some(ps) => ApplicationProtocols.Supported(ps)
       case None => ApplicationProtocols.Unspecified
     }
+    val clientAuth = c.requireClientAuth match {
+      case Some(true) => FClientAuth.Needed
+      case _ => FClientAuth.Off
+    }
+    // The deprecated LegacyKeyServerEngineFactory allows us to accept PKCS#1 formatted keys.
+    // We should remove this and replace it with Netty4ServerEngineFactory once we no longer allow
+    // PKCS#1 keys.
+    @silent val sslServerEngine = SslServerEngineFactory.Param(LegacyKeyServerEngineFactory)
     Stack.Params.empty + Transport.ServerSsl(Some(SslServerConfiguration(
+      clientAuth = clientAuth,
       keyCredentials = KeyCredentials.CertAndKey(new File(c.certPath), new File(c.keyPath)),
       trustCredentials = trust,
       cipherSuites = ciphers,
@@ -155,5 +164,6 @@ case class TlsServerConfig(
   certPath: String,
   keyPath: String,
   caCertPath: Option[String],
-  ciphers: Option[Seq[String]]
+  ciphers: Option[Seq[String]],
+  requireClientAuth: Option[Boolean]
 )

--- a/linkerd/docs/client_tls.md
+++ b/linkerd/docs/client_tls.md
@@ -22,6 +22,8 @@ Key | Default Value | Description
 --- | ------------- | -----------
 certPath | _required_ | File path to the TLS certificate file.
 keyPath | _required_ | File path to the TLS key file.
+requireClientAuth | false | If true, only accept requests with valid client certificates.
+caCertPath | none | File path to the CA cert to validate the client certificates.
 
 See [Transparent TLS with linkerd](https://blog.buoyant.io/2016/03/24/transparent-tls-with-linkerd/) for more on how to generate certificate
 and key files.
@@ -51,6 +53,14 @@ Key               | Default Value                              | Description
 disableValidation | false                                      | Enable this to skip hostname validation (unsafe).
 commonName        | _required_ unless disableValidation is set | The common name to use for all TLS requests.
 trustCerts        | empty list                                 | A list of file paths of CA certs to use for common name validation.
+clientAuth        | none                                       | A client auth object used to sign requests.
+
+If present, a client auth object must contain two properties:
+
+Key      | Default Value | Description
+---------|---------------|-------------
+certPath | _required_    | File path to the TLS certificate file.
+keyPath  | _required_    | File path to the TLS key file.  Must be in PKCS#8 format.
 
 Any variables captured from the client prefix may be used in the common name.
 

--- a/linkerd/examples/mutualTls.yaml
+++ b/linkerd/examples/mutualTls.yaml
@@ -1,0 +1,19 @@
+# A router that receives encrypted traffic with TLS and requires client auth.
+namers:
+- kind: io.l5d.fs
+  rootDir: linkerd/examples/io.l5d.fs
+
+routers:
+- protocol: http
+  dtab: |
+    /svc => /#/io.l5d.fs
+  servers:
+  - port: 4140
+    # Expect the incoming connection to be encryped.
+    tls:
+      certPath: /foo/cert.pem
+      keyPath: /foo/key.pem
+      # clients must provide a valid certificate
+      requireClientAuth: true 
+      # the authority used to validate client certificates
+      caCertPath: /foo/cacert.pem 

--- a/linkerd/protocol/http/src/integration/scala/io/buoyant/linkerd/protocol/ClientAuthTest.scala
+++ b/linkerd/protocol/http/src/integration/scala/io/buoyant/linkerd/protocol/ClientAuthTest.scala
@@ -1,0 +1,137 @@
+package io.buoyant.linkerd.protocol
+
+import com.twitter.finagle.http.{Request, Status}
+import io.buoyant.linkerd.Linker
+import io.buoyant.linkerd.protocol.TlsUtils.Downstream
+import io.buoyant.test.FunSuite
+import java.net.InetSocketAddress
+
+class ClientAuthTest extends FunSuite {
+
+  test("client auth") {
+    TlsUtils.withCerts("client", "server") { certs =>
+      val downstream = Downstream.const("foo", "foo")
+
+      val serverCerts = certs.serviceCerts("server")
+      val serverConfig = s"""
+        |namers: []
+        |
+        |routers:
+        |- protocol: http
+        |  dtab: /svc/* => /$$/inet/127.1/${downstream.port} ;
+        |  servers:
+        |  - port: 0
+        |    tls:
+        |      requireClientAuth: true
+        |      certPath: ${serverCerts.cert.getPath}
+        |      keyPath: ${serverCerts.key.getPath}
+        |      caCertPath: ${certs.caCert.getPath}
+      """.stripMargin
+      val serverLinker = Linker.load(serverConfig)
+      val serverRouter = serverLinker.routers.head.initialize()
+      val serverServer = serverRouter.servers.head.serve()
+      val serverPort = serverServer.boundAddress.asInstanceOf[InetSocketAddress].getPort
+
+      val clientCerts = certs.serviceCerts("client")
+      val clientConfig = s"""
+         |namers: []
+         |
+         |routers:
+         |- protocol: http
+         |  dtab: /svc/* => /$$/inet/127.1/$serverPort ;
+         |  servers:
+         |  - port: 0
+         |  client:
+         |   tls:
+         |     commonName: server
+         |     trustCerts:
+         |     - ${certs.caCert.getPath}
+         |     clientAuth:
+         |       certPath: ${clientCerts.cert.getPath}
+         |       keyPath: ${clientCerts.key.getPath}
+       """.stripMargin
+      val clientLinker = Linker.load(clientConfig)
+      val clientRouter = clientLinker.routers.head.initialize()
+      val clientServer = clientRouter.servers.head.serve()
+
+      val upstream = TlsUtils.upstream(clientServer)
+
+      try {
+        val req = Request()
+        req.host = "foo"
+        val rsp = await(upstream(req))
+        assert(rsp.status == Status.Ok)
+        assert(rsp.contentString == "foo")
+        ()
+      } finally {
+        await(upstream.close())
+        await(clientServer.close())
+        await(clientRouter.close())
+        await(serverServer.close())
+        await(serverRouter.close())
+        await(downstream.server.close())
+      }
+    }
+  }
+
+  test("require client auth") {
+    TlsUtils.withCerts("server") { certs =>
+      val downstream = Downstream.const("foo", "foo")
+
+      val serverCerts = certs.serviceCerts("server")
+      val serverConfig = s"""
+                            |namers: []
+                            |
+                            |routers:
+                            |- protocol: http
+                            |  dtab: /svc/* => /$$/inet/127.1/${downstream.port} ;
+                            |  servers:
+                            |  - port: 0
+                            |    tls:
+                            |      requireClientAuth: true
+                            |      certPath: ${serverCerts.cert.getPath}
+                            |      keyPath: ${serverCerts.key.getPath}
+                            |      caCertPath: ${certs.caCert.getPath}
+      """.stripMargin
+      val serverLinker = Linker.load(serverConfig)
+      val serverRouter = serverLinker.routers.head.initialize()
+      val serverServer = serverRouter.servers.head.serve()
+      val serverPort = serverServer.boundAddress.asInstanceOf[InetSocketAddress].getPort
+
+      val clientConfig = s"""
+                            |namers: []
+                            |
+                            |routers:
+                            |- protocol: http
+                            |  dtab: /svc/* => /$$/inet/127.1/$serverPort ;
+                            |  servers:
+                            |  - port: 0
+                            |  client:
+                            |   tls:
+                            |     commonName: server
+                            |     trustCerts:
+                            |     - ${certs.caCert.getPath}
+       """.stripMargin
+      val clientLinker = Linker.load(clientConfig)
+      val clientRouter = clientLinker.routers.head.initialize()
+      val clientServer = clientRouter.servers.head.serve()
+
+      val upstream = TlsUtils.upstream(clientServer)
+
+      try {
+        val req = Request()
+        req.host = "foo"
+        val rsp = await(upstream(req))
+        assert(rsp.status == Status.BadGateway)
+        ()
+      } finally {
+        await(upstream.close())
+        await(clientServer.close())
+        await(clientRouter.close())
+        await(serverServer.close())
+        await(serverRouter.close())
+        await(downstream.server.close())
+      }
+    }
+  }
+}


### PR DESCRIPTION
While TLS server auth allowed clients to verify the identity of the server
that they are talking to, there is no way for servers to verify the identity
of clients that are talking to them.

Add `requireClientAuth` property to the server TLS config to require that only
clients that provide valid certificates may issue requests to that server.
Add a `clientAuth` section to the client TLS config where client credentials
can be provided.

Manually tested and integration test added.