### PR TITLE
Use ip or hostname from LoadBalancerIngress (#1322)

### DIFF
--- a/k8s/src/main/scala/io/buoyant/k8s/ServiceNamer.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/ServiceNamer.scala
@@ -201,10 +201,11 @@ object ServiceCache {
       status <- service.status.toSeq
       lb <- status.loadBalancer.toSeq
       ingress <- lb.ingress.toSeq.flatten
+      hostname <- ingress.hostname.orElse(ingress.ip)
       spec <- service.spec.toSeq
       port <- spec.ports
     } {
-      ports += port.name -> Address(new InetSocketAddress(ingress.ip, port.port))
+      ports += port.name -> Address(new InetSocketAddress(hostname, port.port))
       portMap += (port.targetPort match {
         case Some(targetPort) => port.port -> targetPort
         case None => port.port -> port.port

--- a/k8s/src/main/scala/io/buoyant/k8s/v1.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/v1.scala
@@ -149,7 +149,8 @@ package object v1 {
   )
 
   case class LoadBalancerIngress(
-    ip: String
+    ip: Option[String] = None,
+    hostname: Option[String] = None
   )
 
   case class ServiceSpec(

--- a/k8s/src/main/scala/io/buoyant/k8s/v1beta1.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/v1beta1.scala
@@ -113,7 +113,8 @@ package object v1beta1 {
   )
 
   case class LoadBalancerIngress(
-    ip: String
+    ip: Option[String] = None,
+    hostname: Option[String] = None
   )
 
 }


### PR DESCRIPTION
Problem
The loadbalanceringress object can have either an `ip` or `hostname`
field however the code is only looking for `ip`.

Solution
Make `ip` and `hostname` options, ensure one is present and use it

Validation
I modified the tests to use an additional service with a `hostname` key.
Wasn't sure the best way to change the tests though since I don't fully
understand what they're testing so I'll leave the testing to you guys.

Fixes #1322 

Todos
Write tests please :D