### PR TITLE
Remove index from api query that attempts consul reconnect

### DIFF
--- a/namer/consul/src/main/scala/io/buoyant/namer/consul/SvcAddr.scala
+++ b/namer/consul/src/main/scala/io/buoyant/namer/consul/SvcAddr.scala
@@ -57,6 +57,9 @@ private[consul] object SvcAddr {
       def loop(index0: Option[String]): Future[Unit] = {
         if (stopped) Future.Unit
         else getAddresses(index0).transform {
+          case Throw(Failure(Some(err: ConnectionFailedException))) =>
+            // Drop the index, in case it's been reset by a consul restart
+            loop(None)
           case Throw(e) =>
             // If an exception escaped getAddresses's retries, we
             // treat it as effectively fatal to the service


### PR DESCRIPTION
Problem:
The consul index can be reset on restart, causing current linkerd queries with
older indexes to hang until consul times them out (i.e. they don't receive
any new updates for 5 minutes).

Solution:
Remove previous indexes on connection failure.
Fixes #1230 

Validation:
Again, this has been validated by hand using the linkerd-examples consul example
and the following commands:

```
curl localhost:4140/helloworld
docker-compose stop consul consul-registrator
sleep 5
docker-compose up -d consul consul-registrator
sleep 5
curl localhost:4140/helloworld
sleep 5
docker-compose stop service
sleep 5
docker-compose up -d service
curl -v http://localhost:8500/v1/catalog/service/helloworld
curl localhost:4140/helloworld
```