### PR TITLE
Use same protocol for thrift clients and servers (#1318)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 ## In the latest release...
 
 * Expire idle services and clients.
+* Convert `thriftProtocol` from a client/server param to a router param.
 
 ## 1.0.2 2017-05-12
 

--- a/linkerd/admin/src/test/scala/io/buoyant/linkerd/admin/ConfigHandlerTest.scala
+++ b/linkerd/admin/src/test/scala/io/buoyant/linkerd/admin/ConfigHandlerTest.scala
@@ -25,11 +25,12 @@ routers:
   - ip: 127.0.0.1
     port: 1
 - protocol: thrift
+  thriftProtocol: binary
   client:
-    thriftProtocol: binary
+    thriftFramed: true
   servers:
   - port: 2
-    thriftProtocol: compact
+    thriftFramed: false
                              """, initializers)
     val handler = new ConfigHandler(linker, initializers.iter)
     val req = Request()
@@ -44,8 +45,9 @@ routers:
       |    {"protocol":"plain","servers":[{"port":1, "ip":"localhost"}]},
       |    {
       |      "protocol":"thrift",
-      |      "servers":[{"thriftProtocol":"compact", "port":2}],
-      |      "client":{"thriftProtocol":"binary", "kind": "io.l5d.global"}
+      |      "thriftProtocol":"binary",
+      |      "servers":[{"thriftFramed":false, "port":2}],
+      |      "client":{"thriftFramed":true, "kind":"io.l5d.global"}
       |    }
       |  ]
       |}""".stripMargin.replaceAll("\\s", ""))

--- a/linkerd/docs/protocol-thrift.md
+++ b/linkerd/docs/protocol-thrift.md
@@ -9,14 +9,13 @@ routers:
   label: port-shifter
   dtab: |
     /svc => /$/inet/127.1/5005;
+  thriftProtocol: compact
   servers:
   - port: 4004
     ip: 0.0.0.0
     thriftFramed: false
-    thriftProtocol: compact
   client:
     thriftFramed: false
-    thriftProtocol: compact
 ```
 
 protocol: `thrift`
@@ -38,6 +37,7 @@ Key | Default Value | Description
 --- | ------------- | -----------
 dstPrefix | `/svc` | A path prefix used in `dtab`.
 thriftMethodInDst | `false` | If `true`, thrift method names are appended to destinations for outgoing requests.
+thriftProtocol | `binary` | Either `binary` (TBinaryProtocol) or `compact` (TCompactProtocol). Applies to both clients and servers.
 
 
 ## Thrift Server Parameters
@@ -46,16 +46,10 @@ Key | Default Value | Description
 --- | ------------- | -----------
 port | `4114` | The TCP port number.
 thriftFramed | `true` | If `true`, a framed thrift transport is used for incoming requests; otherwise, a buffered transport is used. Typically this setting matches the router's `thriftFramed` param.
-thriftProtocol | `binary` | Either `binary` (TBinaryProtocol) or `compact` (TCompactProtocol). Typically this setting matches the router's client `thriftProtocol` param.
 
 ## Thrift Client Parameters
 
 Key | Default Value | Description
 --- | ------------- | -----------
 thriftFramed | `true` | If `true`, a framed thrift transport is used for outgoing requests; otherwise, a buffered transport is used. Typically this setting matches the router's servers' `thriftFramed` param.
-thriftProtocol | `binary` | Either `binary` (TBinaryProtocol) or `compact` (TCompactProtocol). Typically this setting matches the router's servers' `thriftProtocol` param.
 attemptTTwitterUpgrade | `false` | Controls whether thrift protocol upgrade should be attempted.
-
-
-
-

--- a/linkerd/examples/thrift.yaml
+++ b/linkerd/examples/thrift.yaml
@@ -8,14 +8,13 @@ namers:
 # A simple thrift router that looks up each thrift method in io.l5d.fs.
 routers:
 - protocol: thrift
+  thriftProtocol: binary
   thriftMethodInDst: true
   dtab: |
     /svc => /#/io.l5d.fs/thrift;
   servers:
   - port: 4114
-    thriftProtocol: binary
     thriftFramed: true
   client:
-    thriftProtocol: binary
     thriftFramed: true
     attemptTTwitterUpgrade: true

--- a/linkerd/examples/thriftmux.yaml
+++ b/linkerd/examples/thriftmux.yaml
@@ -8,15 +8,14 @@ namers:
 # A simple thriftmux router that looks up each thriftmux method in io.l5d.fs.
 routers:
 - protocol: thriftmux
+  thriftProtocol: binary
   thriftMethodInDst: true
   experimental: true
   dtab: |
     /svc => /#/io.l5d.fs/thrift;
   servers:
   - port: 4400
-    thriftProtocol: binary
     thriftFramed: true
   client:
-    thriftProtocol: binary
     thriftFramed: true
     attemptTTwitterUpgrade: true

--- a/linkerd/protocol/thrift/src/e2e/scala/io/buoyant/linkerd/protocol/ThriftEndToEndTest.scala
+++ b/linkerd/protocol/thrift/src/e2e/scala/io/buoyant/linkerd/protocol/ThriftEndToEndTest.scala
@@ -53,10 +53,10 @@ class ThriftEndToEndTest extends FunSuite {
   test("end-to-end echo routing") {
     val cat = Downstream.const("cat", "meow")
     val router = {
-      val config = new ThriftConfig(None) {
+      val config = new ThriftConfig(Some(true), None) {
         dtab = Some(Dtab.read(s"""/svc/cat => /$$/inet/127.1/${cat.port} ;"""))
         servers = Seq(
-          new ThriftServerConfig(None, None) {
+          new ThriftServerConfig(None) {
             port = Some(Port(0))
           }
         )
@@ -88,10 +88,10 @@ class ThriftEndToEndTest extends FunSuite {
   test("multiple clients") {
     val cat = Downstream.const("cat", "meow")
     val router = {
-      val config = new ThriftConfig(None) {
+      val config = new ThriftConfig(Some(true), None) {
         dtab = Some(Dtab.read(s"""/svc/cat => /$$/inet/127.1/${cat.port} ;"""))
         servers = Seq(
-          new ThriftServerConfig(None, None) {
+          new ThriftServerConfig(None) {
             port = Some(Port(0))
           }
         )
@@ -128,11 +128,11 @@ class ThriftEndToEndTest extends FunSuite {
   test("linker-to-linker echo routing") {
     val cat = Downstream.const("cat", "meow")
     val incoming = {
-      val config = new ThriftConfig(None) {
+      val config = new ThriftConfig(Some(true), None) {
         _label = Some("incoming")
         dtab = Some(Dtab.read(s"""/svc/cat => /$$/inet/127.1/${cat.port} ;"""))
         servers = Seq(
-          new ThriftServerConfig(None, None) {
+          new ThriftServerConfig(None) {
             port = Some(Port(0))
           }
         )
@@ -144,11 +144,11 @@ class ThriftEndToEndTest extends FunSuite {
     }
 
     val outgoing = {
-      val config = new ThriftConfig(None) {
+      val config = new ThriftConfig(Some(true), None) {
         _label = Some("outgoing")
         dtab = Some(Dtab.read(s"""/svc/cat => /$$/inet/127.1/${incoming.boundAddress.asInstanceOf[InetSocketAddress].getPort} ;"""))
         servers = Seq(
-          new ThriftServerConfig(None, None) {
+          new ThriftServerConfig(None) {
             port = Some(Port(0))
           }
         )

--- a/linkerd/protocol/thrift/src/main/scala/io/buoyant/linkerd/protocol/ThriftInitializer.scala
+++ b/linkerd/protocol/thrift/src/main/scala/io/buoyant/linkerd/protocol/ThriftInitializer.scala
@@ -4,7 +4,6 @@ package protocol
 import com.fasterxml.jackson.annotation.{JsonIgnore, JsonProperty, JsonSubTypes, JsonTypeInfo}
 import com.twitter.finagle.Stack.Params
 import com.twitter.finagle.Thrift.param
-import com.twitter.finagle.Thrift.param.{AttemptTTwitterUpgrade, ProtocolFactory}
 import com.twitter.finagle.buoyant.PathMatcher
 import com.twitter.finagle.buoyant.linkerd.{ThriftClientPrep, ThriftServerPrep, ThriftTraceInitializer}
 import io.buoyant.config.types.ThriftProtocol
@@ -24,6 +23,10 @@ class ThriftInitializer extends ProtocolInitializer {
     Thrift.router.withClientStack(clientStack)
   }
 
+  override protected def configureServer(router: Router, server: Server): Server =
+    super.configureServer(router, server)
+      .configured(router.params[param.ProtocolFactory])
+
   protected val adapter = Thrift.Router.IngestingFilter
   protected val defaultServer = {
     val stack = Thrift.server.stack
@@ -40,7 +43,8 @@ class ThriftInitializer extends ProtocolInitializer {
 object ThriftInitializer extends ThriftInitializer
 
 case class ThriftConfig(
-  thriftMethodInDst: Option[Boolean]
+  thriftMethodInDst: Option[Boolean],
+  thriftProtocol: Option[ThriftProtocol]
 ) extends RouterConfig {
 
   var servers: Seq[ThriftServerConfig] = Nil
@@ -57,16 +61,15 @@ case class ThriftConfig(
 
   override def routerParams = super.routerParams
     .maybeWith(thriftMethodInDst.map(Thrift.param.MethodInDst(_)))
+    .maybeWith(thriftProtocol.map(proto => param.ProtocolFactory(proto.factory)))
 }
 
 case class ThriftServerConfig(
-  thriftFramed: Option[Boolean],
-  thriftProtocol: Option[ThriftProtocol]
+  thriftFramed: Option[Boolean]
 ) extends ServerConfig {
   @JsonIgnore
   override protected def serverParams: Params = super.serverParams
     .maybeWith(thriftFramed.map(param.Framed(_)))
-    .maybeWith(thriftProtocol.map(proto => param.ProtocolFactory(proto.factory)))
 }
 
 @JsonTypeInfo(
@@ -91,12 +94,10 @@ class ThriftPrefixConfig(prefix: PathMatcher) extends PrefixConfig(prefix) with 
 trait ThriftClientConfig extends ClientConfig {
 
   var thriftFramed: Option[Boolean] = None
-  var thriftProtocol: Option[ThriftProtocol] = None
   var attemptTTwitterUpgrade: Option[Boolean] = None
 
   @JsonIgnore
   override def params(vars: Map[String, String]) = super.params(vars)
-    .maybeWith(thriftFramed.map(param.Framed(_)))
-    .maybeWith(thriftProtocol.map(proto => param.ProtocolFactory(proto.factory))) +
-    AttemptTTwitterUpgrade(attemptTTwitterUpgrade.getOrElse(false))
+    .maybeWith(thriftFramed.map(param.Framed(_))) +
+    param.AttemptTTwitterUpgrade(attemptTTwitterUpgrade.getOrElse(false))
 }

--- a/linkerd/protocol/thrift/src/test/scala/io/buoyant/linkerd/protocol/ThriftInitializerTest.scala
+++ b/linkerd/protocol/thrift/src/test/scala/io/buoyant/linkerd/protocol/ThriftInitializerTest.scala
@@ -3,7 +3,6 @@ package io.buoyant.linkerd.protocol
 import com.fasterxml.jackson.databind.JsonMappingException
 import com.twitter.finagle.Path
 import com.twitter.finagle.Thrift.param
-import com.twitter.finagle.Thrift.param.AttemptTTwitterUpgrade
 import io.buoyant.linkerd.Linker
 import io.buoyant.router.StackRouter.Client.PerClientParams
 import io.buoyant.router.Thrift.param.MethodInDst
@@ -17,33 +16,33 @@ class ThriftInitializerTest extends FunSuite with Exceptions {
     val config = """
       |routers:
       |- protocol: thrift
+      |  thriftProtocol: compact
       |  thriftMethodInDst: true
       |  client:
       |    thriftFramed: false
-      |    thriftProtocol: binary
       |    attemptTTwitterUpgrade: false
       |  servers:
       |  - thriftFramed: true
-      |    thriftProtocol: compact
     """.stripMargin
 
     val linker = Linker.Initializers(Seq(ThriftInitializer)).load(config)
     val router = linker.routers.head
-    val params = router.params[PerClientParams].paramsFor(Path.read("/foo"))
-    assert(router.params[MethodInDst].enabled)
-    assert(!params[param.Framed].enabled)
-    assert(!params[param.ProtocolFactory].protocolFactory.isInstanceOf[TCompactProtocol.Factory])
-    assert(router.servers.head.params[param.Framed].enabled)
-    assert(router.servers.head.params[param.ProtocolFactory].protocolFactory.isInstanceOf[TCompactProtocol.Factory])
-    assert(!params[AttemptTTwitterUpgrade].upgrade)
+    val routerParams = router.params
+    val serverParams = router.servers.head.params
+    val clientParams = router.params[PerClientParams].paramsFor(Path.read("/foo"))
+    assert(routerParams[MethodInDst].enabled)
+    assert(routerParams[param.ProtocolFactory].protocolFactory.isInstanceOf[TCompactProtocol.Factory])
+    assert(serverParams[param.Framed].enabled)
+    assert(serverParams[param.ProtocolFactory].protocolFactory.isInstanceOf[TCompactProtocol.Factory])
+    assert(!clientParams[param.Framed].enabled)
+    assert(!clientParams[param.AttemptTTwitterUpgrade].upgrade)
   }
 
   test("unsupported thrift protocol") {
     val config = """
       |routers:
       |- protocol: thrift
-      |  servers:
-      |    thriftProtocol: magic
+      |  thriftProtocol: magic
     """.stripMargin
 
     assertThrows[JsonMappingException] {
@@ -55,13 +54,13 @@ class ThriftInitializerTest extends FunSuite with Exceptions {
     val config = """
                    |routers:
                    |- protocol: thrift
+                   |  thriftProtocol: compact
                    |  servers:
                    |  - thriftFramed: true
-                   |    thriftProtocol: compact
                  """.stripMargin
 
     val linker = Linker.Initializers(Seq(ThriftInitializer)).load(config)
     val params = linker.routers.head.params[PerClientParams].paramsFor(Path.read("/foo"))
-    assert(!params[AttemptTTwitterUpgrade].upgrade)
+    assert(!params[param.AttemptTTwitterUpgrade].upgrade)
   }
 }

--- a/linkerd/protocol/thriftmux/src/main/scala/io/buoyant/linkerd/protocol/ThriftMuxInitializer.scala
+++ b/linkerd/protocol/thriftmux/src/main/scala/io/buoyant/linkerd/protocol/ThriftMuxInitializer.scala
@@ -3,8 +3,10 @@ package protocol
 
 import com.fasterxml.jackson.annotation.{JsonIgnore, JsonProperty}
 import com.twitter.finagle.Stack
+import com.twitter.finagle.Thrift.param
 import com.twitter.finagle.buoyant.linkerd.{ThriftClientPrep, ThriftMuxServerPrep, ThriftTraceInitializer}
 import com.twitter.finagle.mux
+import io.buoyant.config.types.ThriftProtocol
 import io.buoyant.router.{Thrift, ThriftMux}
 
 class ThriftMuxInitializer extends ProtocolInitializer {
@@ -23,8 +25,11 @@ class ThriftMuxInitializer extends ProtocolInitializer {
     ThriftMux.router.withClientStack(stack)
   }
 
-  protected val adapter = ThriftMux.Router.IngestingFilter
+  override protected def configureServer(router: Router, server: Server): Server =
+    super.configureServer(router, server)
+      .configured(router.params[param.ProtocolFactory])
 
+  protected val adapter = ThriftMux.Router.IngestingFilter
   protected val defaultServer = {
     val stack = ThriftMux.server.stack
       .insertBefore(Stack.Role("appExceptionHandling"), ThriftTraceInitializer.serverModule[mux.Request, mux.Response])
@@ -40,7 +45,8 @@ class ThriftMuxInitializer extends ProtocolInitializer {
 object ThriftMuxInitializer extends ThriftMuxInitializer
 
 case class ThriftMuxConfig(
-  thriftMethodInDst: Option[Boolean]
+  thriftMethodInDst: Option[Boolean],
+  thriftProtocol: Option[ThriftProtocol]
 ) extends RouterConfig {
 
   var servers: Seq[ThriftServerConfig] = Nil
@@ -55,4 +61,5 @@ case class ThriftMuxConfig(
 
   override def routerParams = super.routerParams
     .maybeWith(thriftMethodInDst.map(Thrift.param.MethodInDst(_)))
+    .maybeWith(thriftProtocol.map(proto => param.ProtocolFactory(proto.factory)))
 }


### PR DESCRIPTION
## Problem

Right now it's possible to configure thrift clients and servers to use different `thriftProtocol` settings, but linkerd does not convert the thrift payloads when forwarding requests and responses, so this configuration is invalid. It's also causing problems for the serializer used when `thriftMethodInDst` is set to true.

## Solution

Move `thriftProtocol` to be a router param, which ensures that both clients and servers use the same protocol.

Fixes #1318.