### PR TITLE
Linkerd configs should accept ints for doubles

### DIFF
--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/LoadBalancerConfig.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/LoadBalancerConfig.scala
@@ -2,6 +2,7 @@ package io.buoyant.linkerd
 
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type
 import com.fasterxml.jackson.annotation.{JsonIgnore, JsonSubTypes}
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.twitter.conversions.time._
 import com.twitter.finagle.Stack
 import com.twitter.finagle.loadbalancer.LoadBalancerFactory.EnableProbation
@@ -41,8 +42,8 @@ case class P2CEwma(decayTimeMs: Option[Int], maxEffort: Option[Int]) extends Loa
 case class Aperture(
   smoothWindowMs: Option[Int],
   maxEffort: Option[Int],
-  lowLoad: Option[Double],
-  highLoad: Option[Double],
+  @JsonDeserialize(contentAs = classOf[java.lang.Double]) lowLoad: Option[Double],
+  @JsonDeserialize(contentAs = classOf[java.lang.Double]) highLoad: Option[Double],
   minAperture: Option[Int]
 ) extends LoadBalancerConfig {
   @JsonIgnore

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/H2Config.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/H2Config.scala
@@ -115,6 +115,7 @@ trait H2EndpointConfig {
   var headerTableBytes: Option[Int] = None
   var maxFrameBytes: Option[Int] = None
   var maxHeaderListBytes: Option[Int] = None
+  @JsonDeserialize(contentAs = classOf[java.lang.Double])
   var windowUpdateRatio: Option[Double] = None
 
   def withEndpointParams(params: Stack.Params): Stack.Params = params

--- a/router/core/src/main/scala/io/buoyant/router/RetryBudgetModule.scala
+++ b/router/core/src/main/scala/io/buoyant/router/RetryBudgetModule.scala
@@ -1,5 +1,6 @@
 package io.buoyant.router
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.twitter.conversions.time._
 import com.twitter.finagle.{ServiceFactory, Stack}
 import com.twitter.finagle.service.{Backoff, Retries, RetryBudget}
@@ -34,5 +35,5 @@ object RetryBudgetModule {
 case class RetryBudgetConfig(
   ttlSecs: Option[Int] = None,
   minRetriesPerSec: Option[Int] = None,
-  percentCanRetry: Option[Double] = None
+  @JsonDeserialize(contentAs = classOf[java.lang.Double]) percentCanRetry: Option[Double] = None
 )

--- a/telemetry/recent-requests/src/main/scala/io/buoyant/telemetry/recentRequests/RecentRequestsInitializer.scala
+++ b/telemetry/recent-requests/src/main/scala/io/buoyant/telemetry/recentRequests/RecentRequestsInitializer.scala
@@ -1,6 +1,7 @@
 package io.buoyant.telemetry.recentRequests
 
 import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.twitter.finagle.Stack.Params
 import io.buoyant.telemetry.{Telemeter, TelemeterConfig, TelemeterInitializer}
 
@@ -10,7 +11,10 @@ class RecentRequestsInitializer extends TelemeterInitializer {
   val configClass = classOf[RecentRequestsConfig]
 }
 
-case class RecentRequestsConfig(sampleRate: Option[Double], capacity: Option[Int] = None) extends TelemeterConfig {
+case class RecentRequestsConfig(
+  @JsonDeserialize(contentAs = classOf[java.lang.Double]) sampleRate: Option[Double],
+  capacity: Option[Int] = None
+) extends TelemeterConfig {
   @JsonIgnore
   private[this] val _sampleRate = sampleRate
     .filter(r => r >= 0.0 && r <= 1.0)

--- a/telemetry/statsd/src/main/scala/io/buoyant/telemetry/StatsDInitializer.scala
+++ b/telemetry/statsd/src/main/scala/io/buoyant/telemetry/StatsDInitializer.scala
@@ -1,6 +1,7 @@
 package io.buoyant.telemetry
 
 import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.timgroup.statsd.NonBlockingStatsDClient
 import com.twitter.finagle.Stack
 import com.twitter.finagle.util.DefaultTimer
@@ -28,7 +29,7 @@ case class StatsDConfig(
   hostname: Option[String],
   port: Option[Int],
   gaugeIntervalMs: Option[Int],
-  sampleRate: Option[Double]
+  @JsonDeserialize(contentAs = classOf[java.lang.Double]) sampleRate: Option[Double]
 ) extends TelemeterConfig {
   import StatsDConfig._
 

--- a/telemetry/tracelog/src/main/scala/io/buoyant/telemetry/TracelogInitializer.scala
+++ b/telemetry/tracelog/src/main/scala/io/buoyant/telemetry/TracelogInitializer.scala
@@ -1,9 +1,10 @@
 package io.buoyant.telemetry
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.twitter.finagle.Stack
 import com.twitter.finagle.buoyant.Sampler
 import com.twitter.finagle.stats.NullStatsReceiver
-import com.twitter.finagle.tracing.{Trace, Record, TraceId, Tracer}
+import com.twitter.finagle.tracing.{Record, Trace, TraceId, Tracer}
 import com.twitter.logging.{Level, Logger}
 
 class TracelogInitializer extends TelemeterInitializer {
@@ -13,7 +14,7 @@ class TracelogInitializer extends TelemeterInitializer {
 }
 
 case class TracelogConfig(
-  sampleRate: Option[Double],
+  @JsonDeserialize(contentAs = classOf[java.lang.Double]) sampleRate: Option[Double],
   level: Option[Level]
 ) extends TelemeterConfig {
 

--- a/telemetry/tracelog/src/test/scala/io/buoyant/telemetry/TracelogInitializerTest.scala
+++ b/telemetry/tracelog/src/test/scala/io/buoyant/telemetry/TracelogInitializerTest.scala
@@ -21,6 +21,18 @@ class TracelogInitializerTest extends FunSuite {
     assert(!telemeter.tracer.isNull)
   }
 
+  test("io.l5d.tracelog telemeter accepts int for sampleRate") {
+    val yaml =
+      """|kind: io.l5d.tracelog
+         |sampleRate: 1
+         |""".stripMargin
+
+    val config = Parser.objectMapper(yaml, Seq(LoadService[TelemeterInitializer]))
+      .readValue[TelemeterConfig](yaml)
+
+    assert(config.asInstanceOf[TracelogConfig].sampleRate == Some(1.0))
+  }
+
   test("io.l5d.tracelog telemeter loads, with log level") {
     val yaml =
       """|kind: io.l5d.tracelog

--- a/telemetry/zipkin/src/main/scala/io/buoyant/telemetry/ZipkinInitializer.scala
+++ b/telemetry/zipkin/src/main/scala/io/buoyant/telemetry/ZipkinInitializer.scala
@@ -1,5 +1,6 @@
 package io.buoyant.telemetry
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.twitter.conversions.time._
 import com.twitter.finagle._
 import com.twitter.finagle.client.DefaultPool
@@ -20,7 +21,7 @@ class ZipkinInitializer extends TelemeterInitializer {
 case class ZipkinConfig(
   host: Option[String],
   port: Option[Int],
-  sampleRate: Option[Double]
+  @JsonDeserialize(contentAs = classOf[java.lang.Double]) sampleRate: Option[Double]
 ) extends TelemeterConfig {
 
   private[this] val tracer: Tracer = new Tracer {


### PR DESCRIPTION
If an int is supplied for a linkerd config property that is expecting a double,
parsing will fail instead of coercing the int to double.

Add the `@JsonDeserialize(contentAs = classOf[java.lang.Double])` annotation
to `Option[Double]` properties to help jackson deserialize them propery.
https://github.com/FasterXML/jackson-module-scala/wiki/FAQ#deserializing-optionint-and-other-primitive-challenges

Added test.

Fixes #1313