### PR TITLE
Better namerd admin ui with no namespaces (#447)

### DIFF
--- a/namerd/main/src/main/scala/io/buoyant/namerd/DtabListHandler.scala
+++ b/namerd/main/src/main/scala/io/buoyant/namerd/DtabListHandler.scala
@@ -18,11 +18,28 @@ class DtabListHandler(
     }
 
   def render(list: Iterable[String]) = {
-    val listHtml = list.map { ns =>
+    val content = if (list.isEmpty) {
       s"""
-        <a class="list-group-item" href="dtab/$ns">$ns</a>
+        <h2 class="router-label-title">No namespaces found</h2>
+        <p>This is likely due to one of two things:</p>
+        <ol>
+          <li>no namespaces have been created in the backend dtab store</li>
+          <li>namerd is not configured to connect to the appropriate backend dtab store</li>
+        </ol>
+        <p>For more information, please consult the
+          <a href="https://linkerd.io/config/latest/namerd">namerd documentation</a>.
+        </p>
       """
-    }.mkString("")
+    } else {
+      s"""
+        <h2 class="router-label-title">Namespaces:</h2>
+        <div class="list-group">
+        ${
+        list.map { ns => s"""<a class="list-group-item" href="dtab/$ns">$ns</a>""" }.mkString("")
+      }
+        </div>
+      """
+    }
 
     s"""
       <!doctype html>
@@ -38,10 +55,7 @@ class DtabListHandler(
           <div class="container-fluid">
             <div class="row">
               <div class="col-lg-6">
-                <h2 class="router-label-title">Namespaces:</h2>
-                <div class="list-group">
-                  $listHtml
-                </div>
+                $content
               </div>
             </div>
           </div>


### PR DESCRIPTION
Problem
With no namespaces configured/found, namerd displays "Namespaces:"
without any context.

Solution
Display a helpful error message informing the user that no namespaces
are found, and point them to the namerd documentation.

Validation
Visual UI check.

fixes #447 

![screen shot 2017-05-22 at 4 53 29 pm](https://cloud.githubusercontent.com/assets/236915/26333061/bce42f3e-3f0f-11e7-9477-f24eb6f82582.png)
