### PR TITLE
Add TLS for mesh and HTTP interfaces (#1191)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 * Expire idle services and clients.
 * Convert `thriftProtocol` from a client/server param to a router param.
 * Add support for client auth TLS.
+* Add TLS support for `io.l5d.httpController` and `io.l5d.mesh`.
 
 ## 1.0.2 2017-05-12
 

--- a/finagle/buoyant/src/main/scala/com/twitter/finagle/buoyant/TlsServerConfig.scala
+++ b/finagle/buoyant/src/main/scala/com/twitter/finagle/buoyant/TlsServerConfig.scala
@@ -1,0 +1,45 @@
+package com.twitter.finagle.buoyant
+
+import com.twitter.finagle.Stack
+import com.twitter.finagle.ssl.{ClientAuth => FClientAuth, _}
+import com.twitter.finagle.ssl.server.{SslServerConfiguration, SslServerEngineFactory}
+import com.twitter.finagle.transport.Transport
+import java.io.File
+
+case class TlsServerConfig(
+  certPath: String,
+  keyPath: String,
+  caCertPath: Option[String] = None,
+  ciphers: Option[Seq[String]] = None,
+  requireClientAuth: Option[Boolean] = None
+) {
+  def params(
+    alpnProtocols: Option[Seq[String]],
+    sslServerEngine: SslServerEngineFactory
+  ): Stack.Params = {
+    val trust = caCertPath match {
+      case Some(caCertPath) => TrustCredentials.CertCollection(new File(caCertPath))
+      case None => TrustCredentials.Unspecified
+    }
+    val cipherSuites = ciphers match {
+      case Some(cs) => CipherSuites.Enabled(cs)
+      case None => CipherSuites.Unspecified
+    }
+    val appProtocols = alpnProtocols match {
+      case Some(ps) => ApplicationProtocols.Supported(ps)
+      case None => ApplicationProtocols.Unspecified
+    }
+    val clientAuth = requireClientAuth match {
+      case Some(true) => FClientAuth.Needed
+      case _ => FClientAuth.Off
+    }
+
+    Stack.Params.empty + Transport.ServerSsl(Some(SslServerConfiguration(
+      clientAuth = clientAuth,
+      keyCredentials = KeyCredentials.CertAndKey(new File(certPath), new File(keyPath)),
+      trustCredentials = trust,
+      cipherSuites = cipherSuites,
+      applicationProtocols = appProtocols
+    ))) + SslServerEngineFactory.Param(sslServerEngine)
+  }
+}

--- a/interpreter/mesh/src/main/scala/io/buoyant/interpreter/MeshInterpreterInitializer.scala
+++ b/interpreter/mesh/src/main/scala/io/buoyant/interpreter/MeshInterpreterInitializer.scala
@@ -3,7 +3,7 @@ package io.buoyant.interpreter
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.twitter.conversions.time._
 import com.twitter.finagle._
-import com.twitter.finagle.buoyant.{H2, TlsClientConfig}
+import com.twitter.finagle.buoyant.{TlsClientConfig, H2}
 import com.twitter.finagle.naming.NameInterpreter
 import com.twitter.finagle.service.Backoff
 import com.twitter.finagle.ssl.ApplicationProtocols
@@ -64,9 +64,10 @@ case class MeshInterpreterConfig(
 
     val Retry(baseRetry, maxRetry) = retry.getOrElse(defaultRetry)
     val backoffs = Backoff.exponentialJittered(baseRetry.seconds, maxRetry.seconds)
+    val tlsParams = tls.map(_.params).getOrElse(Stack.Params.empty)
 
     val client = H2.client
-      .withParams(H2.client.params ++ params)
+      .withParams(H2.client.params ++ tlsParams ++ params)
       .newService(name, label)
 
     root.getOrElse(DefaultRoot) match {

--- a/interpreter/namerd/src/main/scala/io/buoyant/namerd/iface/NamerdHttpInterpreterInitializer.scala
+++ b/interpreter/namerd/src/main/scala/io/buoyant/namerd/iface/NamerdHttpInterpreterInitializer.scala
@@ -3,6 +3,7 @@ package io.buoyant.namerd.iface
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.twitter.conversions.time._
 import com.twitter.finagle._
+import com.twitter.finagle.buoyant.TlsClientConfig
 import com.twitter.finagle.naming.NameInterpreter
 import com.twitter.finagle.param.HighResTimer
 import com.twitter.finagle.service._
@@ -27,7 +28,7 @@ case class NamerdHttpInterpreterConfig(
   dst: Option[Path],
   namespace: Option[String],
   retry: Option[Retry],
-  tls: Option[ClientTlsConfig]
+  tls: Option[TlsClientConfig]
 ) extends NamespacedInterpreterConfig {
 
   @JsonIgnore

--- a/linkerd/docs/client_tls.md
+++ b/linkerd/docs/client_tls.md
@@ -40,6 +40,9 @@ routers:
       commonName: linkerd.io
       trustCerts:
       - /certificates/cacert.pem
+      clientAuth:
+        certPath: /certificates/cert.pem
+        keyPath: /certificates/key.pem
 ```
 
 In order to send outgoing tls traffic, the tls parameter must be defined as a
@@ -75,4 +78,7 @@ routers:
         commonName: "{service}.linkerd.io"
         trustCerts:
         - /certificates/cacert.pem
+        clientAuth:
+          certPath: /certificates/cert.pem
+          keyPath: /certificates/key.pem
 ```

--- a/linkerd/docs/interpreter.md
+++ b/linkerd/docs/interpreter.md
@@ -76,7 +76,7 @@ experimental | _required_ | Because the http interpreter is still considered exp
 dst | _required_ | A Finagle path locating the namerd service.
 namespace | `default` | The name of the namerd dtab to use.
 retry | see [namerd retry](#namerd-retry) | An object configuring retry backoffs for requests to namerd.
-tls | no tls | Requests to namerd will be made using TLS if this parameter is provided.  It must be a [namerd client TLS](#namerd-client-tls) object.
+tls | no tls | Requests to namerd will be made using TLS if this parameter is provided.  It must be a [client TLS](#client-tls) object.
 
 ## namerd mesh
 
@@ -94,7 +94,7 @@ experimental | _required_ | Because the mesh interpreter is still considered exp
 dst | _required_ | A Finagle path locating the namerd service.
 root | `/default` | A single-element Finagle path representing the namerd namespace.
 retry | see [namerd retry](#namerd-retry) | An object configuring retry backoffs for requests to namerd.
-tls | no tls | The namerd mesh interface does not support server TLS configuration at this time.
+tls | no tls | Requests to namerd will be made using TLS if this parameter is provided.  It must be a [client TLS](#client-tls) object.
 
 ## File-System
 

--- a/linkerd/docs/protocol-h2.md
+++ b/linkerd/docs/protocol-h2.md
@@ -20,12 +20,11 @@ routers:
   dtab: |
     /svc => /#/io.l5d.fs ;
   client:
+    prefix: "/#/io.l5d.fs/{service}"
     tls:
       kind: io.l5d.boundPath
       caCertPath: .../ca.pem
-      names:
-      - prefix: "/#/io.l5d.fs/{service}"
-        commonNamePattern: "{service}"
+      commonName: "{service}"
 ```
 
 > Below: plaintext gRPC

--- a/linkerd/examples/namerd-mesh.yaml
+++ b/linkerd/examples/namerd-mesh.yaml
@@ -1,4 +1,4 @@
-# Use the experimental namerd HTTP API for name resolution.
+# Use the experimental namerd gRPC API for name resolution.
 routers:
 - protocol: http
   interpreter:

--- a/linkerd/examples/namerd-tls.yaml
+++ b/linkerd/examples/namerd-tls.yaml
@@ -1,6 +1,13 @@
-# Use namerd for name resolution.  Encrypt the connection with TLS.
+# this linkerd config is intended to work in conjunction with namerd/tls.yaml
+# it runs 4 routers, each connecting to a respective namerd endpoint:
+# 1. namerd-thrift-tls/4140          => thrift/4100
+# 2. namerd-http-tls/4141            => http/4180
+# 3. namerd-http-tls-clientauth/4142 => http/4181 (requireClientAuth: true)
+# 4. namerd-grpc-tls/4143            => mesh/4321 (requireClientAuth: true)
+
 routers:
 - protocol: http
+  label: namerd-thrift-tls
   interpreter:
     kind: io.l5d.namerd
     dst: /$/inet/localhost/4100
@@ -10,4 +17,55 @@ routers:
       caCert: namerd/examples/certs/namerd-cacert.pem
   servers:
   - port: 4140
+    ip: 0.0.0.0
+- protocol: http
+  label: namerd-http-tls
+  interpreter:
+    kind: io.l5d.namerd.http
+    experimental: true
+    dst: /$/inet/localhost/4180
+    namespace: default
+    tls:
+      disableValidation: false
+      commonName: namerd
+      trustCerts:
+      - namerd/examples/certs/namerd-cacert.pem
+  servers:
+  - port: 4141
+    ip: 0.0.0.0
+- protocol: http
+  label: namerd-http-tls-clientauth
+  interpreter:
+    kind: io.l5d.namerd.http
+    experimental: true
+    dst: /$/inet/localhost/4181
+    namespace: default
+    tls:
+      disableValidation: false
+      commonName: linkerd-tls-e2e
+      trustCerts:
+      - finagle/h2/src/e2e/resources/cacert.pem
+      clientAuth:
+        certPath: finagle/h2/src/e2e/resources/linkerd-tls-e2e-cert.pem
+        keyPath: finagle/h2/src/e2e/resources/linkerd-tls-e2e-key.pem
+  servers:
+  - port: 4142
+    ip: 0.0.0.0
+- protocol: http
+  label: namerd-grpc-tls
+  interpreter:
+    kind: io.l5d.mesh
+    experimental: true
+    dst: /$/inet/127.1/4321
+    root: /default
+    tls:
+      disableValidation: false
+      commonName: linkerd-tls-e2e
+      trustCerts:
+      - finagle/h2/src/e2e/resources/cacert.pem
+      clientAuth:
+        certPath: finagle/h2/src/e2e/resources/linkerd-tls-e2e-cert.pem
+        keyPath: finagle/h2/src/e2e/resources/linkerd-tls-e2e-key.pem
+  servers:
+  - port: 4143
     ip: 0.0.0.0

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/H2Config.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/H2Config.scala
@@ -11,10 +11,6 @@ import com.twitter.finagle.buoyant.h2.{LinkerdHeaders, Request, Response, Respon
 import com.twitter.finagle.buoyant.h2.param._
 import com.twitter.finagle.client.StackClient
 import com.twitter.finagle.netty4.ssl.server.Netty4ServerEngineFactory
-import com.twitter.finagle.ssl.ApplicationProtocols
-import com.twitter.finagle.ssl.client.SslClientConfiguration
-import com.twitter.finagle.ssl.server.SslServerEngineFactory
-import com.twitter.finagle.transport.Transport
 import com.twitter.finagle.{Path, Stack, param}
 import com.twitter.util.Monitor
 import io.buoyant.config.PolymorphicConfig

--- a/namerd/core/src/main/scala/io/buoyant/namerd/InterfaceConfig.scala
+++ b/namerd/core/src/main/scala/io/buoyant/namerd/InterfaceConfig.scala
@@ -1,10 +1,14 @@
 package io.buoyant.namerd
 
 import com.fasterxml.jackson.annotation.JsonIgnore
+import com.github.ghik.silencer.silent
+import com.twitter.finagle.Stack
 import com.twitter.finagle.stats.StatsReceiver
 import com.twitter.finagle.{Namer, Path}
 import io.buoyant.config.types.Port
 import io.buoyant.config.{PolymorphicConfig, ConfigInitializer}
+import com.twitter.finagle.buoyant.TlsServerConfig
+import com.twitter.finagle.ssl.server.LegacyKeyServerEngineFactory
 import java.net.{InetAddress, InetSocketAddress}
 
 /**
@@ -13,12 +17,20 @@ import java.net.{InetAddress, InetSocketAddress}
 abstract class InterfaceConfig extends PolymorphicConfig {
   var ip: Option[InetAddress] = None
   var port: Option[Port] = None
+  var tls: Option[TlsServerConfig] = None
 
   @JsonIgnore
   def addr = new InetSocketAddress(
     ip.getOrElse(defaultAddr.getAddress),
     port.map(_.port).getOrElse(defaultAddr.getPort)
   )
+
+  // The deprecated LegacyKeyServerEngineFactory allows us to accept PKCS#1 formatted keys.
+  // We should remove this and replace it with Netty4ServerEngineFactory once we no longer allow
+  // PKCS#1 keys.
+  @JsonIgnore
+  @silent
+  def tlsParams = tls.map(_.params(None, LegacyKeyServerEngineFactory)).getOrElse(Stack.Params.empty)
 
   @JsonIgnore
   protected def defaultAddr: InetSocketAddress

--- a/namerd/docs/interface.md
+++ b/namerd/docs/interface.md
@@ -18,6 +18,7 @@ Key | Default Value | Description
 kind | _required_ | Either [`io.l5d.thriftNameInterpreter`](#thrift-name-interpreter), [`io.l5d.mesh`](#grpc-mesh-interface), or [`io.l5d.httpController`](#http-controller).
 ip | interface dependent | The local IP address on which to serve the namer interface.
 port | interface dependent | The port number on which to server the namer interface.
+tls | no tls | The namer interface will serve over TLS if this parameter is provided. see [Server TLS](https://linkerd.io/config/head/linkerd#server-tls).
 
 ## Thrift Name Interpreter
 
@@ -34,7 +35,7 @@ port | `4100` | The port number on which to server the namer interface.
 retryBaseSecs | `600` | Base number of seconds to tell clients to wait before retrying after an error.
 retryJitterSecs | `60` | Maximum number of seconds to jitter retry time by.
 cache | see [cache](#cache) | Binding and address cache size configuration.
-tls | no tls | The namer interface will serve over TLS if this parameter is provided. see [TLS](#namerd-server-tls).
+tls | no tls | The namer interface will serve over TLS if this parameter is provided. see [Server TLS](https://linkerd.io/config/head/linkerd#server-tls).
 
 ### Cache
 
@@ -44,15 +45,6 @@ bindingCacheActive | `1000` | The size of the binding active cache.
 bindingCacheInactive | `100` | The size of the binding inactive cache.
 addrCacheActive | `1000` | The size of the address active cache.
 addrCacheInactive | `100` | The size of the address inactive cache.
-
-### namerd server tls
-
-In order to accept incoming tls traffic, the tls parameter must be defined.
-
-Key | Default Value | Description
---- | ------------- | -----------
-certPath | _required_ | File path to the TLS certificate file.
-keyPath | _required_ | File path to the TLS key file.
 
 ## gRPC Mesh Interface
 
@@ -66,6 +58,7 @@ Key | Default Value | Description
 --- | ------------- | -----------
 ip | `0.0.0.0` | The local IP address on which to serve the namer interface.
 port | `4321` | The port number on which to server the namer interface.
+tls | no tls | The namer interface will serve over TLS if this parameter is provided. see [Server TLS](https://linkerd.io/config/head/linkerd#server-tls).
 
 ## Http Controller
 
@@ -82,6 +75,7 @@ Key | Default Value | Description
 --- | ------------- | -----------
 ip | loopback | The local IP address on which to serve the namer interface.
 port | `4180` | The port number on which to serve the namer interface.
+tls | no tls | The namer interface will serve over TLS if this parameter is provided. see [Server TLS](https://linkerd.io/config/head/linkerd#server-tls).
 
 ### GET /api/1/dtabs
 

--- a/namerd/examples/tls.yaml
+++ b/namerd/examples/tls.yaml
@@ -1,3 +1,10 @@
+# this namerd config is intended to work in conjunction with linkerd/namerd-tls.yaml
+# it servers 4 endpoints:
+# 1. thrift/4100
+# 2. http/4180
+# 3. http/4181 (requireClientAuth: true)
+# 4. mesh/4321 (requireClientAuth: true)
+
 admin:
   port: 9991
 storage:
@@ -14,3 +21,19 @@ interfaces:
     certPath: namerd/examples/certs/namerd-cert.pem
     keyPath: namerd/examples/certs/namerd-key.pem
 - kind: io.l5d.httpController
+  tls:
+    certPath: namerd/examples/certs/namerd-cert.pem
+    keyPath: namerd/examples/certs/namerd-key.pem
+- kind: io.l5d.httpController
+  port: 4181
+  tls:
+    certPath: finagle/h2/src/e2e/resources/linkerd-tls-e2e-cert.pem
+    keyPath: finagle/h2/src/e2e/resources/linkerd-tls-e2e-key.pem
+    caCertPath: finagle/h2/src/e2e/resources/cacert.pem
+    requireClientAuth: true
+- kind: io.l5d.mesh
+  tls:
+    certPath: finagle/h2/src/e2e/resources/linkerd-tls-e2e-cert.pem
+    keyPath: finagle/h2/src/e2e/resources/linkerd-tls-e2e-key.pem
+    caCertPath: finagle/h2/src/e2e/resources/cacert.pem
+    requireClientAuth: true

--- a/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/HttpControlServiceConfig.scala
+++ b/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/HttpControlServiceConfig.scala
@@ -3,7 +3,8 @@ package io.buoyant.namerd.iface
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.twitter.finagle.naming.NameInterpreter
 import com.twitter.finagle.stats.StatsReceiver
-import com.twitter.finagle.{Namer, Path, Http, ListeningServer}
+import com.twitter.finagle.{Http, ListeningServer, Namer, Path, Stack}
+import com.twitter.finagle.param
 import io.buoyant.namerd._
 import java.net.{InetAddress, InetSocketAddress}
 
@@ -13,7 +14,12 @@ class HttpControlServiceConfig extends InterpreterInterfaceConfig {
     namers: Map[Path, Namer],
     store: DtabStore,
     stats: StatsReceiver
-  ): Servable = HttpControlServable(addr, store, delegate, namers, stats)
+  ): Servable = {
+    val iface = new HttpControlService(store, delegate, namers)
+    val params = tlsParams + param.Stats(stats) + param.Label(HttpControlServiceConfig.kind)
+
+    HttpControlServable(addr, iface, params)
+  }
 
   @JsonIgnore
   def defaultAddr = HttpControlServiceConfig.defaultAddr
@@ -26,17 +32,15 @@ object HttpControlServiceConfig {
 
 case class HttpControlServable(
   addr: InetSocketAddress,
-  store: DtabStore,
-  delegate: Ns => NameInterpreter,
-  namers: Map[Path, Namer],
-  stats: StatsReceiver
+  iface: HttpControlService,
+  params: Stack.Params
 ) extends Servable {
   def kind = HttpControlServiceConfig.kind
-  def serve(): ListeningServer = Http.server
-    .withLabel(HttpControlServiceConfig.kind)
+  val http = Http.server
+  def serve(): ListeningServer = http
+    .withParams(http.params ++ params)
     .withStreaming(true)
-    .withStatsReceiver(stats)
-    .serve(addr, new HttpControlService(store, delegate, namers))
+    .serve(addr, iface)
 }
 
 class HttpControlServiceInitializer extends InterfaceInitializer {

--- a/namerd/iface/control-http/src/test/scala/io/buoyant/namerd/iface/HttpControlServiceConfigTest.scala
+++ b/namerd/iface/control-http/src/test/scala/io/buoyant/namerd/iface/HttpControlServiceConfigTest.scala
@@ -1,0 +1,51 @@
+package io.buoyant.namerd.iface
+
+import io.buoyant.config.Parser
+import org.scalatest.FunSuite
+
+class HttpControlServiceConfigTest extends FunSuite {
+
+  test("address") {
+    val yaml = """
+      |kind: io.l5d.httpController
+      |ip: 1.2.3.4
+      |port: 1234
+    """.stripMargin
+
+    val config = Parser
+      .objectMapper(
+        yaml,
+        Iterable(Seq(new HttpControlServiceInitializer))
+      ).readValue[HttpControlServiceConfig](yaml)
+
+    assert(config.addr.getHostString == "1.2.3.4")
+    assert(config.addr.getPort == 1234)
+  }
+
+  test("tls") {
+    val yaml = """
+      |kind: io.l5d.httpController
+      |tls:
+      |  certPath: cert.pem
+      |  keyPath: key.pem
+      |  caCertPath: cacert.pem
+      |  ciphers:
+      |  - "foo"
+      |  - "bar"
+      |  requireClientAuth: true
+    """.stripMargin
+
+    val config = Parser
+      .objectMapper(
+        yaml,
+        Iterable(Seq(new HttpControlServiceInitializer))
+      ).readValue[HttpControlServiceConfig](yaml)
+
+    val tls = config.tls.get
+    assert(tls.certPath == "cert.pem")
+    assert(tls.keyPath == "key.pem")
+    assert(tls.caCertPath == Some("cacert.pem"))
+    assert(tls.ciphers == Some(List("foo", "bar")))
+    assert(tls.requireClientAuth == Some(true))
+  }
+}

--- a/namerd/iface/interpreter-thrift/src/test/scala/io/buoyant/namerd/iface/ThriftInterpreterInterfaceConfigTest.scala
+++ b/namerd/iface/interpreter-thrift/src/test/scala/io/buoyant/namerd/iface/ThriftInterpreterInterfaceConfigTest.scala
@@ -26,4 +26,31 @@ class ThriftInterpreterInterfaceConfigTest extends FunSuite {
     assert(capacity.addrCacheActive == 6000)
     assert(capacity.addrCacheInactive == ThriftNamerInterface.Capacity.default.addrCacheInactive)
   }
+
+  test("tls") {
+    val yaml = """
+      |kind: io.l5d.thriftNameInterpreter
+      |tls:
+      |  certPath: cert.pem
+      |  keyPath: key.pem
+      |  caCertPath: cacert.pem
+      |  ciphers:
+      |  - "foo"
+      |  - "bar"
+      |  requireClientAuth: true
+    """.stripMargin
+
+    val config = Parser
+      .objectMapper(
+        yaml,
+        Iterable(Seq(new ThriftInterpreterInterfaceInitializer))
+      ).readValue[ThriftInterpreterInterfaceConfig](yaml)
+
+    val tls = config.tls.get
+    assert(tls.certPath == "cert.pem")
+    assert(tls.keyPath == "key.pem")
+    assert(tls.caCertPath == Some("cacert.pem"))
+    assert(tls.ciphers == Some(List("foo", "bar")))
+    assert(tls.requireClientAuth == Some(true))
+  }
 }

--- a/namerd/iface/mesh/src/main/scala/io/buoyant/namerd/iface/MeshIfaceInitializer.scala
+++ b/namerd/iface/mesh/src/main/scala/io/buoyant/namerd/iface/MeshIfaceInitializer.scala
@@ -3,17 +3,27 @@ package iface
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.twitter.finagle.{Path, Namer, Service, Stack}
-import com.twitter.finagle.buoyant.{H2, h2}
+import com.twitter.finagle.buoyant.H2
 import com.twitter.finagle.naming.NameInterpreter
+import com.twitter.finagle.netty4.ssl.server.Netty4ServerEngineFactory
 import com.twitter.finagle.stats.StatsReceiver
 import com.twitter.util.Duration
 import com.twitter.util.TimeConversions._
 import io.buoyant.grpc.runtime.ServerDispatcher
+import io.netty.handler.ssl.ApplicationProtocolNames
 import java.net.InetSocketAddress
 
 class MeshIfaceConfig extends InterfaceConfig {
   @JsonIgnore
   override protected def defaultAddr = MeshIfaceInitializer.defaultAddr
+
+  @JsonIgnore
+  override def tlsParams = tls.map(
+    _.params(
+      Some(Seq(ApplicationProtocolNames.HTTP_2)),
+      Netty4ServerEngineFactory()
+    )
+  ).getOrElse(Stack.Params.empty)
 
   @JsonIgnore
   override def mk(
@@ -30,7 +40,9 @@ class MeshIfaceConfig extends InterfaceConfig {
         val resolver = mesh.ResolverService(namers, stats)
         ServerDispatcher(codec, interpreter, delegator, resolver)
       }
-      H2.serve(addr, dispatcher)
+
+      val h2 = H2.server
+      h2.withParams(h2.params ++ tlsParams).serve(addr, dispatcher)
     }
   }
 }

--- a/namerd/iface/mesh/src/test/scala/io/buoyant/namerd/iface/MeshIfaceInitializerTest.scala
+++ b/namerd/iface/mesh/src/test/scala/io/buoyant/namerd/iface/MeshIfaceInitializerTest.scala
@@ -1,0 +1,56 @@
+package io.buoyant.namerd
+package iface
+
+import com.twitter.finagle.netty4.ssl.server.Netty4ServerEngineFactory
+import com.twitter.finagle.ssl.server.SslServerEngineFactory
+import io.buoyant.config.Parser
+import org.scalatest.FunSuite
+
+class MeshInterpreterInitializerTest extends FunSuite {
+
+  test("address") {
+    val yaml = """
+      |kind: io.l5d.mesh
+      |ip: 1.2.3.4
+      |port: 1234
+    """.stripMargin
+
+    val config = Parser
+      .objectMapper(
+        yaml,
+        Iterable(Seq(new MeshIfaceInitializer))
+      ).readValue[MeshIfaceConfig](yaml)
+
+    assert(config.addr.getHostString == "1.2.3.4")
+    assert(config.addr.getPort == 1234)
+  }
+
+  test("tls") {
+    val yaml = """
+      |kind: io.l5d.mesh
+      |tls:
+      |  certPath: cert.pem
+      |  keyPath: key.pem
+      |  caCertPath: cacert.pem
+      |  ciphers:
+      |  - "foo"
+      |  - "bar"
+      |  requireClientAuth: true
+    """.stripMargin
+
+    val config = Parser
+      .objectMapper(
+        yaml,
+        Iterable(Seq(new MeshIfaceInitializer))
+      ).readValue[MeshIfaceConfig](yaml)
+
+    val tls = config.tls.get
+    assert(tls.certPath == "cert.pem")
+    assert(tls.keyPath == "key.pem")
+    assert(tls.caCertPath == Some("cacert.pem"))
+    assert(tls.ciphers == Some(List("foo", "bar")))
+    assert(tls.requireClientAuth == Some(true))
+
+    assert(config.tlsParams[SslServerEngineFactory.Param].factory.isInstanceOf[Netty4ServerEngineFactory])
+  }
+}

--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -275,6 +275,7 @@ object LinkerdBuild extends Base {
 
       val mesh = projectDir("namerd/iface/mesh")
         .dependsOn(core, Mesh.core)
+        .withTests()
 
       val all = aggregateDir(
         "namerd/iface",


### PR DESCRIPTION
Problem
io.l5d.namerd, io.l5d.namerd.http, io.l5d.thriftNameInterpreter all
support tls, while io.l5d.mesh and io.l5d.httpController do not.

Solution
Add TLS support to io.l5d.mesh and io.l5d.httpController, enabling
TLS for all namerd interfaces.

Validation
Added tests for MeshIfaceInitializer, MeshInterpreterInitializer,
HttpControlServiceConfig, and ThriftInterpreterInterfaceConfig.
Modified linkerd/namerd-tls and namerd/tls example configs to use
tls for mesh and http.

fixes #1191