### PR TITLE
Rewrite path using regex capture groups (#1144)

### DIFF
--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/Message.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/Message.scala
@@ -90,6 +90,12 @@ trait Request extends Message {
   def authority: String
   def path: String
   override def dup(): Request
+  def transform(
+    scheme: String = scheme,
+    method: Method = method,
+    authority: String = authority,
+    path: String = path
+  ): Request
 }
 
 object Request {
@@ -122,6 +128,15 @@ object Request {
     }
     override def authority = headers.get(Headers.Authority).getOrElse("")
     override def path = headers.get(Headers.Path).getOrElse("/")
+    override def transform(scheme: String, method: Method, authority: String, path: String) = copy(
+      Headers(
+        Headers.Scheme -> scheme,
+        Headers.Method -> method.toString,
+        Headers.Authority -> authority,
+        Headers.Path -> path
+      ),
+      stream
+    )
   }
 }
 

--- a/k8s/src/main/scala/io/buoyant/k8s/IngressCache.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/IngressCache.scala
@@ -5,7 +5,6 @@ import com.twitter.finagle.http.{Request, Response}
 import com.twitter.util._
 import java.util.concurrent.atomic.AtomicReference
 import io.buoyant.namer.RichActivity
-
 import scala.util.matching.Regex
 
 case class IngressSpec(

--- a/k8s/src/test/scala/io/buoyant/k8s/IngressCacheTest.scala
+++ b/k8s/src/test/scala/io/buoyant/k8s/IngressCacheTest.scala
@@ -9,8 +9,8 @@ class IngressCacheTest extends FunSuite with Awaits {
 
   test("on multiple path matches, return first match") {
     val paths = Seq(
-      IngressPath(host, Some("/path"), ns.get, "primary-svc", "80"),
-      IngressPath(host, Some("/path"), ns.get, "secondary-svc", "80")
+      IngressPath(host, Some("/path"), None, ns.get, "primary-svc", "80"),
+      IngressPath(host, Some("/path"), None, ns.get, "secondary-svc", "80")
     )
     val spec = IngressSpec(Some("my-ingress"), ns, None, paths)
     val matchingPath = IngressCache.getMatchingPath(host, "/path", Seq(spec))
@@ -18,32 +18,129 @@ class IngressCacheTest extends FunSuite with Awaits {
   }
 
   test("on multiple host matches, return first match") {
-    val resource1 = IngressSpec(Some("polar-bear1"), ns, None, Seq(IngressPath(host, None, ns.get, "svc1", "80")))
-    val resource2 = IngressSpec(Some("polar-bear2"), ns, None, Seq(IngressPath(host, None, ns.get, "svc2", "80")))
+    val resource1 = IngressSpec(Some("polar-bear1"), ns, None, Seq(IngressPath(host, None, None, ns.get, "svc1", "80")))
+    val resource2 = IngressSpec(Some("polar-bear2"), ns, None, Seq(IngressPath(host, None, None, ns.get, "svc2", "80")))
     val matchingPath = IngressCache.getMatchingPath(host, "/path", Seq(resource1, resource2))
     assert(matchingPath.get.svc == "svc1")
   }
 
   test("match on path regex") {
-    val path = IngressPath(host, Some("/prefix/.*"), ns.get, "svc1", "80")
-    assert(path.matches(host, "/prefix/and-other-stuff"))
+    val testCases = Map(
+      "/prefix" -> ingressPath(Some("/prefix.*")),
+      "/prefix" -> ingressPath(Some("/prefix/?.*")),
+      "/prefix/" -> ingressPath(Some("/prefix/.*")),
+      "/prefix/and-other-stuff" -> ingressPath(Some("/prefix/.*")),
+      "/path1/?foo=bar" -> ingressPath(Some("/path1/?.*")),
+      "/path1?foo=bar/" -> ingressPath(Some("/path1/?.*")),
+      "/path1/more/?foo=bar" -> ingressPath(Some("/path1/?.*"))
+    )
+    testCases foreach {
+      case (requestUri, ingressPath) =>
+        assert(ingressPath.matches(host, requestUri), s", '$requestUri' -> '${ingressPath.path.get}'")
+    }
+  }
+
+  test("match on path regex with capturing group") {
+    val testCases = Map(
+      "/prefix" -> ingressPath(Some("/prefix(.*)")),
+      "/prefix" -> ingressPath(Some("/prefix(/?.*)")),
+      "/prefix/" -> ingressPath(Some("/prefix(/?.*)")),
+      "/prefix/and-other-stuff" -> ingressPath(Some("/prefix/(.*)")),
+      "/path1/?foo=bar" -> ingressPath(Some("/path1(/?.*)")),
+      "/path1?foo=bar/" -> ingressPath(Some("/path1(/?.*)")),
+      "/path1/more/?foo=bar" -> ingressPath(Some("/path1(/?.*)"))
+    )
+    testCases foreach {
+      case (requestUri, ingressPath) =>
+        assert(ingressPath.matches(host, requestUri), s", '$requestUri' -> '${ingressPath.path.get}'")
+    }
   }
 
   test("match / with reqs that have empty paths only") {
-    val path = IngressPath(host, Some("/"), ns.get, "svc1", "80")
+    val path = IngressPath(host, Some("/"), None, ns.get, "svc1", "80")
     assert(path.matches(host, "/"))
     assert(!path.matches(host, "/foo"))
   }
 
   test("match empty string with all reqs") {
-    val path = IngressPath(host, Some(""), ns.get, "svc1", "80")
+    val path = IngressPath(host, Some(""), None, ns.get, "svc1", "80")
     assert(path.matches(host, "/"))
     assert(path.matches(host, "/foo"))
   }
 
   test("match omitted path with all reqs") {
-    val path = IngressPath(host, None, ns.get, "svc1", "80")
+    val path = IngressPath(host, None, None, ns.get, "svc1", "80")
     assert(path.matches(host, "/"))
     assert(path.matches(host, "/foo"))
   }
+
+  test("don't rewrite path when not enabled") {
+    val testCases = Map(
+      "/a/b/0" -> C("/a/b/0", ingressPath(None, None), false),
+      "/a/b/1" -> C("/a/b/1", ingressPath(Some(""), None), false),
+      "/a/b/2" -> C("/a/b/2", ingressPath(Some("/a/b/2"), None), false),
+      "/a/b/3" -> C("/a/b/3", ingressPath(Some("/a/b/3"), Some(false)), false),
+      "/a/b/4" -> C("/a/b/4", ingressPath(Some("/a/b/4"), Some(false)), true)
+    )
+
+    testCases foreach {
+      case (requestUri, C(residualUri, ingressPath, globalFlag)) =>
+        val result = ingressPath.rewrite(requestUri, globalFlag)
+        assert(result == residualUri, s", test case: $requestUri -> $residualUri, $ingressPath, $globalFlag")
+    }
+  }
+
+  test("rewrite path when enabled") {
+    val testCases = Map(
+      "/a/b/uri" -> C("/uri", ingressPath(Some("/a/b/(.*)"), Some(true)), false),
+      "/a/b/uri" -> C("/uri", ingressPath(Some("/a/b/(.*)"), Some(true)), true),
+      "/a/b/uri" -> C("/uri", ingressPath(Some("/a/b/(.*)"), None), true)
+    )
+
+    testCases foreach {
+      case (requestUri, C(residualUri, ingressPath, globalFlag)) =>
+        val result = ingressPath.rewrite(requestUri, globalFlag)
+        assert(result == residualUri, s", test case: $requestUri -> $residualUri, $ingressPath, $globalFlag")
+    }
+  }
+
+  test("rewrite path using capture groups") {
+    val testCases = Map(
+      "/nonexistent/" -> C("/", ingressPath(Some("/a/b/c"))),
+      "/a/b/c/" -> C("/", ingressPath(Some("/a/b/c"))),
+      "/a/b/c/" -> C("/a/b/c", ingressPath(Some("(/a/b/c)"))),
+
+      "/a/b/c" -> C("/c", ingressPath(Some("/a/b/(.*)"))),
+      "/a/b/1234/c" -> C("/1234/c", ingressPath(Some("/a/b/([0-9]*)/(.*)"))),
+      "/a/b/1234/c/c" -> C("/1234/c", ingressPath(Some("/a/b/([0-9]*)/c/(.*)"))),
+      "/a/b/1234/c/c/d" -> C("/1234/c", ingressPath(Some("/a/b/([0-9]*)/c/(.*)/d"))),
+
+      "/a/b/c/" -> C("/c", ingressPath(Some("/a/b(.*)"))),
+      "/a/b/c/" -> C("/c", ingressPath(Some("/a/b/(.*)"))),
+      "/a/b/c/1" -> C("/c/1", ingressPath(Some("/a/b(/.*)"))),
+      "/a/b/c/2" -> C("/c", ingressPath(Some("/a/b/(.*/)"))),
+      "/a/b/c/3" -> C("/c", ingressPath(Some("/a/b(/.*/)"))),
+      "/a/b/c/4" -> C("/", ingressPath(Some("/a/b/(/.*/)"))),
+      "/a" -> C("/", ingressPath(Some("/a(/?.*)"))),
+      "/a/" -> C("/", ingressPath(Some("/a(/?.*)"))),
+      "/a/b" -> C("/b", ingressPath(Some("/a(/?.*)"))),
+      "/a/b/" -> C("/b", ingressPath(Some("/a(/?.*)"))),
+      "/a/b/c" -> C("/b/c", ingressPath(Some("/a(/?.*)"))),
+      "/a/b/c/" -> C("/b/c", ingressPath(Some("/a(/?.*)"))),
+      "/a/b/c/d" -> C("/b/c/d", ingressPath(Some("/a(/?.*)"))),
+      "/a/b/c/d/" -> C("/b/c/d", ingressPath(Some("/a(/?.*)"))),
+      "/a/b/?foo=bar#tag" -> C("/b/?foo=bar#tag", ingressPath(Some("/a(/?.*)")))
+    )
+
+    testCases foreach {
+      case (requestUri, C(residualUri, ingressPath, globalFlag)) =>
+        val result = ingressPath.rewrite(requestUri, globalFlag)
+        assert(result == residualUri, s", test case: $requestUri -> $residualUri, $ingressPath, $globalFlag")
+    }
+  }
+
+  case class C(uri: String, ingressPath: IngressPath, useCapturingGroupsGlobal: Boolean = true)
+
+  def ingressPath(path: Option[String], useCapturingGroups: Option[Boolean] = Some(true)): IngressPath =
+    IngressPath(host, path, useCapturingGroups, ns.get, "svc1", "80")
 }

--- a/linkerd/docs/protocol-h2.md
+++ b/linkerd/docs/protocol-h2.md
@@ -251,6 +251,56 @@ Key  | Default Value | Description
 namespace | (all) | The Kubernetes namespace where the ingress resources are deployed. If not specified, linkerd will watch all namespaces.
 host | `localhost` | The Kubernetes master host.
 port | `8001` | The Kubernetes master port.
+useCapturingGroups | `false` | Enable path regular expression capturing groups feature.
+
+#### Capturing groups
+
+> This example watches all ingress resources in all namespaces and uses capturing group feature (using configuration):
+
+```yaml
+routers:
+- protocol: h2
+  identifier:
+    kind: io.l5d.ingress
+    useCapturingGroups: true
+  servers:
+  - port: 4140
+  dtab: /svc => /#/io.l5d.k8s
+
+namers:
+- kind: io.l5d.k8s
+```
+
+> An example ingress resource watched by the linkerd ingress controller (using annotation):
+
+```yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: my-first-ingress
+  namespace: default
+annotations:
+  kubernetes.io/ingress.class: "linkerd"
+  linkerd.io/use-capturing-groups: "true"
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /testpath(/?.*)
+        backend:
+          serviceName: test
+          servicePort: 80
+```
+
+> So an HTTP/2 request like `https://localhost:4140/testpath/1/abcd` would have path rewritten to `/1/abcd`
+
+Ingress path | Request path | Request path to kubernetes service
+------------ | ------------ | ----------------------------------
+`/testpath/(.+)` | `/testpath/a/b/1234` | `/a/b/1234`
+`/testpath/(.+)/b/([0-9]+)` | `/testpath/a/b/1234` | `/a/1234`
+`/testpath/(.+)/(b)/(.+)` | `/testpath/a/b/1234` | `/a/b/1234`
+`/.+/(.+)/(b)/(.+)` | `/testpath/a/b/1234` | `/a/b/1234`
+`/testpath/(.+)` | `/wrong/path` | `/`
 
 #### Identifier Path Parameters
 

--- a/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/IngressIdentifierConfigTest.scala
+++ b/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/IngressIdentifierConfigTest.scala
@@ -1,0 +1,45 @@
+package io.buoyant.linkerd.protocol.http
+
+import com.twitter.finagle.Path
+import com.twitter.finagle.util.LoadService
+import io.buoyant.config.Parser
+import io.buoyant.linkerd.IdentifierInitializer
+import org.scalatest.FunSuite
+
+class IngressIdentifierConfigTest extends FunSuite {
+
+  test("sanity") {
+    // ensure it doesn't totally blowup
+    val _ = new IngressIdentifierConfig(None, None, None, None).newIdentifier(Path.empty)
+  }
+
+  test("service registration") {
+    assert(LoadService[IdentifierInitializer].exists(_.isInstanceOf[IngressIdentifierInitializer]))
+  }
+
+  test("parse config") {
+    val yaml = s"""
+      |kind: io.l5d.ingress
+      |useCapturingGroups: true
+      |namespace: myNameSpace
+      |host: 127.0.0.1
+      |port: 6666
+      """.stripMargin
+
+    val mapper = Parser.objectMapper(yaml, Iterable(Seq(IngressIdentifierInitializer)))
+    val config = mapper.readValue[IngressIdentifierConfig](yaml)
+
+    assert(config.namespace.isDefined)
+    assert(config.namespace.get == "myNameSpace")
+
+    assert(config.host.isDefined)
+    assert(config.host.get == "127.0.0.1")
+
+    assert(config.port.isDefined)
+    assert(config.port.get.port == 6666)
+
+    assert(config.useCapturingGroups.isDefined)
+    assert(config.useCapturingGroups.get)
+  }
+
+}

--- a/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/IngressIdentifierTest.scala
+++ b/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/IngressIdentifierTest.scala
@@ -1,14 +1,13 @@
-package io.buoyant.linkerd.protocol.h2
+package io.buoyant.linkerd.protocol.http
 
 import com.twitter.finagle.buoyant.Dst
-import com.twitter.finagle.buoyant.h2._
-import com.twitter.finagle.{Service, Dtab, Path}
+import com.twitter.finagle.{Dtab, Path, Service}
 import com.twitter.io.Buf
 import com.twitter.util.Future
 import io.buoyant.router.RoutingFactory._
 import io.buoyant.test.Awaits
 import org.scalatest.FunSuite
-import com.twitter.finagle.http.{Request => FRequest, Response => FResponse}
+import com.twitter.finagle.http.{Request, RequestBuilder, Response}
 
 class IngressIdentifierTest extends FunSuite with Awaits {
 
@@ -18,7 +17,15 @@ class IngressIdentifierTest extends FunSuite with Awaits {
     "items": [{
       "kind":"Ingress",
       "apiVersion":"extensions/v1beta",
-      "metadata":{"name":"test-ingress","namespace":"fooNamespace","selfLink":"/apis/extensions/v1beta1/namespaces/srv/ingresses/test-ingress","resourceVersion":"4430527"},
+      "metadata": {
+        "name":"test-ingress",
+        "namespace":"fooNamespace",
+        "selfLink":"/apis/extensions/v1beta1/namespaces/srv/ingresses/test-ingress",
+        "resourceVersion":"4430527",
+        "annotations": {
+          "linkerd.io/use-capturing-groups": "true"
+        }
+      },
       "spec": {
         "backend": {
           "serviceName": "defaultService",
@@ -28,7 +35,7 @@ class IngressIdentifierTest extends FunSuite with Awaits {
           "host": "foo.bar.com",
           "http": {
             "paths": [{
-              "path": "/fooPath/.*",
+              "path": "(/?fooPath)(/?.*)",
               "backend": {
                 "serviceName": "fooPathService",
                 "servicePort": "fooPathPort"
@@ -56,13 +63,13 @@ class IngressIdentifierTest extends FunSuite with Awaits {
     }]
   }""")
 
-  val service = Service.mk[FRequest, FResponse] {
+  val service = Service.mk[Request, Response] {
     case req if req.uri == "/apis/extensions/v1beta1/ingresses" =>
-      val rsp = FResponse()
+      val rsp = Response()
       rsp.content = ingressListResource
       Future.value(rsp)
     case req if req.uri == "/apis/extensions/v1beta1/ingresses?watch=true" =>
-      val rsp = FResponse()
+      val rsp = Response()
       rsp.content = ingressListResource
       Future.value(rsp)
     case req =>
@@ -71,7 +78,7 @@ class IngressIdentifierTest extends FunSuite with Awaits {
 
   test("identifies requests by host, without path") {
     val identifier = new IngressIdentifier(Path.Utf8("svc"), () => Dtab.empty, None, false, service)
-    val req0 = Request("http", Method.Get, "foo.bar.com", "/penguins", Stream.empty())
+    val req0 = request("/penguins", "foo.bar.com")
     await(identifier(req0)) match {
       case IdentifiedRequest(Dst.Path(name, base, local), req1) =>
         assert(name == Path.read("/svc/fooNamespace/fooHostPort/fooHostService"))
@@ -82,7 +89,7 @@ class IngressIdentifierTest extends FunSuite with Awaits {
 
   test("identifies requests by host & path") {
     val identifier = new IngressIdentifier(Path.Utf8("svc"), () => Dtab.empty, None, false, service)
-    val req0 = Request("http", Method.Get, "foo.bar.com", "/fooPath/penguins", Stream.empty())
+    val req0 = request("/fooPath/penguins", "foo.bar.com")
     await(identifier(req0)) match {
       case IdentifiedRequest(Dst.Path(name, _, _), req1) =>
         assert(name == Path.read("/svc/fooNamespace/fooPathPort/fooPathService"))
@@ -93,7 +100,7 @@ class IngressIdentifierTest extends FunSuite with Awaits {
 
   test("falls back to the default backend") {
     val identifier = new IngressIdentifier(Path.Utf8("svc"), () => Dtab.empty, None, false, service)
-    val req0 = Request("http", Method.Get, "authority", "/", Stream.empty())
+    val req0 = request("/")
     await(identifier(req0)) match {
       case IdentifiedRequest(Dst.Path(name, _, _), req1) =>
         assert(name == Path.read("/svc/fooNamespace/defaultPort/defaultService"))
@@ -104,7 +111,7 @@ class IngressIdentifierTest extends FunSuite with Awaits {
 
   test("identifies requests by path and rewrites it using capturing groups") {
     val identifier = new IngressIdentifier(Path.Utf8("svc"), () => Dtab.empty, None, true, service)
-    val req0 = Request("http", Method.Get, "authority", "/barPath/penguins", Stream.empty())
+    val req0 = request("/barPath/penguins")
     await(identifier(req0)) match {
       case IdentifiedRequest(Dst.Path(name, _, _), req1) =>
         assert(name == Path.read("/svc/fooNamespace/barPathPort/barPathService"))
@@ -112,4 +119,10 @@ class IngressIdentifierTest extends FunSuite with Awaits {
       case id: UnidentifiedRequest[Request] => fail(s"unexpected identification: ${id.reason}")
     }
   }
+
+  def request(uri: String, host: String = ""): Request = (uri, host) match {
+    case (_, "") => RequestBuilder.create().url(s"http:///${uri.stripPrefix("/")}").buildGet()
+    case (_, _) => RequestBuilder.create().url(s"http://$host/${uri.stripPrefix("/")}").addHeader("Host", host).buildGet()
+  }
 }
+


### PR DESCRIPTION
Problem
Missing feature for ingress identifier path rewriting

Solution
Use regexp capture groups as the rewritten path segments

Validation
Unit testing

Fixes #1144