### PR TITLE
Use backticks when matching proto enum values

### DIFF
--- a/grpc/eg/src/main/protobuf/eg.proto
+++ b/grpc/eg/src/main/protobuf/eg.proto
@@ -15,7 +15,7 @@ enum Enumeration {
 
 message Message {
   enum Enumeration {
-    ZERO = 0;
+    zero = 0;
     ONE = 1;
     TWO = 2;
     THREEFOUR = 34;

--- a/grpc/gen/src/main/scala/io/buoyant/grpc/gen/Generator.scala
+++ b/grpc/gen/src/main/scala/io/buoyant/grpc/gen/Generator.scala
@@ -134,8 +134,8 @@ object Generator {
 
   private[this] def genEnum(enum: ProtoFile.EnumType, indent: String): String = {
     val decoders = enum.values.map { v => s"case ${v.number} => ${v.name}" }
-    val encoders = enum.values.map { v => s"case ${v.name} => pbos.writeEnumNoTag(${v.number})" }
-    val sizers = enum.values.map { v => s"case ${v.name} => ${PBOS}.computeEnumSizeNoTag(${v.number})" }
+    val encoders = enum.values.map { v => s"case `${v.name}` => pbos.writeEnumNoTag(${v.number})" }
+    val sizers = enum.values.map { v => s"case `${v.name}` => ${PBOS}.computeEnumSizeNoTag(${v.number})" }
 
     s"""|${indent}object ${enum.name} extends scala.Enumeration {
         |${indent}  val ${enum.values.map(_.name).mkString(", ")} = Value


### PR DESCRIPTION
Using lowercase/snakecase enum values generates variable pattern
match.

Scala 2.11 compiles the code with a warning, Scala 2.12 will throw an
error. Although proto3 style guide says to use CAPITALS_WITH_UNDERSCORES
this is not an enforced rule across proto ecosystem.

Using backticks in generated code matches variable name.