### PR TITLE
Add Path to Host identifier in PLUGINS.md

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -5,3 +5,4 @@ developed a linkerd plugin, we'd love a pull request that adds it to this list.
 
 * [linkerd-zipkin telemeter](https://github.com/linkerd/linkerd-zipkin)
 * [Open Policy Agent identifier](https://github.com/open-policy-agent/contrib/tree/master/linkerd_authz)
+* [Path to Host identifier](https://github.com/Attest/linkerd-plugins)


### PR DESCRIPTION
The Path to Host identifier sets the Host header to the first segment in
the path. This is useful when hitting linkerd directly (as opposed to
using it as an HTTP proxy). If you want to use linkerd in this mode
while hitting external services (e.g. 3rd part APIs), setting the Host
this way is mandatory or the request will fail as the Host header will
be set to your linkerd host+port and the server will likely respond with
404 Not Found.

Config example:
```
...

routers:
- ...
  identifier:
  - kind: com.askattest.pathToHost
  - ...

...
```