### PR TITLE
Add specific host transformer

### DIFF
--- a/interpreter/per-host/src/main/resources/META-INF/services/io.buoyant.namer.TransformerInitializer
+++ b/interpreter/per-host/src/main/resources/META-INF/services/io.buoyant.namer.TransformerInitializer
@@ -1,2 +1,3 @@
 io.buoyant.transformer.perHost.LocalhostTransformerInitializer
 io.buoyant.transformer.perHost.PortTransformerInitializer
+io.buoyant.transformer.perHost.SpecificHostTransformerInitializer

--- a/interpreter/per-host/src/main/scala/io/buoyant/transformer/perHost/SpecificHostTransformerInitializer.scala
+++ b/interpreter/per-host/src/main/scala/io/buoyant/transformer/perHost/SpecificHostTransformerInitializer.scala
@@ -1,0 +1,25 @@
+package io.buoyant.transformer
+package perHost
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.twitter.finagle.Path
+import io.buoyant.namer.{NameTreeTransformer, TransformerConfig, TransformerInitializer}
+import java.net.InetAddress
+
+class SpecificHostTransformerInitializer extends TransformerInitializer {
+  val configClass = classOf[SpecificHostTransformerConfig]
+  override val configId = "io.l5d.specificHost"
+}
+
+class SpecificHostTransformerConfig(host: String) extends TransformerConfig {
+  assert(host != null, "io.l5d.specificHost: host property is required")
+
+  @JsonIgnore
+  val defaultPrefix = Path.read("/io.l5d.specificHost")
+
+  @JsonIgnore
+  override def mk(): NameTreeTransformer = {
+    new SubnetLocalTransformer(prefix, Seq(InetAddress.getByName(host)), Netmask("255.255.255.255"))
+  }
+
+}

--- a/linkerd/docs/transformer.md
+++ b/linkerd/docs/transformer.md
@@ -17,7 +17,7 @@ interpreter.  Transformations are applied sequentially in the order they appear.
 
 Key | Default Value | Description
 --- | ------------- | -----------
-kind | _required_ | Either [`io.l5d.localhost`](#localhost), [`io.l5d.port`](#port), [`io.l5d.k8s.daemonset`](#daemonset-kubernetes), [`io.l5d.k8s.localnode`](#localnode-kubernetes), [`io.l5d.replace`](#replace), or [`io.l5d.const`](#const).
+kind | _required_ | Either [`io.l5d.localhost`](#localhost), [`io.l5d.specificHost`](#specific-host), [`io.l5d.port`](#port), [`io.l5d.k8s.daemonset`](#daemonset-kubernetes), [`io.l5d.k8s.localnode`](#localnode-kubernetes), [`io.l5d.replace`](#replace), or [`io.l5d.const`](#const).
 
 ## Localhost
 
@@ -27,6 +27,20 @@ The localhost transformer filters the list of addresses down to only addresses
 that have the same IP address as localhost.  The IP of localhost is determined
 by doing a one-time dns lookup of the local hostname.  This transformer can be
 used by an incoming router to only route traffic to local destinations.
+
+## Specific Host
+
+kind: `io.l5d.specificHost`
+
+The specific host transformer filters the list of addresses down to only
+addresses that have the same IP address as the specified host. This transformer
+can be used by an incoming router to only route traffic to specific
+destinations. This is useful when linkerd is running inside a Docker container
+and the traffic is to be sent to another Docker container in the same host.
+
+Key  | Default Value | Description
+---- | ------------- | -----------
+host | _required_    | The host to use.
 
 ## Port
 


### PR DESCRIPTION
**Problem**
When deploying linkerd in a linker-to-linker + per-host configuration
(i.e. one linkerd container per machine with an incoming router and
outgoing router), the incoming router needs to be able to route the
incoming request to the destination container running on the same
Docker host (i.e. machine).

The destination app container is likely to be registered against
the namer using the IP address of the Docker host it is running on and
the port that is exposed in its Docker container. The problem is that
the incoming router is unaware of the IP address of the Docker host it's
running on so won't know which of the resolved names live on the same
Docker host.

At the moment there is no transformer that can solve this problem as
`io.l5d.localhost` will only look at network interfaces inside the
Docker container while `io.l5d.k8s.daemonset` and `io.l5d.k8s.localnode`
are k8s-specific.

**Solution**
The specific host transformer filters the list of addresses down to only
addresses that have the same IP address as the specified host. This
transformer can be used by an incoming router to only route traffic to
specific destinations. This way, when linkerd is running inside a Docker
container the traffic can be routed to another Docker container in the
same host.