### PR TITLE
Fix client leak in DaemonsetTransformer

### DIFF
--- a/interpreter/k8s/src/main/scala/io/buoyant/transformer/k8s/DaemonSetTransformerInitializer.scala
+++ b/interpreter/k8s/src/main/scala/io/buoyant/transformer/k8s/DaemonSetTransformerInitializer.scala
@@ -43,7 +43,8 @@ case class DaemonSetTransformerConfig(
   @JsonIgnore
   override def mk(): NameTreeTransformer = {
     val client = mkClient(Params.empty).configured(Label("daemonsetTransformer"))
-    def mkNs(ns: String) = Api(client.newService(dst)).withNamespace(ns)
+    val api = Api(client.newService(dst))
+    def mkNs(ns: String) = api.withNamespace(ns)
     val namer = new MultiNsNamer(Path.empty, None, mkNs)
     val daemonSet = namer.bind(NameTree.Leaf(Path.Utf8(namespace, port, service)))
     if (hostNetwork.getOrElse(false))

--- a/interpreter/k8s/src/main/scala/io/buoyant/transformer/k8s/DaemonSetTransformerInitializer.scala
+++ b/interpreter/k8s/src/main/scala/io/buoyant/transformer/k8s/DaemonSetTransformerInitializer.scala
@@ -43,8 +43,7 @@ case class DaemonSetTransformerConfig(
   @JsonIgnore
   override def mk(): NameTreeTransformer = {
     val client = mkClient(Params.empty).configured(Label("daemonsetTransformer"))
-    val api = Api(client.newService(dst))
-    def mkNs(ns: String) = api.withNamespace(ns)
+    def mkNs(ns: String) = Api(client.newService(dst)).withNamespace(ns)
     val namer = new MultiNsNamer(Path.empty, None, mkNs)
     val daemonSet = namer.bind(NameTree.Leaf(Path.Utf8(namespace, port, service)))
     if (hostNetwork.getOrElse(false))

--- a/k8s/src/main/scala/io/buoyant/k8s/Ns.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/Ns.scala
@@ -60,7 +60,8 @@ abstract class Ns[O <: KubeObject: Manifest, W <: Watch[O]: Manifest, L <: KubeL
       case Some(ns) => ns
       case None =>
         val ns = mkCache(name)
-        val closable = retryToActivity { watch(name, labelSelector, ns) }
+        val resource = mkResource(name)
+        val closable = retryToActivity { watch(resource, labelSelector, ns) }
         _watches += (name -> closable)
         caches() = caches.sample + (name -> ns)
         ns
@@ -69,10 +70,14 @@ abstract class Ns[O <: KubeObject: Manifest, W <: Watch[O]: Manifest, L <: KubeL
 
   val namespaces: Var[Set[String]] = caches.map(_.keySet)
 
-  private[this] def watch(namespace: String, labelSelector: Option[String], cache: Cache): Future[Closable] = {
-    val resource = mkResource(namespace)
+  private[this] def watch(
+    resource: NsListResource[O, W, L],
+    labelSelector: Option[String],
+    cache: Cache
+  ): Future[Closable] = {
+
     Trace.letClear {
-      log.info("k8s initializing %s", namespace)
+      log.info("k8s initializing %s", resource.ns)
       resource.get().map { list =>
         cache.initialize(list)
         val (updates, closable) = resource.watch(

--- a/k8s/src/main/scala/io/buoyant/k8s/resources.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/resources.scala
@@ -72,7 +72,7 @@ private[k8s] class NsVersion[O <: KubeObject](
   def listResource[T <: O: TypeReference, W <: Watch[T]: TypeReference, L <: KubeList[T]: TypeReference](
     backoffs: Stream[Duration] = Backoff.exponentialJittered(1.milliseconds, 5.seconds),
     stats: StatsReceiver = DefaultStatsReceiver
-  )(implicit od: ObjectDescriptor[T, W]) = new NsListResource[T, W, L](client, path, backoffs, stats)
+  )(implicit od: ObjectDescriptor[T, W]) = new NsListResource[T, W, L](client, ns, path, backoffs, stats)
 }
 
 /**
@@ -151,6 +151,7 @@ private[k8s] class ListResource[O <: KubeObject: TypeReference, W <: Watch[O]: T
  */
 private[k8s] class NsListResource[O <: KubeObject: TypeReference, W <: Watch[O]: TypeReference, L <: KubeList[O]: TypeReference](
   client: Client,
+  val ns: String,
   basePath: String,
   backoffs: Stream[Duration] = Watchable.DefaultBackoff,
   stats: StatsReceiver = DefaultStatsReceiver


### PR DESCRIPTION
Fixes #1344

When initializing a watch on a k8s object, any failures will result in
recreating the resource which, in some cases, implies recreating the client.
This can leak to connection and client leaks.

We create the resource once, and reuse it for any potential retries.