### PR TITLE
Reconcile namerd config docs and code (#1357)

### DIFF
--- a/namerd/core/src/main/scala/io/buoyant/namerd/NamerdConfig.scala
+++ b/namerd/core/src/main/scala/io/buoyant/namerd/NamerdConfig.scala
@@ -17,11 +17,10 @@ import scala.util.control.NoStackTrace
 private[namerd] case class NamerdConfig(
   admin: Option[AdminConfig],
   storage: DtabStoreConfig,
-  namers: Seq[NamerConfig],
+  namers: Option[Seq[NamerConfig]],
   interfaces: Seq[InterfaceConfig],
   telemetry: Option[Seq[TelemeterConfig]]
 ) {
-  require(namers != null, "'namers' field is required")
   require(interfaces != null, "'interfaces' field is required")
   require(interfaces.nonEmpty, "One or more interfaces must be specified")
   import NamerdConfig._
@@ -72,7 +71,7 @@ private[namerd] case class NamerdConfig(
   }
 
   private[this] def mkNamers(params: Stack.Params): Map[Path, Namer] =
-    namers.foldLeft(Map.empty[Path, Namer]) {
+    namers.getOrElse(Nil).foldLeft(Map.empty[Path, Namer]) {
       case (namers, config) =>
         if (config.prefix.isEmpty)
           throw NamerdConfig.EmptyNamerPrefix

--- a/namerd/core/src/test/scala/io/buoyant/namerd/NamerdConfigTest.scala
+++ b/namerd/core/src/test/scala/io/buoyant/namerd/NamerdConfigTest.scala
@@ -34,23 +34,29 @@ class NamerdConfigTest extends FunSuite {
     """.stripMargin
 
     val config = NamerdConfig.loadNamerd(yaml, initializers)
-    assert(config.namers.head.prefix == Path.read("/#/io.l5d.fs"))
+    assert(config.namers.get.head.prefix == Path.read("/#/io.l5d.fs"))
     assert(config.interfaces.head.addr.getAddress.isLoopbackAddress)
     assert(config.interfaces.head.addr.getPort == 1)
     // just check that this don't blow up
     val _ = config.mk()
   }
 
-  test("missing namers validation") {
-    val missingNamers =
-      """
-        |storage:
-        |  kind: io.buoyant.namerd.TestDtabStore
-      """.stripMargin
-    val namerEx = intercept[JsonMappingException] {
-      NamerdConfig.loadNamerd(missingNamers, initializers)
-    }
-    assert(namerEx.getMessage.contains("'namers' field is required"))
+  test("parse minimal namerd config") {
+    val yaml = """
+      |storage:
+      |  kind: io.buoyant.namerd.TestDtabStore
+      |interfaces:
+      |- kind: test
+      |  ip: 127.0.0.1
+      |  port: 1
+    """.stripMargin
+
+    val config = NamerdConfig.loadNamerd(yaml, initializers)
+    assert(config.namers == None)
+    assert(config.interfaces.head.addr.getAddress.isLoopbackAddress)
+    assert(config.interfaces.head.addr.getPort == 1)
+    // just check that this don't blow up
+    val _ = config.mk()
   }
 
   test("missing interfaces validation") {

--- a/namerd/docs/config.md
+++ b/namerd/docs/config.md
@@ -35,7 +35,7 @@ The configuration may be specified as a JSON or YAML object.
 Key | Required | Description
 --- | -------- | -----------
 [admin](#administrative-interface) | no | Configures namerd's administrative interface. namerd admin has the same options as linkerd admin.
-[interfaces](#interfaces) | no | Configures namerd's published network interfaces.
+[interfaces](#interfaces) | yes | Configures namerd's published network interfaces.
 [storage](#storage) | yes | Configures namerd's storage backend.
 [namers](https://linkerd.io/config/head/linkerd#namers) | no | Configures namerd's integration with various service discovery backends. namerd uses the same namers as linkerd.
 [telemetry](https://linkerd.io/config/head/linkerd#telemetry) | no | Configures namerd's metrics instrumentation. Namerd does not support tracing, so tracers provided by telemeters are ignored.

--- a/namerd/examples/minimal.yaml
+++ b/namerd/examples/minimal.yaml
@@ -1,0 +1,5 @@
+# example config demonstrating the minimal set of namerd config keys required
+storage:
+  kind: io.l5d.inMemory
+interfaces:
+- kind: io.l5d.httpController


### PR DESCRIPTION
Problem
Namerd configs require 'interfaces' and 'namers' sections. The docs say
they are optional.

Solution
Make the `namers` section optional, and fix the docs to indicate
'interfaces' is required.

Validation
Test updates, added a minimal.yaml namerd config.

Fixes #1357