### PR TITLE
Document the io.l5d.mesh interface private key format

### DIFF
--- a/namerd/docs/interface.md
+++ b/namerd/docs/interface.md
@@ -18,7 +18,7 @@ Key | Default Value | Description
 kind | _required_ | Either [`io.l5d.thriftNameInterpreter`](#thrift-name-interpreter), [`io.l5d.mesh`](#grpc-mesh-interface), or [`io.l5d.httpController`](#http-controller).
 ip | interface dependent | The local IP address on which to serve the namer interface.
 port | interface dependent | The port number on which to server the namer interface.
-tls | no tls | The namer interface will serve over TLS if this parameter is provided. see [Server TLS](https://linkerd.io/config/head/linkerd#server-tls).
+tls | no tls | The namer interface will serve over TLS if this parameter is provided. See [Server TLS](https://linkerd.io/config/head/linkerd#server-tls).
 
 ## Thrift Name Interpreter
 
@@ -35,7 +35,7 @@ port | `4100` | The port number on which to server the namer interface.
 retryBaseSecs | `600` | Base number of seconds to tell clients to wait before retrying after an error.
 retryJitterSecs | `60` | Maximum number of seconds to jitter retry time by.
 cache | see [cache](#cache) | Binding and address cache size configuration.
-tls | no tls | The namer interface will serve over TLS if this parameter is provided. see [Server TLS](https://linkerd.io/config/head/linkerd#server-tls).
+tls | no tls | The namer interface will serve over TLS if this parameter is provided. See [Server TLS](https://linkerd.io/config/head/linkerd#server-tls).
 
 ### Cache
 
@@ -58,7 +58,7 @@ Key | Default Value | Description
 --- | ------------- | -----------
 ip | `0.0.0.0` | The local IP address on which to serve the namer interface.
 port | `4321` | The port number on which to server the namer interface.
-tls | no tls | The namer interface will serve over TLS if this parameter is provided. see [Server TLS](https://linkerd.io/config/head/linkerd#server-tls).
+tls | no tls | The namer interface will serve over TLS if this parameter is provided. See [Server TLS](https://linkerd.io/config/head/linkerd#server-tls). The server TLS key file must be in PKCS#8 format.
 
 ## Http Controller
 
@@ -75,7 +75,7 @@ Key | Default Value | Description
 --- | ------------- | -----------
 ip | loopback | The local IP address on which to serve the namer interface.
 port | `4180` | The port number on which to serve the namer interface.
-tls | no tls | The namer interface will serve over TLS if this parameter is provided. see [Server TLS](https://linkerd.io/config/head/linkerd#server-tls).
+tls | no tls | The namer interface will serve over TLS if this parameter is provided. See [Server TLS](https://linkerd.io/config/head/linkerd#server-tls).
 
 ### GET /api/1/dtabs
 


### PR DESCRIPTION
## Problem

Unlike the `io.l5d.namerd` and `io.l5d.namerd.http` interfaces, namerd's `io.l5d.mesh` interface cannot be configured with a PKCS#1 private key. This is due to the interface using netty4 to serve gRPC requests.

## Solution

Specify the format of the key that's required as part of the `io.l5d.mesh` interface documentation.