### PR TITLE
Generated pb case statements not camelized enough

### DIFF
--- a/grpc/eg/src/main/protobuf/eg.proto
+++ b/grpc/eg/src/main/protobuf/eg.proto
@@ -23,7 +23,7 @@ message Message {
 
   Enumeration enumeration = 1;
   oneof result {
-    base.Unit ok = 2;
+    base.Unit ok_response = 2;
     base.Exception exception = 3;
   }
 

--- a/grpc/gen/src/main/scala/io/buoyant/grpc/gen/Generator.scala
+++ b/grpc/gen/src/main/scala/io/buoyant/grpc/gen/Generator.scala
@@ -403,7 +403,7 @@ object Generator {
 
       case FieldArg(name, typ, _, _, Right(o)) =>
         val fieldWriters = o.fields.map { f =>
-          val ftyp = s"${typ}.`${upperHead(f.name)}`"
+          val ftyp = s"${typ}.`${snakeToUpperCamel(f.name)}`"
           val writer = genWriteKind(f, translateType, "value", s"${indent}      ")
           s"""|${indent}    case Some(${ftyp}(value)) =>
               |${writer}""".stripMargin
@@ -448,7 +448,7 @@ object Generator {
 
       case FieldArg(name, typ, _, _, Right(o)) =>
         val fieldSizes = o.fields.map { f =>
-          val ftyp = s"${typ}.${upperHead(f.name)}"
+          val ftyp = s"${typ}.${snakeToUpperCamel(f.name)}"
           val sizeOf = genComputeSizeTagged(f, "value", translateType)
           s"""|${indent}    case Some(${ftyp}(value)) =>
               |${indent}      val sz = ${sizeOf}


### PR DESCRIPTION
Problem:

protobuf fields that 1) are defined as part of a `oneof` and 2) have underscores in their name
do not compile when generated:

```
[error] /Users/esbie/workspace/linkerd/grpc/eg/target/scala-2.12/src_managed/main/compiled_protobuf/io/buoyant/eg/Eg.pb.scala:215: value Ok_response is not a member of object io.buoyant.eg.Eg.Message.OneofResult
[error]           case Some(Message.OneofResult.`Ok_response`(value)) =>
[error]                                         ^
[error] /Users/esbie/workspace/linkerd/grpc/eg/target/scala-2.12/src_managed/main/compiled_protobuf/io/buoyant/eg/Eg.pb.scala:248: value Ok_response is not a member of object io.buoyant.eg.Eg.Message.OneofResult
[error]           case Some(Message.OneofResult.Ok_response(value)) =>
[error]                                         ^
[error] two errors found
```

Solution: Add more camels
Validation: Added to EgTest