### PR TITLE
Port namerd http and thrift to netty4 (#1240)

### DIFF
--- a/interpreter/namerd/src/main/scala/io/buoyant/namerd/iface/NamerdHttpInterpreterInitializer.scala
+++ b/interpreter/namerd/src/main/scala/io/buoyant/namerd/iface/NamerdHttpInterpreterInitializer.scala
@@ -83,7 +83,7 @@ case class NamerdHttpInterpreterConfig(
     val tlsParams = tls.map(_.params).getOrElse(Stack.Params.empty)
 
     val client = Http.client
-      .withParams(Http.client.params ++ tlsParams ++ params)
+      .withParams(Http.client.params ++ tlsParams ++ params + Http.Netty4Impl)
       .withSessionQualifier.noFailFast
       .withSessionQualifier.noFailureAccrual
       .withStreaming(true)

--- a/interpreter/namerd/src/main/scala/io/buoyant/namerd/iface/NamerdInterpreterInitializer.scala
+++ b/interpreter/namerd/src/main/scala/io/buoyant/namerd/iface/NamerdInterpreterInitializer.scala
@@ -107,7 +107,7 @@ case class NamerdInterpreterConfig(
     val tlsParams = tls.map(_.params).getOrElse(Stack.Params.empty)
 
     val client = ThriftMux.client
-      .withParams(ThriftMux.client.params ++ tlsParams ++ params)
+      .withParams(ThriftMux.client.params ++ tlsParams ++ params + Thrift.ThriftImpl.Netty4)
       .transformed(retryTransformer)
       .withSessionQualifier.noFailFast
       .withSessionQualifier.noFailureAccrual

--- a/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/HttpControlServiceConfig.scala
+++ b/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/HttpControlServiceConfig.scala
@@ -16,7 +16,11 @@ class HttpControlServiceConfig extends InterpreterInterfaceConfig {
     stats: StatsReceiver
   ): Servable = {
     val iface = new HttpControlService(store, delegate, namers)
-    val params = tlsParams + param.Stats(stats) + param.Label(HttpControlServiceConfig.kind)
+    val params =
+      tlsParams +
+        param.Stats(stats) +
+        param.Label(HttpControlServiceConfig.kind) +
+        Http.Netty4Impl
 
     HttpControlServable(addr, iface, params)
   }

--- a/namerd/iface/interpreter-thrift/src/main/scala/io/buoyant/namerd/iface/ThriftInterpreterInterfaceConfig.scala
+++ b/namerd/iface/interpreter-thrift/src/main/scala/io/buoyant/namerd/iface/ThriftInterpreterInterfaceConfig.scala
@@ -2,7 +2,7 @@ package io.buoyant.namerd.iface
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.twitter.finagle.stats.StatsReceiver
-import com.twitter.finagle.{Namer, Path, Stack, ThriftMux}
+import com.twitter.finagle.{Namer, Path, Stack, Thrift, ThriftMux}
 import com.twitter.finagle.naming.NameInterpreter
 import com.twitter.finagle.param
 import com.twitter.scrooge.ThriftService
@@ -41,7 +41,11 @@ case class ThriftInterpreterInterfaceConfig(
       cache.map(_.capacity).getOrElse(ThriftNamerInterface.Capacity.default),
       stats
     )
-    val params = tlsParams + param.Stats(stats) + param.Label(ThriftInterpreterInterfaceConfig.kind)
+    val params =
+      tlsParams +
+        param.Stats(stats) +
+        param.Label(ThriftInterpreterInterfaceConfig.kind) +
+        Thrift.ThriftImpl.Netty4
     ThriftServable(addr, iface, params)
   }
 }


### PR DESCRIPTION
Problem
Namerd's http control and thrift servers, and client interpreters, use netty3.

Solution
Port NamerdHttpInterpreterInitializer, NamerdInterpreterInitializer,
HttpControlService, and ThriftInterpreterInterface servers to netty4.

Validation
linkerd-examples/namerd-tls + namerd-examples/tls

fixes #1240