### PR TITLE
namerd and admin default to loopback (#1365)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## In the next release...
+
+* **Breaking Change**: `io.l5d.mesh`, `io.l5d.thriftNameInterpreter`, linkerd
+  admin, and namerd admin now serve on 127.0.0.1 by default (instead of
+  0.0.0.0).
+
 ## 1.1.3 2017-08-09
 
 The 1.1.3 release of Linkerd is mostly focused on improving our HTTP/2 support,

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/Linker.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/Linker.scala
@@ -16,7 +16,7 @@ import io.buoyant.namer.Param.Namers
 import io.buoyant.namer._
 import io.buoyant.telemetry._
 import io.buoyant.telemetry.admin.{AdminMetricsExportTelemeter, histogramSnapshotInterval}
-import java.net.InetSocketAddress
+import java.net.{InetAddress, InetSocketAddress}
 import scala.util.control.NoStackTrace
 
 /**
@@ -34,7 +34,7 @@ trait Linker {
 object Linker {
   private[this] val log = Logger()
 
-  private[this] val DefaultAdminAddress = new InetSocketAddress(9990)
+  private[this] val DefaultAdminAddress = new InetSocketAddress(InetAddress.getLoopbackAddress, 9990)
   private[this] val DefaultAdminConfig = AdminConfig()
 
   private[linkerd] case class Initializers(

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/LinkerTest.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/LinkerTest.scala
@@ -231,7 +231,7 @@ class LinkerTest extends FunSuite with Exceptions {
   test("with admin") {
     val yaml =
       """|admin:
-         |  ip: 127.0.0.1
+         |  ip: 0.0.0.0
          |  port: 42000
          |routers:
          |- protocol: plain
@@ -239,7 +239,7 @@ class LinkerTest extends FunSuite with Exceptions {
          |  - port: 1
          |""".stripMargin
     val linker = parse(yaml)
-    assert(linker.admin.address.asInstanceOf[InetSocketAddress].getHostString == "127.0.0.1")
+    assert(linker.admin.address.asInstanceOf[InetSocketAddress].getHostString == "0.0.0.0")
     assert(linker.admin.address.asInstanceOf[InetSocketAddress].getPort == 42000)
   }
 
@@ -251,7 +251,7 @@ class LinkerTest extends FunSuite with Exceptions {
         |  - port: 1
         |""".stripMargin
     val linker = parse(yaml)
-    assert(linker.admin.address.asInstanceOf[InetSocketAddress].getHostString == "0.0.0.0")
+    assert(linker.admin.address.asInstanceOf[InetSocketAddress].getHostString == "localhost")
     assert(linker.admin.address.asInstanceOf[InetSocketAddress].getPort == 9990)
   }
 

--- a/namerd/core/src/main/scala/io/buoyant/namerd/NamerdConfig.scala
+++ b/namerd/core/src/main/scala/io/buoyant/namerd/NamerdConfig.scala
@@ -11,7 +11,7 @@ import io.buoyant.config.{ConfigError, ConfigInitializer, Parser}
 import io.buoyant.namer.{NamerConfig, NamerInitializer, TransformerInitializer}
 import io.buoyant.telemetry._
 import io.buoyant.telemetry.admin.{AdminMetricsExportTelemeter, histogramSnapshotInterval}
-import java.net.InetSocketAddress
+import java.net.{InetAddress, InetSocketAddress}
 import scala.util.control.NoStackTrace
 
 private[namerd] case class NamerdConfig(
@@ -94,7 +94,7 @@ private[namerd] case class NamerdConfig(
 private[namerd] object NamerdConfig {
   private val log = Logger()
 
-  private def DefaultAdminAddress = new InetSocketAddress(9991)
+  private def DefaultAdminAddress = new InetSocketAddress(InetAddress.getLoopbackAddress, 9991)
   private def DefaultAdminConfig = AdminConfig()
 
   case class ConflictingNamers(prefix0: Path, prefix1: Path) extends ConfigError {

--- a/namerd/iface/interpreter-thrift/src/main/scala/io/buoyant/namerd/iface/ThriftInterpreterInterfaceConfig.scala
+++ b/namerd/iface/interpreter-thrift/src/main/scala/io/buoyant/namerd/iface/ThriftInterpreterInterfaceConfig.scala
@@ -10,7 +10,7 @@ import com.twitter.util.Duration
 import com.twitter.util.TimeConversions._
 import io.buoyant.namerd.iface.ThriftNamerInterface.LocalStamper
 import io.buoyant.namerd._
-import java.net.InetSocketAddress
+import java.net.{InetAddress, InetSocketAddress}
 import scala.util.Random
 
 case class ThriftInterpreterInterfaceConfig(
@@ -53,7 +53,7 @@ case class ThriftInterpreterInterfaceConfig(
 
 object ThriftInterpreterInterfaceConfig {
   val kind = "io.l5d.thriftNameInterpreter"
-  val defaultAddr = new InetSocketAddress(4100)
+  val defaultAddr = new InetSocketAddress(InetAddress.getLoopbackAddress, 4100)
 }
 
 class ThriftInterpreterInterfaceInitializer extends InterfaceInitializer {

--- a/namerd/iface/mesh/src/main/scala/io/buoyant/namerd/iface/MeshIfaceInitializer.scala
+++ b/namerd/iface/mesh/src/main/scala/io/buoyant/namerd/iface/MeshIfaceInitializer.scala
@@ -11,7 +11,7 @@ import com.twitter.util.Duration
 import com.twitter.util.TimeConversions._
 import io.buoyant.grpc.runtime.ServerDispatcher
 import io.netty.handler.ssl.ApplicationProtocolNames
-import java.net.InetSocketAddress
+import java.net.{InetAddress, InetSocketAddress}
 
 class MeshIfaceConfig extends InterfaceConfig {
   @JsonIgnore
@@ -51,7 +51,7 @@ class MeshIfaceConfig extends InterfaceConfig {
 
 object MeshIfaceInitializer {
   val kind = "io.l5d.mesh"
-  val defaultAddr = new InetSocketAddress(4321)
+  val defaultAddr = new InetSocketAddress(InetAddress.getLoopbackAddress, 4321)
 }
 
 class MeshIfaceInitializer extends InterfaceInitializer {


### PR DESCRIPTION
Problem
`io.l5d.mesh`, `io.l5d.thriftNameInterpreter`, linkerd admin, and namerd
admin all default to listening on 0.0.0.0.

Solution
Modify the default address to be 127.0.0.1

Validation
Ran namerd-examples/tls in docker, linkerd-examples/namerd-tls on
localhost, confirmed that tls.yaml required `0.0.0.0` to be set for
connection to succeed.

Fixes #1365