### PR TITLE
Reset h2 streams when frames cannot be received (#1346)

### DIFF
--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4StreamTransport.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4StreamTransport.scala
@@ -472,11 +472,17 @@ private[h2] trait Netty4StreamTransport[SendMsg <: Message, RecvMsg <: Message] 
 
           case Open(remote@RemoteStreaming()) =>
             if (recvFrame(toFrame(data), remote)) true
-            else recv(data)
+            else {
+              if (resetFromLocal(remote, Reset.Closed)) false
+              else recv(data)
+            }
 
           case LocalClosed(remote@RemoteStreaming()) =>
             if (recvFrame(toFrame(data), remote)) true
-            else recv(data)
+            else {
+              if (resetFromLocal(remote, Reset.Closed)) false
+              else recv(data)
+            }
         }
     }
   }


### PR DESCRIPTION
## Problem

If a linkerd h2 connection receives a data frame from the remote and is unable to accept it due to the local frame queue already being reset, it falls into a recursive infinite loop trying to accept the frame.

## Solution

Instead of retrying on failure, send a reset frame back to the remote so that it will not continue to send frames.

## Validation

I wasn't able to write a test that tests for this behavior, unfortunately. I did validate the fix using the repro steps provided in #1346. Previously, when the error occurred, the logs looked like this:

```
TRACE 0608 16:19:40.668 PDT finagle/netty4-1: 
----------------INBOUND--------------------
[id: 0x51fe5688, L:/127.0.0.1:55756 - R:/127.0.0.1:5003] DATA: streamId=5, padding=0, endStream=false, length=22, bytes=0000000011220f0a0d080012047f000001188e272200
------------------------------------
D 0608 23:19:40.668 UTC THREAD95: [C L:/127.0.0.1:55756 R:/127.0.0.1:5003 S:5] remote offer failed
D 0608 23:19:40.668 UTC THREAD95: [C L:/127.0.0.1:55756 R:/127.0.0.1:5003 S:5] remote offer failed
D 0608 23:19:40.668 UTC THREAD95: [C L:/127.0.0.1:55756 R:/127.0.0.1:5003 S:5] remote offer failed
D 0608 23:19:40.668 UTC THREAD95: [C L:/127.0.0.1:55756 R:/127.0.0.1:5003 S:5] remote offer failed
D 0608 23:19:40.668 UTC THREAD95: [C L:/127.0.0.1:55756 R:/127.0.0.1:5003 S:5] remote offer failed
...
```

With this fix in place, the remote offer only fails once before the stream is reset:

```
TRACE 0608 16:19:40.668 PDT finagle/netty4-1: 
----------------INBOUND--------------------
[id: 0x51fe5688, L:/127.0.0.1:55756 - R:/127.0.0.1:5003] DATA: streamId=5, padding=0, endStream=false, length=22, bytes=0000000011220f0a0d080012047f000001188e272200
------------------------------------
D 0608 23:19:40.668 UTC THREAD95: [C L:/127.0.0.1:55756 R:/127.0.0.1:5003 S:5] remote offer failed
D 0608 23:19:40.669 UTC THREAD95 TraceId:b8c136e130f20843: [C L:/127.0.0.1:55756 R:/127.0.0.1:5003 S:5] stream reset from local; resetting remote
TRACE 0608 16:19:40.672 PDT finagle/netty4-1: 
----------------OUTBOUND--------------------
[id: 0x51fe5688, L:/127.0.0.1:55756 - R:/127.0.0.1:5003] RST_STREAM: streamId=5, errorCode=5
------------------------------------
```

## Open Question

It's surprising (to me) that we ever end up in a state where the local frame queue has been reset, but the remote stream has not been reset and continues to send frames. This situation happens when the [`failOnInterrupt` handler](https://github.com/linkerd/linkerd/blob/master/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/Stream.scala#L83) fires, which occurs when we destroy a client that's been configured with a namerd h2 watch (`io.l5d.mesh` interpreter). We destroy clients if they're idle or if we've run out of room in the client cache. Maybe we should update the `failOnInterrupt` handler to also reset the stream at the time that it is interrupted?

Fixes #1346.