### PR TITLE
Add Istio namer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 * Add TLS support for `io.l5d.httpController` and `io.l5d.mesh`.
 * Add support for HTTP/2 tracing.
 * Cache dtab observations in the io.l5d.consul store.
+* Add Istio namer that uses Istio-Manager's Service Discovery Service.
 
 ## 1.0.2 2017-05-12
 

--- a/k8s/src/main/scala/io/buoyant/k8s/ClientConfig.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/ClientConfig.scala
@@ -8,7 +8,10 @@ import com.twitter.finagle.{Http, Stack}
  * produce a k8s API client.
  */
 trait ClientConfig {
-  import ClientConfig._
+
+  protected val DefaultHost = "localhost"
+  protected val DefaultNamespace = "default"
+  protected val DefaultPort = 8001
 
   def host: Option[String]
   def portNum: Option[Int]
@@ -28,10 +31,4 @@ trait ClientConfig {
       .withStreaming(true)
       .filtered(setHost)
   }
-}
-
-object ClientConfig {
-  val DefaultHost = "localhost"
-  val DefaultNamespace = "default"
-  val DefaultPort = 8001
 }

--- a/k8s/src/main/scala/io/buoyant/k8s/IstioNamer.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/IstioNamer.scala
@@ -6,11 +6,11 @@ import com.twitter.finagle.util.DefaultTimer
 import com.twitter.util.{Activity, Duration, Timer, Var}
 
 /**
-  * The Istio namer reads service discovery information from the Istio-Manager's Service Discvoery
-  * Service API.
-  * https://lyft.github.io/envoy/docs/configuration/cluster_manager/sds_api.html
-  * Each lookup is backed by a polling loop.
-  */
+ * The Istio namer reads service discovery information from the Istio-Manager's Service Discvoery
+ * Service API.
+ * https://lyft.github.io/envoy/docs/configuration/cluster_manager/sds_api.html
+ * Each lookup is backed by a polling loop.
+ */
 class IstioNamer(
   sdsClient: SdsClient,
   idPrefix: Path,

--- a/k8s/src/main/scala/io/buoyant/k8s/IstioNamer.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/IstioNamer.scala
@@ -1,0 +1,79 @@
+package io.buoyant.k8s
+
+import com.twitter.conversions.time._
+import com.twitter.finagle._
+import com.twitter.finagle.util.DefaultTimer
+import com.twitter.util.{Activity, Duration, Timer, Var}
+
+/**
+  * The Istio namer reads service discovery information from the Istio-Manager's Service Discvoery
+  * Service API.
+  * https://lyft.github.io/envoy/docs/configuration/cluster_manager/sds_api.html
+  * Each lookup is backed by a polling loop.
+  */
+class IstioNamer(
+  sdsClient: SdsClient,
+  idPrefix: Path,
+  pollInterval: Duration = 5.seconds
+)(implicit timer: Timer = DefaultTimer.twitter) extends Namer {
+
+  private[this] val PrefixLen = 4
+  private[this] val LabelPattern = """(.*):(.*)""".r
+
+  /**
+   * Accepts names in the form:
+   *   /<namespace>/<port-name>/<svc-name>/<labels>/residual/path
+   *
+   * and initiates a polling loop against the SDS API.  The labels segment must be a :: delimited
+   * list of label:value pairs.  To avoid duplication, the labels must be in alphabetical order
+   * by label name.  e.g.
+   *
+   * /default/http/foo/az:us-west::env:prod::version:v1
+   *
+   * Use :: alone to specify an empty list of labels
+   *
+   * /default/http/foo/::
+   */
+  def lookup(path: Path): Activity[NameTree[Name]] = {
+    val id = path.take(PrefixLen) match {
+      case Path.Utf8(segments@_*) => Path.Utf8(segments.map(_.toLowerCase): _*)
+    }
+    id match {
+      case Path.Utf8(nsName, portName, serviceName, labels) =>
+        val residual = path.drop(PrefixLen)
+
+        val selectors = labels.split("::").collect {
+          case LabelPattern(key, value) => key -> value
+        }.toMap
+
+        log.debug("SDS lookup: %s %s", id.show, residual.show)
+
+        val vaddr = sdsClient.watch(nsName, portName, serviceName, selectors, pollInterval).run.map {
+          case Activity.Ok(rsp) =>
+            Addr.Bound(rsp.hosts.map { host =>
+              Address(host.ip_address, host.port)
+            }.toSet)
+          case Activity.Pending =>
+            Addr.Pending
+          case Activity.Failed(e) =>
+            Addr.Failed(e)
+        }
+
+        // it's okay, scalac.  We all need a little help sometimes.
+        val state: Var[Activity.State[NameTree[Name]]] = vaddr.map {
+          case Addr.Bound(addrs, _) if addrs.isEmpty =>
+            Activity.Ok(NameTree.Neg)
+          case Addr.Bound(addrs, _) =>
+            Activity.Ok(NameTree.Leaf(Name.Bound(vaddr, id, residual)))
+          case Addr.Pending =>
+            Activity.Pending
+          case Addr.Failed(_) =>
+            Activity.Ok(NameTree.Neg)
+        }
+
+        Activity(state)
+      case _ =>
+        Activity.value(NameTree.Neg)
+    }
+  }
+}

--- a/k8s/src/main/scala/io/buoyant/k8s/SdsClient.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/SdsClient.scala
@@ -1,0 +1,58 @@
+package io.buoyant.k8s
+
+import com.twitter.finagle.Service
+import com.twitter.finagle.http.{Request, Response}
+import com.twitter.finagle.util.DefaultTimer
+import com.twitter.logging.Logger
+import com.twitter.util._
+import io.buoyant.config.Parser
+import io.buoyant.k8s.SdsClient.SdsResponse
+
+/**
+  * A client for talking to the Service Discovery Service.
+  * https://lyft.github.io/envoy/docs/configuration/cluster_manager/sds_api.html
+  */
+class SdsClient(client: Service[Request, Response], clusterSuffix: String = "svc.cluster.local") {
+
+  private[this] val log = Logger()
+
+  private[this] val mapper = Parser.jsonObjectMapper(Nil)
+
+  def get(ns: String, port: String, service: String, labels: Map[String, String]): Future[SdsResponse] = {
+    val selectors = Seq(port) ++ labels.map { case (k, v) => s"$k=$v" }
+    val req = Request(s"/v1/registration/$service.$ns.$clusterSuffix|${selectors.mkString("|")}")
+    client(req).map { rsp =>
+      mapper.readValue[SdsResponse](rsp.contentString)
+    }
+  }
+
+  def watch(
+    ns: String,
+    port: String,
+    service: String,
+    labels: Map[String, String],
+    pollInterval: Duration
+  )(implicit timer: Timer = DefaultTimer.twitter): Activity[SdsResponse] = {
+    val state = Var.async[Activity.State[SdsResponse]](Activity.Pending) { update =>
+
+      def doUpdate() = get(ns, port, service, labels).respond {
+        case Return(rsp) => update.update(Activity.Ok(rsp))
+        case Throw(e) =>
+          log.error(e, "SDS update failed")
+          update.update(Activity.Failed(e))
+      }
+
+      val _ = doUpdate()
+
+      timer.schedule(pollInterval) {
+        val _ = doUpdate()
+      }
+    }
+    Activity(state)
+  }
+}
+
+object SdsClient {
+  case class SdsResponse(hosts: Seq[SdsEndpoint])
+  case class SdsEndpoint(ip_address: String, port: Int)
+}

--- a/k8s/src/main/scala/io/buoyant/k8s/SdsClient.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/SdsClient.scala
@@ -9,9 +9,9 @@ import io.buoyant.config.Parser
 import io.buoyant.k8s.SdsClient.SdsResponse
 
 /**
-  * A client for talking to the Service Discovery Service.
-  * https://lyft.github.io/envoy/docs/configuration/cluster_manager/sds_api.html
-  */
+ * A client for talking to the Service Discovery Service.
+ * https://lyft.github.io/envoy/docs/configuration/cluster_manager/sds_api.html
+ */
 class SdsClient(client: Service[Request, Response], clusterSuffix: String = "svc.cluster.local") {
 
   private[this] val log = Logger()

--- a/linkerd/docs/namer.md
+++ b/linkerd/docs/namer.md
@@ -439,7 +439,52 @@ port-name | yes | The port name.
 svc-name | yes | The name of the service.
 label-value | yes if `labelSelector` is defined | The label value used to filter services.
 
+### Istio Configuration
 
+> Configure an Istio namer
+
+```yaml
+namers:
+- kind: io.l5d.k8s.istio
+  experimental: true
+  host: istio-manager.default.svc.cluster.local
+  port: 8080
+  pollIntervalMs: 5000
+```
+
+> Then reference the namer in the dtab to use it:
+
+```
+dtab: |
+  /svc/reviews => /#/io.l5d.k8s.istio/prod/http/reviews/version:v1;
+```
+
+The [Istio](https://istio.io/) namer uses the Istio-Manager's Service Discovery Service to lookup
+the endpoints for a given namespace, port, service, and list of label selectors.
+
+Key | Default Value | Description
+--- | ------------- | -----------
+prefix | `io.l5d.k8s.istio` | Resolves names with `/#/<prefix>`.
+experimental | _required_ | Because this namer is still considered experimental, you must set this to `true` to use it.
+host | `istio-manager.default.svc.cluster.local` | The host of the Istio-Manager.
+port | `8080` | The port of the Istio-Manager.
+pollIntervalMs | 5 seconds | How frequently to poll the SDS, in milliseconds.
+
+### Istio Path Parameters
+
+> Dtab Path Format
+
+```yaml
+/#/<prefix>/<namespace>/<port-name>/<svc-name>/<labels>
+```
+
+Key | Required | Description
+--- | -------- | -----------
+prefix | yes | Tells linkerd to resolve the request path using the Istio namer.
+namespace | yes | The Kubernetes namespace.
+port-name | yes | The port name.
+svc-name | yes | The name of the service.
+labels | yes | A `::` delimited list of `label:value` pairs.  Only endpoints that match all of these label selectors will be returned.
 
 <a name="marathon"></a>
 ## Marathon service discovery

--- a/linkerd/examples/istio.yaml
+++ b/linkerd/examples/istio.yaml
@@ -1,0 +1,14 @@
+namers:
+- kind: io.l5d.k8s.istio
+  host: localhost
+  port: 8080
+
+routers:
+- protocol: http
+  dtab:
+    /svc/v1 => /#/io.l5d.k8s.istio/default/http/reviews/version:v1;
+    /svc/v2 => /#/io.l5d.k8s.istio/default/http/reviews/version:v2;
+    /svc/v3 => /#/io.l5d.k8s.istio/default/http/reviews/version:v3;
+    /svc/all => /#/io.l5d.k8s.istio/default/http/reviews/::;
+  servers:
+  - port: 4140

--- a/linkerd/examples/istio.yaml
+++ b/linkerd/examples/istio.yaml
@@ -1,5 +1,6 @@
 namers:
 - kind: io.l5d.k8s.istio
+  experimental: true
   host: localhost
   port: 8080
 

--- a/namer/k8s/src/main/resources/META-INF/services/io.buoyant.namer.NamerInitializer
+++ b/namer/k8s/src/main/resources/META-INF/services/io.buoyant.namer.NamerInitializer
@@ -1,3 +1,4 @@
 io.buoyant.namer.k8s.K8sExternalInitializer
 io.buoyant.namer.k8s.K8sInitializer
 io.buoyant.namer.k8s.K8sNamespacedInitializer
+io.buoyant.namer.k8s.IstioInitializer

--- a/namer/k8s/src/main/scala/io/buoyant/namer/k8s/IstioInitializer.scala
+++ b/namer/k8s/src/main/scala/io/buoyant/namer/k8s/IstioInitializer.scala
@@ -1,0 +1,64 @@
+package io.buoyant.namer.k8s
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.twitter.conversions.time._
+import com.twitter.finagle._
+import io.buoyant.config.types.Port
+import io.buoyant.k8s._
+import io.buoyant.namer.{NamerConfig, NamerInitializer}
+
+/**
+ * Supports namer configurations in the form:
+ *
+ * <pre>
+ * namers:
+ * - kind: io.l5d.k8s.istio
+ *   experimental: true
+ *   host: istio-manager.default.svc.cluster.local
+ *   port: 8080
+ *   pollIntervalMs: 5000
+ * </pre>
+ */
+class IstioInitializer extends NamerInitializer {
+  val configClass = classOf[IstioConfig]
+  override def configId = "io.l5d.k8s.istio"
+}
+
+object IstioInitializer extends IstioInitializer
+
+case class IstioConfig(
+  host: Option[String],
+  port: Option[Port],
+  pollIntervalMs: Option[Long]
+) extends NamerConfig with ClientConfig {
+
+  @JsonIgnore
+  override val experimentalRequired = true
+
+  @JsonIgnore
+  override val DefaultHost = "istio-manager.default.svc.cluster.local"
+  @JsonIgnore
+  override val DefaultPort = 8080
+
+  @JsonIgnore
+  override def defaultPrefix: Path = Path.read("/io.l5d.k8s.istio")
+
+  @JsonIgnore
+  def portNum = port.map(_.port)
+
+  @JsonIgnore
+  private[this] val DefaultPollInterval = 5.seconds
+  @JsonIgnore
+  private[this] val pollInterval = pollIntervalMs.map(_.millis).getOrElse(DefaultPollInterval)
+
+  /**
+   * Construct a namer.
+   */
+  @JsonIgnore
+  override def newNamer(params: Stack.Params): Namer = {
+    val client = mkClient(params)
+    val label = param.Label(s"namer${prefix.show}")
+    val sdsClient = new SdsClient(client.configured(label).newService(dst))
+    new IstioNamer(sdsClient, prefix, pollInterval)
+  }
+}

--- a/namerd/storage/k8s/src/main/scala/io/buoyant/namerd/storage/K8sDtabStoreInitializer.scala
+++ b/namerd/storage/k8s/src/main/scala/io/buoyant/namerd/storage/K8sDtabStoreInitializer.scala
@@ -18,7 +18,7 @@ case class K8sConfig(
   override def mkDtabStore: DtabStore = {
     val client = mkClient()
 
-    new K8sDtabStore(client, dst, namespace.getOrElse(ClientConfig.DefaultNamespace))
+    new K8sDtabStore(client, dst, namespace.getOrElse(DefaultNamespace))
   }
 }
 


### PR DESCRIPTION
Add a namer which retrieves addresses from Istio-Manager's Service Discovery
Service.  Each lookup is implemented as a polling loop against SDS.

Accepts names in the form:
`/<namespace>/<port-name>/<svc-name>/<labels>/residual/path`
and initiates a polling loop against the SDS API.  The labels segment must be a :: delimited
list of label:value pairs.  To avoid duplication, the labels must be in alphabetical order
by label name.  e.g.

```
/default/http/foo/az:us-west::env:prod::version:v1
```

Use :: alone to specify an empty list of labels

```
/default/http/foo/::
```