### PR TITLE
Generate protobuf maps as Map instead of Seq of tuples

### DIFF
--- a/grpc/eg/src/main/protobuf/eg.proto
+++ b/grpc/eg/src/main/protobuf/eg.proto
@@ -33,6 +33,8 @@ message Message {
   Path path = 4;
 
   io.buoyant.eg.Enumeration outer = 5;
+
+  map<string, string> foo = 6;
 }
 
 message Req {

--- a/grpc/gen/src/main/scala/io/buoyant/grpc/gen/Generator.scala
+++ b/grpc/gen/src/main/scala/io/buoyant/grpc/gen/Generator.scala
@@ -1,10 +1,10 @@
 package io.buoyant.grpc.gen
 
 import com.google.protobuf.DescriptorProtos._
-import com.google.protobuf.DescriptorProtos.FieldDescriptorProto.Label._
 import com.google.protobuf.DescriptorProtos.FieldDescriptorProto.Type._
 import com.google.protobuf.compiler.PluginProtos.{CodeGeneratorRequest, CodeGeneratorResponse}
-import com.twitter.util.{Future, Return, Throw, Try}
+import com.twitter.util.{Return, Throw, Try}
+import io.buoyant.grpc.gen.ProtoFile.TypeRef
 import java.io.InputStream
 import scala.collection.JavaConverters._
 
@@ -184,19 +184,34 @@ object Generator {
     val msgTypeName = upperHead(msgType.name)
     val scope = s"${scope0}.`${msgTypeName}`"
 
+    val mapMessages = msgType.messages.filter(_.isMap)
+
     // First off, let's figure out the list of fields that will be
     // present in the case class. We have to merge oneofs and fields
     // to accomplish this (since we only have one slot to represent
     // all fields in the oneof):
-
     val fieldArgs = msgType.fields.map {
       case f =>
         val name = snakeToLowerCamel(f.name)
-        val typ = genFieldType(f, translateType)
-        val boxed = if (f.isRepeated) s"Seq[${typ}]" else s"Option[${typ}]"
-        val default = if (f.isRepeated) "Nil" else "None"
-        FieldArg(name, typ, boxed, default, Left(f))
+        f.typeRef match {
+          case ProtoFile.TypeRef.Message(msg) if f.isMap =>
+            // find the nested message that represents entries in the map
+            // we expect this message to have "key" and "value" fields
+            mapMessages.collectFirst {
+              case mp if msg.endsWith(mp.name) =>
+                val key = mapEntryType(mp, "key", translateType)
+                val value = mapEntryType(mp, "value", translateType)
+                val typ = s"Map[${key}, ${value}]"
+                FieldArg(name, typ, typ, s"${typ}()", Left(f))
+            }.getOrElse(throw new IllegalArgumentException(s"expected ${name} to have nested map entry message type"))
+          case _ =>
+            val typ = genFieldType(f, translateType)
+            val boxed = if (f.isRepeated) s"Seq[${typ}]" else s"Option[${typ}]"
+            val default = if (f.isRepeated) "Nil" else "None"
+            FieldArg(name, typ, boxed, default, Left(f))
+        }
     }
+
     val oneofArgs = msgType.oneofs.toSeq.map {
       case (_, o) =>
         val name = snakeToLowerCamel(o.name)
@@ -225,6 +240,11 @@ object Generator {
         |${indent}}
         |""".stripMargin
   }
+
+  private[this] def mapEntryType(mp: ProtoFile.MessageType, fieldName: String, translateType: String => String): String =
+    mp.fields.collectFirst {
+      case f if f.name.equals(fieldName) => genFieldType(f, translateType)
+    }.getOrElse("String")
 
   private[this] def genNestedTypes(
     msgType: ProtoFile.MessageType,
@@ -284,13 +304,22 @@ object Generator {
         s"var ${name}Arg: $boxed = $default"
     }
     val varNames = args.map(a => s"${a.name}Arg")
-
     val varDecoders = args.flatMap {
       case FieldArg(name, _, _, _, Left(f)) =>
         val wireType = genWireType(f)
         val reader = genReader(f)
         val readArg =
-          if (f.isRepeated) s"${name}Arg :+ ${reader}"
+          if (f.isMap) {
+            val ref = f.typeRef match {
+              case TypeRef.Message(msg) => translateType(msg)
+              case _ => throw new IllegalArgumentException("expected message")
+            }
+            //convert reader's tuple value into message entries
+            s"""|${name}Arg ++ ${ref}.unapply(${reader}).flatMap {
+                |${indent}    case (Some(a), Some(b)) => Some((a,b))
+                |${indent}    case _ => None
+                |${indent}  }""".stripMargin
+          } else if (f.isRepeated) s"${name}Arg :+ ${reader}"
           else s"Option(${reader})"
 
         s"""|${indent}      case ${f.number} => // ${name}: ${f.typeRef}
@@ -384,7 +413,15 @@ object Generator {
   ): String = {
     val encoders = args.map {
       case FieldArg(name, typ, _, _, Left(f)) if f.isRepeated =>
-        val writer = genWriteKind(f, translateType, "value", s"${indent}    ")
+        val writer =
+          //when iterating over maps, convert tuple value into entry types
+          if (f.isMap) f.typeRef match {
+            case ProtoFile.TypeRef.Message(msg) =>
+              genWriteKind(f, translateType, s"${translateType(msg)}(Some(value._1), Some(value._2))", s"${indent}    ")
+            case _ => throw new IllegalArgumentException("excepted typeRef of type Message")
+          }
+          else genWriteKind(f, translateType, "value", s"${indent}    ")
+
         s"""|${indent}  val ${name}Iter = msg.`${name}`.iterator
             |${indent}  while (${name}Iter.hasNext) {
             |${indent}    val value = ${name}Iter.next()
@@ -428,6 +465,19 @@ object Generator {
     indent: String
   ): String = {
     val sizeAdditions = args.map {
+      case FieldArg(name, typ, _, _, Left(f)) if f.isMap =>
+        val sizeOf = f.typeRef match {
+          case ProtoFile.TypeRef.Message(msg) =>
+            genComputeSizeTagged(f, s"${translateType(msg)}(Some(value._1), Some(value._2))", translateType)
+          case _ => ""
+        }
+        s"""|${indent}  val ${name}Iter = msg.`${name}`.iterator
+            |${indent}  while (${name}Iter.hasNext) {
+            |${indent}    val value = ${name}Iter.next()
+            |${indent}    val sz = ${sizeOf}
+            |${indent}    size += sz
+            |${indent}  }""".stripMargin
+
       case FieldArg(name, typ, _, _, Left(f)) if f.isRepeated =>
         val sizeOf = genComputeSizeTagged(f, "value", translateType)
         s"""|${indent}  val ${name}Iter = msg.`${name}`.iterator
@@ -517,6 +567,11 @@ object Generator {
       s"""|${indent}pbos.writeTag(${f.number}, ${WIRET}_VARINT)
           |${indent}${typ}.codec.encode(${valueName}, pbos)""".stripMargin
 
+    case ProtoFile.TypeRef.Message(msgt) if f.isMap =>
+      val typ = translateType(msgt)
+      s"""|${indent}pbos.writeTag(${f.number}, ${WIRET}_LENGTH_DELIMITED)
+          |${indent}${typ}.codec.encodeEmbedded(${valueName}, pbos)""".stripMargin
+
     case ProtoFile.TypeRef.Message(msgt) =>
       val typ = translateType(msgt)
       s"""|${indent}pbos.writeTag(${f.number}, ${WIRET}_LENGTH_DELIMITED)
@@ -538,6 +593,8 @@ object Generator {
   ): String = f.typeRef match {
     case ProtoFile.TypeRef.Enum(typ) =>
       s"${translateType(typ)}.codec.sizeOf(${name})"
+    case ProtoFile.TypeRef.Message(typ) if f.isMap =>
+      s"${translateType(typ)}.codec.sizeOfEmbedded(${name})"
     case ProtoFile.TypeRef.Message(typ) =>
       s"${translateType(typ)}.codec.sizeOfEmbedded(${name})"
     case ProtoFile.TypeRef.Simple(TYPE_BYTES) =>


### PR DESCRIPTION
**Problem:**
I have json (generated via golang protobuf) that contains a map created from a `map<string,string>` field. I wasn't able to parse the map into a scala protobuf object, because linkerd protobuf maps are generated as repeated entries. Here's how the generator currently works:

for each map, a map entry is created eg:
```
case class FooEntry(
  `key`: Option[String] = None,
  `value`: Option[String] = None
)
```

then the map is defined as:
```
Seq[FooEntry]
```

**Solution:**
I've changed all map fields to be generated as:
`Map[String, String]`

This enables jackson parsing directly into the generated protobuf case classes.

**Validation:**
`map<string, string>` declaration added to EgTest

