### PR TITLE
Fix some minor dev issues

### DIFF
--- a/project/Base.scala
+++ b/project/Base.scala
@@ -36,10 +36,25 @@ class Base extends Build {
 
   object Git {
     def git(arg: String, args: String*) = Process("git" +: arg +: args)
-    val headRevision = git("rev-parse", "--short", "HEAD").!!.trim
-    val version = git("name-rev", "--tags", "--name-only", headRevision).!!.trim match {
-      case tag if tag == headVersion || tag == s"${headVersion}^0" => headVersion
-      case _ => s"$headVersion-SNAPSHOT"
+    val devnull = new ProcessLogger {
+      def info (s: => String) {}
+      def error (s: => String) { }
+      def buffer[T] (f: => T): T = f
+    }
+    val noGit = git("status").!<(devnull) != 0
+    val version = {
+      if (noGit) headVersion
+      else {
+        val headRevision = git("rev-parse", "--short", "HEAD").!!.trim
+        git("name-rev", "--tags", "--name-only", headRevision).!!.trim match {
+          case tag if tag == headVersion || tag == s"${headVersion}^0" => headVersion
+          case _ => s"$headVersion-SNAPSHOT"
+        }
+      }
+    }
+    val revision = {
+      if (noGit) ""
+      else git("rev-parse", "HEAD").!!.trim
     }
   }
 
@@ -264,7 +279,7 @@ class Base extends Build {
     def withBuildProperties(path: String): Project = project
       .settings((resourceGenerators in Compile) <+=
         (resourceManaged in Compile, name, version).map { (dir, name, ver) =>
-          val rev = Process("git" :: "rev-parse" :: "HEAD" :: Nil).!!.trim
+          val rev = Git.revision
           val build = new java.text.SimpleDateFormat("yyyyMMdd-HHmmss").format(new java.util.Date)
           val contents = s"name=$name\nversion=$ver\nbuild_revision=$rev\nbuild_name=$build"
           val file = dir / path / "build.properties"

--- a/protoc
+++ b/protoc
@@ -14,10 +14,13 @@ protocversion=3.0.0
 protocurl="https://github.com/google/protobuf/releases/download/v${protocversion}/protoc-${protocversion}-${os}-${arch}.zip"
 
 if [ ! -f "$protocbin" ]; then
-  echo "downloading $protocbin" >&2
+  echo "downloading $protocbin"
   tmp=$(mktemp -d -t protoc.XXX)
-  curl -L --silent --fail -o "$tmp/$protocbin.zip" "$protocurl"
-  unzip -q "$tmp/$protocbin.zip" -d "$tmp"
+  pushd "$tmp" > /dev/null
+  curl -L --silent --fail -o "$protocbin.zip" "$protocurl"
+  jar xf "$protocbin.zip"
+  chmod +x bin/protoc
+  popd > /dev/null
   mv "$tmp/bin/protoc" "$protocbin"
   rm -rf "$tmp"
 fi


### PR DESCRIPTION
## Problem

The Linkerd source code tarball won't build readily on new systems due to our build files relying on the build being run from within a git checkout, and our `protoc` script depending on the `unzip` utility.

## Solution

If we're not in a git checkout, assume that we are building a stable version. And switch from `unzip` to `jar xf` for extracting zip files.

Fixes #1371. Fixes #1372.