### PR TITLE
Remove echo statement from protoc script

### DIFF
--- a/protoc
+++ b/protoc
@@ -14,7 +14,6 @@ protocversion=3.0.0
 protocurl="https://github.com/google/protobuf/releases/download/v${protocversion}/protoc-${protocversion}-${os}-${arch}.zip"
 
 if [ ! -f "$protocbin" ]; then
-  echo "downloading $protocbin"
   tmp=$(mktemp -d -t protoc.XXX)
   pushd "$tmp" > /dev/null
   curl -L --silent --fail -o "$protocbin.zip" "$protocurl"


### PR DESCRIPTION
Since this is a wrapper script, we don't want the wrapper writing to stdout. Relates to #1376.