### PR TITLE
Add service level stats to the Service page

### DIFF
--- a/admin/src/main/resources/io/buoyant/admin/css/dashboard.css
+++ b/admin/src/main/resources/io/buoyant/admin/css/dashboard.css
@@ -414,21 +414,14 @@ a.router-list-item:last-of-type:after {
 .service-subsection-header {
   color: #878787;
   font-size: 14px;
-}
-
-.service-client-metrics {
-  margin: 10px 0 0 30px;
-}
-
-.service-client-metrics .metric-large {
   margin-bottom: 10px;
 }
-.service-client-metrics .client-metrics div {
-  padding: 12px 0 2px 0;
+
+.svc-client-metrics .client-metrics {
+  padding: 5px 15px;
+  font-size: 18px;
 }
 
-.service-client-metrics .trail-in {
-  text-align: center;
-  margin-left: 10px;
-  border-left: 1px solid white;
+.svc-client-metrics .metric-large {
+  margin-bottom: 10px;
 }

--- a/admin/src/main/resources/io/buoyant/admin/js/src/colors.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/colors.js
@@ -68,5 +68,15 @@ define(['lodash'], function(_) {
     }
   });
 
-  return colorOrder;
+  function assignColors(items) {
+    return _.reduce(items, function(colorMapping, item, idx) {
+      colorMapping[item] = colorOrder[idx % colorOrder.length];
+      return colorMapping;
+    }, {});
+  }
+
+  return {
+    colorOrder: colorOrder,
+    assignColors: assignColors
+  };
 });

--- a/admin/src/main/resources/io/buoyant/admin/js/src/router_clients.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/router_clients.js
@@ -43,13 +43,6 @@ define([
     var expandStates = { expanded: "EXPANDED", collapsed: "COLLAPSED", custom: "CUSTOM" };
     var clientExpandState = {};
 
-    function assignColorsToClients(colors, clients) {
-      return _.reduce(clients, function(clientMapping, client, idx) {
-        clientMapping[client] = colors[idx % colors.length];
-        return clientMapping;
-      }, {});
-    }
-
     function shouldExpandClient(routerName, initialClients) {
       // if there are many clients, collapse them by default to improve page perfomance
       if (clientExpandState[routerName] === expandStates.custom) {
@@ -78,8 +71,7 @@ define([
       Handlebars.registerPartial('rateMetricPartial', rateMetricPartial);
 
       var clients = _.sortBy(initialData[routerName].clients);
-      var colorList = Colors;
-      var clientToColor = assignColorsToClients(colorList, clients);
+      var clientToColor = Colors.assignColors(clients);
       var combinedClientGraph = CombinedClientGraph(metricsCollector, initialData, routerName, $combinedClientGraphEl, clientToColor);
 
       activeClients[routerName] = {};
@@ -168,7 +160,7 @@ define([
         clients = _(clients).concat(filteredClients).uniq().value();
 
         // reassign colors
-        clientToColor = assignColorsToClients(colorList, clients);
+        clientToColor = Colors.assignColors(clients);
 
         // pass new colors to combined request graph, add new clients to graph
         combinedClientGraph.updateColors(clientToColor);

--- a/admin/src/main/resources/io/buoyant/admin/js/src/router_server.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/router_server.js
@@ -18,7 +18,7 @@ define([
   var RouterServer = (function() {
     var template = templates.router_server;
 
-    var desiredLatencyColors = Colors[3].colorFamily; // match the success rate graph
+    var desiredLatencyColors = Colors.colorOrder[3].colorFamily; // match the success rate graph
     var latencyLegend = LatencyUtil.createLatencyLegend(desiredLatencyColors);
 
     function getMetricDefinitions(routerName, serverName) {

--- a/admin/src/main/resources/io/buoyant/admin/js/src/router_service.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/router_service.js
@@ -1,33 +1,131 @@
 "use strict";
 
 define([
-  'jQuery',
+  'jQuery', 'handlebars.runtime',
   'template/compiled_templates',
+  'src/utils',
+  'src/colors',
+  'src/latency_color_util',
+  'src/combined_client_graph',
+  'src/success_rate_graph',
   'bootstrap'
-], function($, templates) {
+], function($, Handlebars,
+  templates,
+  Utils,
+  Colors,
+  LatencyUtil,
+  CombinedClientGraph,
+  SuccessRateGraph
+) {
 
-  function render(svcClientMetrics, $container) {
-    var clientsHtml = templates.router_service_metrics({
-      clients: svcClientMetrics
-    });
+  var desiredServiceMetrics = [
+    { description: "Successes", dataKey: "success", accessor: "delta" },
+    { description: "Requests", dataKey: "requests", accessor: "delta" },
+    { description: "Failures", dataKey: "failures", accessor: "delta" },
+    { description: "Pending", dataKey: "pending", accessor: "gauge" }
+  ];
 
-    $container.html(clientsHtml);
+  var desiredLatencyColors = Colors.colorOrder[3].colorFamily; // match the success rate graph
+  var latencyLegend = LatencyUtil.createLatencyLegend(desiredLatencyColors);
+
+  function getServiceTemplateData(svcMetrics) {
+    return _.reduce(desiredServiceMetrics, function(mem, metricSpec) {
+      mem[metricSpec.dataKey] = {
+        description: metricSpec.description,
+        value: _.get(svcMetrics, [metricSpec.dataKey, metricSpec.accessor])
+      }
+      return mem;
+    }, {});
   }
 
-  return function(metricsCollector, $routerContainer, service) {
+  function getLatencyTemplateData(svcMetrics) {
+    return LatencyUtil.getLatencyData(svcMetrics.request_latency_ms, latencyLegend);
+  }
+
+  function render(clientData, serviceData, $serviceContainer, $clientContainer) {
+    var serviceHtml = templates.router_service_metrics(serviceData);
+    var clientsHtml = templates.router_service_client_metrics(clientData);
+
+    $serviceContainer.html(serviceHtml);
+    $clientContainer.html(clientsHtml);
+  }
+
+  return function(metricsCollector, $routerContainer, router, service, initialData) {
+    var metricPartial = templates["metric.partial"];
+    Handlebars.registerPartial('metricPartial', metricPartial);
+    var latencyPartial = templates["latencies.partial"];
+    Handlebars.registerPartial('latencyPartial', latencyPartial);
+
+    var clients = initialData[router].clients;
+
     var $svcContainer = $(templates.router_service_container({
       service: service
     }));
     $routerContainer.append($svcContainer);
 
-    var $metricsContainer = $($svcContainer.find(".svc-metrics")[0]);
+    var $svcMetricsContainer = $($svcContainer.find(".svc-metrics")[0]);
+    var $clientsMetricsContainer = $($svcContainer.find(".svc-client-metrics")[0]);
+
+    var clientToColor = Colors.assignColors(clients);
+
+    var $combinedClientGraphEl = $svcContainer.find(".combined-client-graph .router-graph");
+    var combinedClientGraph = CombinedClientGraph(null, initialData, router, $combinedClientGraphEl, clientToColor, true);
+
+    var $serviceSuccessGraphEl = $routerContainer.find(".svc-success-graph");
+    var serviceSuccessGraph = SuccessRateGraph($serviceSuccessGraphEl, "#4AD8AC");
+
+
+    function getSuccessGraphMetrics(svcData) {
+      var suc = (new Utils.SuccessRate(svcData.success.value || 0, svcData.failures.value || 0)).get();
+      var rateToDisplay =  suc  === -1 ? 1 : suc;
+
+      return [{ name: "successRate", delta: rateToDisplay * 100 }];
+    }
+
+    function getCombinedClientGraphMetrics(metrics) {
+      var clientStats = metrics.clientStats;
+
+      return _.map(clientStats, function(clientData) {
+        return {
+          name: clientData.client + "/requests",
+          delta: clientData.requests
+        };
+      });
+    }
 
     function onMetricsUpdate(metrics) {
-      render(metrics, $metricsContainer);
+      if (!metrics) {
+        metrics = { serviceStats: {}, clientStats: {}};
+      }
+
+      var svcTemplateData = getServiceTemplateData(metrics.serviceStats);
+      var clientData = {
+        colorMap: clientToColor,
+        clients: metrics.clientStats
+      };
+
+      var serviceData = {
+        service: svcTemplateData,
+        latencies: getLatencyTemplateData(metrics.serviceStats)
+      };
+
+      render(clientData, serviceData, $svcMetricsContainer, $clientsMetricsContainer);
+      combinedClientGraph.updateMetrics(getCombinedClientGraphMetrics(metrics));
+      serviceSuccessGraph.updateMetrics(getSuccessGraphMetrics(svcTemplateData));
+    }
+
+    function onAddedClients(addedClients) {
+      clients = _(clients).concat(_.keys(addedClients)).uniq().value();
+      clientToColor = Colors.assignColors(clients);
+
+      // pass new colors to combined request graph, add new clients to graph
+      combinedClientGraph.updateColors(clientToColor);
+      combinedClientGraph.addClients(clients);
     }
 
     return {
-      onMetricsUpdate: onMetricsUpdate
+      onMetricsUpdate: onMetricsUpdate,
+      onAddedClients: onAddedClients
     }
   };
 });

--- a/admin/src/main/resources/io/buoyant/admin/js/src/success_rate_graph.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/success_rate_graph.js
@@ -24,10 +24,11 @@ define([
     }
 
     function chartWidthFn() {
-      var serverWidth = $(".router-server").width();
+      var serverWidth = $(".router-row-container").width();
       if (serverWidth < defaultWidth) {
         return serverWidth;
       }
+
       return serverWidth - colMd6Width;
     }
 

--- a/admin/src/main/resources/io/buoyant/admin/js/template/compiled_templates.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/template/compiled_templates.js
@@ -485,25 +485,18 @@ templates['router_server_container'] = template({"compiler":[7,">= 4.0.0"],"main
 
   return "<div class=\"server-header router-header-large\">\n  "
     + container.escapeExpression(((helper = (helper = helpers.server || (depth0 != null ? depth0.server : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : {},{"name":"server","hash":{},"data":data}) : helper)))
-    + "\n</div>\n\n<div class=\"router-server clearfix\">\n  <div class=\"server-metrics metrics-container col-md-6\"></div>\n  <div class=\"server-success-chart col-md-6\">\n    <div class=\"router-graph-header\">Server success rate</div>\n  </div>\n</div>\n";
+    + "\n</div>\n\n<div class=\"router-server router-row-container clearfix\">\n  <div class=\"server-metrics metrics-container col-md-6\"></div>\n  <div class=\"server-success-chart col-md-6\">\n    <div class=\"router-graph-header\">Server success rate</div>\n  </div>\n</div>\n";
 },"useData":true});
-templates['router_service_container'] = template({"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {
-    var helper, alias1=depth0 != null ? depth0 : {}, alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
+templates['router_service_client_metrics'] = template({"1":function(container,depth0,helpers,partials,data,blockParams,depths) {
+    var stack1, helper, alias1=depth0 != null ? depth0 : {}, alias2=container.escapeExpression;
 
-  return "<div class=\"svc-container\" data-service=\""
-    + alias4(((helper = (helper = helpers.service || (depth0 != null ? depth0.service : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"service","hash":{},"data":data}) : helper)))
-    + "\">\n  <div class=\"metric-large\">"
-    + alias4(((helper = (helper = helpers.service || (depth0 != null ? depth0.service : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"service","hash":{},"data":data}) : helper)))
-    + "</div>\n  <div class=\"svc-metrics\"></div>\n</div>\n";
-},"useData":true});
-templates['router_service_metrics'] = template({"1":function(container,depth0,helpers,partials,data) {
-    var stack1, helper, alias1=depth0 != null ? depth0 : {};
-
-  return "  <div class=\"client-metrics row\">\n    <div class=\"col-md-1 trail-in\">\n"
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.requests : depth0),{"name":"if","hash":{},"fn":container.program(2, data, 0),"inverse":container.program(4, data, 0),"data":data})) != null ? stack1 : "")
-    + "    </div>\n    <div class=\"col-md-2\">"
-    + container.escapeExpression(((helper = (helper = helpers.client || (depth0 != null ? depth0.client : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(alias1,{"name":"client","hash":{},"data":data}) : helper)))
-    + "</div>\n  </div>\n";
+  return "  <div class=\"client-metrics row\"\n    style=\"border-left: 3px solid "
+    + alias2(helpers.lookup.call(alias1,helpers.lookup.call(alias1,(depths[1] != null ? depths[1].colorMap : depths[1]),(depth0 != null ? depth0.client : depth0),{"name":"lookup","hash":{},"data":data}),"color",{"name":"lookup","hash":{},"data":data}))
+    + ";\">\n    <div class=\"col-md-2\">"
+    + alias2(((helper = (helper = helpers.client || (depth0 != null ? depth0.client : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(alias1,{"name":"client","hash":{},"data":data}) : helper)))
+    + "</div>\n    <div class=\"col-md-1\">\n"
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.requests : depth0),{"name":"if","hash":{},"fn":container.program(2, data, 0, blockParams, depths),"inverse":container.program(4, data, 0, blockParams, depths),"data":data})) != null ? stack1 : "")
+    + "    </div>\n  </div>\n";
 },"2":function(container,depth0,helpers,partials,data) {
     var helper;
 
@@ -512,13 +505,35 @@ templates['router_service_metrics'] = template({"1":function(container,depth0,he
     + "\n";
 },"4":function(container,depth0,helpers,partials,data) {
     return "        0\n";
-},"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {
+},"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data,blockParams,depths) {
     var stack1;
 
-  return "<div class=\"service-client-metrics row\">\n  <div class=\"service-subsection-header\">Requests per client</div>\n"
-    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : {},(depth0 != null ? depth0.clients : depth0),{"name":"each","hash":{},"fn":container.program(1, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
-    + "</div>\n";
+  return "  <div class=\"service-subsection-header\">Requests per client</div>\n"
+    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : {},(depth0 != null ? depth0.clients : depth0),{"name":"each","hash":{},"fn":container.program(1, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + "  </div>\n";
+},"useData":true,"useDepths":true});
+templates['router_service_container'] = template({"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {
+    var helper, alias1=depth0 != null ? depth0 : {}, alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
+
+  return "<div class=\"svc-container\" data-service=\""
+    + alias4(((helper = (helper = helpers.service || (depth0 != null ? depth0.service : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"service","hash":{},"data":data}) : helper)))
+    + "\">\n  <div class=\"metric-large\">"
+    + alias4(((helper = (helper = helpers.service || (depth0 != null ? depth0.service : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"service","hash":{},"data":data}) : helper)))
+    + "</div>\n\n  <div class=\"combined-client-graph\">\n    <div class=\"router-graph-header\">Requests per client</div>\n    <canvas class=\"router-graph\" height=\"181\"></canvas>\n  </div>\n\n  <div class=\"router-row-container clearfix\">\n    <div class=\"svc-metrics metrics-container col-md-6\"></div>\n    <div class=\"svc-success-graph col-md-6\">\n      <div class=\"router-graph-header\">Service success rate</div>\n    </div>\n  </div>\n\n  <div class=\"svc-client-metrics\"></div>\n</div>\n";
 },"useData":true});
+templates['router_service_metrics'] = template({"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {
+    var stack1;
+
+  return "<div class=\"service-client-metrics\">\n  <div class=\"service-metrics row\">\n    <div class=\"col-md-2\">\n"
+    + ((stack1 = container.invokePartial(partials.metricPartial,((stack1 = (depth0 != null ? depth0.service : depth0)) != null ? stack1.success : stack1),{"name":"metricPartial","hash":{"metricClass":"success-metric metric-large","containerClass":"metric-container success-metric-container"},"data":data,"indent":"      ","helpers":helpers,"partials":partials,"decorators":container.decorators})) != null ? stack1 : "")
+    + ((stack1 = container.invokePartial(partials.metricPartial,((stack1 = (depth0 != null ? depth0.service : depth0)) != null ? stack1.requests : stack1),{"name":"metricPartial","hash":{"metricClass":"metric-large","containerClass":"neutral-metric-container metric-container"},"data":data,"indent":"      ","helpers":helpers,"partials":partials,"decorators":container.decorators})) != null ? stack1 : "")
+    + "    </div>\n\n    <div class=\"col-md-2\">\n"
+    + ((stack1 = container.invokePartial(partials.metricPartial,((stack1 = (depth0 != null ? depth0.service : depth0)) != null ? stack1.failures : stack1),{"name":"metricPartial","hash":{"metricClass":"failure-metric metric-large","containerClass":"metric-container failure-metric-container"},"data":data,"indent":"      ","helpers":helpers,"partials":partials,"decorators":container.decorators})) != null ? stack1 : "")
+    + ((stack1 = container.invokePartial(partials.metricPartial,((stack1 = (depth0 != null ? depth0.service : depth0)) != null ? stack1.pending : stack1),{"name":"metricPartial","hash":{"metricClass":"metric-large","containerClass":"neutral-metric-container metric-container"},"data":data,"indent":"      ","helpers":helpers,"partials":partials,"decorators":container.decorators})) != null ? stack1 : "")
+    + "    </div>\n\n"
+    + ((stack1 = container.invokePartial(partials.latencyPartial,(depth0 != null ? depth0.latencies : depth0),{"name":"latencyPartial","data":data,"indent":"    ","helpers":helpers,"partials":partials,"decorators":container.decorators})) != null ? stack1 : "")
+    + "  </div>\n</div>\n";
+},"usePartial":true,"useData":true});
 templates['router_services_container'] = template({"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {
     var helper, alias1=depth0 != null ? depth0 : {}, alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
 

--- a/admin/src/main/resources/io/buoyant/admin/js/template/router_server_container.handlebars
+++ b/admin/src/main/resources/io/buoyant/admin/js/template/router_server_container.handlebars
@@ -2,7 +2,7 @@
   {{server}}
 </div>
 
-<div class="router-server clearfix">
+<div class="router-server router-row-container clearfix">
   <div class="server-metrics metrics-container col-md-6"></div>
   <div class="server-success-chart col-md-6">
     <div class="router-graph-header">Server success rate</div>

--- a/admin/src/main/resources/io/buoyant/admin/js/template/router_service_client_metrics.handlebars
+++ b/admin/src/main/resources/io/buoyant/admin/js/template/router_service_client_metrics.handlebars
@@ -1,0 +1,15 @@
+  <div class="service-subsection-header">Requests per client</div>
+  {{#each clients}}
+  <div class="client-metrics row"
+    style="border-left: 3px solid {{ lookup (lookup ../colorMap client) "color"}};">
+    <div class="col-md-2">{{client}}</div>
+    <div class="col-md-1">
+      {{#if requests}}
+        {{requests}}
+      {{else}}
+        0
+      {{/if}}
+    </div>
+  </div>
+  {{/each}}
+  </div>

--- a/admin/src/main/resources/io/buoyant/admin/js/template/router_service_container.handlebars
+++ b/admin/src/main/resources/io/buoyant/admin/js/template/router_service_container.handlebars
@@ -1,4 +1,17 @@
 <div class="svc-container" data-service="{{service}}">
   <div class="metric-large">{{service}}</div>
-  <div class="svc-metrics"></div>
+
+  <div class="combined-client-graph">
+    <div class="router-graph-header">Requests per client</div>
+    <canvas class="router-graph" height="181"></canvas>
+  </div>
+
+  <div class="router-row-container clearfix">
+    <div class="svc-metrics metrics-container col-md-6"></div>
+    <div class="svc-success-graph col-md-6">
+      <div class="router-graph-header">Service success rate</div>
+    </div>
+  </div>
+
+  <div class="svc-client-metrics"></div>
 </div>

--- a/admin/src/main/resources/io/buoyant/admin/js/template/router_service_metrics.handlebars
+++ b/admin/src/main/resources/io/buoyant/admin/js/template/router_service_metrics.handlebars
@@ -1,15 +1,15 @@
-<div class="service-client-metrics row">
-  <div class="service-subsection-header">Requests per client</div>
-  {{#each clients}}
-  <div class="client-metrics row">
-    <div class="col-md-1 trail-in">
-      {{#if requests}}
-        {{requests}}
-      {{else}}
-        0
-      {{/if}}
+<div class="service-client-metrics">
+  <div class="service-metrics row">
+    <div class="col-md-2">
+      {{> metricPartial service.success containerClass="metric-container success-metric-container" metricClass="success-metric metric-large"}}
+      {{> metricPartial service.requests containerClass="neutral-metric-container metric-container" metricClass="metric-large"}}
     </div>
-    <div class="col-md-2">{{client}}</div>
+
+    <div class="col-md-2">
+      {{> metricPartial service.failures containerClass="metric-container failure-metric-container" metricClass="failure-metric metric-large"}}
+      {{> metricPartial service.pending containerClass="neutral-metric-container metric-container" metricClass="metric-large"}}
+    </div>
+
+    {{> latencyPartial latencies}}
   </div>
-  {{/each}}
 </div>


### PR DESCRIPTION
* Add combined client graph on service level
* Add service metrics section
* Add service success rate graph
* Add Service latencies table
* Add colour to client request stats

Still not pretty, gonna get design input and refine afterwards. This update does get all the service level stats displayed on the page, and the color mapping for the clients, should we need that.

![screen shot 2017-06-12 at 11 27 43 am](https://user-images.githubusercontent.com/549258/27057347-a7d1af32-4f80-11e7-9e1e-a822491c4126.png)

Part of #1250