### PR TITLE
Accept named targetPort

### DIFF
--- a/k8s/src/main/scala/io/buoyant/k8s/ServiceNamer.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/ServiceNamer.scala
@@ -112,10 +112,10 @@ class ServiceCache(namespace: String)
     stabilize(unstable)
   }
 
-  def getPortMapping(serviceName: String, port: Int): Var[Option[Var[Int]]] = synchronized {
+  def getPortMapping(serviceName: String, port: Int): Var[Option[Var[String]]] = synchronized {
     // we call this unstable because every change to the target port will cause
     // the entire Var[Option[Int]] to update.
-    val unstable: Var[Option[Int]] = cache.get(serviceName) match {
+    val unstable: Var[Option[String]] = cache.get(serviceName) match {
       case Some(ports) =>
         ports.map(_.portMap.get(port))
       case None =>
@@ -189,11 +189,11 @@ class ServiceCache(namespace: String)
 
 object ServiceCache {
 
-  case class CacheEntry(ports: Map[String, Address], portMap: Map[Int, Int])
+  case class CacheEntry(ports: Map[String, Address], portMap: Map[Int, String])
 
   private def extractPorts(service: Service): CacheEntry = {
     val ports = mutable.Map.empty[String, Address]
-    val portMap = mutable.Map.empty[Int, Int]
+    val portMap = mutable.Map.empty[Int, String]
 
     for {
       meta <- service.metadata.toSeq
@@ -210,7 +210,7 @@ object ServiceCache {
 
       portMap += (port.targetPort match {
         case Some(targetPort) => port.port -> targetPort
-        case None => port.port -> port.port
+        case None => port.port -> port.port.toString
       })
     }
     CacheEntry(ports.toMap, portMap.toMap)

--- a/k8s/src/main/scala/io/buoyant/k8s/v1.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/v1.scala
@@ -159,7 +159,7 @@ package object v1 {
 
   case class ServicePort(
     port: Int,
-    targetPort: Option[Int],
+    targetPort: Option[String],
     name: String
   )
 }

--- a/k8s/src/test/scala/io/buoyant/k8s/EndpointsNamerTest.scala
+++ b/k8s/src/test/scala/io/buoyant/k8s/EndpointsNamerTest.scala
@@ -20,7 +20,7 @@ class EndpointsNamerTest extends FunSuite with Awaits {
 
     val ScaleDown = Buf.Utf8("""{"type":"MODIFIED","object":{"kind":"Endpoints","apiVersion":"v1","metadata":{"name":"sessions","namespace":"srv","selfLink":"/api/v1/namespaces/srv/endpoints/sessions","uid":"6a698096-525e-11e5-9859-42010af01815","resourceVersion":"5319605","creationTimestamp":"2015-09-03T17:08:37Z"},"subsets":[{"addresses":[{"ip":"10.248.4.9","targetRef":{"kind":"Pod","namespace":"srv","name":"sessions-293kc","uid":"69f5a7d2-525e-11e5-9859-42010af01815","resourceVersion":"4962471"}},{"ip":"10.248.7.11","targetRef":{"kind":"Pod","namespace":"srv","name":"sessions-mr9gb","uid":"69f5b78e-525e-11e5-9859-42010af01815","resourceVersion":"4962524"}},{"ip":"10.248.8.9","targetRef":{"kind":"Pod","namespace":"srv","name":"sessions-nicom","uid":"69f5b623-525e-11e5-9859-42010af01815","resourceVersion":"4962517"}}],"ports":[{"name":"http","port":8083,"protocol":"TCP"}]}]}}""")
 
-    val Services = Buf.Utf8("""{"kind":"ServiceList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/srv/services","resourceVersion":"33787896"},"items":[{"metadata":{"name":"sessions","namespace":"srv","selfLink":"/api/v1/namespaces/srv/services/sessions","uid":"8122d7d0-1042-11e7-b340-42010af00004","resourceVersion":"33186979","creationTimestamp":"2017-03-24T03:32:27Z","labels":{"name":"sessions"}},"spec":{"ports":[{"name":"http","protocol":"TCP","port":80,"targetPort":54321},{"name":"admin","protocol":"TCP","port":9990}],"selector":{"name":"sessions"},"clusterIP":"10.199.240.9","type":"LoadBalancer","sessionAffinity":"None"},"status":{"loadBalancer":{"ingress":[{"ip":"35.184.61.229"}]}}},{"metadata":{"name":"projects","namespace":"srv","selfLink":"/api/v1/namespaces/srv/services/projects","uid":"8122d7d0-1042-11e7-b340-42010af00005","resourceVersion":"33186980","creationTimestamp":"2017-03-24T03:32:27Z","labels":{"name":"projects"}},"spec":{"ports":[{"name":"http","protocol":"TCP","port":80,"targetPort":54321},{"name":"admin","protocol":"TCP","port":9990}],"selector":{"name":"projects"},"clusterIP":"10.199.240.9","type":"LoadBalancer","sessionAffinity":"None"},"status":{"loadBalancer":{}}},{"metadata":{"name":"events","namespace":"srv","selfLink":"/api/v1/namespaces/srv/services/events","uid":"8122d7d0-1042-11e7-b340-42010af00006","resourceVersion":"33186981","creationTimestamp":"2017-03-24T03:32:27Z","labels":{"name":"events"}},"spec":{"ports":[{"name":"http","protocol":"TCP","port":80,"targetPort":54321},{"name":"admin","protocol":"TCP","port":9990}],"selector":{"name":"events"},"clusterIP":"10.199.240.9","type":"LoadBalancer","sessionAffinity":"None"},"status":{"loadBalancer":{"ingress":[{"hostname":"linkerd.io"}]}}}]}""")
+    val Services = Buf.Utf8("""{"apiVersion":"v1","items":[{"metadata":{"creationTimestamp":"2017-03-24T03:32:27Z","labels":{"name":"sessions"},"name":"sessions","namespace":"srv","resourceVersion":"33186979","selfLink":"/api/v1/namespaces/srv/services/sessions","uid":"8122d7d0-1042-11e7-b340-42010af00004"},"spec":{"clusterIP":"10.199.240.9","ports":[{"name":"http","port":80,"protocol":"TCP","targetPort":54321},{"name":"admin","port":9990,"protocol":"TCP"}],"selector":{"name":"sessions"},"sessionAffinity":"None","type":"LoadBalancer"},"status":{"loadBalancer":{"ingress":[{"ip":"35.184.61.229"}]}}},{"metadata":{"creationTimestamp":"2017-03-24T03:32:27Z","labels":{"name":"projects"},"name":"projects","namespace":"srv","resourceVersion":"33186980","selfLink":"/api/v1/namespaces/srv/services/projects","uid":"8122d7d0-1042-11e7-b340-42010af00005"},"spec":{"clusterIP":"10.199.240.9","ports":[{"name":"http","port":80,"protocol":"TCP","targetPort":54321},{"name":"admin","port":9990,"protocol":"TCP"}],"selector":{"name":"projects"},"sessionAffinity":"None","type":"LoadBalancer"},"status":{"loadBalancer":{}}},{"metadata":{"creationTimestamp":"2017-03-24T03:32:27Z","labels":{"name":"events"},"name":"events","namespace":"srv","resourceVersion":"33186981","selfLink":"/api/v1/namespaces/srv/services/events","uid":"8122d7d0-1042-11e7-b340-42010af00006"},"spec":{"clusterIP":"10.199.240.9","ports":[{"name":"http","port":80,"protocol":"TCP","targetPort":54321},{"name":"admin","port":9990,"protocol":"TCP"}],"selector":{"name":"events"},"sessionAffinity":"None","type":"LoadBalancer"},"status":{"loadBalancer":{"ingress":[{"hostname":"linkerd.io"}]}}},{"metadata":{"creationTimestamp":"2017-03-24T03:32:27Z","labels":{"name":"auth"},"name":"auth","namespace":"srv","resourceVersion":"33186981","selfLink":"/api/v1/namespaces/srv/services/auth","uid":"8122d7d0-1042-11e7-b340-42010af00007"},"spec":{"clusterIP":"10.199.240.10","ports":[{"name":"http","port":80,"protocol":"TCP","targetPort":"http"},{"name":"admin","port":9990,"protocol":"TCP"}],"selector":{"name":"auth"},"sessionAffinity":"None","type":"LoadBalancer"},"status":{"loadBalancer":{"ingress":[{"hostname":"linkerd.io"}]}}}],"kind":"ServiceList","metadata":{"resourceVersion":"33787896","selfLink":"/api/v1/namespaces/srv/services"}}""")
   }
 
   trait Fixtures {
@@ -320,6 +320,18 @@ class EndpointsNamerTest extends FunSuite with Awaits {
       doInit.setDone()
 
       assert(state == Activity.Ok(NameTree.Neg))
+    }
+  }
+
+  test("port numbers can map to named target port") {
+    val _ = new Fixtures {
+
+      override def name = "/srv/80/auth"
+
+      assert(state == Activity.Pending)
+      doInit.setDone()
+
+      assert(addrs == Set(Address("10.248.0.10", 8082), Address("10.248.1.9", 8082), Address("10.248.5.9", 8082)))
     }
   }
 


### PR DESCRIPTION
Fixes #1385 

We assume that the targetPort property of a service port is an int but the k8s
spec allows it to be either an int or a string.  If the targetPort is a string
(named port) then linkerd throws a ClassCastException.

We parse targetPort as a string and then attempt to convert it to an int.  If
this conversion is successful we treat targetPort as a port number otherwise
we treat it as a port name.

Added a test in EndpointsNamerTest.