### PR TITLE
Update to finagle 6.45.0, netty 4.1.10

### DIFF
--- a/admin/src/main/scala/io/buoyant/admin/names/DelegateApiHandler.scala
+++ b/admin/src/main/scala/io/buoyant/admin/names/DelegateApiHandler.scala
@@ -4,7 +4,6 @@ package admin.names
 import com.fasterxml.jackson.annotation._
 import com.fasterxml.jackson.core.{io => _, _}
 import com.fasterxml.jackson.databind._
-import com.fasterxml.jackson.databind.annotation.JsonSerialize.Inclusion
 import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
@@ -243,7 +242,7 @@ object DelegateApiHandler {
     }
   }
 
-  private implicit val timer = DefaultTimer.twitter
+  private implicit val timer = DefaultTimer
 
   def getDelegateRsp(dtab: String, path: String, delegator: Delegator): Future[Response] = {
     val dtabTry = if (dtab == null) Return(Dtab.empty) else Try(Dtab.read(dtab))

--- a/admin/src/main/scala/io/buoyant/admin/names/DelegateHandler.scala
+++ b/admin/src/main/scala/io/buoyant/admin/names/DelegateHandler.scala
@@ -15,7 +15,7 @@ class DelegateHandler(
   interpreter: String => NameInterpreter
 ) extends Service[Request, Response] {
 
-  private[this] implicit val time = DefaultTimer.twitter
+  private[this] implicit val time = DefaultTimer
 
   def apply(req: Request): Future[Response] = {
 

--- a/etcd/src/integration/scala/io/buoyant/etcd/EtcdFixture.scala
+++ b/etcd/src/integration/scala/io/buoyant/etcd/EtcdFixture.scala
@@ -1,6 +1,5 @@
 package io.buoyant.etcd
 
-import com.twitter.conversions.time._
 import com.twitter.finagle.Http
 import com.twitter.finagle.util.DefaultTimer
 import io.buoyant.test.Awaits
@@ -57,7 +56,7 @@ class EtcdFixture extends FunSuite with Awaits with BeforeAndAfterAll {
 
   def serverName = s"/$$/inet/127.1/$etcdPort"
 
-  private[this] implicit val timer = DefaultTimer.twitter
+  private[this] implicit val timer = DefaultTimer
 
   type FixtureParam = Etcd
 

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4H2Listener.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4H2Listener.scala
@@ -3,12 +3,9 @@ package netty4
 
 import com.twitter.finagle.Stack
 import com.twitter.finagle.netty4.Netty4Listener
-import com.twitter.finagle.netty4.channel.AnyToHeapInboundHandler
 import com.twitter.finagle.server.Listener
 import com.twitter.finagle.transport.Transport
-import io.netty.buffer.ByteBuf
 import io.netty.channel._
-import io.netty.channel.socket.SocketChannel
 import io.netty.handler.codec.http2._
 import io.netty.handler.ssl.{ApplicationProtocolNames, ApplicationProtocolNegotiationHandler}
 
@@ -43,7 +40,7 @@ object Netty4H2Listener {
 
   private[this] object PlaintextListener extends ListenerMaker {
     override protected[this] def pipelineInit(codec: => H2FrameCodec) = { p: ChannelPipeline =>
-      p.addLast(AnyToHeapInboundHandler)
+      p.addLast(UnpoolHandler)
       p.addLast(new ServerUpgradeHandler(codec)); ()
     }
   }
@@ -51,7 +48,7 @@ object Netty4H2Listener {
   private[this] object TlsListener extends ListenerMaker {
     val PlaceholderKey = "h2 framer placeholder"
     override protected[this] def pipelineInit(codec: => H2FrameCodec) = { p: ChannelPipeline =>
-      p.addLast(AnyToHeapInboundHandler)
+      p.addLast(UnpoolHandler)
       p.addLast(PlaceholderKey, new ChannelDuplexHandler)
         .addLast("alpn", new Alpn(codec)); ()
     }

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4H2Transporter.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4H2Transporter.scala
@@ -5,7 +5,6 @@ import com.twitter.finagle.Stack
 import com.twitter.finagle.client.Transporter
 import com.twitter.finagle.netty4.Netty4Transporter
 import com.twitter.finagle.netty4.buoyant.BufferingConnectDelay
-import com.twitter.finagle.netty4.channel.AnyToHeapInboundHandler
 import com.twitter.finagle.transport.Transport
 import io.netty.channel.ChannelPipeline
 import io.netty.handler.codec.http2._
@@ -38,7 +37,7 @@ object Netty4H2Transporter {
         // secure
         p =>
           {
-            p.addLast(AnyToHeapInboundHandler)
+            p.addLast(UnpoolHandler)
             p.addLast(FramerKey, framer); ()
           }
       } else {
@@ -52,7 +51,7 @@ object Netty4H2Transporter {
             // Prior Knowledge: ensure messages are buffered until
             // handshake completes.
             p => {
-              p.addLast(AnyToHeapInboundHandler)
+              p.addLast(UnpoolHandler)
               p.addLast(framer)
               p.addLast(new BufferingConnectDelay); ()
             }

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4H2Writer.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4H2Writer.scala
@@ -32,7 +32,7 @@ private[netty4] trait Netty4H2Writer extends H2Transport.Writer {
   }
 
   override def write(id: Int, buf: Buf, eos: Boolean): Future[Unit] = {
-    val bb = BufAsByteBuf.Owned(buf)
+    val bb = BufAsByteBuf(buf)
     val frame = new DefaultHttp2DataFrame(bb, eos)
     if (id >= 0) frame.streamId(id)
     write(frame.retain()).ensure {

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4Message.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4Message.scala
@@ -95,7 +95,7 @@ private[h2] object Netty4Message {
 
     def apply(f: Http2DataFrame, updateWindow: Int => Future[Unit]): Frame.Data = {
       val sz = f.content.readableBytes + f.padding
-      val buf = ByteBufAsBuf.Owned(f.content.retain())
+      val buf = ByteBufAsBuf(f.content.retain())
       val releaser: () => Future[Unit] =
         if (sz > 0) () => updateWindow(sz)
         else () => Future.Unit

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/UnpoolHandler.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/UnpoolHandler.scala
@@ -1,0 +1,56 @@
+package com.twitter.finagle.buoyant.h2
+package netty4
+
+import io.netty.buffer.{ByteBuf, ByteBufHolder, EmptyByteBuf, Unpooled}
+import io.netty.channel.ChannelHandler.Sharable
+import io.netty.channel.{ChannelHandlerContext, ChannelInboundHandlerAdapter}
+
+/**
+ * This was originally copied from finagle's implementation of AnyToHeapInboundHandler:
+ * https://github.com/twitter/finagle/blob/c86789cf0e064483ebf4509b52c9a216c31dd134/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/channel/AnyToHeapInboundHandler.scala
+ *
+ * An inbound channel handler that copies byte buffers onto the JVM heap
+ * and gives them a deterministic lifecycle. This handler also makes sure to
+ * use the unpooled byte buffer (regardless of what channel's allocator is) as
+ * its destination thereby defining a clear boundaries between pooled and unpooled
+ * environments.
+ *
+ * @note If the input buffer is not readable it's still guaranteed to be released
+ *       and replaced with EmptyByteBuf.
+ *
+ * @note This handler recognizes both ByteBuf's and ByteBufHolder's (think of HTTP
+ *       messages extending ByteBufHolder's in Netty).
+ *
+ * @note If your protocol manages ref-counting or if you are delegating ref-counting
+ *       to application space you don't need this handler in your pipeline. Every
+ *       other use case needs this handler or you will with very high probability
+ *       incur a direct buffer leak.
+ */
+@Sharable
+object UnpoolHandler extends ChannelInboundHandlerAdapter {
+  private[this] final def copyOnHeapAndRelease(bb: ByteBuf): ByteBuf = {
+    try {
+      if (bb.readableBytes > 0) Unpooled.buffer(bb.readableBytes, bb.capacity).writeBytes(bb)
+      else Unpooled.EMPTY_BUFFER
+    } finally {
+      val _ = bb.release()
+    }
+  }
+
+  override def channelRead(ctx: ChannelHandlerContext, msg: Any): Unit = msg match {
+    case bb: ByteBuf =>
+      val _ = ctx.fireChannelRead(copyOnHeapAndRelease(bb))
+
+    // This case is special since it helps to avoid unnecessary `replace`
+    // when the underlying content is already `EmptyByteBuffer`.
+    case bbh: ByteBufHolder if bbh.content.isInstanceOf[EmptyByteBuf] =>
+      val _ = ctx.fireChannelRead(bbh)
+
+    case bbh: ByteBufHolder =>
+      val onHeapContent = copyOnHeapAndRelease(bbh.content)
+      val _ = ctx.fireChannelRead(bbh.replace(onHeapContent))
+
+    case _ =>
+      val _ = ctx.fireChannelRead(msg)
+  }
+}

--- a/finagle/h2/src/test/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4ClientDispatcherTest.scala
+++ b/finagle/h2/src/test/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4ClientDispatcherTest.scala
@@ -128,11 +128,11 @@ class Netty4ClientDispatcherTest extends FunSuite {
 
     assert(recvq.offer({
       val buf = Buf.Utf8("sup")
-      new DefaultHttp2DataFrame(BufAsByteBuf.Owned(buf), true).streamId(3)
+      new DefaultHttp2DataFrame(BufAsByteBuf(buf), true).streamId(3)
     }))
     assert(recvq.offer({
       val buf = Buf.Utf8("yo")
-      new DefaultHttp2DataFrame(BufAsByteBuf.Owned(buf), true).streamId(5)
+      new DefaultHttp2DataFrame(BufAsByteBuf(buf), true).streamId(5)
     }))
 
     val d0f = rsp0.stream.read()

--- a/finagle/h2/src/test/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4StreamTransportTest.scala
+++ b/finagle/h2/src/test/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4StreamTransportTest.scala
@@ -8,7 +8,6 @@ import com.twitter.finagle.stats.InMemoryStatsReceiver
 import com.twitter.io.Buf
 import com.twitter.util._
 import io.buoyant.test.FunSuite
-import io.netty.buffer.ByteBuf
 import io.netty.handler.codec.http2._
 import java.net.SocketAddress
 import java.util.concurrent.atomic.AtomicBoolean
@@ -148,7 +147,7 @@ class Netty4StreamTransportTest extends FunSuite {
     assert(!dataf.isDefined)
 
     val buf = Buf.Utf8("space ghost coast to coast")
-    transport.recv(new DefaultHttp2DataFrame(BufAsByteBuf.Owned(buf)).streamId(id))
+    transport.recv(new DefaultHttp2DataFrame(BufAsByteBuf(buf)).streamId(id))
     transport.recv({
       val hs = new DefaultHttp2Headers
       hs.set("trailers", "yea")
@@ -437,7 +436,7 @@ class Netty4StreamTransportTest extends FunSuite {
     val d0f = req.stream.read()
     assert(!d0f.isDefined)
     assert(transport.recv({
-      val bb = BufAsByteBuf.Owned(Buf.Utf8("data"))
+      val bb = BufAsByteBuf(Buf.Utf8("data"))
       new DefaultHttp2DataFrame(bb, false).streamId(id)
     }))
     assert(d0f.isDefined)
@@ -493,13 +492,13 @@ class Netty4StreamTransportTest extends FunSuite {
     val buf = Buf.Utf8("Looks like some tests were totally excellent")
     assert(rspStreamQ.offer(Frame.Data(buf, false)))
     ctx.synchronized {
-      assert(written.head == new DefaultHttp2DataFrame(BufAsByteBuf.Owned(buf), false).streamId(id))
+      assert(written.head == new DefaultHttp2DataFrame(BufAsByteBuf(buf), false).streamId(id))
       written = written.tail
     }
 
     assert(rspStreamQ.offer(Frame.Data(buf, false)))
     ctx.synchronized {
-      assert(written.head == new DefaultHttp2DataFrame(BufAsByteBuf.Owned(buf), false).streamId(id))
+      assert(written.head == new DefaultHttp2DataFrame(BufAsByteBuf(buf), false).streamId(id))
       written = written.tail
     }
 

--- a/interpreter/mesh/src/main/scala/io/buoyant/interpreter/MeshInterpreterInitializer.scala
+++ b/interpreter/mesh/src/main/scala/io/buoyant/interpreter/MeshInterpreterInitializer.scala
@@ -3,16 +3,13 @@ package io.buoyant.interpreter
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.twitter.conversions.time._
 import com.twitter.finagle._
-import com.twitter.finagle.buoyant.{TlsClientConfig, H2}
+import com.twitter.finagle.buoyant.{H2, TlsClientConfig}
 import com.twitter.finagle.naming.NameInterpreter
 import com.twitter.finagle.service.Backoff
-import com.twitter.finagle.ssl.ApplicationProtocols
-import com.twitter.finagle.transport.Transport
 import com.twitter.finagle.util.DefaultTimer
 import com.twitter.logging.Logger
 import io.buoyant.interpreter.mesh.Client
 import io.buoyant.namer.{InterpreterConfig, InterpreterInitializer}
-import io.netty.handler.ssl.ApplicationProtocolNames
 import scala.util.control.NoStackTrace
 
 /**
@@ -72,7 +69,7 @@ case class MeshInterpreterConfig(
 
     root.getOrElse(DefaultRoot) match {
       case r@Path.Utf8(_) =>
-        Client(r, client, backoffs, DefaultTimer.twitter)
+        Client(r, client, backoffs, DefaultTimer)
 
       case r =>
         val msg = s"io.l5d.mesh: `root` may only contain a single path element (for now): ${r.show}"

--- a/interpreter/mesh/src/test/scala/io/buoyant/interpreter/mesh/ClientTest.scala
+++ b/interpreter/mesh/src/test/scala/io/buoyant/interpreter/mesh/ClientTest.scala
@@ -3,7 +3,7 @@ package io.buoyant.interpreter.mesh
 import com.twitter.finagle.{Addr, Address, Dtab, Name, NameTree, Path}
 import com.twitter.finagle.util.DefaultTimer
 import com.twitter.io.Buf
-import com.twitter.util.{Activity, Future, Promise, Var}
+import com.twitter.util.{Activity, Future, Promise}
 import io.buoyant.grpc.runtime.{GrpcStatus, Stream}
 import io.buoyant.test.FunSuite
 import io.linkerd.mesh
@@ -38,7 +38,7 @@ class ClientTest extends FunSuite {
           addrRsps
         }
       }
-      Client(Path.Utf8("foons"), interp, resolv, unusedDelegator, scala.Stream.empty, DefaultTimer.twitter)
+      Client(Path.Utf8("foons"), interp, resolv, unusedDelegator, scala.Stream.empty, DefaultTimer)
     }
 
     val act = client.bind(Dtab.read("/stuff => /mas"), Path.read("/some/name"))

--- a/k8s/src/main/scala/io/buoyant/k8s/EndpointsNamer.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/EndpointsNamer.scala
@@ -15,7 +15,7 @@ class MultiNsNamer(
   labelName: Option[String],
   mkApi: String => NsApi,
   backoff: Stream[Duration] = Backoff.exponentialJittered(10.milliseconds, 10.seconds)
-)(implicit timer: Timer = DefaultTimer.twitter) extends EndpointsNamer(idPrefix, mkApi, backoff)(timer) {
+)(implicit timer: Timer = DefaultTimer) extends EndpointsNamer(idPrefix, mkApi, backoff)(timer) {
 
   val PrefixLen = 3
   private[this] val variablePrefixLength = PrefixLen + labelName.size
@@ -63,7 +63,7 @@ class SingleNsNamer(
   nsName: String,
   mkApi: String => NsApi,
   backoff: Stream[Duration] = Backoff.exponentialJittered(10.milliseconds, 10.seconds)
-)(implicit timer: Timer = DefaultTimer.twitter) extends EndpointsNamer(idPrefix, mkApi, backoff)(timer) {
+)(implicit timer: Timer = DefaultTimer) extends EndpointsNamer(idPrefix, mkApi, backoff)(timer) {
 
   val PrefixLen = 2
   private[this] val variablePrefixLength = PrefixLen + labelName.size
@@ -109,7 +109,7 @@ abstract class EndpointsNamer(
   idPrefix: Path,
   mkApi: String => NsApi,
   backoff: Stream[Duration] = Backoff.exponentialJittered(10.milliseconds, 10.seconds)
-)(implicit timer: Timer = DefaultTimer.twitter) extends EnumeratingNamer {
+)(implicit timer: Timer = DefaultTimer) extends EnumeratingNamer {
 
   import EndpointsNamer._
 

--- a/k8s/src/main/scala/io/buoyant/k8s/Ns.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/Ns.scala
@@ -9,7 +9,7 @@ import io.buoyant.k8s.Ns.ObjectCache
 
 abstract class Ns[O <: KubeObject: Manifest, W <: Watch[O]: Manifest, L <: KubeList[O]: Manifest, Cache <: ObjectCache[O, W, L]](
   backoff: Stream[Duration] = Backoff.exponentialJittered(10.milliseconds, 10.seconds),
-  timer: Timer = DefaultTimer.twitter
+  timer: Timer = DefaultTimer
 ) {
   // note that caches must be updated with synchronized
   private[this] val caches = Var[Map[String, Cache]](Map.empty[String, Cache])

--- a/k8s/src/main/scala/io/buoyant/k8s/ServiceNamer.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/ServiceNamer.scala
@@ -22,7 +22,7 @@ class ServiceNamer(
   labelName: Option[String],
   mkApi: String => NsApi,
   backoff: Stream[Duration] = Backoff.exponentialJittered(10.milliseconds, 10.seconds)
-)(implicit timer: Timer = DefaultTimer.twitter) extends Namer {
+)(implicit timer: Timer = DefaultTimer) extends Namer {
 
   private[this] val PrefixLen = 3
   private[this] val variablePrefixLength = PrefixLen + labelName.size

--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/LinkerdAdmin.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/LinkerdAdmin.scala
@@ -2,13 +2,13 @@ package io.buoyant.linkerd
 package admin
 
 import com.twitter.finagle._
-import com.twitter.finagle.buoyant.DstBindingFactory
+import com.twitter.finagle.naming.buoyant.DstBindingFactory
 import com.twitter.finagle.naming.NameInterpreter
-import com.twitter.server.handler.{ResourceHandler, SummaryHandler => _}
+import com.twitter.server.handler.ResourceHandler
 import io.buoyant.admin.Admin.{Handler, NavItem}
 import io.buoyant.admin.names.{BoundNamesHandler, DelegateApiHandler, DelegateHandler}
 import io.buoyant.admin.{Admin, ConfigHandler, StaticFilter, _}
-import io.buoyant.namer.{Delegator, EnumeratingNamer, NamespacedInterpreterConfig}
+import io.buoyant.namer.EnumeratingNamer
 import io.buoyant.router.RoutingFactory
 
 object LinkerdAdmin {

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/ClientConfig.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/ClientConfig.scala
@@ -3,7 +3,7 @@ package io.buoyant.linkerd
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.twitter.conversions.time._
 import com.twitter.finagle.Stack
-import com.twitter.finagle.buoyant.{ClientAuth, DstBindingFactory, PathMatcher, TlsClientConfig => FTlsClientConfig}
+import com.twitter.finagle.buoyant.{ClientAuth, PathMatcher, TlsClientConfig => FTlsClientConfig}
 import com.twitter.finagle.client.DefaultPool
 import com.twitter.finagle.service._
 import io.buoyant.router.RetryBudgetConfig

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/Linker.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/Linker.scala
@@ -1,7 +1,6 @@
 package io.buoyant.linkerd
 
-import com.twitter.conversions.time._
-import com.twitter.finagle.buoyant.DstBindingFactory
+import com.twitter.finagle.naming.buoyant.DstBindingFactory
 import com.twitter.finagle.naming.NameInterpreter
 import com.twitter.finagle.param.Label
 import com.twitter.finagle.stats.{BroadcastStatsReceiver, LoadedStatsReceiver, NullStatsReceiver}
@@ -12,9 +11,9 @@ import com.twitter.logging.Logger
 import com.twitter.server.util.JvmStats
 import io.buoyant.admin.{Admin, AdminConfig}
 import io.buoyant.config._
+import io.buoyant.linkerd.telemeter.UsageDataTelemeterConfig
 import io.buoyant.namer.Param.Namers
 import io.buoyant.namer._
-import io.buoyant.linkerd.telemeter.UsageDataTelemeterConfig
 import io.buoyant.telemetry._
 import io.buoyant.telemetry.admin.{AdminMetricsExportTelemeter, histogramSnapshotInterval}
 import java.net.InetSocketAddress
@@ -112,7 +111,7 @@ object Linker {
       val metrics = MetricsTree()
 
       val telemeterParams = Stack.Params.empty + param.LinkerConfig(this) + metrics
-      val adminTelemeter = new AdminMetricsExportTelemeter(metrics, histogramSnapshotInterval(), DefaultTimer.twitter)
+      val adminTelemeter = new AdminMetricsExportTelemeter(metrics, histogramSnapshotInterval(), DefaultTimer)
       val usageTelemeter = usage.getOrElse(UsageDataTelemeterConfig()).mk(telemeterParams)
 
       val telemeters = telemetry.toSeq.flatten.map {

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/Router.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/Router.scala
@@ -1,13 +1,12 @@
 package io.buoyant.linkerd
 
 import com.fasterxml.jackson.annotation.{JsonIgnore, JsonProperty, JsonTypeInfo}
-import com.fasterxml.jackson.core.{io => _}
 import com.twitter.conversions.time._
 import com.twitter.finagle._
-import com.twitter.finagle.buoyant.DstBindingFactory
+import com.twitter.finagle.naming.buoyant.DstBindingFactory
 import com.twitter.finagle.naming.NameInterpreter
 import com.twitter.finagle.service._
-import com.twitter.util.{Closable, Duration}
+import com.twitter.util.Closable
 import io.buoyant.namer.{DefaultInterpreterConfig, InterpreterConfig}
 import io.buoyant.router.{ClassifiedRetries, Originator, RoutingFactory}
 

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/telemeter/UsageDataTelemeter.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/telemeter/UsageDataTelemeter.scala
@@ -244,7 +244,7 @@ case class UsageDataTelemeterConfig(
   def mk(params: Stack.Params): Telemeter =
     if (enabled.getOrElse(true)) {
       val LinkerConfig(config) = params[LinkerConfig]
-      implicit val timer = DefaultTimer.twitter
+      implicit val timer = DefaultTimer
 
       new UsageDataTelemeter(
         Name.bound(Address("stats.buoyant.io", 443)),

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/RouterTest.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/RouterTest.scala
@@ -1,11 +1,9 @@
 package io.buoyant.linkerd
 
-import com.twitter.conversions.time._
-import com.twitter.finagle.{Path, Dtab, Stack}
-import com.twitter.finagle.buoyant.DstBindingFactory
-import com.twitter.finagle.service.TimeoutFilter
+import com.twitter.finagle.{Dtab, Path, Stack}
+import com.twitter.finagle.naming.buoyant.DstBindingFactory
 import io.buoyant.config.Parser
-import io.buoyant.namer.{ConfiguredNamersInterpreter, InterpreterInitializer, TestInterpreterInitializer, TestInterpreter}
+import io.buoyant.namer.{ConfiguredNamersInterpreter, InterpreterInitializer, TestInterpreter, TestInterpreterInitializer}
 import io.buoyant.router.{Originator, RetryBudgetConfig, RoutingFactory}
 import io.buoyant.test.Exceptions
 import java.net.InetAddress

--- a/marathon/src/main/scala/io/buoyant/marathon/v2/AppIdNamer.scala
+++ b/marathon/src/main/scala/io/buoyant/marathon/v2/AppIdNamer.scala
@@ -1,8 +1,8 @@
 package io.buoyant.marathon.v2
 
 import com.twitter.finagle._
-import com.twitter.finagle.util.DefaultTimer
 import com.twitter.finagle.tracing.Trace
+import com.twitter.finagle.util.DefaultTimer
 import com.twitter.util.{NonFatal => _, _}
 import scala.util.control.NonFatal
 
@@ -14,7 +14,7 @@ class AppIdNamer(
   api: Api,
   prefix: Path,
   ttl: Duration,
-  timer: Timer = DefaultTimer.twitter
+  timer: Timer = DefaultTimer
 ) extends Namer {
 
   import AppIdNamer._

--- a/namer/core/src/main/scala/io/buoyant/namer/NamerInitializer.scala
+++ b/namer/core/src/main/scala/io/buoyant/namer/NamerInitializer.scala
@@ -2,7 +2,7 @@ package io.buoyant.namer
 
 import com.fasterxml.jackson.annotation.{JsonIgnore, JsonProperty}
 import com.twitter.finagle._
-import io.buoyant.config.{PolymorphicConfig, ConfigInitializer}
+import io.buoyant.config.{ConfigInitializer, PolymorphicConfig}
 
 /**
  * Read a single namer configuration in the form:

--- a/namerd/core/src/main/scala/io/buoyant/namerd/NamerdConfig.scala
+++ b/namerd/core/src/main/scala/io/buoyant/namerd/NamerdConfig.scala
@@ -35,7 +35,7 @@ private[namerd] case class NamerdConfig(
     val metrics = MetricsTree()
 
     val telemeterParams = Stack.Params.empty + metrics
-    val adminTelemeter = new AdminMetricsExportTelemeter(metrics, histogramSnapshotInterval(), DefaultTimer.twitter)
+    val adminTelemeter = new AdminMetricsExportTelemeter(metrics, histogramSnapshotInterval(), DefaultTimer)
     val telemeters = telemetry.toSeq.flatten.map {
       case t if t.disabled =>
         val msg = s"The ${t.getClass.getCanonicalName} telemeter is experimental and must be " +

--- a/namerd/iface/interpreter-thrift/src/main/scala/io/buoyant/namerd/iface/ThriftNamerClient.scala
+++ b/namerd/iface/interpreter-thrift/src/main/scala/io/buoyant/namerd/iface/ThriftNamerClient.scala
@@ -19,7 +19,7 @@ class ThriftNamerClient(
   namespace: String,
   statsReceiver: StatsReceiver = NullStatsReceiver,
   clientId: Path = Path.empty,
-  _timer: Timer = DefaultTimer.twitter
+  _timer: Timer = DefaultTimer
 ) extends NameInterpreter with Delegator {
   import ThriftNamerInterface._
 

--- a/namerd/storage/in-memory/src/main/scala/io/buoyant/namerd/storage/InMemoryDtabStore.scala
+++ b/namerd/storage/in-memory/src/main/scala/io/buoyant/namerd/storage/InMemoryDtabStore.scala
@@ -5,8 +5,8 @@ import com.twitter.finagle.Dtab
 import com.twitter.finagle.util.DefaultTimer
 import com.twitter.io.Buf
 import com.twitter.util._
-import io.buoyant.namerd.DtabStore.{DtabNamespaceDoesNotExistException, DtabVersionMismatchException, DtabNamespaceAlreadyExistsException}
-import io.buoyant.namerd.{Ns, VersionedDtab, DtabStore}
+import io.buoyant.namerd.DtabStore.{DtabNamespaceAlreadyExistsException, DtabNamespaceDoesNotExistException, DtabVersionMismatchException}
+import io.buoyant.namerd.{DtabStore, Ns, VersionedDtab}
 import java.nio.ByteBuffer
 
 /**
@@ -45,7 +45,7 @@ class InMemoryDtabStore(namespaces: Map[String, Dtab]) extends DtabStore {
           }.keySet
           update.update(keySet)
         }
-        Future.sleep(1.second)(DefaultTimer.twitter).before(loop())
+        Future.sleep(1.second)(DefaultTimer).before(loop())
       }
     }
 

--- a/namerd/storage/zk/src/main/scala/com/twitter/finagle/serverset2/buoyant/ZkDtabStore.scala
+++ b/namerd/storage/zk/src/main/scala/com/twitter/finagle/serverset2/buoyant/ZkDtabStore.scala
@@ -29,7 +29,7 @@ class ZkDtabStore(
   private[this] val retryStream = RetryStream()
   private[this] val stats = DefaultStatsReceiver.scope("zkclient").scope(Zk2Resolver.statsOf(hosts))
 
-  private[this] implicit val timer = DefaultTimer.twitter
+  private[this] implicit val timer = DefaultTimer
   private[this] val builder = ClientBuilder()
     .hosts(hosts)
     .sessionTimeout(sessionTimeout.getOrElse(FZkSession.DefaultSessionTimeout))

--- a/project/Base.scala
+++ b/project/Base.scala
@@ -63,7 +63,7 @@ class Base extends Build {
     version := Git.version,
     homepage := Some(url("https://linkerd.io")),
     scalaVersion in GlobalScope := "2.12.1",
-    crossScalaVersions in GlobalScope := Seq("2.11.8", "2.12.1"),
+    crossScalaVersions in GlobalScope := Seq("2.11.11", "2.12.1"),
     ivyScala := ivyScala.value.map(_.copy(overrideScalaVersion = true)),
     scalacOptions ++=
       Seq("-Xfatal-warnings", "-deprecation", "-Ywarn-value-discard", "-feature"),

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -8,20 +8,20 @@ object Deps {
 
   // process lifecycle
   val twitterServer =
-    ("com.twitter" %% "twitter-server" % "1.29.0")
+    ("com.twitter" %% "twitter-server" % "1.30.0")
       .exclude("com.twitter", "finagle-zipkin_2.12")
 
   def twitterUtil(mod: String) =
-    "com.twitter" %% s"util-$mod" % "6.43.0"
+    "com.twitter" %% s"util-$mod" % "6.45.0"
 
   // networking
   def finagle(mod: String) =
-    "com.twitter" %% s"finagle-$mod" % "6.44.0"
+    "com.twitter" %% s"finagle-$mod" % "6.45.0"
 
   def netty4(mod: String) =
-    "io.netty" % s"netty-$mod" % "4.1.9.Final"
+    "io.netty" % s"netty-$mod" % "4.1.10.Final"
 
-  val boringssl = "io.netty" % "netty-tcnative-boringssl-static" % "2.0.0.Final"
+  val boringssl = "io.netty" % "netty-tcnative-boringssl-static" % "2.0.1.Final"
 
   def zkCandidate = "com.twitter.common.zookeeper" % "candidate" % "0.0.76"
 

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -23,7 +23,9 @@ object Deps {
 
   val boringssl = "io.netty" % "netty-tcnative-boringssl-static" % "2.0.1.Final"
 
-  def zkCandidate = "com.twitter.common.zookeeper" % "candidate" % "0.0.76"
+  def zkCandidate =
+    ("com.twitter.common.zookeeper" % "candidate" % "0.0.84")
+      .exclude("com.twitter.common", "util")
 
   // Jackson (parsing)
   val jacksonVersion = "2.8.4"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -18,7 +18,7 @@ addSbtPlugin("com.eed3si9n"      % "sbt-assembly"  % "0.14.1")
 addSbtPlugin("se.marcuslonnberg" % "sbt-docker"    % "1.4.1")
 
 // scrooge
-addSbtPlugin("com.twitter" %% "scrooge-sbt-plugin" % "4.16.0")
+addSbtPlugin("com.twitter" %% "scrooge-sbt-plugin" % "4.18.0")
 
 // microbenchmarking for tests.
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.6")

--- a/router/core/src/main/scala/com/twitter/finagle/naming/buoyant/DstBindingFactory.scala
+++ b/router/core/src/main/scala/com/twitter/finagle/naming/buoyant/DstBindingFactory.scala
@@ -1,12 +1,12 @@
-package com.twitter.finagle.buoyant
+package com.twitter.finagle.naming
+package buoyant
 
 import com.twitter.conversions.time._
 import com.twitter.finagle._
-import com.twitter.finagle.factory.{NameTreeFactory, ServiceFactoryCache}
-import com.twitter.finagle.naming._
+import com.twitter.finagle.buoyant.Dst
+import com.twitter.finagle.factory.ServiceFactoryCache
 import com.twitter.finagle.stats.{DefaultStatsReceiver, StatsReceiver}
 import com.twitter.finagle.util.DefaultTimer
-import com.twitter.logging.Logger
 import com.twitter.util._
 import java.util.concurrent.atomic.AtomicReference
 
@@ -140,7 +140,7 @@ object DstBindingFactory {
     capacity: Capacity = Capacity.default,
     bindingTimeout: BindingTimeout = BindingTimeout.default,
     idleTtl: IdleTtl = IdleTtl.default
-  )(implicit timer: Timer = DefaultTimer.twitter) extends DstBindingFactory[Req, Rsp] {
+  )(implicit timer: Timer = DefaultTimer) extends DstBindingFactory[Req, Rsp] {
     private[this]type Cache[Key] = ServiceFactoryCache[Key, Req, Rsp]
 
     def apply(dst: Dst.Path, conn: ClientConnection): Future[Service[Req, Rsp]] = {
@@ -217,6 +217,6 @@ object DstBindingFactory {
     def close(deadline: Time) =
       Closable.sequence(caches: _*).close(deadline)
 
-    def status = Status.worstOf[Cache[_]](caches, _.status)
+    def status = Status.Open
   }
 }

--- a/router/core/src/main/scala/com/twitter/finagle/naming/buoyant/DynBoundFactory.scala
+++ b/router/core/src/main/scala/com/twitter/finagle/naming/buoyant/DynBoundFactory.scala
@@ -1,6 +1,8 @@
-package com.twitter.finagle.buoyant
+package com.twitter.finagle.naming
+package buoyant
 
 import com.twitter.finagle._
+import com.twitter.finagle.buoyant.Dst
 import com.twitter.finagle.factory.ServiceFactoryCache
 import com.twitter.finagle.stats.{NullStatsReceiver, StatsReceiver}
 import com.twitter.finagle.tracing.Trace

--- a/router/core/src/main/scala/io/buoyant/router/Router.scala
+++ b/router/core/src/main/scala/io/buoyant/router/Router.scala
@@ -3,6 +3,7 @@ package io.buoyant.router
 import com.twitter.finagle._
 import com.twitter.finagle.buoyant._
 import com.twitter.finagle.client._
+import com.twitter.finagle.naming.buoyant.DstBindingFactory
 import com.twitter.finagle.server.StackServer
 import com.twitter.finagle.service.{FailFastFactory, Retries, StatsFilter}
 import com.twitter.finagle.stack.Endpoint

--- a/router/core/src/main/scala/io/buoyant/router/RoutingFactory.scala
+++ b/router/core/src/main/scala/io/buoyant/router/RoutingFactory.scala
@@ -1,9 +1,10 @@
 package io.buoyant.router
 
 import com.twitter.finagle.{param => _, _}
-import com.twitter.finagle.buoyant.{Dst, DstBindingFactory}
+import com.twitter.finagle.buoyant.Dst
+import com.twitter.finagle.naming.buoyant.DstBindingFactory
 import com.twitter.finagle.tracing.Trace
-import com.twitter.util.{Throw, Return, Future, Time}
+import com.twitter.util.{Future, Return, Throw, Time}
 import scala.util.control.NoStackTrace
 
 object RoutingFactory {

--- a/router/core/src/test/scala/com/twitter/finagle/naming/buoyant/DstBindingFactoryTest.scala
+++ b/router/core/src/test/scala/com/twitter/finagle/naming/buoyant/DstBindingFactoryTest.scala
@@ -1,10 +1,11 @@
-package com.twitter.finagle.buoyant
+package com.twitter.finagle.naming
+package buoyant
 
 import com.twitter.conversions.time._
 import com.twitter.finagle._
-import com.twitter.finagle.naming.NameInterpreter
+import com.twitter.finagle.buoyant.Dst
 import com.twitter.util._
-import io.buoyant.test.{Exceptions, Awaits}
+import io.buoyant.test.{Awaits, Exceptions}
 import java.util.concurrent.atomic.AtomicBoolean
 import org.scalatest.FunSuite
 

--- a/router/core/src/test/scala/io/buoyant/router/RouterTest.scala
+++ b/router/core/src/test/scala/io/buoyant/router/RouterTest.scala
@@ -2,16 +2,13 @@ package io.buoyant.router
 
 import com.twitter.finagle._
 import com.twitter.finagle.buoyant._
-import com.twitter.finagle.client.{StackClient, StdStackClient}
+import com.twitter.finagle.client.StackClient
 import com.twitter.finagle.naming.NameInterpreter
-import com.twitter.finagle.service.{Backoff, Retries, RetryBudget}
+import com.twitter.finagle.naming.buoyant.DstBindingFactory
 import com.twitter.finagle.stack.{Endpoint, nilStack}
-import com.twitter.finagle.stats.InMemoryStatsReceiver
-import com.twitter.finagle.transport.Transport
-import com.twitter.util.{Activity, Duration, Future, MockTimer, Return, Throw, Time, Try, Var}
+import com.twitter.util.{Activity, Future, Var}
 import io.buoyant.router.RoutingFactory.IdentifiedRequest
 import io.buoyant.test.FunSuite
-import java.util.concurrent.atomic.AtomicInteger
 
 // This is a sort of end-to-end test, but is intended to improve test
 // coverage of Router.scala

--- a/router/core/src/test/scala/io/buoyant/router/RoutingFactoryTest.scala
+++ b/router/core/src/test/scala/io/buoyant/router/RoutingFactoryTest.scala
@@ -2,7 +2,8 @@ package io.buoyant.router
 
 import com.twitter.finagle._
 import com.twitter.finagle.buoyant._
-import com.twitter.finagle.tracing.Annotation.{BinaryAnnotation, Rpc}
+import com.twitter.finagle.naming.buoyant.DstBindingFactory
+import com.twitter.finagle.tracing.Annotation.BinaryAnnotation
 import com.twitter.finagle.tracing._
 import com.twitter.util.{Future, Time}
 import io.buoyant.router.RoutingFactory.IdentifiedRequest

--- a/router/http/src/main/scala/io/buoyant/router/Http.scala
+++ b/router/http/src/main/scala/io/buoyant/router/Http.scala
@@ -5,7 +5,6 @@ import com.twitter.finagle.http.{Request, Response, TlsFilter}
 import com.twitter.finagle.http.service.HttpResponseClassifier
 import com.twitter.finagle.param.{ProtocolLibrary, ResponseClassifier}
 import com.twitter.finagle.server.StackServer
-import com.twitter.finagle.service.StatsFilter
 import com.twitter.finagle.{Http => FinagleHttp, Server => FinagleServer, http => fhttp, _}
 import io.buoyant.router.ClassifiedRetries.ResponseDiscarder
 import io.buoyant.router.Http.param.HttpIdentifier
@@ -81,7 +80,7 @@ object Http extends Router[Request, Response] with FinagleServer[Request, Respon
 
   object Server {
     val stack: Stack[ServiceFactory[Request, Response]] =
-      (AddForwardedHeader.module +: FinagleHttp.Server.stack)
+      (AddForwardedHeader.module +: FinagleHttp.server.stack)
         .insertBefore(http.TracingFilter.role, ProxyRewriteFilter.module)
 
     private val serverResponseClassifier = ClassifiedRetries.orElse(

--- a/telemetry/statsd/src/main/scala/io/buoyant/telemetry/StatsDInitializer.scala
+++ b/telemetry/statsd/src/main/scala/io/buoyant/telemetry/StatsDInitializer.scala
@@ -57,7 +57,7 @@ case class StatsDConfig(
     new StatsDTelemeter(
       new StatsDStatsReceiver(statsDClient, statsDSampleRate),
       statsDInterval,
-      DefaultTimer.twitter
+      DefaultTimer
     )
   }
 }

--- a/telemetry/zipkin/src/main/scala/io/buoyant/telemetry/ZipkinInitializer.scala
+++ b/telemetry/zipkin/src/main/scala/io/buoyant/telemetry/ZipkinInitializer.scala
@@ -49,7 +49,7 @@ case class ZipkinConfig(
       val rawTracer = ScribeRawZipkinTracer(
         client,
         NullStatsReceiver,
-        DefaultTimer.twitter
+        DefaultTimer
       )
       new ZipkinTracer(
         rawTracer,

--- a/validator/src/main/scala/io/buoyant/namerd/Validator.scala
+++ b/validator/src/main/scala/io/buoyant/namerd/Validator.scala
@@ -12,7 +12,7 @@ import scala.sys.process.{Process, ProcessLogger}
 
 object Validator extends TwitterServer {
 
-  private[this] implicit val timer = DefaultTimer.twitter
+  private[this] implicit val timer = DefaultTimer
 
   val namerdExec = flag("namerd.exec", "", "Path to namerd executable")
   val linkerdExec = flag("linkerd.exec", "", "Path to linkerd executable")


### PR DESCRIPTION
As part of this change I'm creating a local copy of finagle's [AnyToHeapInboundHandler](https://github.com/twitter/finagle/blob/c86789cf0e064483ebf4509b52c9a216c31dd134/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/channel/AnyToHeapInboundHandler.scala), which was removed as part of this release. I'm also moving DstBindingFactory and DynBoundFactory to package com.twitter.finagle.naming.buoyant, to mirror the change in package for finagle's NameTreeFactory.