### PR TITLE
RouteManager cache and updated path format

### DIFF
--- a/k8s/src/main/scala/io/buoyant/k8s/RouteManager.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/RouteManager.scala
@@ -1,35 +1,49 @@
 package io.buoyant.k8s
 
+import com.twitter.conversions.time._
+import com.twitter.finagle.Http
+import com.twitter.finagle.param.Label
+import com.twitter.finagle.tracing.NullTracer
 import com.twitter.util._
 import io.buoyant.k8s.IstioPilotClient.RouteRuleConfig
-import java.util.concurrent.atomic.AtomicReference
-import istio.proxy.v1.config.RouteRule
 import io.buoyant.namer.RichActivity
+import istio.proxy.v1.config.RouteRule
 
 class RouteManager(api: IstioPilotClient, pollInterval: Duration) {
-  private[this] val states: Var[Activity.State[Map[String, RouteRule]]] = api.watchRouteRules(pollInterval).run.map {
-    case Activity.Ok(rsp) =>
-      log.trace("istio route-rules received")
-      Activity.Ok(mkRouteMap(rsp))
-    case Activity.Pending =>
-      log.trace("istio route manager is pending")
-      Activity.Pending
-    case Activity.Failed(e) =>
-      log.error(e, "failed to update istio routing rules")
-      Activity.Failed(e)
-  }
+  private[this] val states: Activity[Map[String, RouteRule]] = api.watchRouteRules(pollInterval).map(mkRouteMap)
 
   private[this] def mkRouteMap(routeList: Seq[RouteRuleConfig]): Map[String, RouteRule] =
-    routeList.flatMap {
-      case RouteRuleConfig(typ, Some(name), Some(spec)) => Some(name -> spec)
-      case _ => None
-    }.toMap[String, RouteRule]
+    routeList.collect {
+      case RouteRuleConfig(typ, Some(name), Some(spec)) => name -> spec
+    }.toMap
 
   private[this] lazy val routeRules: Activity[Map[String, RouteRule]] = {
-    val act = Activity(states)
-    val _ = act.states.respond(_ => ()) // register a listener forever to keep the Activity open
-    act
+    val _ = states.states.respond(_ => ()) // register a listener forever to keep the Activity open
+    states
   }
 
   def getRules(): Future[Map[String, RouteRule]] = routeRules.toFuture
+}
+
+object RouteManager {
+  private[this] val managers = Var(Map.empty[(String, Int), RouteManager])
+
+  def getManagerFor(host: String, port: Int): RouteManager = {
+    synchronized {
+      val sample = managers.sample()
+      sample.collectFirst { case ((h, p), manager) if h == h && p == p => manager }.getOrElse {
+        val setHost = new SetHostFilter(host, port)
+        val client = Http.client
+          .withTracer(NullTracer)
+          .withStreaming(true)
+          .filtered(setHost)
+          .configured(Label("istio-route-manager"))
+        val api = new IstioPilotClient(client.newService(s"/$$/inet/$host/$port"))
+        val routeManager = new RouteManager(api, 5.seconds) //TODO: make port configurable
+        val entry = (host, port) -> routeManager
+        managers.update(sample + entry)
+        routeManager
+      }
+    }
+  }
 }

--- a/linkerd/docs/protocol-http.md
+++ b/linkerd/docs/protocol-http.md
@@ -383,20 +383,28 @@ Key  | Default Value | Description
 ---- | ------------- | -----------
 host | `istio-manager.default.svc.cluster.local` | The host of the Istio-Manager.
 port | 8081 | The port of the Istio-Manager's apiserver.
-pollIntervalMs | 5000 | How frequently to poll the Istio-Manager for route-rule updates.
 
 #### Identifier Path Parameters
 
-> Dtab Path Format
+> Dtab Path Format if the request matches a route-rule
 
 ```
-  / dstPrefix / route-rule 
+  / dstPrefix / "route" / route-rule 
+```
+
+
+> Dtab Path Format if the request DOES NOT match a route-rule
+
+```
+  / dstPrefix / "dest" / host / port 
 ```
 
 Key | Default Value | Description
 --- | ------------- | -----------
 dstPrefix | `/svc` | The `dstPrefix` as set in the routers block.
-rout-rule | N/A | The name of the route-rule that matches the incoming request.
+route-rule | N/A | The name of the route-rule that matches the incoming request.
+host | N/A | The host to forward the request to.
+port | N/A | The port to forward the request to.
 
 <a name="static-identifier"></a>
 ### Static Identifier

--- a/linkerd/examples/istio.yaml
+++ b/linkerd/examples/istio.yaml
@@ -4,8 +4,7 @@ routers:
     kind: io.l5d.istio
     host: localhost
   dtab:
-    /svc/localhost => /#/io.l5d.fs/default;
-    /svc/pet/8888 => /#/io.l5d.fs/cat;
-    /svc/pet/8800 => /#/io.l5d.fs/dog;
+    /svc/route => /#/io.l5d.fs;
+    /svc/dest => /$/inet;
   servers:
   - port: 4140


### PR DESCRIPTION
Adds `RouteManager` cache and changes identifier path format to accommodate request forwarding. Paths will either be returned in `/svc/route/route-name` format for requests that match an istio route-rule or `/svc/dest/host/port` for requests that do not match.