### PR TITLE
Add Istio Interpreter

### DIFF
--- a/interpreter/k8s/src/main/resources/META-INF/services/io.buoyant.namer.InterpreterInitializer
+++ b/interpreter/k8s/src/main/resources/META-INF/services/io.buoyant.namer.InterpreterInitializer
@@ -1,0 +1,1 @@
+io.buoyant.interpreter.k8s.IstioInterpreterInitializer

--- a/interpreter/k8s/src/main/scala/io/buoyant/interpreter/k8s/IstioInterpreter.scala
+++ b/interpreter/k8s/src/main/scala/io/buoyant/interpreter/k8s/IstioInterpreter.scala
@@ -35,7 +35,7 @@ object IstioInterpreter {
 
     val routesDtab = routes.map { routeTable =>
       val dentries = routeTable.map { _ =>
-        val route = "my-cool-route"
+        val route = "reviews-default"
         val ns = "default"
         val service = "reviews"
         val labels = "version:v1"

--- a/interpreter/k8s/src/main/scala/io/buoyant/interpreter/k8s/IstioInterpreter.scala
+++ b/interpreter/k8s/src/main/scala/io/buoyant/interpreter/k8s/IstioInterpreter.scala
@@ -1,0 +1,56 @@
+package io.buoyant.interpreter.k8s
+
+import com.twitter.finagle._
+import com.twitter.finagle.buoyant.PathMatcher
+import com.twitter.finagle.naming.NameInterpreter
+import com.twitter.util.Activity
+import io.buoyant.namer.{ConfiguredDtabNamer, RewritingNamer}
+
+object IstioInterpreter {
+  private val noLabelsPfx = "/#/no-labels"
+  private val istioPfx = "/#/io.l5d.k8s.istio"
+  private val defaultRouteDtab = Dtab.read(s"""
+    |/svc/dest => /$$/inet ;
+    |/destPath/local/cluster/svc => $noLabelsPfx ;
+    |/svc/dest => /$$/io.buoyant.http.domainToPathPfx/destPath ;
+  """.stripMargin)
+
+  /* A typical delegation for the default route
+
+   /svc/dest/foo.default.svc.cluster.local/http
+   /$/io.buoyant.domainToPathPfx/destPath/foo.default.svc.cluster.local/http
+   /destPath/local/cluster/svc/default/foo/http
+   /#/no-labels/default/foo/http
+   /#/io.l5d.k8s.istio/default/foo/::/http
+
+   A typical delegation for a matching route
+   /svc/route/my-cool-route/http
+   /#/io.l5d.k8s.istio/default/reviews/version:v1/http
+  */
+
+  def apply(routeManager: Unit, istioNamer: Namer): NameInterpreter = {
+
+    // val routes = routerManager.routes
+    val routes: Activity[IndexedSeq[Unit]] = Activity.value(IndexedSeq(()))
+
+    val routesDtab = routes.map { routeTable =>
+      val dentries = routeTable.map { _ =>
+        val route = "my-cool-route"
+        val ns = "default"
+        val service = "reviews"
+        val labels = "version:v1"
+        Dentry.read(s"/svc/route/$route => $istioPfx/$ns/$service/$labels")
+      }
+      Dtab(dentries)
+    }
+
+    val noLabelsRewriteNamer = new RewritingNamer(PathMatcher("/{ns}/{svc}/{port}"), s"$istioPfx/{ns}/{svc}/::/{port}")
+
+    val dtab = routesDtab.map(defaultRouteDtab ++ _)
+
+    ConfiguredDtabNamer(dtab, Seq(
+      Path.read(istioPfx) -> istioNamer,
+      Path.read(noLabelsPfx) -> noLabelsRewriteNamer
+    ))
+  }
+}

--- a/interpreter/k8s/src/main/scala/io/buoyant/interpreter/k8s/IstioInterpreter.scala
+++ b/interpreter/k8s/src/main/scala/io/buoyant/interpreter/k8s/IstioInterpreter.scala
@@ -31,10 +31,12 @@ object IstioInterpreter {
   def apply(routeManager: Unit, istioNamer: Namer): NameInterpreter = {
 
     // val routes = routerManager.routes
+    // TODO: Get routes from the route manager
     val routes: Activity[IndexedSeq[Unit]] = Activity.value(IndexedSeq(()))
 
     val routesDtab = routes.map { routeTable =>
       val dentries = routeTable.map { _ =>
+        // TODO: map route into dentry
         val route = "reviews-default"
         val ns = "default"
         val service = "reviews"

--- a/interpreter/k8s/src/main/scala/io/buoyant/interpreter/k8s/IstioInterpreterInitializer.scala
+++ b/interpreter/k8s/src/main/scala/io/buoyant/interpreter/k8s/IstioInterpreterInitializer.scala
@@ -6,7 +6,7 @@ import com.twitter.finagle.{Path, Stack, param}
 import com.twitter.finagle.naming.NameInterpreter
 import io.buoyant.config.types.Port
 import io.buoyant.k8s.{ClientConfig, IstioNamer, SdsClient}
-import io.buoyant.namer.{InterpreterConfig, InterpreterInitializer}
+import io.buoyant.namer.{InterpreterConfig, InterpreterInitializer, Paths}
 
 class IstioInterpreterInitializer extends InterpreterInitializer {
   val configClass = classOf[IstioInterpreterConfig]
@@ -44,7 +44,7 @@ case class IstioInterpreterConfig(
     val label = param.Label("namer/io.l5d.k8s.istio")
     val client = mkClient(params).configured(label).newService(dst)
     val sdsClient = new SdsClient(client)
-    val istioNamer = new IstioNamer(sdsClient, prefix, pollInterval)
+    val istioNamer = new IstioNamer(sdsClient, Paths.ConfiguredNamerPrefix ++ prefix, pollInterval)
     val routeManager = /* RouteManager(client) */ ()
     IstioInterpreter(routeManager, istioNamer)
   }

--- a/interpreter/k8s/src/main/scala/io/buoyant/interpreter/k8s/IstioInterpreterInitializer.scala
+++ b/interpreter/k8s/src/main/scala/io/buoyant/interpreter/k8s/IstioInterpreterInitializer.scala
@@ -1,0 +1,51 @@
+package io.buoyant.interpreter.k8s
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.twitter.conversions.time._
+import com.twitter.finagle.{Path, Stack, param}
+import com.twitter.finagle.naming.NameInterpreter
+import io.buoyant.config.types.Port
+import io.buoyant.k8s.{ClientConfig, IstioNamer, SdsClient}
+import io.buoyant.namer.{InterpreterConfig, InterpreterInitializer}
+
+class IstioInterpreterInitializer extends InterpreterInitializer {
+  val configClass = classOf[IstioInterpreterConfig]
+  override val configId = "io.l5d.k8s.istio"
+}
+
+object IstioInterpreterInitializer extends IstioInterpreterInitializer
+
+case class IstioInterpreterConfig(
+  host: Option[String],
+  port: Option[Port],
+  pollIntervalMs: Option[Long]
+) extends InterpreterConfig with ClientConfig {
+
+  @JsonIgnore
+  override val experimentalRequired = true
+
+  @JsonIgnore
+  override val DefaultHost = "istio-manager.default.svc.cluster.local"
+  @JsonIgnore
+  override val DefaultPort = 8080
+
+  @JsonIgnore
+  val prefix: Path = Path.read("/io.l5d.k8s.istio")
+
+  @JsonIgnore
+  def portNum = port.map(_.port)
+
+  @JsonIgnore
+  private[this] val DefaultPollInterval = 5.seconds
+  @JsonIgnore
+  private[this] val pollInterval = pollIntervalMs.map(_.millis).getOrElse(DefaultPollInterval)
+
+  override protected def newInterpreter(params: Stack.Params): NameInterpreter = {
+    val label = param.Label("namer/io.l5d.k8s.istio")
+    val client = mkClient(params).configured(label).newService(dst)
+    val sdsClient = new SdsClient(client)
+    val istioNamer = new IstioNamer(sdsClient, prefix, pollInterval)
+    val routeManager = /* RouteManager(client) */ ()
+    IstioInterpreter(routeManager, istioNamer)
+  }
+}

--- a/interpreter/k8s/src/main/scala/io/buoyant/interpreter/k8s/IstioInterpreterInitializer.scala
+++ b/interpreter/k8s/src/main/scala/io/buoyant/interpreter/k8s/IstioInterpreterInitializer.scala
@@ -45,6 +45,7 @@ case class IstioInterpreterConfig(
     val client = mkClient(params).configured(label).newService(dst)
     val sdsClient = new SdsClient(client)
     val istioNamer = new IstioNamer(sdsClient, Paths.ConfiguredNamerPrefix ++ prefix, pollInterval)
+    // TODO: Use the route manager
     val routeManager = /* RouteManager(client) */ ()
     IstioInterpreter(routeManager, istioNamer)
   }

--- a/k8s/src/main/scala/io/buoyant/k8s/ClientConfig.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/ClientConfig.scala
@@ -8,7 +8,10 @@ import com.twitter.finagle.{Http, Stack}
  * produce a k8s API client.
  */
 trait ClientConfig {
-  import ClientConfig._
+
+  protected val DefaultHost = "localhost"
+  protected val DefaultNamespace = "default"
+  protected val DefaultPort = 8001
 
   def host: Option[String]
   def portNum: Option[Int]
@@ -28,10 +31,4 @@ trait ClientConfig {
       .withStreaming(true)
       .filtered(setHost)
   }
-}
-
-object ClientConfig {
-  val DefaultHost = "localhost"
-  val DefaultNamespace = "default"
-  val DefaultPort = 8001
 }

--- a/k8s/src/main/scala/io/buoyant/k8s/ClusterCache.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/ClusterCache.scala
@@ -1,0 +1,34 @@
+package io.buoyant.k8s
+
+import com.twitter.conversions.time._
+import com.twitter.finagle.Service
+import com.twitter.finagle.http.{Request, Response}
+import com.twitter.logging.Logger
+import com.twitter.util.{Duration, Future}
+import io.buoyant.k8s.ClusterCache.Cluster
+
+class ClusterCache(client: Service[Request, Response], pollInternal: Duration = 5.seconds) {
+
+  private[this] val log = Logger()
+  private[this] val rdsClient = new RdsClient(client)
+
+  private[this] val clusters = rdsClient.watch(pollInternal).map { routes =>
+    routes.flatMap(_.virtual_hosts).flatMap { vHost =>
+      vHost.name.split('|') match {
+        case Array(dest, port) =>
+          vHost.domains.map(_ -> Cluster(dest, port))
+        case _ => // vHost name is invalid
+          log.error(s"Invalid virtual_host name: ${vHost.name}")
+          Nil
+      }
+    }.toMap
+  }
+
+  def get(domain: String): Future[Option[Cluster]] = {
+    clusters.values.toFuture.flatMap(Future.const).map(_.get(domain))
+  }
+}
+
+object ClusterCache {
+  case class Cluster(dest: String, port: String)
+}

--- a/k8s/src/main/scala/io/buoyant/k8s/IstioNamer.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/IstioNamer.scala
@@ -64,7 +64,7 @@ class IstioNamer(
           case Addr.Bound(addrs, _) if addrs.isEmpty =>
             Activity.Ok(NameTree.Neg)
           case Addr.Bound(addrs, _) =>
-            Activity.Ok(NameTree.Leaf(Name.Bound(vaddr, id, residual)))
+            Activity.Ok(NameTree.Leaf(Name.Bound(vaddr, idPrefix ++ id, residual)))
           case Addr.Pending =>
             Activity.Pending
           case Addr.Failed(_) =>

--- a/k8s/src/main/scala/io/buoyant/k8s/IstioNamer.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/IstioNamer.scala
@@ -1,0 +1,79 @@
+package io.buoyant.k8s
+
+import com.twitter.conversions.time._
+import com.twitter.finagle._
+import com.twitter.finagle.util.DefaultTimer
+import com.twitter.util.{Activity, Duration, Timer, Var}
+
+/**
+ * The Istio namer reads service discovery information from the Istio-Manager's Service Discvoery
+ * Service API.
+ * https://lyft.github.io/envoy/docs/configuration/cluster_manager/sds_api.html
+ * Each lookup is backed by a polling loop.
+ */
+class IstioNamer(
+  sdsClient: SdsClient,
+  idPrefix: Path,
+  pollInterval: Duration = 5.seconds
+)(implicit timer: Timer = DefaultTimer.twitter) extends Namer {
+
+  private[this] val PrefixLen = 4
+  private[this] val LabelPattern = """(.*):(.*)""".r
+
+  /**
+   * Accepts names in the form:
+   *   /<namespace>/<svc-name>/<labels>/<port-name>/residual/path
+   *
+   * and initiates a polling loop against the SDS API.  The labels segment must be a :: delimited
+   * list of label:value pairs.  To avoid duplication, the labels must be in alphabetical order
+   * by label name.  e.g.
+   *
+   * /default/foo/az:us-west::env:prod::version:v1/http
+   *
+   * Use :: alone to specify an empty list of labels
+   *
+   * /default/foo/::/http
+   */
+  def lookup(path: Path): Activity[NameTree[Name]] = {
+    val id = path.take(PrefixLen) match {
+      case Path.Utf8(segments@_*) => Path.Utf8(segments.map(_.toLowerCase): _*)
+    }
+    id match {
+      case Path.Utf8(nsName, serviceName, labels, portName) =>
+        val residual = path.drop(PrefixLen)
+
+        val selectors = labels.split("::").collect {
+          case LabelPattern(key, value) => key -> value
+        }.toMap
+
+        log.debug("SDS lookup: %s %s", id.show, residual.show)
+
+        val vaddr = sdsClient.watch(nsName, portName, serviceName, selectors, pollInterval).run.map {
+          case Activity.Ok(rsp) =>
+            Addr.Bound(rsp.hosts.map { host =>
+              Address(host.ip_address, host.port)
+            }.toSet)
+          case Activity.Pending =>
+            Addr.Pending
+          case Activity.Failed(e) =>
+            Addr.Failed(e)
+        }
+
+        // it's okay, scalac.  We all need a little help sometimes.
+        val state: Var[Activity.State[NameTree[Name]]] = vaddr.map {
+          case Addr.Bound(addrs, _) if addrs.isEmpty =>
+            Activity.Ok(NameTree.Neg)
+          case Addr.Bound(addrs, _) =>
+            Activity.Ok(NameTree.Leaf(Name.Bound(vaddr, id, residual)))
+          case Addr.Pending =>
+            Activity.Pending
+          case Addr.Failed(_) =>
+            Activity.Ok(NameTree.Neg)
+        }
+
+        Activity(state)
+      case _ =>
+        Activity.value(NameTree.Neg)
+    }
+  }
+}

--- a/k8s/src/main/scala/io/buoyant/k8s/RdsClient.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/RdsClient.scala
@@ -7,6 +7,7 @@ import com.twitter.logging.Logger
 import com.twitter.util._
 import io.buoyant.config.Parser
 
+// TODO: All Istio-Pilot clients are very similar.  DRY them up and re-use the underlying client
 class RdsClient(client: Service[Request, Response]) {
   import RdsClient._
 

--- a/k8s/src/main/scala/io/buoyant/k8s/RdsClient.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/RdsClient.scala
@@ -1,0 +1,49 @@
+package io.buoyant.k8s
+
+import com.twitter.finagle.Service
+import com.twitter.finagle.http.{Request, Response}
+import com.twitter.finagle.util.DefaultTimer
+import com.twitter.logging.Logger
+import com.twitter.util._
+import io.buoyant.config.Parser
+
+class RdsClient(client: Service[Request, Response]) {
+  import RdsClient._
+
+  private[this] val log = Logger()
+
+  private[this] val mapper = Parser.jsonObjectMapper(Nil)
+
+  def get(): Future[Seq[RouteConfig]] = {
+    val req = Request(s"/v1/routes")
+    client(req).map { rsp =>
+      mapper.readValue[Seq[RouteConfig]](rsp.contentString)
+    }
+  }
+
+  def watch(
+    pollInterval: Duration
+  )(implicit timer: Timer = DefaultTimer.twitter): Activity[Seq[RouteConfig]] = {
+    val state = Var.async[Activity.State[Seq[RouteConfig]]](Activity.Pending) { update =>
+
+      def doUpdate() = get().respond {
+        case Return(rsp) => update.update(Activity.Ok(rsp))
+        case Throw(e) =>
+          log.error(e, "RDS update failed")
+          update.update(Activity.Failed(e))
+      }
+
+      val _ = doUpdate()
+
+      timer.schedule(pollInterval) {
+        val _ = doUpdate()
+      }
+    }
+    Activity(state)
+  }
+}
+
+object RdsClient {
+  case class RouteConfig(virtual_hosts: Seq[VHost])
+  case class VHost(name: String, domains: Seq[String])
+}

--- a/k8s/src/main/scala/io/buoyant/k8s/SdsClient.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/SdsClient.scala
@@ -1,0 +1,58 @@
+package io.buoyant.k8s
+
+import com.twitter.finagle.Service
+import com.twitter.finagle.http.{Request, Response}
+import com.twitter.finagle.util.DefaultTimer
+import com.twitter.logging.Logger
+import com.twitter.util._
+import io.buoyant.config.Parser
+import io.buoyant.k8s.SdsClient.SdsResponse
+
+/**
+ * A client for talking to the Service Discovery Service.
+ * https://lyft.github.io/envoy/docs/configuration/cluster_manager/sds_api.html
+ */
+class SdsClient(client: Service[Request, Response], clusterSuffix: String = "svc.cluster.local") {
+
+  private[this] val log = Logger()
+
+  private[this] val mapper = Parser.jsonObjectMapper(Nil)
+
+  def get(ns: String, port: String, service: String, labels: Map[String, String]): Future[SdsResponse] = {
+    val selectors = Seq(port) ++ labels.map { case (k, v) => s"$k=$v" }
+    val req = Request(s"/v1/registration/$service.$ns.$clusterSuffix|${selectors.mkString("|")}")
+    client(req).map { rsp =>
+      mapper.readValue[SdsResponse](rsp.contentString)
+    }
+  }
+
+  def watch(
+    ns: String,
+    port: String,
+    service: String,
+    labels: Map[String, String],
+    pollInterval: Duration
+  )(implicit timer: Timer = DefaultTimer.twitter): Activity[SdsResponse] = {
+    val state = Var.async[Activity.State[SdsResponse]](Activity.Pending) { update =>
+
+      def doUpdate() = get(ns, port, service, labels).respond {
+        case Return(rsp) => update.update(Activity.Ok(rsp))
+        case Throw(e) =>
+          log.error(e, "SDS update failed")
+          update.update(Activity.Failed(e))
+      }
+
+      val _ = doUpdate()
+
+      timer.schedule(pollInterval) {
+        val _ = doUpdate()
+      }
+    }
+    Activity(state)
+  }
+}
+
+object SdsClient {
+  case class SdsResponse(hosts: Seq[SdsEndpoint])
+  case class SdsEndpoint(ip_address: String, port: Int)
+}

--- a/linkerd/docs/namer.md
+++ b/linkerd/docs/namer.md
@@ -439,7 +439,52 @@ port-name | yes | The port name.
 svc-name | yes | The name of the service.
 label-value | yes if `labelSelector` is defined | The label value used to filter services.
 
+### Istio Configuration
 
+> Configure an Istio namer
+
+```yaml
+namers:
+- kind: io.l5d.k8s.istio
+  experimental: true
+  host: istio-manager.default.svc.cluster.local
+  port: 8080
+  pollIntervalMs: 5000
+```
+
+> Then reference the namer in the dtab to use it:
+
+```
+dtab: |
+  /svc/reviews => /#/io.l5d.k8s.istio/prod/http/reviews/version:v1;
+```
+
+The [Istio](https://istio.io/) namer uses the Istio-Manager's Service Discovery Service to lookup
+the endpoints for a given namespace, port, service, and list of label selectors.
+
+Key | Default Value | Description
+--- | ------------- | -----------
+prefix | `io.l5d.k8s.istio` | Resolves names with `/#/<prefix>`.
+experimental | _required_ | Because this namer is still considered experimental, you must set this to `true` to use it.
+host | `istio-manager.default.svc.cluster.local` | The host of the Istio-Manager.
+port | `8080` | The port of the Istio-Manager.
+pollIntervalMs | 5 seconds | How frequently to poll the SDS, in milliseconds.
+
+### Istio Path Parameters
+
+> Dtab Path Format
+
+```yaml
+/#/<prefix>/<namespace>/<port-name>/<svc-name>/<labels>
+```
+
+Key | Required | Description
+--- | -------- | -----------
+prefix | yes | Tells linkerd to resolve the request path using the Istio namer.
+namespace | yes | The Kubernetes namespace.
+port-name | yes | The port name.
+svc-name | yes | The name of the service.
+labels | yes | A `::` delimited list of `label:value` pairs.  Only endpoints that match all of these label selectors will be returned.
 
 <a name="marathon"></a>
 ## Marathon service discovery

--- a/linkerd/examples/istio.yaml
+++ b/linkerd/examples/istio.yaml
@@ -3,9 +3,9 @@ routers:
   identifier:
     kind: io.l5d.istio
     host: localhost
-  dtab:
-    /svc/localhost => /#/io.l5d.fs/default;
-    /svc/pet/8888 => /#/io.l5d.fs/cat;
-    /svc/pet/8800 => /#/io.l5d.fs/dog;
+  interpreter:
+    kind: io.l5d.k8s.istio
+    experimental: true
+    host: localhost
   servers:
   - port: 4140

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/IstioIdentifier.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/IstioIdentifier.scala
@@ -27,8 +27,8 @@ class IstioIdentifier(pfx: Path, baseDtab: () => Dtab, routeManager: RouteManage
       if (filteredRules.isEmpty) {
         unidentified
       } else {
-        val topRule = rules.maxBy[Int] { case (m: String, d: RouteRule) => d.`precedence`.getOrElse(0) }
-        val path = pfx ++ Path.Utf8(topRule._1)
+        val topRule = filteredRules.maxBy[Int] { case (m: String, d: RouteRule) => d.`precedence`.getOrElse(0) }
+        val path = pfx ++ Path.Utf8("route", topRule._1, "http") // HTTP port hardcoded for now
         val dst = Dst.Path(path, baseDtab(), Dtab.local)
         new IdentifiedRequest(dst, req)
       }
@@ -42,9 +42,9 @@ case class IstioIdentifierConfig(
   pollIntervalMs: Option[Long]
 ) extends HttpIdentifierConfig with ClientConfig {
   @JsonIgnore
-  val DefaultPort = 8081
+  override val DefaultPort = 8081
   @JsonIgnore
-  val DefaultHost = "istio-manager.default.svc.cluster.local"
+  override val DefaultHost = "istio-manager.default.svc.cluster.local"
 
   @JsonIgnore
   def portNum = port.map(_.port)

--- a/namer/k8s/src/main/resources/META-INF/services/io.buoyant.namer.NamerInitializer
+++ b/namer/k8s/src/main/resources/META-INF/services/io.buoyant.namer.NamerInitializer
@@ -1,3 +1,4 @@
 io.buoyant.namer.k8s.K8sExternalInitializer
 io.buoyant.namer.k8s.K8sInitializer
 io.buoyant.namer.k8s.K8sNamespacedInitializer
+io.buoyant.namer.k8s.IstioInitializer

--- a/namer/k8s/src/main/scala/io/buoyant/namer/k8s/IstioInitializer.scala
+++ b/namer/k8s/src/main/scala/io/buoyant/namer/k8s/IstioInitializer.scala
@@ -1,0 +1,64 @@
+package io.buoyant.namer.k8s
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.twitter.conversions.time._
+import com.twitter.finagle._
+import io.buoyant.config.types.Port
+import io.buoyant.k8s._
+import io.buoyant.namer.{NamerConfig, NamerInitializer}
+
+/**
+ * Supports namer configurations in the form:
+ *
+ * <pre>
+ * namers:
+ * - kind: io.l5d.k8s.istio
+ *   experimental: true
+ *   host: istio-manager.default.svc.cluster.local
+ *   port: 8080
+ *   pollIntervalMs: 5000
+ * </pre>
+ */
+class IstioInitializer extends NamerInitializer {
+  val configClass = classOf[IstioConfig]
+  override def configId = "io.l5d.k8s.istio"
+}
+
+object IstioInitializer extends IstioInitializer
+
+case class IstioConfig(
+  host: Option[String],
+  port: Option[Port],
+  pollIntervalMs: Option[Long]
+) extends NamerConfig with ClientConfig {
+
+  @JsonIgnore
+  override val experimentalRequired = true
+
+  @JsonIgnore
+  override val DefaultHost = "istio-manager.default.svc.cluster.local"
+  @JsonIgnore
+  override val DefaultPort = 8080
+
+  @JsonIgnore
+  override def defaultPrefix: Path = Path.read("/io.l5d.k8s.istio")
+
+  @JsonIgnore
+  def portNum = port.map(_.port)
+
+  @JsonIgnore
+  private[this] val DefaultPollInterval = 5.seconds
+  @JsonIgnore
+  private[this] val pollInterval = pollIntervalMs.map(_.millis).getOrElse(DefaultPollInterval)
+
+  /**
+   * Construct a namer.
+   */
+  @JsonIgnore
+  override def newNamer(params: Stack.Params): Namer = {
+    val client = mkClient(params)
+    val label = param.Label(s"namer${prefix.show}")
+    val sdsClient = new SdsClient(client.configured(label).newService(dst))
+    new IstioNamer(sdsClient, prefix, pollInterval)
+  }
+}

--- a/namerd/storage/k8s/src/main/scala/io/buoyant/namerd/storage/K8sDtabStoreInitializer.scala
+++ b/namerd/storage/k8s/src/main/scala/io/buoyant/namerd/storage/K8sDtabStoreInitializer.scala
@@ -18,7 +18,7 @@ case class K8sConfig(
   override def mkDtabStore: DtabStore = {
     val client = mkClient()
 
-    new K8sDtabStore(client, dst, namespace.getOrElse(ClientConfig.DefaultNamespace))
+    new K8sDtabStore(client, dst, namespace.getOrElse(DefaultNamespace))
   }
 }
 


### PR DESCRIPTION
Add the Istio Interpreter and the Istio Namer that it uses.

TODOS:
* wire it up to RouteManager
* actually map routes into dentries
* DRY up Istio-Pilot clients and reuse the underlying finagle client