### PR TITLE
Move CircleCI parallelism setting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,8 +9,8 @@ jobs:
       - image: openjdk:8
         environment:
           CI_TERRIBLENESS: 30.seconds
-        # Run two containers, $CIRCLE_NODE_TOTAL = 2, $CIRCLE_NODE_INDEX = [0|1]
-        parallelism: 2
+    # Run two containers, $CIRCLE_NODE_TOTAL = 2, $CIRCLE_NODE_INDEX = [0|1]
+    parallelism: 2
     working_directory: ~/linkerd
     # All run steps execute in both containers unless otherwise specified.
     # Deploy steps execute on container 0.


### PR DESCRIPTION
## Problem

CircleCI recently changed its 2.0 config file format and moved the place in the config where `parallelism` is specified. This effectively reduced our CI parallelism to 1x. [More info](https://discuss.circleci.com/t/why-arent-my-2-0-tests-using-parallel-containers/13410).

## Solution

Move the `parallelism` key up a level.

## Validation

https://circleci.com/gh/linkerd/linkerd/5001