### PR TITLE
Pin the base docker image's JRE version

### DIFF
--- a/project/Base.scala
+++ b/project/Base.scala
@@ -155,7 +155,7 @@ class Base extends Build {
     assemblyJarName in assembly := s"${name.value}-${version.value}-${configuration.value}-exec",
     docker <<= docker dependsOn (assembly in configuration),
     dockerEnvPrefix := "",
-    dockerJavaImage <<= (dockerJavaImage in Global).?(_.getOrElse("library/java:openjdk-8-jre")),
+    dockerJavaImage <<= (dockerJavaImage in Global).?(_.getOrElse("openjdk:8u131-jre")),
     dockerfile in docker := new Dockerfile {
       val envPrefix = dockerEnvPrefix.value.toUpperCase
       val home = s"/${organization.value}/${name.value}/${version.value}"


### PR DESCRIPTION
## Problem

By depending on the "java:openjdk-8-jre" tag, docker just uses whatever minor version of the JRE is available the first time that image is pulled. This can lead to unpredictable minor versions across releases. For instance:

```
$ docker run --rm --entrypoint=sh buoyantio/linkerd:0.9.1 -c 'echo $JAVA_DEBIAN_VERSION'
8u111-b14-2~bpo8+1
$ docker run --rm --entrypoint=sh buoyantio/linkerd:1.0.0 -c 'echo $JAVA_DEBIAN_VERSION'
8u102-b14.1-1~bpo8+1
$ docker run --rm --entrypoint=sh buoyantio/linkerd:1.0.2 -c 'echo $JAVA_DEBIAN_VERSION'
8u111-b14-2~bpo8+1
```

## Solution

Pin our base image to a known recent minor version: "openjdk:8u131-jre". As part of this change I'm also switching us from the "java" image to the "openjdk" image, since "java" is deprecated.