### PR TITLE
Istio Identifier for H2

### DIFF
--- a/interpreter/k8s/src/main/scala/io/buoyant/interpreter/k8s/IstioInterpreterInitializer.scala
+++ b/interpreter/k8s/src/main/scala/io/buoyant/interpreter/k8s/IstioInterpreterInitializer.scala
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import com.twitter.finagle.naming.NameInterpreter
 import com.twitter.finagle.{Path, Stack}
 import io.buoyant.config.types.Port
-import io.buoyant.k8s.istio.{DiscoveryClient, IstioNamer, RouteCache}
 import io.buoyant.namer.{InterpreterConfig, InterpreterInitializer, Paths}
 
 class IstioInterpreterInitializer extends InterpreterInitializer {
@@ -21,19 +20,10 @@ case class IstioInterpreterConfig(
   apiserverPort: Option[Port],
   pollIntervalMs: Option[Long]
 ) extends InterpreterConfig {
+  import io.buoyant.k8s.istio._
 
   @JsonIgnore
   override val experimentalRequired = true
-
-  @JsonIgnore
-  val DefaultDiscoveryHost = "istio-manager.default.svc.cluster.local"
-  @JsonIgnore
-  val DefaultDiscoveryPort = 8080
-
-  @JsonIgnore
-  val DefaultApiserverHost = "istio-manager.default.svc.cluster.local"
-  @JsonIgnore
-  val DefaultApiserverPort = 8081
 
   @JsonIgnore
   val prefix: Path = Path.read("/io.l5d.k8s.istio")

--- a/k8s/src/main/scala/io/buoyant/k8s/istio/IdentifierPreconditions.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/istio/IdentifierPreconditions.scala
@@ -1,0 +1,54 @@
+package io.buoyant.k8s.istio
+
+import com.twitter.finagle.Path
+import istio.proxy.v1.config.{MatchCondition, RouteRule, StringMatch}
+import istio.proxy.v1.config.StringMatch.OneofMatchType
+
+trait IdentifierPreconditions {
+  def headerMatches(headerValue: String, stringMatch: StringMatch): Boolean = {
+    stringMatch.`matchType` match {
+      case Some(OneofMatchType.Exact(value)) => headerValue == value
+      case Some(OneofMatchType.Prefix(pfx)) => headerValue.startsWith(pfx)
+      case Some(OneofMatchType.Regex(r)) => headerValue.matches(r)
+      case None => throw new IllegalArgumentException("stringMatch missing matchType")
+    }
+  }
+
+  def pfx: Path
+  def externalRequestPath(host: String): Path = {
+    host.split(":") match {
+      case Array(h: String, p: String) => pfx ++ Path.Utf8("ext", h, p)
+      case Array(h: String) => pfx ++ Path.Utf8("ext", h, "80")
+      case _ => throw new IllegalArgumentException("unable to parse host for request")
+    }
+  }
+
+  def matchesAllConditions(getHeader: (String) => Option[String], matchCondition: MatchCondition): Boolean = {
+    val matchesHeaders = matchCondition.`httpHeaders`.forall {
+      case (headerName, stringMatch) =>
+        // return false if the headerName does not appear in the request's headerMap
+        getHeader(headerName) match {
+          case Some(headerValue) => headerMatches(headerValue, stringMatch)
+          case None => false
+        }
+    }
+    //TODO: add other match conditions
+    matchesHeaders
+  }
+
+  def filterRules(rules: Map[String, RouteRule], dest: String, getHeader: (String) => Option[String]): Seq[(String, RouteRule)] = rules.filter {
+    case (_, r) if r.`destination`.contains(dest) =>
+      // return true if no match conditions were defined on the route-rule
+      r.`match`.forall(matchesAllConditions(getHeader, _))
+    case _ => false
+  }.toSeq
+
+  def maxPrecedenceRuleName(rules: Seq[(String, RouteRule)]): Option[String] = {
+    if (rules.isEmpty) {
+      None
+    } else {
+      val rule = rules.maxBy[Int] { case (m: String, d: RouteRule) => d.`precedence`.getOrElse(0) }
+      Some(rule._1)
+    }
+  }
+}

--- a/k8s/src/main/scala/io/buoyant/k8s/istio/package.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/istio/package.scala
@@ -1,0 +1,9 @@
+package io.buoyant.k8s
+
+package object istio {
+  val DefaultDiscoveryHost = "istio-manager"
+  val DefaultDiscoveryPort = 8080
+
+  val DefaultApiserverHost = "istio-manager"
+  val DefaultApiserverPort = 8081
+}

--- a/linkerd/docs/protocol-h2.md
+++ b/linkerd/docs/protocol-h2.md
@@ -267,6 +267,61 @@ namespace | N/A | The Kubernetes namespace.
 port | N/A | The port name.
 svc | N/A | The name of the service.
 
+<a href="istio-identifier></a>
+### Istio Identifier
+
+kind: `io.l5d.istio`
+
+This identifier compares H2 requests to
+[istio route-rules](https://istio.io/docs/concepts/traffic-management/rules-configuration.html) and assigns a name based
+on those rules.
+
+ #### Identifier Configuration:
+
+```yaml
+routers:
+- protocol: h2
+  experimental: true
+  identifier:
+    kind: io.l5d.istio
+```
+
+Key  | Default Value | Description
+---- | ------------- | -----------
+discoveryHost | `istio-manager` | The host of the Istio-Pilot.
+discoveryPort | 8080 | The port of the Istio-Pilot's discovery service.
+apiserverHost | `istio-manager` | The host of the Istio-Pilot.
+apiserverPort | 8081 | The port of the Istio-Pilot's apiserver.
+
+#### Identifier Path Parameters
+
+> Dtab Path Format if the request does not point to a valid k8s cluster
+
+```
+  / dstPrefix / "ext" / host / port
+```
+
+> Dtab Path Format if the request has a valid cluster but DOES NOT match a route-rule
+
+```
+  / dstPrefix / "dest" / cluster / port
+```
+
+> Dtab Path Format if the request matches a route-rule
+
+```
+  / dstPrefix / "route" / route-rule
+```
+
+
+Key | Default Value | Description
+--- | ------------- | -----------
+dstPrefix | `/svc` | The `dstPrefix` as set in the routers block.
+route-rule | N/A | The name of the route-rule that matches the incoming request.
+host | N/A | The host to send the request to.
+cluster | N/A | The cluster to send the request to.
+port | N/A | The port to send the request to.
+
 ## HTTP/2 Headers
 
 linkerd reads and sets several headers prefixed by `l5d-`, as is done

--- a/linkerd/docs/protocol-http.md
+++ b/linkerd/docs/protocol-http.md
@@ -376,35 +376,43 @@ routers:
 - protocol: http
   identifier:
     kind: io.l5d.istio
-    pollIntervalMs: 10000
 ```
 
 Key  | Default Value | Description
 ---- | ------------- | -----------
-host | `istio-manager.default.svc.cluster.local` | The host of the Istio-Manager.
-port | 8081 | The port of the Istio-Manager's apiserver.
+discoveryHost | `istio-manager` | The host of the Istio-Pilot.
+discoveryPort | 8080 | The port of the Istio-Pilot's discovery service.
+apiserverHost | `istio-manager` | The host of the Istio-Pilot.
+apiserverPort | 8081 | The port of the Istio-Pilot's apiserver.
 
 #### Identifier Path Parameters
+
+> Dtab Path Format if the request does not point to a valid k8s cluster
+
+```
+  / dstPrefix / "ext" / host / port
+```
+
+> Dtab Path Format if the request has a valid cluster but DOES NOT match a route-rule
+
+```
+  / dstPrefix / "dest" / cluster / port
+```
 
 > Dtab Path Format if the request matches a route-rule
 
 ```
-  / dstPrefix / "route" / route-rule 
+  / dstPrefix / "route" / route-rule
 ```
 
-
-> Dtab Path Format if the request DOES NOT match a route-rule
-
-```
-  / dstPrefix / "dest" / host / port 
-```
 
 Key | Default Value | Description
 --- | ------------- | -----------
 dstPrefix | `/svc` | The `dstPrefix` as set in the routers block.
 route-rule | N/A | The name of the route-rule that matches the incoming request.
-host | N/A | The host to forward the request to.
-port | N/A | The port to forward the request to.
+host | N/A | The host to send the request to.
+cluster | N/A | The cluster to send the request to.
+port | N/A | The port to send the request to.
 
 <a name="static-identifier"></a>
 ### Static Identifier

--- a/linkerd/protocol/h2/src/main/resources/META-INF/services/io.buoyant.linkerd.IdentifierInitializer
+++ b/linkerd/protocol/h2/src/main/resources/META-INF/services/io.buoyant.linkerd.IdentifierInitializer
@@ -1,3 +1,4 @@
 io.buoyant.linkerd.protocol.h2.HeaderTokenIdentifierInitializer
 io.buoyant.linkerd.protocol.h2.HeaderPathIdentifierInitializer
 io.buoyant.linkerd.protocol.h2.IngressIdentifierInitializer
+io.buoyant.linkerd.protocol.h2.IstioIdentifierInitializer

--- a/linkerd/protocol/h2/src/test/scala/io/buoyant/linkerd/protocol/h2/IstioIdentifierConfigTest.scala
+++ b/linkerd/protocol/h2/src/test/scala/io/buoyant/linkerd/protocol/h2/IstioIdentifierConfigTest.scala
@@ -1,0 +1,35 @@
+package io.buoyant.linkerd.protocol.h2
+
+import com.twitter.finagle.Stack.Params
+import com.twitter.finagle.util.LoadService
+import io.buoyant.config.Parser
+import io.buoyant.config.types.Port
+import io.buoyant.linkerd.IdentifierInitializer
+import io.buoyant.linkerd.protocol.H2IdentifierConfig
+import io.buoyant.test.Awaits
+import org.scalatest.FunSuite
+
+class IstioIdentifierConfigTest extends FunSuite with Awaits {
+  test("sanity") {
+    // ensure it doesn't totally blow up
+    val _ = new IstioIdentifierConfig(None, None, None, None).newIdentifier(Params.empty)
+  }
+
+  test("service registration") {
+    assert(LoadService[IdentifierInitializer].exists(_.isInstanceOf[IstioIdentifierInitializer]))
+  }
+
+  test("parse config") {
+    val yaml =
+      s"""|kind: io.l5d.istio
+        |discoveryHost: myHost
+        |discoveryPort: 9999
+        |""".stripMargin
+
+    val mapper = Parser.objectMapper(yaml, Iterable(Seq(IstioIdentifierInitializer)))
+    val config = mapper.readValue[H2IdentifierConfig](yaml).asInstanceOf[IstioIdentifierConfig]
+
+    assert(config.discoveryHost == Some("myHost"))
+    assert(config.discoveryPort == Some(Port(9999)))
+  }
+}


### PR DESCRIPTION
Moves common precondition-checking logic into `IdentifierPreconditions`.
Adds/updates documentation
Fixes #1408