### PR TITLE
Reduce lock contention from Metrics Stats addition.

### DIFF
--- a/project/Base.scala
+++ b/project/Base.scala
@@ -208,6 +208,8 @@ class Base extends Build {
   val testUtil = projectDir("test-util")
     .settings(coverageExcludedPackages := "io.buoyant.test.*")
     .settings(libraryDependencies += Deps.scalatest)
+    .settings(libraryDependencies += Deps.scalacheck)
+    .settings(libraryDependencies += Deps.junit)
     .settings(libraryDependencies ++= {
       val deps = Deps.twitterUtil("core") :: Deps.twitterUtil("logging") :: Nil
       if (doDevelopTwitterDeps.value) {

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -52,6 +52,12 @@ object Deps {
   // testing. duh.
   val scalatest = "org.scalatest" %% "scalatest" % "3.0.1"
 
+  // scalacheck for Property-based testing
+  val scalacheck = "org.scalacheck" %% "scalacheck" % "1.13.4"
+
+  // junit
+  val junit = "junit" % "junit" % "4.10"
+
   // guava
   val guava = "com.google.guava" % "guava" % "19.0"
 

--- a/telemetry/core/src/main/scala/com/twitter/finagle/stats/buoyant/BucketedHistogram.scala
+++ b/telemetry/core/src/main/scala/com/twitter/finagle/stats/buoyant/BucketedHistogram.scala
@@ -1,7 +1,5 @@
 package com.twitter.finagle.stats.buoyant
 
-import com.twitter.finagle.stats.{BucketedHistogram => MetricsBucketedHistogram}
-
 class BucketedHistogram(limits: Array[Int])
   extends MetricsBucketedHistogram(limits)
 

--- a/telemetry/core/src/main/scala/com/twitter/finagle/stats/buoyant/MetricsBucketedHistogram.scala
+++ b/telemetry/core/src/main/scala/com/twitter/finagle/stats/buoyant/MetricsBucketedHistogram.scala
@@ -1,0 +1,311 @@
+package com.twitter.finagle.stats.buoyant
+
+import com.twitter.finagle.stats.BucketAndCount
+import com.twitter.common.stats
+import java.util
+
+private[twitter] object MetricsBucketedHistogram {
+
+  /**
+   * Given an error, compute all the bucket values from 1 until we run out of positive
+   * 32-bit ints. The error should be in percent, between 0.0 and 1.0.
+   *
+   * Each value in the returned array will be at most `1 + (2 * error)` larger than
+   * the previous (before rounding).
+   *
+   * Because percentiles are then computed as the midpoint between two adjacent limits,
+   * this means that a value can be at most `1 + error` percent off of the actual
+   * percentile.
+   *
+   * The last bucket tracks up to `Int.MaxValue`.
+   */
+  private[this] def makeLimitsFor(error: Double): Array[Int] = {
+    def build(maxValue: Double, factor: Double, n: Double): Stream[Double] = {
+      val next = n * factor
+      if (next >= maxValue)
+        Stream.empty
+      else
+        Stream.cons(next, build(maxValue, factor, next))
+    }
+    require(error > 0.0 && error <= 1.0, error)
+
+    val values = build(Int.MaxValue.toDouble, 1.0 + (error * 2), 1.0)
+      .map(_.toInt + 1) // this ensures that the smallest value is 2 (below we prepend `1`)
+      .distinct
+      .force
+    (Seq(1) ++ values).toArray
+  }
+
+  // 0.5% error => 1797 buckets, 7188 bytes, max 11 compares on binary search
+  private[stats] val DefaultErrorPercent = 0.005
+
+  private[this] val DefaultLimits: Array[Int] =
+    makeLimitsFor(DefaultErrorPercent)
+
+  /** check all the limits are non-negative and increasing in value. */
+  private def assertLimits(limits: Array[Int]): Unit = {
+    require(limits.length > 0)
+    var i = 0
+    var prev = -1L
+    while (i < limits.length) {
+      val value = limits(i)
+      require(value >= 0 && value > prev, i)
+      prev = value
+      i += 1
+    }
+  }
+
+  /**
+   * Creates an instance using the default bucket limits.
+   */
+  def apply(): MetricsBucketedHistogram =
+    new MetricsBucketedHistogram(DefaultLimits)
+
+}
+
+/**
+ * This is a clone of [[com.twitter.finagle.stats.BucketedHistogram]]
+ * modified to be internally thread-safe to avoid taking a lock on the
+ * entire object.
+ *
+ * Allows for computing approximate percentiles from a stream of
+ * data points.
+ *
+ * The precision is relative to the size of the data points that are
+ * collected (not the number of points, but how big each value is).
+ *
+ * For instances created using the defaults via [[BucketedHistogram.apply()]],
+ * the memory footprint should be around 7.2 KB.
+ *
+ * This version is designed to be internally thread-safe.
+ *
+ * ''Note:'' while the interface for [[MetricsBucketedHistogram.add(Long)]] takes a `Long`,
+ * internally the maximum value we will observe is `Int.MaxValue`. This is subject
+ * to change and should be considered the minimum upper bound. Also, the smallest
+ * value we will record is `0`.
+ *
+ * ''Note:'' this code borrows heavily from
+ * [[https://github.com/twitter/ostrich/blob/master/src/main/scala/com/twitter/ostrich/stats/Histogram.scala Ostrich's Histogram]].
+ * A few of the differences include:
+ *  - bucket limits are configurable instead of fixed
+ *  - counts per bucket are stored in int's
+ *  - all synchronization is external
+ *  - no tracking of min, max, sum
+ *
+ * @param limits the values at each index represent upper bounds, exclusive,
+ *               of values for the bucket. As an example, given limits of `Array(1, 3, MaxValue)`,
+ *               index=0 counts values `[0..1)`,
+ *               index=1 counts values `[1..3)`, and
+ *               index=2 counts values `[3..MaxValue)`.
+ *               An Int per bucket should suffice, as standard usage only gives
+ *               20 seconds before rolling to the next BucketedHistogram.
+ *               This gives you up to Int.MaxValue / 20 = ~107MM add()s per second
+ *               to a ''single'' bucket.
+ *
+ * @see [[BucketedHistogram.apply()]] for creation.
+ */
+private[stats] class MetricsBucketedHistogram(
+  limits: Array[Int]
+)
+  extends stats.Histogram {
+  MetricsBucketedHistogram.assertLimits(limits)
+
+  private[this] val countsLength: Int = limits.length + 1
+
+  /** number of samples seen per corresponding bucket in `limits` */
+  private[this] val counts = new Array[Int](countsLength)
+
+  /** total number of samples seen */
+  private[this] var num = 0L
+
+  /** total value of all samples seen */
+  private[this] var total = 0L
+
+  /**
+   * Note: only values between `0` and `Int.MaxValue`, inclusive, are recorded.
+   *
+   * @inheritdoc
+   */
+  def add(value: Long): Unit = {
+    var index = 0
+    var valueToAdd = 0L
+
+    if (value >= Int.MaxValue) {
+      index = countsLength - 1
+      valueToAdd = Int.MaxValue
+    } else {
+      val asInt = value.toInt
+      // recall that limits represent upper bounds, exclusive — so take the next position (+1).
+      // we assume that no inputs can be larger than the largest value in the limits array.
+      index = Math.abs(util.Arrays.binarySearch(limits, asInt)) + 1
+      valueToAdd = value
+    }
+
+    counts.synchronized {
+      total += valueToAdd
+      counts(index) += 1
+      num += 1
+    }
+  }
+
+  /**
+   * @inheritdoc
+   */
+  override def clear(): Unit = {
+    counts.synchronized {
+      var i = 0
+      while (i < countsLength) {
+        counts(i) = 0
+        i += 1
+      }
+      num = 0
+      total = 0
+    }
+  }
+
+  /**
+   * Calculate the value of the percentile rank, `p`, for the added data points
+   * such that `p * 100`-percent of the data points are the same or less than it.
+   *
+   * @param p must be within 0.0 to 1.0, inclusive.
+   * @return the approximate value for the requested percentile.
+   *         The returned value will be within
+   *         [[BucketedHistogram.DefaultErrorPercent]] of the actual value.
+   */
+  def percentile(p: Double): Long = {
+    if (p < 0.0 || p > 1.0)
+      throw new AssertionError(s"percentile must be within 0.0 to 1.0 inclusive: $p")
+
+    val target = counts.synchronized {
+      Math.round(p * num)
+    }
+    var total = 0L
+    var i = 0
+    counts.synchronized {
+      while (i < countsLength && total < target) {
+        total += counts(i)
+        i += 1
+      }
+    }
+
+    i match {
+      case 0 => 0
+      case _ if i == countsLength => maximum
+      case _ => limitMidpoint(i - 1)
+    }
+  }
+
+  /**
+   * The maximum value seen by calls to [[add]].
+   *
+   * @return 0 if no values have been added.
+   *         The returned value will be within
+   *         [[BucketedHistogram.DefaultErrorPercent]] of the actual value.
+   */
+  def maximum: Long = {
+    counts.synchronized {
+      if (num == 0) {
+        0L
+      } else if (counts(countsLength - 1) > 0) {
+        Int.MaxValue
+      } else {
+        var i = countsLength - 2 // already checked the last, start 1 before
+        while (i >= 0 && counts(i) == 0) {
+          i -= 1
+        }
+        if (i == 0) 0
+        else limitMidpoint(i)
+      }
+    }
+  }
+
+  /**
+   * The minimum value seen by calls to [[add]].
+   *
+   * @return 0 if no values have been added.
+   *         The returned value will be within
+   *         [[BucketedHistogram.DefaultErrorPercent]] of the actual value.
+   */
+  def minimum: Long = {
+    counts.synchronized {
+      if (num == 0) {
+        0L
+      } else {
+        var i = 0
+        while (i < countsLength && counts(i) == 0) {
+          i += 1
+        }
+        limitMidpoint(i)
+      }
+    }
+  }
+
+  /** Get the midpoint of bucket `i` */
+  private[this] def limitMidpoint(i: Int): Long = {
+    i match {
+      case 0 => 0
+      case _ if i >= limits.length => Int.MaxValue
+      case _ => (limits(i - 1).toLong + limits(i)) / 2
+    }
+  }
+
+  override def getQuantile(quantile: Double): Long =
+    percentile(quantile)
+
+  override def getQuantiles(quantiles: Array[Double]): Array[Long] = {
+    val ps = new Array[Long](quantiles.length)
+    var i = 0
+    while (i < ps.length) {
+      // Note: we could speed this up via just one pass over `counts` instead of
+      // of a pass per quantile.
+      // We could speed up calls to `percentile` by tracking the maximum
+      // bucket used during `add()`s to minimize how much of `counts` to scan.
+      ps(i) = percentile(quantiles(i))
+      i += 1
+    }
+    ps
+  }
+
+  /**
+   * The total of all the values seen by calls to [[add]].
+   */
+  def sum: Long = total
+
+  /**
+   * The number of values [[add added]].
+   */
+  def count: Long = num
+
+  /**
+   * The average, or arithmetic mean, of all values seen
+   * by calls to [[add]].
+   *
+   * @return 0.0 if no values have been [[add added]].
+   */
+  def average: Double = counts.synchronized {
+    if (num == 0) 0.0 else total / num.toDouble
+  }
+
+  /**
+   * Returns a seq containing nonzero values of the histogram.
+   * The sequence contains instances of BucketAndCount which are
+   * the bucket's upper and lower limits and a count of the number
+   * of times a value in range of the limits was added.
+   */
+  def bucketAndCounts: Seq[BucketAndCount] = counts.synchronized {
+    counts.zipWithIndex.collect {
+      case (count, idx) if count != 0 =>
+        // counts is 1 bucket longer than limits
+        // The last bucket of counts tracks added
+        // values greater than or equal to Int.MaxValue
+        val upperLimit = if (idx != limits.length) {
+          limits(idx)
+        } else Int.MaxValue
+        val lowerLimit = if (idx != 0) {
+          limits(idx - 1)
+        } else 0
+        BucketAndCount(lowerLimit, upperLimit, count)
+    }.toSeq
+  }
+
+}

--- a/telemetry/core/src/main/scala/com/twitter/finagle/stats/buoyant/MetricsBucketedHistogram.scala
+++ b/telemetry/core/src/main/scala/com/twitter/finagle/stats/buoyant/MetricsBucketedHistogram.scala
@@ -4,6 +4,8 @@ import com.twitter.finagle.stats.BucketAndCount
 import com.twitter.common.stats
 import java.util
 
+// Originally copied from
+// finagle/finagle-stats/src/main/scala/com/twitter/finagle/stats/BucketedHistogram.scala
 private[twitter] object MetricsBucketedHistogram {
 
   /**
@@ -127,18 +129,16 @@ private[stats] class MetricsBucketedHistogram(
    * @inheritdoc
    */
   def add(value: Long): Unit = {
-    var index = 0
     var valueToAdd = 0L
-
-    if (value >= Int.MaxValue) {
-      index = countsLength - 1
+    val index = if (value >= Int.MaxValue) {
       valueToAdd = Int.MaxValue
+      countsLength - 1
     } else {
+      valueToAdd = value
       val asInt = value.toInt
       // recall that limits represent upper bounds, exclusive — so take the next position (+1).
       // we assume that no inputs can be larger than the largest value in the limits array.
-      index = Math.abs(util.Arrays.binarySearch(limits, asInt)) + 1
-      valueToAdd = value
+      Math.abs(util.Arrays.binarySearch(limits, asInt) + 1)
     }
 
     counts.synchronized {

--- a/telemetry/core/src/main/scala/io/buoyant/telemetry/Metric.scala
+++ b/telemetry/core/src/main/scala/io/buoyant/telemetry/Metric.scala
@@ -27,21 +27,21 @@ object Metric {
     private[this] var resetTime = Time.now
     def startingAt: Time = resetTime
 
-    def add(value: Float): Unit = underlying.synchronized {
+    def add(value: Float): Unit = {
       // TODO track update time to allow detection of stale stats.
       underlying.add(value.toLong)
     }
 
-    def peek: Seq[BucketAndCount] = underlying.synchronized {
+    def peek: Seq[BucketAndCount] = {
       underlying.bucketAndCounts
     }
 
-    def snapshot(): HistogramSummary = underlying.synchronized {
+    def snapshot(): HistogramSummary = {
       summarySnapshot = summary
       summarySnapshot
     }
 
-    def reset(): (Seq[BucketAndCount], Duration) = underlying.synchronized {
+    def reset(): (Seq[BucketAndCount], Duration) = {
       val buckets = underlying.bucketAndCounts
       underlying.clear()
       val now = Time.now
@@ -50,7 +50,7 @@ object Metric {
       (buckets, delta)
     }
 
-    def summary: HistogramSummary = underlying.synchronized {
+    def summary: HistogramSummary = {
       HistogramSummary(
         underlying.count,
         underlying.minimum,

--- a/telemetry/core/src/test/scala/com/twitter/finagle/stats/buoyant/MetricsBucketedHistogramTest.scala
+++ b/telemetry/core/src/test/scala/com/twitter/finagle/stats/buoyant/MetricsBucketedHistogramTest.scala
@@ -1,0 +1,222 @@
+package com.twitter.finagle.stats.buoyant
+
+import com.twitter.finagle.stats.BucketAndCount
+
+import org.junit.runner.RunWith
+import org.scalacheck.Gen
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatest.{Matchers, FunSuite}
+import org.scalatest.junit.JUnitRunner
+
+// Originally copied from
+// finagle/finagle-stats/src/test/scala/com/twitter/finagle/stats/BucketedHistogramTest.scala
+
+@RunWith(classOf[JUnitRunner])
+class MetricsBucketedHistogramTest extends FunSuite
+  with GeneratorDrivenPropertyChecks
+  with Matchers {
+  test("constructor limits cannot be empty") {
+    intercept[IllegalArgumentException] { new MetricsBucketedHistogram(new Array[Int](0)) }
+  }
+
+  test("constructor limits cannot have negative values") {
+    intercept[IllegalArgumentException] { new MetricsBucketedHistogram(Array[Int](-1)) }
+  }
+
+  test("constructor limits must be increasing in value") {
+    intercept[IllegalArgumentException] { new MetricsBucketedHistogram(Array[Int](0, 0)) }
+  }
+
+  test("percentile when empty") {
+    val h = MetricsBucketedHistogram()
+    assert(h.percentile(0.0) == 0)
+    assert(h.percentile(0.5) == 0)
+    assert(h.percentile(1.0) == 0)
+  }
+
+  private def assertWithinError(ideal: Long, actual: Long): Unit = {
+    val epsilon = Math.round(ideal * MetricsBucketedHistogram.DefaultErrorPercent)
+    if (epsilon == 0) {
+      val _ = assert(actual == ideal)
+    } else {
+      val _ = actual should be(ideal +- epsilon)
+    }
+  }
+
+  test("percentile 1 to 100000") {
+    val h = MetricsBucketedHistogram()
+    val wantedPs = Array[Double](0.0, 0.5, 0.9, 0.99, 0.999, 0.9999, 1.0)
+
+    def assertPercentiles(maxVal: Long): Unit = {
+      val actuals = h.getQuantiles(wantedPs)
+      actuals.zip(wantedPs).foreach {
+        case (actual, wantedP) =>
+          withClue(s"percentile=$wantedP") {
+            // verify that each percentile is within the error bounds.
+            val ideal = Math.round(wantedP * maxVal)
+            assertWithinError(ideal, actual)
+
+            // verify that getting each percentile 1-at-a-time
+            // is the same as the bulk call
+            assert(h.percentile(wantedP) == actual)
+          }
+      }
+    }
+
+    1L.to(100L).foreach(h.add)
+    assertPercentiles(100)
+
+    101L.to(1000L).foreach(h.add)
+    assertPercentiles(1000)
+
+    1001L.to(10000L).foreach(h.add)
+    assertPercentiles(10000)
+
+    10001L.to(100000L).foreach(h.add)
+    assertPercentiles(100000)
+  }
+
+  test("percentile edge cases") {
+    val max = MetricsBucketedHistogram()
+    max.add(Long.MaxValue)
+    assert(max.percentile(0.1) == 0)
+    assert(max.percentile(1.0) == Int.MaxValue)
+
+    val zero = MetricsBucketedHistogram()
+    zero.add(0)
+    assert(zero.percentile(0.0) == 0)
+    assert(zero.percentile(0.1) == 0)
+    assert(zero.percentile(1.0) == 0)
+  }
+
+  test("clear") {
+    val h = MetricsBucketedHistogram()
+    assert(h.percentile(0.0) == 0)
+    assert(h.percentile(0.5) == 0)
+    assert(h.percentile(1.0) == 0)
+
+    h.add(100)
+    assert(h.percentile(0.0) == 0)
+    assert(h.percentile(0.5) == 100)
+    assert(h.percentile(1.0) == 100)
+
+    h.clear()
+    assert(h.percentile(0.0) == 0)
+    assert(h.percentile(0.5) == 0)
+    assert(h.percentile(1.0) == 0)
+  }
+
+  test("sum") {
+    val h = MetricsBucketedHistogram()
+    assert(h.sum == 0)
+
+    h.add(100)
+    h.add(200)
+    assert(h.sum == 300)
+
+    h.clear()
+    assert(h.sum == 0)
+  }
+
+  test("count") {
+    val h = MetricsBucketedHistogram()
+    assert(h.count == 0)
+
+    h.add(100)
+    h.add(200)
+    assert(h.count == 2)
+
+    h.clear()
+    assert(h.count == 0)
+  }
+
+  test("average") {
+    val h = MetricsBucketedHistogram()
+    assert(h.average == 0.0)
+
+    h.add(100)
+    h.add(200)
+    assert(h.average == 150.0)
+
+    h.clear()
+    assert(h.average == 0)
+  }
+
+  test("outliers are handled") {
+    val h = MetricsBucketedHistogram()
+    h.add(2137204091L)
+    h.add(-1)
+    h.add(Long.MinValue)
+    h.add(Long.MaxValue)
+  }
+
+  test("exporting counts starts empty") {
+    val h = MetricsBucketedHistogram()
+    assert(h.bucketAndCounts == Seq.empty)
+  }
+
+  test("exporting counts tracks negative and extreme values") {
+    val h = MetricsBucketedHistogram()
+    h.add(-1)
+    h.add(0)
+    h.add(1)
+    h.add(1)
+    h.add(1)
+    h.add(Int.MaxValue)
+    h.add(Int.MaxValue)
+    assert(h.bucketAndCounts == Seq(BucketAndCount(0, 1, 2), BucketAndCount(1, 2, 3),
+      BucketAndCount(2137204091, Int.MaxValue, 2)))
+  }
+
+  test("exporting counts responds to clear") {
+    val h = MetricsBucketedHistogram()
+    h.add(-1)
+    h.add(0)
+    h.add(1)
+    h.add(5)
+    h.add(Int.MaxValue)
+    h.clear()
+    assert(h.bucketAndCounts == Seq.empty)
+  }
+
+  test("percentile and min and max stays within error bounds") {
+    forAll(MetricsBucketedHistogramTest.generator) {
+      case (samples: List[Int], p: Double) =>
+        // although this uses Gen.nonEmptyContainerOf I observed an empty List
+        // generated. As an example, this failed with an NPE:
+        //
+        //      Occurred when passed generated values (
+        //        arg0 = (List(),0.941512699565841) // 4 shrinks
+        //
+        // Also, observed negative values even with Gen.chooseNum constraint:
+        //
+        //      Occurred when passed generated values (
+        //        arg0 = (List(-1),0.9370612091967268) // 33 shrinks
+        //
+        whenever(samples.nonEmpty && samples.forall(_ >= 0)) {
+          val h = MetricsBucketedHistogram()
+          samples.foreach { s => h.add(s.toLong) }
+
+          val sorted = samples.sorted.toIndexedSeq
+          val index = (Math.round(sorted.size * p).toInt - 1).max(0)
+          val ideal = sorted(index).toLong
+          val actual = h.percentile(p)
+          assertWithinError(ideal, actual)
+
+          // check min and max too
+          assertWithinError(sorted.head, h.minimum)
+          assertWithinError(sorted.last, h.maximum)
+        }
+    }
+  }
+
+}
+
+private object MetricsBucketedHistogramTest {
+
+  def generator = for {
+    samples <- Gen.nonEmptyContainerOf[List, Int](Gen.chooseNum(0, Int.MaxValue))
+    percentile <- Gen.choose(0.5, 0.9999)
+  } yield (samples, percentile)
+
+}


### PR DESCRIPTION
Problem:
At high concurrency, Metrics$Stat.add becomes our top contention
hotspot, accounting for 25% of our thread blockage.

Solution:
Copy finagle's BucketedHistogram into our tree and use finer grained
locking to avoid contention.

Shortening the lock, specifically avoiding a binary search in the middle
of holding a lock reduces overall thread blocking by roughly 20% in a
load test with concurrency 100. This particular lock drops from the top
spot to number 6.

Testing:
The tests were copied from finagle.

Fixes #1381