### PR TITLE
Workaround slow hashing of large Dtabs

### DIFF
--- a/router/core/src/main/scala/com/twitter/finagle/buoyant/Dst.scala
+++ b/router/core/src/main/scala/com/twitter/finagle/buoyant/Dst.scala
@@ -24,7 +24,10 @@ object Dst {
      * potentially very expensive.
      */
     override def hashCode() = (path, localDtab).hashCode()
-    override def equals() = (path, localDtab).equals()
+    override def equals(other: Any) = other match {
+      case Path(p, _, d) => path == p && localDtab == d
+      case _ => false
+    }
   }
 
   implicit object Path extends Stack.Param[Path] {

--- a/router/core/src/main/scala/com/twitter/finagle/buoyant/Dst.scala
+++ b/router/core/src/main/scala/com/twitter/finagle/buoyant/Dst.scala
@@ -18,6 +18,12 @@ object Dst {
       namer.bind(baseDtab ++ localDtab, path).map(BoundTree(_, path))
 
     def mk(): (Path, Stack.Param[Path]) = (this, Path)
+
+    /*
+     * XXX the baseDtab should not be considered for equality/hashing, since it's
+     * potentially very expensive.
+     */
+    override def hashCode() = (path, localDtab).hashCode()
   }
 
   implicit object Path extends Stack.Param[Path] {

--- a/router/core/src/main/scala/com/twitter/finagle/buoyant/Dst.scala
+++ b/router/core/src/main/scala/com/twitter/finagle/buoyant/Dst.scala
@@ -24,6 +24,7 @@ object Dst {
      * potentially very expensive.
      */
     override def hashCode() = (path, localDtab).hashCode()
+    override def equals() = (path, localDtab).equals()
   }
 
   implicit object Path extends Stack.Param[Path] {


### PR DESCRIPTION
Large dtabs introduce high latency due to slowness computing hashCode across
all entries.  As a temporary workaround, we can simply ignore this field when
computing the hashCode().

Fixes #1442 