### PR TITLE
H2 should multiplex streams over a single connection

### DIFF
--- a/finagle/h2/src/main/java/io/netty/handler/codec/http2/BetterHttp2ConnectionEncoder.java
+++ b/finagle/h2/src/main/java/io/netty/handler/codec/http2/BetterHttp2ConnectionEncoder.java
@@ -1,0 +1,517 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.netty.handler.codec.http2;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.CoalescingBufferQueue;
+import io.netty.util.internal.UnstableApi;
+
+import java.util.ArrayDeque;
+
+import static io.netty.handler.codec.http2.Http2CodecUtil.DEFAULT_PRIORITY_WEIGHT;
+import static io.netty.handler.codec.http2.Http2Error.PROTOCOL_ERROR;
+import static io.netty.handler.codec.http2.Http2Exception.connectionError;
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
+import static java.lang.Integer.MAX_VALUE;
+import static java.lang.Math.min;
+
+/**
+ * This is a copy of DefaultHttp2ConnectionEncoder with this fix applied:
+ * https://github.com/netty/netty/pull/6916
+ * This fixes a race condition when sending a HEADERS frame at the same time as reading a RST frame.
+ *
+ * We should delete this and go back to using DefaultHttp2ConnectionEncoder once we pick up the fix.
+ * (Probably in netty-4.1.13.final)
+ */
+@UnstableApi
+public class BetterHttp2ConnectionEncoder implements Http2ConnectionEncoder {
+    private final Http2FrameWriter frameWriter;
+    private final Http2Connection connection;
+    private Http2LifecycleManager lifecycleManager;
+    // We prefer ArrayDeque to LinkedList because later will produce more GC.
+    // This initial capacity is plenty for SETTINGS traffic.
+    private final ArrayDeque<Http2Settings> outstandingLocalSettingsQueue = new ArrayDeque<Http2Settings>(4);
+
+    public BetterHttp2ConnectionEncoder(Http2Connection connection, Http2FrameWriter frameWriter) {
+        this.connection = checkNotNull(connection, "connection");
+        this.frameWriter = checkNotNull(frameWriter, "frameWriter");
+        if (connection.remote().flowController() == null) {
+            connection.remote().flowController(new DefaultHttp2RemoteFlowController(connection));
+        }
+    }
+
+    @Override
+    public void lifecycleManager(Http2LifecycleManager lifecycleManager) {
+        this.lifecycleManager = checkNotNull(lifecycleManager, "lifecycleManager");
+    }
+
+    @Override
+    public Http2FrameWriter frameWriter() {
+        return frameWriter;
+    }
+
+    @Override
+    public Http2Connection connection() {
+        return connection;
+    }
+
+    @Override
+    public final Http2RemoteFlowController flowController() {
+        return connection().remote().flowController();
+    }
+
+    @Override
+    public void remoteSettings(Http2Settings settings) throws Http2Exception {
+        Boolean pushEnabled = settings.pushEnabled();
+        Http2FrameWriter.Configuration config = configuration();
+        Http2HeadersEncoder.Configuration outboundHeaderConfig = config.headersConfiguration();
+        Http2FrameSizePolicy outboundFrameSizePolicy = config.frameSizePolicy();
+        if (pushEnabled != null) {
+            if (!connection.isServer() && pushEnabled) {
+                throw connectionError(PROTOCOL_ERROR,
+                        "Client received a value of ENABLE_PUSH specified to other than 0");
+            }
+            connection.remote().allowPushTo(pushEnabled);
+        }
+
+        Long maxConcurrentStreams = settings.maxConcurrentStreams();
+        if (maxConcurrentStreams != null) {
+            connection.local().maxActiveStreams((int) min(maxConcurrentStreams, MAX_VALUE));
+        }
+
+        Long headerTableSize = settings.headerTableSize();
+        if (headerTableSize != null) {
+            outboundHeaderConfig.maxHeaderTableSize((int) min(headerTableSize, MAX_VALUE));
+        }
+
+        Long maxHeaderListSize = settings.maxHeaderListSize();
+        if (maxHeaderListSize != null) {
+            outboundHeaderConfig.maxHeaderListSize(maxHeaderListSize);
+        }
+
+        Integer maxFrameSize = settings.maxFrameSize();
+        if (maxFrameSize != null) {
+            outboundFrameSizePolicy.maxFrameSize(maxFrameSize);
+        }
+
+        Integer initialWindowSize = settings.initialWindowSize();
+        if (initialWindowSize != null) {
+            flowController().initialWindowSize(initialWindowSize);
+        }
+    }
+
+    @Override
+    public ChannelFuture writeData(final ChannelHandlerContext ctx, final int streamId, ByteBuf data, int padding,
+                                   final boolean endOfStream, ChannelPromise promise) {
+        final Http2Stream stream;
+        try {
+            stream = requireStream(streamId);
+
+            // Verify that the stream is in the appropriate state for sending DATA frames.
+            switch (stream.state()) {
+                case OPEN:
+                case HALF_CLOSED_REMOTE:
+                    // Allowed sending DATA frames in these states.
+                    break;
+                default:
+                    throw new IllegalStateException(String.format(
+                            "Stream %d in unexpected state: %s", stream.id(), stream.state()));
+            }
+        } catch (Throwable e) {
+            data.release();
+            return promise.setFailure(e);
+        }
+
+        // Hand control of the frame to the flow controller.
+        flowController().addFlowControlled(stream,
+                new FlowControlledData(stream, data, padding, endOfStream, promise));
+        return promise;
+    }
+
+    @Override
+    public ChannelFuture writeHeaders(ChannelHandlerContext ctx, int streamId, Http2Headers headers, int padding,
+                                      boolean endStream, ChannelPromise promise) {
+        return writeHeaders(ctx, streamId, headers, 0, DEFAULT_PRIORITY_WEIGHT, false, padding, endStream, promise);
+    }
+
+    @Override
+    public ChannelFuture writeHeaders(final ChannelHandlerContext ctx, final int streamId,
+                                      final Http2Headers headers, final int streamDependency, final short weight,
+                                      final boolean exclusive, final int padding, final boolean endOfStream, ChannelPromise promise) {
+        try {
+            Http2Stream stream = connection.stream(streamId);
+            if (stream == null) {
+                try {
+                    stream = connection.local().createStream(streamId, endOfStream);
+                } catch (Http2Exception cause) {
+                    if (connection.remote().mayHaveCreatedStream(streamId)) {
+                        promise.tryFailure(new IllegalStateException("Stream no longer exists: " + streamId, cause));
+                        return promise;
+                    }
+                    throw cause;
+                }
+            } else {
+                switch (stream.state()) {
+                    case RESERVED_LOCAL:
+                        stream.open(endOfStream);
+                        break;
+                    case OPEN:
+                    case HALF_CLOSED_REMOTE:
+                        // Allowed sending headers in these states.
+                        break;
+                    default:
+                        throw new IllegalStateException(String.format(
+                                "Stream %d in unexpected state: %s", stream.id(), stream.state()));
+                }
+            }
+
+            // Trailing headers must go through flow control if there are other frames queued in flow control
+            // for this stream.
+            Http2RemoteFlowController flowController = flowController();
+            if (!endOfStream || !flowController.hasFlowControlled(stream)) {
+                if (endOfStream) {
+                    final Http2Stream finalStream = stream;
+                    final ChannelFutureListener closeStreamLocalListener = new ChannelFutureListener() {
+                        @Override
+                        public void operationComplete(ChannelFuture future) throws Exception {
+                            lifecycleManager.closeStreamLocal(finalStream, future);
+                        }
+                    };
+                    promise = promise.unvoid().addListener(closeStreamLocalListener);
+                }
+                ChannelFuture future = frameWriter.writeHeaders(ctx, streamId, headers, streamDependency,
+                        weight, exclusive, padding, endOfStream, promise);
+                // Writing headers may fail during the encode state if they violate HPACK limits.
+                Throwable failureCause = future.cause();
+                if (failureCause == null) {
+                    // Synchronously set the headersSent flag to ensure that we do not subsequently write
+                    // other headers containing pseudo-header fields.
+                    stream.headersSent();
+                } else {
+                    lifecycleManager.onError(ctx, failureCause);
+                }
+
+                return future;
+            } else {
+                // Pass headers to the flow-controller so it can maintain their sequence relative to DATA frames.
+                flowController.addFlowControlled(stream,
+                        new FlowControlledHeaders(stream, headers, streamDependency, weight, exclusive, padding,
+                                true, promise));
+                return promise;
+            }
+        } catch (Throwable t) {
+            lifecycleManager.onError(ctx, t);
+            promise.tryFailure(t);
+            return promise;
+        }
+    }
+
+    @Override
+    public ChannelFuture writePriority(ChannelHandlerContext ctx, int streamId, int streamDependency, short weight,
+                                       boolean exclusive, ChannelPromise promise) {
+        return frameWriter.writePriority(ctx, streamId, streamDependency, weight, exclusive, promise);
+    }
+
+    @Override
+    public ChannelFuture writeRstStream(ChannelHandlerContext ctx, int streamId, long errorCode,
+                                        ChannelPromise promise) {
+        // Delegate to the lifecycle manager for proper updating of connection state.
+        return lifecycleManager.resetStream(ctx, streamId, errorCode, promise);
+    }
+
+    @Override
+    public ChannelFuture writeSettings(ChannelHandlerContext ctx, Http2Settings settings,
+                                       ChannelPromise promise) {
+        outstandingLocalSettingsQueue.add(settings);
+        try {
+            Boolean pushEnabled = settings.pushEnabled();
+            if (pushEnabled != null && connection.isServer()) {
+                throw connectionError(PROTOCOL_ERROR, "Server sending SETTINGS frame with ENABLE_PUSH specified");
+            }
+        } catch (Throwable e) {
+            return promise.setFailure(e);
+        }
+
+        return frameWriter.writeSettings(ctx, settings, promise);
+    }
+
+    @Override
+    public ChannelFuture writeSettingsAck(ChannelHandlerContext ctx, ChannelPromise promise) {
+        return frameWriter.writeSettingsAck(ctx, promise);
+    }
+
+    @Override
+    public ChannelFuture writePing(ChannelHandlerContext ctx, boolean ack, ByteBuf data, ChannelPromise promise) {
+        return frameWriter.writePing(ctx, ack, data, promise);
+    }
+
+    @Override
+    public ChannelFuture writePushPromise(ChannelHandlerContext ctx, int streamId, int promisedStreamId,
+                                          Http2Headers headers, int padding, ChannelPromise promise) {
+        try {
+            if (connection.goAwayReceived()) {
+                throw connectionError(PROTOCOL_ERROR, "Sending PUSH_PROMISE after GO_AWAY received.");
+            }
+
+            Http2Stream stream = requireStream(streamId);
+            // Reserve the promised stream.
+            connection.local().reservePushStream(promisedStreamId, stream);
+
+            ChannelFuture future = frameWriter.writePushPromise(ctx, streamId, promisedStreamId, headers, padding,
+                    promise);
+            // Writing headers may fail during the encode state if they violate HPACK limits.
+            Throwable failureCause = future.cause();
+            if (failureCause == null) {
+                stream.pushPromiseSent();
+            } else {
+                lifecycleManager.onError(ctx, failureCause);
+            }
+            return future;
+        } catch (Throwable t) {
+            lifecycleManager.onError(ctx, t);
+            promise.tryFailure(t);
+            return promise;
+        }
+    }
+
+    @Override
+    public ChannelFuture writeGoAway(ChannelHandlerContext ctx, int lastStreamId, long errorCode, ByteBuf debugData,
+                                     ChannelPromise promise) {
+        return lifecycleManager.goAway(ctx, lastStreamId, errorCode, debugData, promise);
+    }
+
+    @Override
+    public ChannelFuture writeWindowUpdate(ChannelHandlerContext ctx, int streamId, int windowSizeIncrement,
+                                           ChannelPromise promise) {
+        return promise.setFailure(new UnsupportedOperationException("Use the Http2[Inbound|Outbound]FlowController" +
+                " objects to control window sizes"));
+    }
+
+    @Override
+    public ChannelFuture writeFrame(ChannelHandlerContext ctx, byte frameType, int streamId, Http2Flags flags,
+                                    ByteBuf payload, ChannelPromise promise) {
+        return frameWriter.writeFrame(ctx, frameType, streamId, flags, payload, promise);
+    }
+
+    @Override
+    public void close() {
+        frameWriter.close();
+    }
+
+    @Override
+    public Http2Settings pollSentSettings() {
+        return outstandingLocalSettingsQueue.poll();
+    }
+
+    @Override
+    public Configuration configuration() {
+        return frameWriter.configuration();
+    }
+
+    private Http2Stream requireStream(int streamId) {
+        Http2Stream stream = connection.stream(streamId);
+        if (stream == null) {
+            final String message;
+            if (connection.streamMayHaveExisted(streamId)) {
+                message = "Stream no longer exists: " + streamId;
+            } else {
+                message = "Stream does not exist: " + streamId;
+            }
+            throw new IllegalArgumentException(message);
+        }
+        return stream;
+    }
+
+    /**
+     * Wrap a DATA frame so it can be written subject to flow-control. Note that this implementation assumes it
+     * only writes padding once for the entire payload as opposed to writing it once per-frame. This makes the
+     * {@link #size} calculation deterministic thereby greatly simplifying the implementation.
+     * <p>
+     * If frame-splitting is required to fit within max-frame-size and flow-control constraints we ensure that
+     * the passed promise is not completed until last frame write.
+     * </p>
+     */
+    private final class FlowControlledData extends FlowControlledBase {
+        private final CoalescingBufferQueue queue;
+        private int dataSize;
+
+        FlowControlledData(Http2Stream stream, ByteBuf buf, int padding, boolean endOfStream,
+                           ChannelPromise promise) {
+            super(stream, padding, endOfStream, promise);
+            queue = new CoalescingBufferQueue(promise.channel());
+            queue.add(buf, promise);
+            dataSize = queue.readableBytes();
+        }
+
+        @Override
+        public int size() {
+            return dataSize + padding;
+        }
+
+        @Override
+        public void error(ChannelHandlerContext ctx, Throwable cause) {
+            queue.releaseAndFailAll(cause);
+            // Don't update dataSize because we need to ensure the size() method returns a consistent size even after
+            // error so we don't invalidate flow control when returning bytes to flow control.
+            lifecycleManager.onError(ctx, cause);
+        }
+
+        @Override
+        public void write(ChannelHandlerContext ctx, int allowedBytes) {
+            int queuedData = queue.readableBytes();
+            if (!endOfStream) {
+                if (queuedData == 0) {
+                    // There's no need to write any data frames because there are only empty data frames in the queue
+                    // and it is not end of stream yet. Just complete their promises by writing an empty buffer.
+                    ChannelPromise writePromise = ctx.newPromise().addListener(this);
+                    queue.remove(0, writePromise).release();
+                    ctx.write(Unpooled.EMPTY_BUFFER, writePromise);
+                    return;
+                }
+
+                if (allowedBytes == 0) {
+                    return;
+                }
+            }
+
+            // Determine how much data to write.
+            int writableData = min(queuedData, allowedBytes);
+            ChannelPromise writePromise = ctx.newPromise().addListener(this);
+            ByteBuf toWrite = queue.remove(writableData, writePromise);
+            dataSize = queue.readableBytes();
+
+            // Determine how much padding to write.
+            int writablePadding = min(allowedBytes - writableData, padding);
+            padding -= writablePadding;
+
+            // Write the frame(s).
+            frameWriter().writeData(ctx, stream.id(), toWrite, writablePadding,
+                    endOfStream && size() == 0, writePromise);
+        }
+
+        @Override
+        public boolean merge(ChannelHandlerContext ctx, Http2RemoteFlowController.FlowControlled next) {
+            FlowControlledData nextData;
+            if (FlowControlledData.class != next.getClass() ||
+                    MAX_VALUE - (nextData = (FlowControlledData) next).size() < size()) {
+                return false;
+            }
+            nextData.queue.copyTo(queue);
+            dataSize = queue.readableBytes();
+            // Given that we're merging data into a frame it doesn't really make sense to accumulate padding.
+            padding = Math.max(padding, nextData.padding);
+            endOfStream = nextData.endOfStream;
+            return true;
+        }
+    }
+
+    /**
+     * Wrap headers so they can be written subject to flow-control. While headers do not have cost against the
+     * flow-control window their order with respect to other frames must be maintained, hence if a DATA frame is
+     * blocked on flow-control a HEADER frame must wait until this frame has been written.
+     */
+    private final class FlowControlledHeaders extends FlowControlledBase {
+        private final Http2Headers headers;
+        private final int streamDependency;
+        private final short weight;
+        private final boolean exclusive;
+
+        FlowControlledHeaders(Http2Stream stream, Http2Headers headers, int streamDependency, short weight,
+                              boolean exclusive, int padding, boolean endOfStream, ChannelPromise promise) {
+            super(stream, padding, endOfStream, promise);
+            this.headers = headers;
+            this.streamDependency = streamDependency;
+            this.weight = weight;
+            this.exclusive = exclusive;
+        }
+
+        @Override
+        public int size() {
+            return 0;
+        }
+
+        @Override
+        public void error(ChannelHandlerContext ctx, Throwable cause) {
+            if (ctx != null) {
+                lifecycleManager.onError(ctx, cause);
+            }
+            promise.tryFailure(cause);
+        }
+
+        @Override
+        public void write(ChannelHandlerContext ctx, int allowedBytes) {
+            if (promise.isVoid()) {
+                promise = ctx.newPromise();
+            }
+            promise.addListener(this);
+
+            ChannelFuture f = frameWriter.writeHeaders(ctx, stream.id(), headers, streamDependency, weight, exclusive,
+                    padding, endOfStream, promise);
+            // Writing headers may fail during the encode state if they violate HPACK limits.
+            Throwable failureCause = f.cause();
+            if (failureCause == null) {
+                stream.headersSent();
+            } else {
+                lifecycleManager.onError(ctx, failureCause);
+            }
+        }
+
+        @Override
+        public boolean merge(ChannelHandlerContext ctx, Http2RemoteFlowController.FlowControlled next) {
+            return false;
+        }
+    }
+
+    /**
+     * Common base type for payloads to deliver via flow-control.
+     */
+    public abstract class FlowControlledBase implements Http2RemoteFlowController.FlowControlled,
+            ChannelFutureListener {
+        protected final Http2Stream stream;
+        protected ChannelPromise promise;
+        protected boolean endOfStream;
+        protected int padding;
+
+        FlowControlledBase(final Http2Stream stream, int padding, boolean endOfStream,
+                           final ChannelPromise promise) {
+            if (padding < 0) {
+                throw new IllegalArgumentException("padding must be >= 0");
+            }
+            this.padding = padding;
+            this.endOfStream = endOfStream;
+            this.stream = stream;
+            this.promise = promise;
+        }
+
+        @Override
+        public void writeComplete() {
+            if (endOfStream) {
+                lifecycleManager.closeStreamLocal(stream, promise);
+            }
+        }
+
+        @Override
+        public void operationComplete(ChannelFuture future) throws Exception {
+            if (!future.isSuccess()) {
+                error(flowController().channelHandlerContext(), future.cause());
+            }
+        }
+    }
+}

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/DelayedReleaseService.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/DelayedReleaseService.scala
@@ -1,0 +1,55 @@
+package com.twitter.finagle.buoyant.h2
+
+import com.twitter.finagle.client.StackClient
+import com.twitter.finagle.util.AsyncLatch
+import com.twitter.finagle._
+import com.twitter.util.{Future, Promise, Return, Time}
+import java.util.concurrent.atomic.AtomicBoolean
+
+object DelayedRelease {
+  val role = StackClient.Role.prepFactory
+  val description = "Prevents an H2 service from being closed until its response stream completes"
+  val module: Stackable[ServiceFactory[Request, Response]] =
+    new Stack.Module0[ServiceFactory[Request, Response]] {
+      val role = DelayedRelease.role
+      val description = DelayedRelease.description
+      def make(next: ServiceFactory[Request, Response]) = next.map(new DelayedReleaseService(_))
+    }
+}
+
+class DelayedReleaseService(
+  service: Service[Request, Response]
+) extends ServiceProxy[Request, Response](service) {
+
+  protected[this] val latch = new AsyncLatch
+
+  private[this] def releaseOnEnd(req: Request, rsp: Response): Unit = {
+    val released = new AtomicBoolean(false)
+    // wait until both Request and Response streams are complete
+    val _ = Future.join(req.stream.onEnd, rsp.stream.onEnd).respond { _ =>
+      if (released.compareAndSet(false, true)) {
+        val _ = latch.decr()
+      }
+    }
+  }
+
+  override def apply(req: Request): Future[Response] = {
+    latch.incr()
+    service(req) transform {
+      case Return(rsp) =>
+        releaseOnEnd(req, rsp)
+        Future.value(rsp)
+      case t =>
+        latch.decr()
+        Future.const(t)
+    }
+  }
+
+  override final def close(deadline: Time): Future[Unit] = {
+    val p = new Promise[Unit]
+    latch.await {
+      p.become(service.close(deadline))
+    }
+    p
+  }
+}

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/Message.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/Message.scala
@@ -50,6 +50,8 @@ object Headers {
   def apply(hd: (String, String), tl: (String, String)*): Headers =
     apply(hd +: tl)
 
+  val empty: Headers = apply(Nil)
+
   /**
    * Typically, headers wrap underlying netty types; but since we
    * don't want to bind user code to any netty APIs, we provide

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/Stream.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/Stream.scala
@@ -120,7 +120,7 @@ object Stream {
   def const(s: String): Stream =
     const(Buf.Utf8(s))
 
-  def empty(): Stream = empty(new AsyncQueue[Frame](1))
+  def empty(): Stream with Writer = empty(new AsyncQueue[Frame](1))
 
   def empty(frameQ: AsyncQueue[Frame]): Stream with Writer =
     new Stream with Writer {

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/Stream.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/Stream.scala
@@ -120,15 +120,10 @@ object Stream {
   def const(s: String): Stream =
     const(Buf.Utf8(s))
 
-  def empty(q: AsyncQueue[Frame]): Stream =
-    new AsyncQueueReader {
-      override protected[this] val frameQ = q
-      override def isEmpty = true
-    }
+  def empty(): Stream = empty(new AsyncQueue[Frame](1))
 
-  def empty(): Stream with Writer =
+  def empty(frameQ: AsyncQueue[Frame]): Stream with Writer =
     new Stream with Writer {
-      private[this] val frameQ = new AsyncQueue[Frame](1)
       override def isEmpty = true
       override def onEnd = Future.Unit
       override def read(): Future[Frame] = failOnInterrupt(frameQ.poll(), frameQ)

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4ClientDispatcher.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4ClientDispatcher.scala
@@ -1,6 +1,7 @@
 package com.twitter.finagle.buoyant.h2
 package netty4
 
+import com.twitter.concurrent.AsyncMutex
 import com.twitter.finagle.{Service, Status => SvcStatus}
 import com.twitter.finagle.transport.Transport
 import com.twitter.logging.Logger
@@ -73,25 +74,36 @@ class Netty4ClientDispatcher(
     goAway(GoAway.ProtocolError).before(Future.exception(e))
   }
 
+  /*
+   * In order to ensure that the initial frame for each stream is written to the
+   * transport in order of its stream id, we hold a mutex from when the stream id
+   * is allocated to when the initial frame of that stream is written.
+   */
+  val mutex = new AsyncMutex()
+
   /**
    * Write a request on the underlying connection and return its
    * response when it is received.
    */
   override def apply(req: Request): Future[Response] = {
-    val st = newStreamTransport()
-    // Stream the request while receiving the response and
-    // continue streaming the request until it is complete,
-    // canceled,  or the response fails.
-    val sendFF = st.send(req)
 
-    // If the stream is reset prematurely, cancel the pending write
-    st.onReset.onFailure {
-      case StreamError.Remote(rst: Reset) => sendFF.flatten.raise(rst)
-      case StreamError.Remote(e) => sendFF.flatten.raise(Reset.Cancel)
-      case e => sendFF.flatten.raise(e)
+    mutex.acquire().flatMap { permit =>
+      val st = newStreamTransport()
+      // Stream the request while receiving the response and
+      // continue streaming the request until it is complete,
+      // canceled,  or the response fails.
+      val sendFF = st.send(req)
+
+      // If the stream is reset prematurely, cancel the pending write
+      st.onReset.onFailure {
+        case StreamError.Remote(rst: Reset) => sendFF.flatten.raise(rst)
+        case StreamError.Remote(e) => sendFF.flatten.raise(Reset.Cancel)
+        case e => sendFF.flatten.raise(e)
+      }
+
+      sendFF.ensure(permit.release())
+      sendFF.unit.before(st.onRecvMessage)
     }
-
-    sendFF.unit.before(st.onRecvMessage)
   }
 
 }

--- a/finagle/h2/src/main/scala/io/netty/handler/codec/http2/H2FrameCodec.scala
+++ b/finagle/h2/src/main/scala/io/netty/handler/codec/http2/H2FrameCodec.scala
@@ -203,7 +203,7 @@ object H2FrameCodec {
 
     val encoder = {
       val fw = new Http2OutboundFrameLogger(new DefaultHttp2FrameWriter, frameLogger)
-      new DefaultHttp2ConnectionEncoder(conn, fw)
+      new BetterHttp2ConnectionEncoder(conn, fw)
     }
 
     val decoder = {

--- a/grpc/eg/src/test/scala/io/buoyant/grpc/EgTest.scala
+++ b/grpc/eg/src/test/scala/io/buoyant/grpc/EgTest.scala
@@ -179,6 +179,8 @@ class EgEndToEndTest extends FunSuite {
       rspP.setValue(Eg.Rsp(Some(Eg.Message.Enumeration.THREEFOUR)))
       assert(await(rspF) == Eg.Rsp(Some(Eg.Message.Enumeration.THREEFOUR)))
 
+      await(tx.close())
+
     } finally {
       await(h2client.close().before(h2srv.close()))
     }

--- a/grpc/runtime/src/main/scala/io/buoyant/grpc/runtime/Codec.scala
+++ b/grpc/runtime/src/main/scala/io/buoyant/grpc/runtime/Codec.scala
@@ -78,11 +78,14 @@ object Codec {
       stream.read().flatMap {
         case t: h2.Frame.Trailers =>
           val status = GrpcStatus.fromTrailers(t)
+          t.release()
           Future.value(orig -> status)
 
         case d: h2.Frame.Data =>
           val buf = orig.concat(d.buf)
-          if (d.isEnd) Future.value(buf -> GrpcStatus.Unknown())
+          val isEnd = d.isEnd
+          d.release()
+          if (isEnd) Future.value(buf -> GrpcStatus.Unknown())
           else accum(buf)
       }
 

--- a/linkerd/protocol/h2/src/e2e/scala/io/buoyant/linkerd/protocol/h2/H2EndToEndTest.scala
+++ b/linkerd/protocol/h2/src/e2e/scala/io/buoyant/linkerd/protocol/h2/H2EndToEndTest.scala
@@ -1,0 +1,222 @@
+package io.buoyant.linkerd.protocol.h2
+
+import com.twitter.concurrent.AsyncQueue
+import com.twitter.finagle.buoyant.H2
+import com.twitter.finagle.buoyant.h2._
+import com.twitter.finagle.stats.{InMemoryStatsReceiver, NullStatsReceiver}
+import com.twitter.finagle.tracing.NullTracer
+import com.twitter.finagle.{param => fparam, Status => _, _}
+import com.twitter.io.Buf
+import com.twitter.logging.Level
+import com.twitter.util.{Future, Promise, Var}
+import io.buoyant.linkerd.Linker
+import io.buoyant.linkerd.protocol.H2Initializer
+import io.buoyant.test.FunSuite
+import java.net.InetSocketAddress
+import scala.collection.mutable
+
+class H2EndToEndTest extends FunSuite {
+
+  case class Downstream(name: String, server: ListeningServer) {
+    val address = server.boundAddress.asInstanceOf[InetSocketAddress]
+    val port = address.getPort
+    val dentry = Dentry(
+      Path.read(s"/svs/$name"),
+      NameTree.read(s"/$$/inet/127.1/$port")
+    )
+  }
+
+  object Downstream {
+    def mk(name: String)(f: Request=>Future[Response]): Downstream = {
+      val service = Service.mk { req: Request => f(req) }
+      val server = H2.server
+        .configured(fparam.Label(name))
+        .configured(fparam.Tracer(NullTracer))
+        .serve(":*", service)
+      Downstream(name, server)
+    }
+
+    def const(name: String, value: String, status: Status = Status.Ok): Downstream =
+      mk(name) { _ =>
+        Future.value(Response(status, Stream.const(value)))
+      }
+
+    def promise(name: String): (Downstream, mutable.Seq[Promise[Response]]) = {
+      val ps = mutable.MutableList[Promise[Response]]()
+      val svc = mk(name) { _ =>
+        val p = new Promise[Response]()
+        ps += p
+        p
+      }
+      (svc, ps)
+    }
+  }
+
+  def upstream(server: ListeningServer) = {
+    val address = Address(server.boundAddress.asInstanceOf[InetSocketAddress])
+    val name = Name.Bound(Var.value(Addr.Bound(address)), address)
+    H2.client
+      .configured(fparam.Stats(NullStatsReceiver))
+      .configured(fparam.Tracer(NullTracer))
+      .newClient(name, "upstream").toService
+  }
+
+  def readDataStream(stream: Stream): Future[Buf] = {
+    stream.read().flatMap {
+      case frame: Frame.Data if frame.isEnd =>
+        val buf = frame.buf
+        val _ = frame.release()
+        Future.value(buf)
+      case frame: Frame.Data =>
+        val buf = frame.buf
+        val _ = frame.release()
+        readDataStream(stream).map(buf.concat)
+      case frame: Frame.Trailers =>
+        val _ = frame.release()
+        Future.value(Buf.Empty)
+    }
+  }
+
+  def readDataString(stream: Stream): Future[String] =
+    readDataStream(stream).map(Buf.Utf8.unapply).map(_.get)
+
+  test("single request") {
+    val stats = new InMemoryStatsReceiver
+
+    val dog = Downstream.const("dog", "woof")
+
+
+    val config =
+      s"""|routers:
+          |- protocol: h2
+          |  experimental: true
+          |  dtab: |
+          |    /svc/dog => /$$/inet/127.1/${dog.port} ;
+          |  servers:
+          |  - port: 0
+          |""".stripMargin
+
+    val linker = Linker.Initializers(Seq(H2Initializer)).load(config)
+      .configured(fparam.Stats(stats))
+    val router = linker.routers.head.initialize()
+    val server = router.servers.head.serve()
+
+    val client = upstream(server)
+    def get(host: String, path: String = "/")(f: Response => Unit) = {
+      val req = Request("http", Method.Get, host, path, Stream.empty())
+      val rsp = await(client(req))
+      f(rsp)
+    }
+
+    get("dog") { rsp =>
+      assert(rsp.status == Status.Ok)
+      assert(await(readDataString(rsp.stream)) == "woof")
+      ()
+    }
+    assert(stats.counters(Seq("rt", "h2", "client", s"$$/inet/127.1/${dog.port}", "connects")) == 1)
+
+    await(client.close())
+    await(dog.server.close())
+    await(server.close())
+    await(router.close())
+  }
+
+  test("concurrent requests") {
+    val stats = new InMemoryStatsReceiver
+    val (dog, rsps) = Downstream.promise("dog")
+
+    val config =
+      s"""|routers:
+          |- protocol: h2
+          |  experimental: true
+          |  dtab: |
+          |    /svc/dog => /$$/inet/127.1/${dog.port} ;
+          |  servers:
+          |  - port: 0
+          |""".stripMargin
+
+    val linker = Linker.Initializers(Seq(H2Initializer)).load(config)
+      .configured(fparam.Stats(stats))
+    val router = linker.routers.head.initialize()
+    val server = router.servers.head.serve()
+
+    val client = upstream(server)
+
+
+    val req0 = Request("http", Method.Get, "dog", "/", Stream.empty())
+    val fRsp0 = client(req0)
+
+    eventually { // wait for the promise to be generated
+      assert(rsps.size == 1)
+    }
+
+    val req1 = Request("http", Method.Get, "dog", "/", Stream.empty())
+    val fRsp1 = client(req1)
+
+    eventually { // wait for the promise to be generated
+      assert(rsps.size == 2)
+    }
+
+    rsps(1).setValue(Response(Status.Ok, Stream.const("bow")))
+    val rsp1 = await(fRsp1)
+    assert(await(readDataString(rsp1.stream)) == "bow")
+
+    rsps(0).setValue(Response(Status.Ok, Stream.const("wow")))
+    val rsp0 = await(fRsp0)
+    assert(await(readDataString(rsp0.stream)) == "wow")
+
+    // should multiplex over a single connection
+    assert(stats.counters(Seq("rt", "h2", "client", s"$$/inet/127.1/${dog.port}", "connects")) == 1)
+
+    await(client.close())
+    await(dog.server.close())
+    await(server.close())
+    await(router.close())
+  }
+
+  test("wait for stream to complete before closing") {
+    val stats = new InMemoryStatsReceiver
+    val (dog, rsps) = Downstream.promise("dog")
+
+    val config =
+      s"""|routers:
+          |- protocol: h2
+          |  experimental: true
+          |  dtab: |
+          |    /svc/dog => /$$/inet/127.1/${dog.port} ;
+          |  servers:
+          |  - port: 0
+          |""".stripMargin
+
+    val linker = Linker.Initializers(Seq(H2Initializer)).load(config)
+      .configured(fparam.Stats(stats))
+    val router = linker.routers.head.initialize()
+    val server = router.servers.head.serve()
+
+    val client = upstream(server)
+
+    val req = Request("http", Method.Get, "dog", "/", Stream.empty())
+    val fRsp = client(req)
+
+    eventually { // wait for the promise to be generated
+      assert(rsps.size == 1)
+    }
+
+    val q = new AsyncQueue[Frame]()
+    val stream = Stream(q)
+
+    rsps(0).setValue(Response(Status.Ok, stream))
+    val rsp = await(fRsp)
+
+    q.offer(Frame.Data("bow", eos = false))
+    q.offer(Frame.Data("wow", eos = true))
+
+    assert(await(readDataString(rsp.stream)) == "bowwow")
+
+    await(client.close())
+    await(server.close())
+    await(router.close())
+    await(dog.server.close())
+  }
+
+}

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/H2Config.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/H2Config.scala
@@ -34,12 +34,7 @@ class H2Initializer extends ProtocolInitializer.Simple {
     val pathStack = H2.router.pathStack
       .insertAfter(ClassifiedRetries.role, DupRequest.module)
       .prepend(LinkerdHeaders.Dst.PathFilter.module)
-
-    // I think we can safely ignore the DelayedRelease module (as
-    // applied by finagle-http), since we don't ever run in
-    // FactoryToService mode?
-    //
-    //   .replace(StackClient.Role.prepFactory, DelayedRelease.module)
+      .replace(StackClient.Role.prepFactory, DelayedRelease.module)
 
     val boundStack = H2.router.boundStack
       .prepend(LinkerdHeaders.Dst.BoundFilter.module)

--- a/linkerd/protocol/h2/src/test/scala/io/buoyant/linkerd/protocol/h2/H2InitializerTest.scala
+++ b/linkerd/protocol/h2/src/test/scala/io/buoyant/linkerd/protocol/h2/H2InitializerTest.scala
@@ -1,0 +1,75 @@
+package io.buoyant.linkerd.protocol.h2
+
+import com.twitter.concurrent.AsyncQueue
+import com.twitter.finagle.buoyant.h2._
+import com.twitter.finagle.{Service, ServiceFactory, Stack}
+import com.twitter.util.{Future, Promise, Time}
+import io.buoyant.linkerd.protocol.H2Initializer
+import io.buoyant.test.FunSuite
+import scala.language.reflectiveCalls
+
+class H2InitializerTest extends FunSuite {
+
+  test("path stack: services are not closed until streams are complete") {
+    // Build a path stack that is controllable with promises. This is
+    // only really useful for a single request.
+    val serviceP, responseP, bodyP, respondingP, closedP = Promise[Unit]
+    val http = new H2Initializer {
+      val svc = new Service[Request, Response] {
+        def apply(req: Request) = {
+          val q = new AsyncQueue[Frame]
+          val rsp = Response(Status.Ok, Stream(q))
+          bodyP.onSuccess { _ => q.offer(Frame.Data.eos("woof")); () }
+          respondingP.setDone()
+          responseP.before(Future.value(rsp))
+        }
+
+        override def close(d: Time) = {
+          closedP.setDone()
+          Future.Unit
+        }
+      }
+      val sf = ServiceFactory { () => serviceP.before(Future.value(svc)) }
+
+      def make(params: Stack.Params = Stack.Params.empty) =
+        (defaultRouter.pathStack ++ Stack.Leaf(Stack.Role("leaf"), sf)).make(params)
+    }
+
+    // The factory is returned immediately because it is wrapped in a
+    // FactoryToService.
+    val factory = http.make()
+    val svcf = factory()
+    assert(svcf.isDefined)
+    val svc = await(svcf)
+
+    // When a request is processed, first the service must be acquired
+    // from the service factory, and then the response must be
+    // returned from the service.
+    val rspf = svc(Request(Headers.empty, Stream.empty()))
+    assert(!rspf.isDefined)
+    assert(!respondingP.isDefined)
+
+    serviceP.setDone()
+    eventually { assert(respondingP.isDefined) }
+    assert(!rspf.isDefined)
+
+    responseP.setDone()
+    eventually { assert(rspf.isDefined) }
+
+    // Once the response is returned, FactoryToService tries to close
+    // the service factory. Ensure that the service is not closed
+    // until the response body is completely sent.
+    val rsp = await(rspf)
+    assert(!closedP.isDefined)
+
+    // When the response body is written, it must be fully read from
+    // response before the service will be closed.
+    bodyP.setDone()
+    assert(!closedP.isDefined)
+
+    val frame = await(rsp.stream.read())
+    assert(frame.isEnd)
+    await(frame.release())
+    eventually { assert(closedP.isDefined) }
+  }
+}

--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -474,7 +474,7 @@ object LinkerdBuild extends Base {
 
       val h2 = projectDir("linkerd/protocol/h2")
         .dependsOn(core, Router.h2, k8s)
-        .withTests()
+        .withTests().withE2e()
         .withTwitterLibs(Deps.finagle("netty4"))
 
       val http = projectDir("linkerd/protocol/http")

--- a/test-util/src/main/scala/io/buoyant/test/Awaits.scala
+++ b/test-util/src/main/scala/io/buoyant/test/Awaits.scala
@@ -14,7 +14,7 @@ trait Awaits extends Eventually {
   implicit override val patienceConfig =
     PatienceConfig(timeout = scaled(Span(defaultWait.inMillis, Millis)))
 
-  def awaitStackDepth: Int = 4
+  def awaitStackDepth: Int = 5
 
   def await[T](t: Duration)(f: => Future[T]): T =
     try Await.result(f, t) catch {


### PR DESCRIPTION
Finagle's DefaultPool (WatermarkPool specifically) will only hand out a service
to one caller at a time.  This means that each connection will only have one
(bidirectional) stream on it at any given time.

Replace DefaultPool with SingletonPool which hands out a single refcounted
service to all callers.  This takes advantage of H2's multiplexing.  To make
this work we fixed a couple issues:
* Added a delayed release module for H2 that delays release of a service until
  both the request and response streams have completed.
* Fixed a race condition in Netty4ClientDispatcher where the initial frame for
  a stream with a higher stream id could be written to the transport before
  the initial frame for a stream with a lower stream id.

I've manually tested this up to about 150rps with a concurrency of about 3.
More industrial strength load testing is required.