### PR TITLE
Add HeadFilter to admin service (#1412)

### DIFF
--- a/admin/src/main/scala/io/buoyant/admin/Admin.scala
+++ b/admin/src/main/scala/io/buoyant/admin/Admin.scala
@@ -3,6 +3,7 @@ package io.buoyant.admin
 import com.twitter.app.{App => TApp}
 import com.twitter.finagle._
 import com.twitter.finagle.http.{HttpMuxer, Request, Response}
+import com.twitter.finagle.http.filter.HeadFilter
 import com.twitter.finagle.stats.NullStatsReceiver
 import com.twitter.finagle.tracing.NullTracer
 import com.twitter.logging.Logger
@@ -114,7 +115,7 @@ class Admin(val address: SocketAddress) {
         log.debug(s"admin: $url => ${service.getClass.getName}")
         muxer.withHandler(url, service)
     }
-    notFoundView.andThen(muxer)
+    HeadFilter.andThen(notFoundView.andThen(muxer))
   }
 
   def serve(app: TApp, extHandlers: Seq[Handler]): ListeningServer =

--- a/admin/src/main/scala/io/buoyant/admin/Admin.scala
+++ b/admin/src/main/scala/io/buoyant/admin/Admin.scala
@@ -115,7 +115,7 @@ class Admin(val address: SocketAddress) {
         log.debug(s"admin: $url => ${service.getClass.getName}")
         muxer.withHandler(url, service)
     }
-    HeadFilter.andThen(notFoundView.andThen(muxer))
+    HeadFilter andThen notFoundView andThen muxer
   }
 
   def serve(app: TApp, extHandlers: Seq[Handler]): ListeningServer =


### PR DESCRIPTION
Previously, the `admin/ping` route returns a message body for all request verbs, including HEAD.
This is not standards-compliant and produces a spurious finagle log message.

I've added a `HeadFilte`r to the admin service. This ensures that all HEAD requests have empty
message bodies.

`curl -X HEAD http://localhost:9990/admin/ping` no longer returns a message body.

Fixes #1412