### PR TITLE
Decide to use default failure accrual backoff lazily (#1439)

### DIFF
--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/FailureAccrualInitializer.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/FailureAccrualInitializer.scala
@@ -16,7 +16,7 @@ abstract class FailureAccrualConfig extends PolymorphicConfig {
   var backoff: Option[BackoffConfig] = None
 
   @JsonIgnore
-  lazy val backoffOrDefault =
+  def backoffOrDefault: Stream[Duration] =
     backoff.map(_.mk).getOrElse(FailureAccrualConfig.defaultBackoff)
 }
 

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/FailureAccrualInitializer.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/FailureAccrualInitializer.scala
@@ -16,7 +16,7 @@ abstract class FailureAccrualConfig extends PolymorphicConfig {
   var backoff: Option[BackoffConfig] = None
 
   @JsonIgnore
-  val backoffOrDefault =
+  lazy val backoffOrDefault =
     backoff.map(_.mk).getOrElse(FailureAccrualConfig.defaultBackoff)
 }
 

--- a/linkerd/failure-accrual/src/test/scala/io/buoyant/linkerd/failureAccrual/ConfigTest.scala
+++ b/linkerd/failure-accrual/src/test/scala/io/buoyant/linkerd/failureAccrual/ConfigTest.scala
@@ -3,15 +3,14 @@ package io.buoyant.linkerd.failureAccrual
 import io.buoyant.config.Parser
 import io.buoyant.linkerd.{ConstantBackoffConfig, FailureAccrualConfig, JitteredBackoffConfig}
 import io.buoyant.test.FunSuite
-import org.scalatest.{Matchers, OptionValues, OutcomeOf}
+import org.scalatest.OptionValues
 import com.twitter.conversions.time._
 import org.scalatest.prop.PropertyChecks
 import org.scalacheck.Gen
 
 class ConfigTest extends FunSuite
   with OptionValues
-  with PropertyChecks
-  with OutcomeOf {
+  with PropertyChecks {
 
   def parse(yaml: String): FailureAccrualConfig = {
     val mapper = Parser.objectMapper(yaml, Seq(Seq(

--- a/linkerd/failure-accrual/src/test/scala/io/buoyant/linkerd/failureAccrual/ConfigTest.scala
+++ b/linkerd/failure-accrual/src/test/scala/io/buoyant/linkerd/failureAccrual/ConfigTest.scala
@@ -102,7 +102,7 @@ class ConfigTest extends FunSuite
 
   test("jittered backoff configs throw exceptions when passed invalid min/max") {
     forAll { (min: Int, max: Int) =>
-      whenever(min >= max || min <= 0 || max <= 0) {
+      whenever(min > max || min <= 0 || max <= 0) {
         assertThrows[IllegalArgumentException] { JitteredBackoffConfig(Some(min), Some(max)).mk }
       }
     }

--- a/linkerd/failure-accrual/src/test/scala/io/buoyant/linkerd/failureAccrual/ConfigTest.scala
+++ b/linkerd/failure-accrual/src/test/scala/io/buoyant/linkerd/failureAccrual/ConfigTest.scala
@@ -94,7 +94,7 @@ class ConfigTest extends FunSuite
     forAll((positiveInts, "min"), (positiveInts, "max")) { (min: Int, max: Int) =>
       whenever(min < max) {
         val n_unique = JitteredBackoffConfig(Some(min), Some(max)).mk
-                          .take(300).toSet.size
+          .take(300).toSet.size
         assert(n_unique >= 2)
       }
     }
@@ -107,7 +107,7 @@ class ConfigTest extends FunSuite
       }
     }
     assertThrows[IllegalArgumentException] { JitteredBackoffConfig(None, Some(1000)).mk }
-    assertThrows[IllegalArgumentException] {JitteredBackoffConfig(Some(1000), None).mk }
+    assertThrows[IllegalArgumentException] { JitteredBackoffConfig(Some(1000), None).mk }
     assertThrows[IllegalArgumentException] { JitteredBackoffConfig(None, None).mk }
   }
 

--- a/linkerd/failure-accrual/src/test/scala/io/buoyant/linkerd/failureAccrual/ConfigTest.scala
+++ b/linkerd/failure-accrual/src/test/scala/io/buoyant/linkerd/failureAccrual/ConfigTest.scala
@@ -5,7 +5,7 @@ import io.buoyant.linkerd.{ConstantBackoffConfig, FailureAccrualConfig, Jittered
 import io.buoyant.test.FunSuite
 import org.scalatest.{Matchers, OptionValues, OutcomeOf}
 import com.twitter.conversions.time._
-import org.scalatest.prop.{PropertyChecks}
+import org.scalatest.prop.PropertyChecks
 import org.scalacheck.Gen
 
 class ConfigTest extends FunSuite
@@ -76,7 +76,9 @@ class ConfigTest extends FunSuite
   private[this] val positiveInts = for { n <- Gen.choose(1, Integer.MAX_VALUE) } yield n
 
   test("constant backoff configs produce streams of constant durations") {
-    forAll { (n: Int) => ConstantBackoffConfig(n).mk.take(100).forall(_ == n.millis) }
+    forAll { (n: Int) =>
+      ConstantBackoffConfig(n).mk.take(100).foreach(d => assert(d == n.millis))
+    }
   }
 
   test("jittered backoff configs produce streams of durations between the minimum and maximum") {
@@ -84,7 +86,7 @@ class ConfigTest extends FunSuite
       whenever(min < max) {
         JitteredBackoffConfig(Some(min), Some(max)).mk
           .take(100)
-          .forall(d => d >= min.millis && d <= max.millis)
+          .foreach(d => assert(d >= min.millis && d <= max.millis))
       }
     }
   }

--- a/linkerd/failure-accrual/src/test/scala/io/buoyant/linkerd/failureAccrual/ConfigTest.scala
+++ b/linkerd/failure-accrual/src/test/scala/io/buoyant/linkerd/failureAccrual/ConfigTest.scala
@@ -62,7 +62,7 @@ class ConfigTest extends FunSuite
     for {
       kind <- kinds
       (config, backoff) <- backoffs
-    } yield outcomeOf {
+    } {
       val yaml =
         s"""$kind
              |backoff:

--- a/linkerd/failure-accrual/src/test/scala/io/buoyant/linkerd/failureAccrual/ConfigTest.scala
+++ b/linkerd/failure-accrual/src/test/scala/io/buoyant/linkerd/failureAccrual/ConfigTest.scala
@@ -72,7 +72,7 @@ class ConfigTest extends FunSuite
     }
   }
 
-  private[this] val positiveInts = for { n <- Gen.choose(1, Integer.MAX_VALUE) } yield n
+  private[this] val positiveInts = Gen.choose(1, Integer.MAX_VALUE)
 
   test("constant backoff configs produce streams of constant durations") {
     forAll { (n: Int) =>

--- a/linkerd/failure-accrual/src/test/scala/io/buoyant/linkerd/failureAccrual/ConfigTest.scala
+++ b/linkerd/failure-accrual/src/test/scala/io/buoyant/linkerd/failureAccrual/ConfigTest.scala
@@ -1,0 +1,80 @@
+package io.buoyant.linkerd.failureAccrual
+
+import com.twitter.finagle.service.Backoff
+import com.twitter.util.Duration
+import io.buoyant.config.Parser
+import io.buoyant.linkerd.{ConstantBackoffConfig, FailureAccrualConfig, JitteredBackoffConfig}
+import io.buoyant.test.FunSuite
+import org.scalatest.{Matchers, OptionValues, OutcomeOf}
+import com.twitter.conversions.time._
+import org.scalatest.prop.TableDrivenPropertyChecks
+
+/**
+ * Created by eliza on 6/27/17.
+ */
+class ConfigTest extends FunSuite
+  with Matchers
+  with OptionValues
+  with TableDrivenPropertyChecks
+  with OutcomeOf {
+
+  def parse(yaml: String): FailureAccrualConfig = {
+    val mapper = Parser.objectMapper(yaml, Seq(Seq(
+      new ConsecutiveFailuresInitializer,
+      new NoneInitializer,
+      new SuccessRateInitializer,
+      new SuccessRateWindowedInitializer
+    )))
+    mapper.readValue[FailureAccrualConfig](yaml)
+  }
+
+  val kinds =
+    Table(
+      ("kind"),
+      ("kind: io.l5d.consecutiveFailures"),
+      ("kind: io.l5d.successRate"),
+      ("kind: io.l5d.successRateWindowed"),
+      ("kind: none")
+    )
+
+  val backoffs =
+    Table(
+      ("config", "backoff"),
+      ("  kind: constant\n  ms: 10000", ConstantBackoffConfig(10000)),
+      ("  kind: jittered\n  maxMs: 10000", JitteredBackoffConfig(None, Some(10000))),
+      ("  kind: jittered\n  minMs: 10000", JitteredBackoffConfig(Some(10000), None)),
+      (
+        """|  kind: jittered
+          |  minMs: 300
+          |  maxMs: 400""".stripMargin,
+        JitteredBackoffConfig(Some(300), Some(400))
+      )
+    )
+
+  test("configs parse to the correct kinds") {
+    // TODO: this could look nicer as a table-based property check
+    parse("kind: io.l5d.consecutiveFailures") shouldBe a[ConsecutiveFailuresConfig]
+    parse("kind: io.l5d.successRate") shouldBe a[SuccessRateConfig]
+    parse("kind: io.l5d.successRateWindowed") shouldBe a[SuccessRateWindowedConfig]
+    parse("kind: none") shouldBe a[NoneConfig]
+  }
+
+  test("unspecified backoffs should parse to None") {
+    forAll(kinds) { parse(_).backoff shouldBe None }
+  }
+
+  test("configs with backoff configurations have the correct backoff") {
+    for {
+      kind <- kinds
+      (config, backoff) <- backoffs
+    } yield outcomeOf {
+      val yaml =
+        s"""$kind
+             |backoff:
+             |$config
+             """.stripMargin
+      parse(yaml).backoff.value shouldEqual backoff
+    }
+  }
+
+}

--- a/linkerd/failure-accrual/src/test/scala/io/buoyant/linkerd/failureAccrual/ConfigTest.scala
+++ b/linkerd/failure-accrual/src/test/scala/io/buoyant/linkerd/failureAccrual/ConfigTest.scala
@@ -1,21 +1,13 @@
 package io.buoyant.linkerd.failureAccrual
 
-import com.twitter.finagle.service.Backoff
-import com.twitter.util.Duration
 import io.buoyant.config.Parser
 import io.buoyant.linkerd.{ConstantBackoffConfig, FailureAccrualConfig, JitteredBackoffConfig}
 import io.buoyant.test.FunSuite
 import org.scalatest.{Matchers, OptionValues, OutcomeOf}
 import com.twitter.conversions.time._
-import org.scalatest.junit.JUnitRunner
-import org.scalatest.prop.{PropertyChecks, TableDrivenPropertyChecks}
+import org.scalatest.prop.{PropertyChecks}
 import org.scalacheck.Gen
-import org.junit.runner.RunWith
 
-/**
- * Created by eliza on 6/27/17.
- */
-@RunWith(classOf[JUnitRunner])
 class ConfigTest extends FunSuite
   with Matchers
   with OptionValues

--- a/linkerd/failure-accrual/src/test/scala/io/buoyant/linkerd/failureAccrual/ConfigTest.scala
+++ b/linkerd/failure-accrual/src/test/scala/io/buoyant/linkerd/failureAccrual/ConfigTest.scala
@@ -23,13 +23,11 @@ class ConfigTest extends FunSuite
     mapper.readValue[FailureAccrualConfig](yaml)
   }
 
-  val kinds =
-    Table(
-      ("kind"),
-      ("kind: io.l5d.consecutiveFailures"),
-      ("kind: io.l5d.successRate"),
-      ("kind: io.l5d.successRateWindowed"),
-      ("kind: none")
+  val kinds = Seq(
+      "kind: io.l5d.consecutiveFailures",
+      "kind: io.l5d.successRate",
+      "kind: io.l5d.successRateWindowed",
+      "kind: none"
     )
 
   val backoffs =
@@ -47,7 +45,6 @@ class ConfigTest extends FunSuite
     )
 
   test("configs parse to the correct kinds") {
-    // TODO: this could look nicer as a table-based property check
     assert(parse("kind: io.l5d.consecutiveFailures").isInstanceOf[ConsecutiveFailuresConfig])
     assert(parse("kind: io.l5d.successRate").isInstanceOf[SuccessRateConfig])
     assert(parse("kind: io.l5d.successRateWindowed").isInstanceOf[SuccessRateWindowedConfig])
@@ -55,7 +52,7 @@ class ConfigTest extends FunSuite
   }
 
   test("unspecified backoffs should parse to None") {
-    forAll(kinds) { cfg => assert(parse(cfg).backoff.isEmpty) }
+    kinds.foreach { cfg => assert(parse(cfg).backoff.isEmpty) }
   }
 
   test("configs with backoff configurations have the correct backoff") {

--- a/linkerd/failure-accrual/src/test/scala/io/buoyant/linkerd/failureAccrual/ConfigTest.scala
+++ b/linkerd/failure-accrual/src/test/scala/io/buoyant/linkerd/failureAccrual/ConfigTest.scala
@@ -94,11 +94,20 @@ class ConfigTest extends FunSuite
           .take(100)
           .forall(d => d >= min.millis && d <= max.millis)
       }
+    }
+  }
+
+  test("jittered backoff configs produce streams containing at least two unique durations") {
+    forAll((positiveInts, "min"), (positiveInts, "max")) { (min: Int, max: Int) =>
+      whenever(min < max) {
+        JitteredBackoffConfig(Some(min), Some(max)).mk.take(300).toSet.size should be >= 2
+      }
+    }
   }
 
   test("jittered backoff configs throw exceptions when passed invalid min/max") {
     forAll { (min: Int, max: Int) =>
-      whenever(min >= max || min <= 0 || max <= 0 ) {
+      whenever(min >= max || min <= 0 || max <= 0) {
         an[IllegalArgumentException] should be thrownBy JitteredBackoffConfig(Some(min), Some(max)).mk
       }
     }

--- a/linkerd/failure-accrual/src/test/scala/io/buoyant/linkerd/failureAccrual/ConsecutiveFailuresTest.scala
+++ b/linkerd/failure-accrual/src/test/scala/io/buoyant/linkerd/failureAccrual/ConsecutiveFailuresTest.scala
@@ -2,10 +2,24 @@ package io.buoyant.linkerd.failureAccrual
 
 import com.twitter.finagle.liveness.FailureAccrualPolicy
 import com.twitter.finagle.util.LoadService
-import io.buoyant.linkerd.FailureAccrualInitializer
+import com.twitter.conversions.time._
+import io.buoyant.config.Parser
+import io.buoyant.linkerd.{FailureAccrualConfig, FailureAccrualInitializer}
 import io.buoyant.test.FunSuite
+import org.scalatest.Matchers
 
-class ConsecutiveFailuresTest extends FunSuite {
+class ConsecutiveFailuresTest extends FunSuite
+  with Matchers {
+  def parse(yaml: String): FailureAccrualConfig = {
+    val mapper = Parser.objectMapper(yaml, Seq(Seq(
+      new ConsecutiveFailuresInitializer,
+      new NoneInitializer,
+      new SuccessRateInitializer,
+      new SuccessRateWindowedInitializer
+    )))
+    mapper.readValue[FailureAccrualConfig](yaml)
+  }
+
   test("sanity") {
     val failures = 2
     val config = ConsecutiveFailuresConfig(failures)
@@ -15,5 +29,27 @@ class ConsecutiveFailuresTest extends FunSuite {
 
   test("service registration") {
     assert(LoadService[FailureAccrualInitializer].exists(_.isInstanceOf[ConsecutiveFailuresInitializer]))
+  }
+
+  test("constant backoff") {
+    val yaml = """|kind: io.l5d.consecutiveFailures
+                  |failures: 5
+                  |backoff:
+                  |  kind: constant
+                  |  ms: 10000""".stripMargin
+    val policy = parse(yaml).policy()
+    val probeDelays = Stream.continually(policy.markDeadOnFailure()).take(20)
+    probeDelays.take(4) should contain only (None)
+    probeDelays should contain inOrderOnly (None, Some(10000.millis))
+  }
+
+  test("default (exponential) backoff") {
+    val yaml =
+      """|kind: io.l5d.consecutiveFailures
+         |failures: 5""".stripMargin
+
+    val policy = parse(yaml).policy()
+    val probeDelays = Stream.continually(policy.markDeadOnFailure()).take(20)
+    probeDelays shouldBe sorted // todo: better assertion that the increase is exponential
   }
 }

--- a/linkerd/failure-accrual/src/test/scala/io/buoyant/linkerd/failureAccrual/ConsecutiveFailuresTest.scala
+++ b/linkerd/failure-accrual/src/test/scala/io/buoyant/linkerd/failureAccrual/ConsecutiveFailuresTest.scala
@@ -39,8 +39,8 @@ class ConsecutiveFailuresTest extends FunSuite
                   |  ms: 10000""".stripMargin
     val policy = parse(yaml).policy()
     val probeDelays = Stream.continually(policy.markDeadOnFailure()).take(20)
-    probeDelays.take(4) should contain only (None)
-    probeDelays should contain inOrderOnly (None, Some(10000.millis))
+    probeDelays.take(4) should contain only None
+    probeDelays.drop(4) should contain only Some(10000.millis)
   }
 
   test("default (exponential) backoff") {

--- a/linkerd/failure-accrual/src/test/scala/io/buoyant/linkerd/failureAccrual/ConsecutiveFailuresTest.scala
+++ b/linkerd/failure-accrual/src/test/scala/io/buoyant/linkerd/failureAccrual/ConsecutiveFailuresTest.scala
@@ -2,7 +2,6 @@ package io.buoyant.linkerd.failureAccrual
 
 import com.twitter.finagle.liveness.FailureAccrualPolicy
 import com.twitter.finagle.util.LoadService
-import com.twitter.conversions.time._
 import io.buoyant.config.Parser
 import io.buoyant.linkerd.{FailureAccrualConfig, FailureAccrualInitializer}
 import io.buoyant.test.FunSuite

--- a/project/Base.scala
+++ b/project/Base.scala
@@ -208,6 +208,8 @@ class Base extends Build {
   val testUtil = projectDir("test-util")
     .settings(coverageExcludedPackages := "io.buoyant.test.*")
     .settings(libraryDependencies += Deps.scalatest)
+    .settings(libraryDependencies += Deps.scalacheck)
+    .settings(libraryDependencies += Deps.junit)
     .settings(libraryDependencies ++= {
       val deps = Deps.twitterUtil("core") :: Deps.twitterUtil("logging") :: Nil
       if (doDevelopTwitterDeps.value) {

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -52,6 +52,12 @@ object Deps {
   // testing. duh.
   val scalatest = "org.scalatest" %% "scalatest" % "3.0.1"
 
+  // scalacheck for Property-based testing
+  val scalacheck = "org.scalacheck" %% "scalacheck" % "1.13.4"
+
+  // junit
+  val junit = "junit" % "junit" % "4.10"
+
   // guava
   val guava = "com.google.guava" % "guava" % "19.0"
 


### PR DESCRIPTION
## Problem:
As described in issue #1439, custom failure accrual back off policies specified in YAML are currently ignored – linkerd uses the default backoff policy regardless of what is specified.

## Solution:
I traced the issue to the `backoffOrDefault` value member in `FailureAccrualInitializer`. This value, which is set to the class's `backoff` member if it is defined, and to the default otherwise, was
being evaluated eagerly when instances of the initialiser are constructed. However, the `backoff` member, which is mutable, is *always* set to `None` initially, and is mutated to the config value
*after* the class is instantiated. Thus, `backoffOrDefault` is always set to the default.

I've fixed the issue simply by changing `backoffOrDefault` to a lazily-evaluated value.

## Validation:
In an attempt to localize this fault, I've added a number of unit tests.

I initially thought the fault was in how we parse configs for failure accrual policies, so I've added several tests for config parsing. I then proceeded to add tests which simulate failure accrual by repeatedly calling the failure method on a failure accrual policy and asserting the resulting Stream of values contains the correct probe durations.

Some of my unit tests were written with the ScalaCheck property testing
library, so our tests now depend on ScalaCheck.

Fixes #1439