### PR TITLE
ec2Host per-host-interpreter to filter requests to the ec2 host you are running on

### DIFF
--- a/interpreter/per-host/src/main/resources/META-INF/services/io.buoyant.namer.TransformerInitializer
+++ b/interpreter/per-host/src/main/resources/META-INF/services/io.buoyant.namer.TransformerInitializer
@@ -1,3 +1,4 @@
 io.buoyant.transformer.perHost.LocalhostTransformerInitializer
 io.buoyant.transformer.perHost.PortTransformerInitializer
 io.buoyant.transformer.perHost.SpecificHostTransformerInitializer
+io.buoyant.transformer.perHost.Ec2HostTransformerInitializer

--- a/interpreter/per-host/src/main/scala/io/buoyant/transformer/perHost/Ec2HostTransformerInitializer.scala
+++ b/interpreter/per-host/src/main/scala/io/buoyant/transformer/perHost/Ec2HostTransformerInitializer.scala
@@ -1,0 +1,36 @@
+package io.buoyant.transformer
+package perHost
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import io.buoyant.namer.{NameTreeTransformer, TransformerConfig, TransformerInitializer}
+import java.net.InetAddress
+import com.twitter.finagle.{Http, Stack, http, Path}
+import com.twitter.util.Await
+
+class Ec2HostTransformerInitializer extends TransformerInitializer {
+  val configClass = classOf[Ec2HostTransformerConfig]
+  override val configId = "io.l5d.ec2Host"
+}
+
+class Ec2HostTransformerConfig extends TransformerConfig {
+
+  @JsonIgnore
+  val defaultPrefix = Path.read("/io.l5d.ec2Host")
+
+  @JsonIgnore
+  override def mk(params: Stack.Params): NameTreeTransformer = {
+
+    val servicePort = 80
+    val serviceHost = "169.254.169.254"
+    val service = Http.client
+      .newService(s"/$$/inet/$serviceHost/$servicePort")
+
+    val req = http.Request("latest/meta-data/local-ipv4")
+    req.method = http.Method.Get
+    val response = Await.result(service.apply(req))
+    val ec2HostIp = response.contentString
+
+    new SubnetLocalTransformer(prefix, Seq(InetAddress.getByName(ec2HostIp)), Netmask("255.255.255.255"))
+  }
+
+}

--- a/interpreter/subnet/src/main/scala/io/buoyant/transformer/SubnetLocalTransformer.scala
+++ b/interpreter/subnet/src/main/scala/io/buoyant/transformer/SubnetLocalTransformer.scala
@@ -1,7 +1,9 @@
 package io.buoyant.transformer
 
-import com.twitter.finagle.{Address, Path}
 import java.net.InetAddress
+
+import com.twitter.finagle.{Address, Path}
+import com.twitter.util.Activity
 import io.buoyant.namer.FilteringNameTreeTransformer
 
 /**
@@ -16,4 +18,21 @@ class SubnetLocalTransformer(val prefix: Path, localIP: Seq[InetAddress], netmas
     case Address.Inet(addr, _) => localIP.exists(netmask.local(addr.getAddress, _))
     case address => true // non-inet addresses assumed to be local (pipes, etc)
   }
+}
+
+class FutureSubnetLocalTransformer(val prefix: Path, val futureIps: Activity[Seq[InetAddress]], netmask: Netmask)
+  extends FilteringNameTreeTransformer {
+
+  override protected val predicate: Address => Boolean = {
+
+    case Address.Inet(addr, _) => {
+      futureIps.run.map {
+        case Activity.Ok(ips) => ips.exists(netmask.local(addr.getAddress, _))
+        case _ => false
+      }.sample()
+    }
+    case _ => true // non-inet addresses assumed to be local (pipes, etc)
+
+  }
+
 }

--- a/linkerd/docs/transformer.md
+++ b/linkerd/docs/transformer.md
@@ -135,3 +135,12 @@ returns the configured path, even when the original NameTree is `Neg`.
 Key | Default Value | Description
 --- | ------------- | -----------
 path | _required_ | Ignore the input and return this path.
+
+## Ec2Host
+
+kind: `io.l5d.ec2Host`
+
+The ec2Host transformer filters the list of addresses down to only addresses
+that have the same IP address as ec2 instance that linkerd is running on.  The IP address is determined
+by doing a one-time lookup using the [AWS meta endpoint](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html).  
+This transformer can be used by an incoming router to only route traffic to local destinations.

--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -436,6 +436,7 @@ object LinkerdBuild extends Base {
 
     val perHost = projectDir("interpreter/per-host")
       .dependsOn(Namer.core, subnet)
+      .withTwitterLib(Deps.finagle("http"))
       .withTests()
 
     val k8s = projectDir("interpreter/k8s")


### PR DESCRIPTION

The transformer uses the aws meta endpoint on to retrieve the ip of the host and filter based upon this.  This is especially useful if you are running on a docker container in AWS ECS and you want to filter requests to other docker containers running on the same ec2 instance.

To use the interpreter kind is: `io.l5d.ec2Host`.

Example config snippet:

```
interpreter:
    kind: default
    transformers:
    - kind: io.l5d.ec2Host
```