### PR TITLE
Fallback to egress cluster for services w/ no cluster

### DIFF
--- a/interpreter/k8s/src/main/scala/io/buoyant/interpreter/k8s/IstioInterpreterInitializer.scala
+++ b/interpreter/k8s/src/main/scala/io/buoyant/interpreter/k8s/IstioInterpreterInitializer.scala
@@ -2,8 +2,11 @@ package io.buoyant.interpreter.k8s
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.twitter.finagle.naming.NameInterpreter
-import com.twitter.finagle.{Path, Stack}
+import com.twitter.finagle.tracing.NullTracer
+import com.twitter.finagle.{Http, Path, Stack, param}
 import io.buoyant.config.types.Port
+import io.buoyant.k8s.{SetHostFilter, SingleNsNamer}
+import io.buoyant.k8s.v1.Api
 import io.buoyant.namer.{InterpreterConfig, InterpreterInitializer, Paths}
 
 class IstioInterpreterInitializer extends InterpreterInitializer {
@@ -14,6 +17,10 @@ class IstioInterpreterInitializer extends InterpreterInitializer {
 object IstioInterpreterInitializer extends IstioInterpreterInitializer
 
 case class IstioInterpreterConfig(
+  k8sApiserverHost: Option[String],
+  k8sApiserverPort: Option[Port],
+  envVar: Option[String],
+  labelSelector: Option[String],
   discoveryHost: Option[String],
   discoveryPort: Option[Port],
   apiserverHost: Option[String],
@@ -28,6 +35,9 @@ case class IstioInterpreterConfig(
   @JsonIgnore
   val prefix: Path = Path.read("/io.l5d.k8s.istio")
 
+  @JsonIgnore
+  def nsName = sys.env.get(envVar.getOrElse("POD_NAMESPACE"))
+
   override protected def newInterpreter(params: Stack.Params): NameInterpreter = {
     val discoveryClient = DiscoveryClient(
       discoveryHost.getOrElse(DefaultDiscoveryHost),
@@ -38,6 +48,23 @@ case class IstioInterpreterConfig(
       apiserverHost.getOrElse(DefaultApiserverHost),
       apiserverPort.map(_.port).getOrElse(DefaultApiserverPort)
     )
-    IstioInterpreter(routeManager, istioNamer)
+
+    val namespace = nsName.getOrElse("default")
+    val k8sHost = k8sApiserverHost.getOrElse("localhost")
+    val k8sPort = k8sApiserverPort.map(_.port).getOrElse(8001)
+    val setHost = new SetHostFilter(k8sHost, k8sPort)
+    val client = Http.client.withParams(Http.client.params ++ params)
+      .withTracer(NullTracer)
+      .withStreaming(true)
+      .filtered(setHost)
+
+    def mkNs(ns: String) = {
+      val label = param.Label(s"namer${prefix.show}/$ns")
+      val dst = s"/$$/inet/$k8sHost/$k8sPort"
+      Api(client.configured(label).newService(dst)).withNamespace(ns)
+    }
+    val k8sNamer = new SingleNsNamer(Paths.ConfiguredNamerPrefix ++ prefix, labelSelector, namespace, mkNs)
+
+    IstioInterpreter(routeManager, istioNamer, k8sNamer)
   }
 }

--- a/interpreter/k8s/src/test/scala/IstioInterpreterTest.scala
+++ b/interpreter/k8s/src/test/scala/IstioInterpreterTest.scala
@@ -6,6 +6,7 @@ import com.twitter.util.Future
 import io.buoyant.k8s.istio._
 import io.buoyant.namer.Paths
 import com.twitter.conversions.time._
+import io.buoyant.k8s.SingleNsNamer
 import io.buoyant.test.{Awaits, FunSuite}
 
 class IstioInterpreterTest extends FunSuite with Awaits {
@@ -45,7 +46,8 @@ class IstioInterpreterTest extends FunSuite with Awaits {
 
   test("successfully parses route-rules with no route field") {
     val istioNamer = new IstioNamer(discoveryClient, Paths.ConfiguredNamerPrefix ++ Path.read("/io.l5d.k8s.istio"))
-    val interpreter = IstioInterpreter(routeCache, istioNamer)
+    val k8sNamer = new SingleNsNamer(Path.read("/io.l5d.k8s.istio"), None, "default", null)
+    val interpreter = IstioInterpreter(routeCache, istioNamer, k8sNamer)
     await(interpreter.bind(Dtab.empty, Path.read("/svc/route/httpbin-3s-rule")).values.toFuture.flatMap(Future.const))
   }
 


### PR DESCRIPTION
Problem:
K8s services of type ExternalName have entries in RDS but not in CDS,
causing negative nametree resolution.

Solution:
Send traffic to egress cluster as a fallback

Verification:
Minikube manual testing