### PR TITLE
Update default netty version in docs

### DIFF
--- a/linkerd/docs/protocol-http.md
+++ b/linkerd/docs/protocol-http.md
@@ -416,7 +416,7 @@ alternate HTTP implementation to be used.
 
 Key | Default Value | Description
 --- | ------------- | -----------
-kind | `netty3` | Either `netty3` or `netty4` (`netty4` will become default in an upcoming release).
+kind | `netty4` | Either `netty3` or `netty4`
 
 <a name="http-headers"></a>
 ## HTTP Headers


### PR DESCRIPTION
The current default version of netty is netty4 but the linkerd docs say that it
is netty3.

Update the docs to indicate that netty4 is the default.