### PR TITLE
Fix null pointer in delegator when address is not resolvable

### DIFF
--- a/admin/src/main/scala/io/buoyant/admin/names/DelegateApiHandler.scala
+++ b/admin/src/main/scala/io/buoyant/admin/names/DelegateApiHandler.scala
@@ -30,8 +30,10 @@ object DelegateApiHandler {
   case class Address(ip: String, port: Int, meta: Map[String, Any])
   object Address {
     def mk(addr: FAddress): Option[Address] = addr match {
-      case FAddress.Inet(isa, meta) => Some(Address(isa.getAddress.getHostAddress, isa.getPort, meta))
-      case _ => None
+      case FAddress.Inet(isa, meta) if isa.getAddress != null =>
+        Some(Address(isa.getAddress.getHostAddress, isa.getPort, meta))
+      case _ =>
+        None
     }
 
     def toFinagle(addr: Address): FAddress =

--- a/admin/src/main/scala/io/buoyant/admin/names/DelegateApiHandler.scala
+++ b/admin/src/main/scala/io/buoyant/admin/names/DelegateApiHandler.scala
@@ -30,8 +30,10 @@ object DelegateApiHandler {
   case class Address(ip: String, port: Int, meta: Map[String, Any])
   object Address {
     def mk(addr: FAddress): Option[Address] = addr match {
-      case FAddress.Inet(isa, meta) if isa.getAddress != null =>
-        Some(Address(isa.getAddress.getHostAddress, isa.getPort, meta))
+      case FAddress.Inet(isa, meta) =>
+        Option(isa.getAddress).map { address =>
+          Address(address.getHostAddress, isa.getPort, meta)
+        }
       case _ =>
         None
     }


### PR DESCRIPTION
Fixes #1387 (probably)

If the delegator gets an unresolvable address, it throws a
NullPointerException.

Check that the address is not null before using it in a delegation.

I wasn't able to reproduce this issue because unresolable addresses appear as
Negs for me.  It's unclear to me how to get an Addr.Bound with an unresolvable
address in it.  However, based on the stack trace in the bug report, this
should fix the problem.