### PR TITLE
Add HTTP Router Loggers

### DIFF
--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/Linker.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/Linker.scala
@@ -46,10 +46,11 @@ object Linker {
     classifier: Seq[ResponseClassifierInitializer] = Nil,
     telemetry: Seq[TelemeterInitializer] = Nil,
     announcer: Seq[AnnouncerInitializer] = Nil,
-    failureAccrual: Seq[FailureAccrualInitializer] = Nil
+    failureAccrual: Seq[FailureAccrualInitializer] = Nil,
+    loggers: Seq[LoggerInitializer] = Nil
   ) {
     def iter: Iterable[Seq[ConfigInitializer]] =
-      Seq(protocol, namer, interpreter, identifier, transformer, classifier, telemetry, announcer, failureAccrual)
+      Seq(protocol, namer, interpreter, identifier, transformer, classifier, telemetry, announcer, failureAccrual, loggers)
 
     def all: Seq[ConfigInitializer] = iter.flatten.toSeq
 
@@ -69,7 +70,8 @@ object Linker {
     LoadService[ResponseClassifierInitializer],
     LoadService[TelemeterInitializer],
     LoadService[AnnouncerInitializer],
-    LoadService[FailureAccrualInitializer]
+    LoadService[FailureAccrualInitializer],
+    LoadService[LoggerInitializer]
   )
 
   def parse(

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/LoggerInitializer.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/LoggerInitializer.scala
@@ -1,0 +1,5 @@
+package io.buoyant.linkerd
+
+import io.buoyant.config.ConfigInitializer
+
+abstract class LoggerInitializer extends ConfigInitializer

--- a/linkerd/docs/protocol-http.md
+++ b/linkerd/docs/protocol-http.md
@@ -31,6 +31,7 @@ Key | Default Value | Description
 dstPrefix | `/svc` | A path prefix used by [Http-specific identifiers](#http-1-1-identifiers).
 httpAccessLog | none | Sets the access log path.  If not specified, no access log is written.
 identifier | The `io.l5d.header.token` identifier | An identifier or list of identifiers.  See [Http-specific identifiers](#http-1-1-identifiers).
+loggers | A list of loggers.  See [Http-specific loggers](#http-1-1-loggers).
 maxChunkKB | 8 | The maximum size of an HTTP chunk.
 maxHeadersKB | 8 | The maximum size of all headers in an HTTP message.
 maxInitialLineKB | 4 | The maximum size of an initial HTTP message line.
@@ -392,6 +393,17 @@ Key | Default Value | Description
 --- | ------------- | -----------
 dstPrefix | `/svc` | The `dstPrefix` as set in the routers block.
 path | N/A | The path given in the configuration.
+
+<a name="http-1-1-loggers"></a>
+## HTTP/1.1 Loggers
+
+Loggers allow recording of arbitrary information about requests. Destination of
+information is specific to each logger. All HTTP/1.1 loggers have a `kind`. If a
+list of loggers is provided, they each log in the order they are defined.
+
+Key | Default Value | Description
+--- | ------------- | -----------
+kind | _required_ | No loggers currently supported.
 
 <a name="http-engines"></a>
 ## HTTP Engines

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpLoggerConfig.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpLoggerConfig.scala
@@ -1,0 +1,56 @@
+package io.buoyant.linkerd.protocol
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.twitter.finagle.{Filter, Service, ServiceFactory, Stack, Stackable}
+import com.twitter.finagle.http.{Request, Response}
+import com.twitter.finagle.stack.nilStack
+import com.twitter.util.Future
+import io.buoyant.config.PolymorphicConfig
+
+abstract class HttpLoggerConfig extends PolymorphicConfig { config =>
+
+  @JsonIgnore
+  def role: Stack.Role
+  @JsonIgnore
+  def description: String
+  @JsonIgnore
+  def parameters: Seq[Stack.Param[_]]
+
+  @JsonIgnore
+  def mk(params: Stack.Params): Filter[Request, Response, Request, Response]
+
+  @JsonIgnore
+  def module = new Stack.Module[ServiceFactory[Request, Response]] {
+    override def role: Stack.Role = config.role
+    override def description: String = config.description
+    override def parameters: Seq[Stack.Param[_]] = config.parameters
+
+    override def make(
+      params: Stack.Params,
+      next: Stack[ServiceFactory[Request, Response]]
+    ): Stack[ServiceFactory[Request, Response]] = {
+      val filter = mk(params)
+      Stack.Leaf(role, filter.andThen(next.make(params)))
+    }
+  }
+}
+
+object HttpLoggerConfig {
+  object param {
+    case class Logger(loggerStack: Stack[ServiceFactory[Request, Response]])
+    implicit object Logger extends Stack.Param[Logger] {
+      val default = Logger(nilStack)
+    }
+  }
+
+  def module: Stackable[ServiceFactory[Request, Response]] =
+    new Stack.Module[ServiceFactory[Request, Response]] {
+      override val role = Stack.Role("HttpLogger")
+      override val description = "HTTP Logger"
+      override val parameters = Seq(implicitly[Stack.Param[param.Logger]])
+      def make(params: Stack.Params, next: Stack[ServiceFactory[Request, Response]]): Stack[ServiceFactory[Request, Response]] = {
+        val param.Logger(loggerStack) = params[param.Logger]
+        loggerStack ++ next
+      }
+    }
+}


### PR DESCRIPTION
Problem
Linkerd lacks the ability to inject arbitrary loggers into the request
stack.

Solution
Add a new `routers` config section for HTTP `loggers`.

Validation
Coming as part of #1435

precursor to #1435