### PR TITLE
Support istio rewrite routing-rules

### DIFF
--- a/k8s/src/main/scala/io/buoyant/k8s/istio/IdentifierPreconditions.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/istio/IdentifierPreconditions.scala
@@ -5,6 +5,16 @@ import istio.proxy.v1.config.{HTTPRewrite, MatchCondition, RouteRule, StringMatc
 import istio.proxy.v1.config.StringMatch.OneofMatchType
 
 trait IdentifierPreconditions {
+  case class IstioRequestMeta(
+    uri: String,
+    scheme: String,
+    method: String,
+    authority: String,
+    getHeader: (String) => Option[String]
+  )
+
+  def pathFromUri(uri: String): String = "/" + uri.split("/").drop(1).mkString("/")
+
   def headerMatches(headerValue: String, stringMatch: StringMatch): Boolean = {
     stringMatch.`matchType` match {
       case Some(OneofMatchType.Exact(value)) => headerValue == value
@@ -23,12 +33,15 @@ trait IdentifierPreconditions {
     }
   }
 
-  def matchesAllConditions(getHeader: (String) => Option[String], matchCondition: MatchCondition): Boolean = {
+  def matchesAllConditions(req: IstioRequestMeta, matchCondition: MatchCondition): Boolean = {
     val matchesHeaders = matchCondition.`httpHeaders`.forall {
+      case ("uri", m) => headerMatches(req.uri, m)
+      case ("scheme", m) => headerMatches(req.scheme, m)
+      case ("method", m) => headerMatches(req.method, m)
+      case ("authority", m) => headerMatches(req.authority, m)
       case (headerName, stringMatch) =>
-        // return false if the headerName does not appear in the request's headerMap
-        getHeader(headerName) match {
-          case Some(headerValue) => headerMatches(headerValue, stringMatch)
+        req.getHeader(headerName) match {
+          case Some(a) => headerMatches(a, stringMatch)
           case None => false
         }
     }
@@ -52,10 +65,10 @@ trait IdentifierPreconditions {
     }
   }
 
-  def filterRules(rules: Map[String, RouteRule], dest: String, getHeader: (String) => Option[String]): Seq[(String, RouteRule)] = rules.filter {
+  def filterRules(rules: Map[String, RouteRule], dest: String, req: IstioRequestMeta): Seq[(String, RouteRule)] = rules.filter {
     case (_, r) if r.`destination`.contains(dest) =>
       // return true if no match conditions were defined on the route-rule
-      r.`match`.forall(matchesAllConditions(getHeader, _))
+      r.`match`.forall(matchesAllConditions(req, _))
     case _ => false
   }.toSeq
 

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/IstioIdentifier.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/IstioIdentifier.scala
@@ -2,7 +2,7 @@ package io.buoyant.linkerd.protocol.h2
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.twitter.finagle.buoyant.Dst
-import com.twitter.finagle.buoyant.h2.Request
+import com.twitter.finagle.buoyant.h2.{Headers, Request}
 import com.twitter.finagle.{Dtab, Path, Stack}
 import com.twitter.util.Future
 import io.buoyant.config.types.Port
@@ -19,9 +19,14 @@ class IstioIdentifier(val pfx: Path, baseDtab: () => Dtab, routeCache: RouteCach
     Future.join(clusterCache.get(req.authority), routeCache.getRules).map {
       case (Some(Cluster(dest, port)), rules) =>
         val filteredRules = filterRules(rules, dest, req.headers.get)
-        maxPrecedenceRuleName(filteredRules).map(pfx ++ Path.Utf8("route", _, port)).getOrElse {
+        maxPrecedenceRuleName(filteredRules) match {
+          case Some((ruleName, rule)) =>
+            val (uri, authority) = httpRewrite(rule, req.path, Some(req.authority))
+            req.headers.set(Headers.Path, uri)
+            req.headers.set(Headers.Authority, authority.getOrElse(""))
+            pfx ++ Path.Utf8("route", ruleName, port)
           //forward requests which have no matching rules to an empty label selector
-          pfx ++ Path.Utf8("dest", dest, "::", port)
+          case None => pfx ++ Path.Utf8("dest", dest, "::", port)
         }
       case b =>
         // forward requests which have no matching vhosts to external

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/IstioIdentifier.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/IstioIdentifier.scala
@@ -18,7 +18,8 @@ class IstioIdentifier(val pfx: Path, baseDtab: () => Dtab, routeCache: RouteCach
   override def apply(req: Request): Future[RequestIdentification[Request]] = {
     Future.join(clusterCache.get(req.authority), routeCache.getRules).map {
       case (Some(Cluster(dest, port)), rules) =>
-        val filteredRules = filterRules(rules, dest, req.headers.get)
+        val meta = IstioRequestMeta(req.path, req.scheme, req.method.toString, req.authority, req.headers.get)
+        val filteredRules = filterRules(rules, dest, meta)
         maxPrecedenceRuleName(filteredRules) match {
           case Some((ruleName, rule)) =>
             val (uri, authority) = httpRewrite(rule, req.path, Some(req.authority))

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/IstioIdentifier.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/IstioIdentifier.scala
@@ -21,7 +21,11 @@ class IstioIdentifier(val pfx: Path, baseDtab: () => Dtab, routeCache: RouteCach
           case (Some(Cluster(dest, port)), rules) =>
             val filteredRules = filterRules(rules, dest, req.headerMap.get)
             maxPrecedenceRuleName(filteredRules) match {
-              case Some(ruleName) => pfx ++ Path.Utf8("route", ruleName, port)
+              case Some((ruleName, rule)) =>
+                val (uri, authority) = httpRewrite(rule, req.uri, req.host)
+                req.uri = uri
+                req.host = authority.getOrElse("")
+                pfx ++ Path.Utf8("route", ruleName, port)
               //forward requests which have no matching rules to an empty label selector
               case None => pfx ++ Path.Utf8("dest", dest, "::", port)
             }

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/IstioIdentifier.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/IstioIdentifier.scala
@@ -19,7 +19,9 @@ class IstioIdentifier(val pfx: Path, baseDtab: () => Dtab, routeCache: RouteCach
       case Some(host) =>
         Future.join(clusterCache.get(host), routeCache.getRules).map {
           case (Some(Cluster(dest, port)), rules) =>
-            val filteredRules = filterRules(rules, dest, req.headerMap.get)
+            //TODO: request scheme?
+            val meta = IstioRequestMeta(pathFromUri(req.path), "", req.method.toString, req.host.getOrElse(""), req.headerMap.get)
+            val filteredRules = filterRules(rules, dest, meta)
             maxPrecedenceRuleName(filteredRules) match {
               case Some((ruleName, rule)) =>
                 val (uri, authority) = httpRewrite(rule, req.uri, req.host)

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/IstioIngressIdentifier.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/IstioIngressIdentifier.scala
@@ -48,7 +48,11 @@ class IstioIngressIdentifier(
           case (Some(port), rules) =>
             val filteredRules = filterRules(rules, clusterName, req.headerMap.get)
             val path = maxPrecedenceRuleName(filteredRules) match {
-              case Some(ruleName) => pfx ++ Path.Utf8("route", ruleName, port)
+              case Some((ruleName, rule)) =>
+                val (uri, authority) = httpRewrite(rule, req.uri, req.host)
+                req.uri = uri
+                req.host = authority.getOrElse("")
+                pfx ++ Path.Utf8("route", ruleName, port)
               //forward requests which have no matching rules to an empty label selector
               case None => pfx ++ Path.Utf8("dest", clusterName, "::", port)
             }

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/IstioIngressIdentifier.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/IstioIngressIdentifier.scala
@@ -46,7 +46,9 @@ class IstioIngressIdentifier(
 
         Future.join(portName, routeCache.getRules).map {
           case (Some(port), rules) =>
-            val filteredRules = filterRules(rules, clusterName, req.headerMap.get)
+            //TODO: request scheme?
+            val meta = IstioRequestMeta(pathFromUri(req.path), "", req.method.toString, req.host.getOrElse(""), req.headerMap.get)
+            val filteredRules = filterRules(rules, clusterName, meta)
             val path = maxPrecedenceRuleName(filteredRules) match {
               case Some((ruleName, rule)) =>
                 val (uri, authority) = httpRewrite(rule, req.uri, req.host)

--- a/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/IstioIdentifierTest.scala
+++ b/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/IstioIdentifierTest.scala
@@ -245,7 +245,6 @@ class IstioIdentifierTest extends FunSuite with Awaits {
     val reqWithMatchingPath = FRequest()
     reqWithMatchingPath.host = "bird-watcher.default.svc.cluster"
     reqWithMatchingPath.uri = "bird-watcher.default.svc.cluster/my/bird/prefix/and/residual"
-    reqWithMatchingPath.headerMap.add("uri", "/my/bird/prefix/and/residual")
 
     await(identifier(reqWithMatchingPath)) match {
       case IdentifiedRequest(Dst.Path(name, base, local), req1) =>


### PR DESCRIPTION
Implements https://istio.io/docs/reference/config/traffic-rules/routing-rules.html#httprewrite
Related to #1419 

Also updates header matching to accommodate special keywords ("uri", "scheme", "method", etc) as described in https://istio.io/docs/reference/config/traffic-rules/routing-rules.html#matchcondition

Question: how do I get http/https scheme from finagle http requests?