### PR TITLE
Add HttpResponseException

### DIFF
--- a/linkerd/failure-accrual/src/test/scala/io/buoyant/linkerd/failureAccrual/ConfigTest.scala
+++ b/linkerd/failure-accrual/src/test/scala/io/buoyant/linkerd/failureAccrual/ConfigTest.scala
@@ -23,11 +23,11 @@ class ConfigTest extends FunSuite
   }
 
   val kinds = Seq(
-      "kind: io.l5d.consecutiveFailures",
-      "kind: io.l5d.successRate",
-      "kind: io.l5d.successRateWindowed",
-      "kind: none"
-    )
+    "kind: io.l5d.consecutiveFailures",
+    "kind: io.l5d.successRate",
+    "kind: io.l5d.successRateWindowed",
+    "kind: none"
+  )
 
   val backoffs =
     Table(


### PR DESCRIPTION
There are several places in Linkerd where it is desirable to stop processing
the current request and return a specific response.  However, many of those
places (such as identifiers, for example) do not expose any interface for
returning responses.

We introduce the HttpResponseException which contains a Response object.  By
returning a failed Future with this exception, we can halt processing of the
current request and return the given response.