### PR TITLE
Add a filter for duplicate `Content-Length` headers in requests

### DIFF
--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpConfig.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpConfig.scala
@@ -31,6 +31,7 @@ class HttpInitializer extends ProtocolInitializer.Simple {
       .prepend(Headers.Dst.PathFilter.module)
       .replace(StackClient.Role.prepFactory, DelayedRelease.module)
       .prepend(http.ErrorResponder.module)
+      .insertBefore(ClassifiedRetries.role, RequestFramingFilter.module)
     val boundStack = Http.router.boundStack
       .prepend(Headers.Dst.BoundFilter.module)
     val clientStack = Http.router.clientStack

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpConfig.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpConfig.scala
@@ -31,7 +31,7 @@ class HttpInitializer extends ProtocolInitializer.Simple {
       .prepend(Headers.Dst.PathFilter.module)
       .replace(StackClient.Role.prepFactory, DelayedRelease.module)
       .prepend(http.ErrorResponder.module)
-      .insertBefore(ClassifiedRetries.role, RequestFramingFilter.module)
+      .insertAfter(http.ErrorResponder.role, RequestFramingFilter.module)
     val boundStack = Http.router.boundStack
       .prepend(Headers.Dst.BoundFilter.module)
     val clientStack = Http.router.clientStack

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/RequestFramingFilter.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/RequestFramingFilter.scala
@@ -1,0 +1,39 @@
+package io.buoyant.linkerd.protocol.http
+
+import com.twitter.finagle._
+import com.twitter.finagle.http.{Request, Response, Status}
+import com.twitter.logging.Logger
+import com.twitter.util.Future
+
+/**
+  * A filter that fails badly-framed requests.
+  */
+class RequestFramingFilter extends SimpleFilter[Request, Response] {
+  private[this] lazy val log = Logger.get("RequestFramingFilter")
+
+  override def apply(request: Request,
+                     service: Service[Request, Response]): Future[Response] =
+    if (request.headerMap.getAll("Content-Length").length > 1) {
+      // if the length of the Content-Length key in the request's header map
+      // is greater than 1, then there are duplicate values.
+      log.error("request with duplicate Content-Length headers", request)
+      ???
+    } else {
+      // otherwise, the request is fine!
+      service(request)
+    }
+
+}
+
+object RequestFramingFilter {
+
+  val role = Stack.Role("RequestFramingFilter")
+  val module: Stackable[ServiceFactory[Request, Response]] =
+    new Stack.Module0[ServiceFactory[Request, Response]] {
+      val role = RequestFramingFilter.role
+      val description = "Fails badly-framed HTTP requests"
+      val filter = new RequestFramingFilter
+      def make(factory: ServiceFactory[Request, Response]) =
+        filter.andThen(factory)
+    }
+}

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/RequestFramingFilter.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/RequestFramingFilter.scala
@@ -24,7 +24,7 @@ class RequestFramingFilter extends SimpleFilter[Request, Response] {
         "Request contained duplicate `Content-Length` headers",
         Status.BadRequest
       )
-      Future(resp)
+      Future.value(resp)
     } else {
       // otherwise, the request is fine!
       service(request)

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/RequestFramingFilter.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/RequestFramingFilter.scala
@@ -10,7 +10,7 @@ import com.twitter.util.Future
  * A filter that fails badly-framed requests.
  */
 class RequestFramingFilter extends SimpleFilter[Request, Response] {
-  private[this] lazy val log = Logger.get("RequestFramingFilter")
+  private[this] val log = Logger.get("RequestFramingFilter")
 
   override def apply(
     request: Request,

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/RequestFramingFilter.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/RequestFramingFilter.scala
@@ -16,7 +16,7 @@ class RequestFramingFilter extends SimpleFilter[Request, Response] {
     request: Request,
     service: Service[Request, Response]
   ): Future[Response] =
-    if (request.headerMap.getAll("Content-Length").length > 1) {
+    if (request.headerMap.getAll("Content-Length").toSet.size > 1) {
       // if the length of the Content-Length key in the request's header map
       // is greater than 1, then there are duplicate values.
       log.error("request with duplicate Content-Length headers", request)


### PR DESCRIPTION
Problem:
---------

The HTTP 1.1 specification for proxies says the following: 
> If a message is received without Transfer-Encoding and with
> either multiple Content-Length header fields having differing
> field-values or a single Content-Length header field having an
> invalid value, then the message framing is invalid and MUST be
> treated as an error to prevent request or response smuggling.

Testing with [`flossy`](https://github.com/BuoyantIO/flossy) indicates that we don't handle this case correctly – we just forward these requests to the downstream service (see https://github.com/linkerd/linkerd/issues/682#issuecomment-312730463).

Solution
--------

I added a `RequestFramingFilter` to the Path stack in `HttpConfig`. This filter detects requests with duplicate `Content-Length` headers and responds with error code 400. The filter is inserted into the stack above `ClassifiedRetries` so that we don't waste time retrying these malformed requests.

In the future, this filter can be expanded to handle more types of bad request framing (such as the case of conflicting `Transfer-Encoding` and `Content-Length` headers, which I _strongly suspect_ we are also not handling correctly).

Validation
----------

I reran `flossy` against the linkerd proxy example, and the corresponding test now passes.

Fixes #1475.