### PR TITLE
Preallocate telemeter StringBuilders

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 ## In the next release...
 
 * We fixed an issue where requests that time out were not being retried.
+* Improved memory allocation in InfluxDb and Prometheus telemeters.
 
 ## 1.1.1 2017-07-10
 

--- a/telemetry/core/src/main/scala/io/buoyant/telemetry/Telemeter.scala
+++ b/telemetry/core/src/main/scala/io/buoyant/telemetry/Telemeter.scala
@@ -16,6 +16,10 @@ trait Telemeter {
 
 object Telemeter {
 
+  // default initial buffer size for StringBuilder objects, used by
+  // InfluxDbTelemeter and PrometheusTelemeter
+  val DefaultBufferSize = 16384
+
   /**
    * A utility useful when a Telemeter has no _run_ning to do.
    */

--- a/telemetry/influxdb/src/main/scala/io/buoyant/telemetry/influxdb/InfluxDbTelemeter.scala
+++ b/telemetry/influxdb/src/main/scala/io/buoyant/telemetry/influxdb/InfluxDbTelemeter.scala
@@ -20,7 +20,7 @@ class InfluxDbTelemeter(metrics: MetricsTree) extends Telemeter with Admin.WithH
     val response = Response()
     response.version = request.version
     response.mediaType = MediaType.Txt
-    val sb = new StringBuilder()
+    val sb = new StringBuilder(Telemeter.DefaultBufferSize)
     val host = request.host.getOrElse("none")
     writeMetrics(metrics, sb, Nil, Seq("host" -> host))
     response.contentString = sb.toString

--- a/telemetry/prometheus/src/main/scala/io/buoyant/telemetry/prometheus/PrometheusTelemeter.scala
+++ b/telemetry/prometheus/src/main/scala/io/buoyant/telemetry/prometheus/PrometheusTelemeter.scala
@@ -20,7 +20,7 @@ class PrometheusTelemeter(metrics: MetricsTree) extends Telemeter with Admin.Wit
     val response = Response()
     response.version = request.version
     response.mediaType = MediaType.Txt
-    val sb = new StringBuilder()
+    val sb = new StringBuilder(Telemeter.DefaultBufferSize)
     writeMetrics(metrics, sb)
     response.contentString = sb.toString
     Future.value(response)


### PR DESCRIPTION
Problem
Influx and Prometheus Telemeter StringBuilders initialize with default
16 byte capacity. Typical Telemeter payloads can grow to 1MB or more.
This causes many unneed reallocations.

Solution
Set initial StringBuilder capacity to 16384.

Validation
Unit tests

Part of #1488