### PR TITLE
Add import to BetterHttp2ConnectionEncoder

### DIFF
--- a/finagle/h2/src/main/java/io/netty/handler/codec/http2/BetterHttp2ConnectionEncoder.java
+++ b/finagle/h2/src/main/java/io/netty/handler/codec/http2/BetterHttp2ConnectionEncoder.java
@@ -28,6 +28,7 @@ import java.util.ArrayDeque;
 import static io.netty.handler.codec.http2.Http2CodecUtil.DEFAULT_PRIORITY_WEIGHT;
 import static io.netty.handler.codec.http2.Http2Error.PROTOCOL_ERROR;
 import static io.netty.handler.codec.http2.Http2Exception.connectionError;
+import static io.netty.handler.codec.http2.Http2FrameWriter.Configuration;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 import static java.lang.Integer.MAX_VALUE;
 import static java.lang.Math.min;


### PR DESCRIPTION
For reasons that I cannot fathom, BetterHttp2ConnectionEncoder fails to compile
when publishing artifacts even though it compiles successfully with the
compile task.  The compilation error is
```
[error] /Users/alex/workspace/linkerd/finagle/h2/src/main/java/io/netty/handler/codec/http2/BetterHttp2ConnectionEncoder.java:324: not found: type Configuration
[error]     public Configuration configuration() {
[error]            ^
```

Adding an explicit import of Configuration seems to fix the issue.