### PR TITLE
Re-enable sending H2 GO_AWAY frame

### DIFF
--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4H2Writer.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4H2Writer.scala
@@ -69,9 +69,7 @@ private[netty4] trait Netty4H2Writer extends H2Transport.Writer {
   }
 
   override def goAway(err: GoAway, deadline: Time): Future[Unit] = {
-    write(goAwayFrame(err))
-
-    close(deadline)
+    write(goAwayFrame(err)).flatMap { _ => close(deadline) }
   }
 }
 

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4H2Writer.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4H2Writer.scala
@@ -58,21 +58,18 @@ private[netty4] trait Netty4H2Writer extends H2Transport.Writer {
    * Connection errors
    */
 
-  // private[this] def goAwayFrame(err: GoAway): Http2GoAwayFrame = {
-  //   val code = err match {
-  //     case GoAway.EnhanceYourCalm => Http2Error.ENHANCE_YOUR_CALM
-  //     case GoAway.InternalError => Http2Error.INTERNAL_ERROR
-  //     case GoAway.NoError => Http2Error.NO_ERROR
-  //     case GoAway.ProtocolError => Http2Error.PROTOCOL_ERROR
-  //   }
-  //   new DefaultHttp2GoAwayFrame(code)
-  // }
+  private[this] def goAwayFrame(err: GoAway): Http2GoAwayFrame = {
+    val code = err match {
+      case GoAway.EnhanceYourCalm => Http2Error.ENHANCE_YOUR_CALM
+      case GoAway.InternalError => Http2Error.INTERNAL_ERROR
+      case GoAway.NoError => Http2Error.NO_ERROR
+      case GoAway.ProtocolError => Http2Error.PROTOCOL_ERROR
+    }
+    new DefaultHttp2GoAwayFrame(code)
+  }
 
   override def goAway(err: GoAway, deadline: Time): Future[Unit] = {
-    // XXX Our version of netty has a bug that prevents us from
-    // sending AWAYs, so just close until that's fixed.
-    // See: https://github.com/netty/netty/issues/5307
-    //write(goAwayFrame(err))
+    write(goAwayFrame(err))
 
     close(deadline)
   }


### PR DESCRIPTION
As described in #1296, we disabled some code for sending a `GO_AWAY` frame when closing an H2 connection, because of an upstream issue in Netty (netty/netty#5307).

Since that issue was fixed in netty/netty@79f2e3604e4c2f1ff6ed6edf04e660c3f46e0200, we should be able to re-enable this code.

All of our existing tests [pass on CI](https://circleci.com/gh/linkerd/linkerd/5260?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link) with these changes. 

Fixes #1296 