### PR TITLE
Add TLS client configuration to Marathon namer (#1445)

### DIFF
--- a/linkerd/docs/namer.md
+++ b/linkerd/docs/namer.md
@@ -522,6 +522,7 @@ port | `80` | The Marathon master port.
 uriPrefix | none | The Marathon API prefix. This prefix depends on your Marathon configuration. For example, running Marathon locally, the API is available at `localhost:8080/v2/`, while the default setup on AWS/DCOS is `$(dcos config show core.dcos_url)/marathon/v2/apps`.
 ttlMs | `5000` | The polling interval in milliseconds against the Marathon API.
 useHealthCheck | `false` | If `true`, exclude app instances that are failing Marathon health checks. Even if `false`, linkerd's built-in resiliency algorithms will still apply.
+tls | no tls | The Marathon namer will make requests to Marathon/DCOS using TLS if this parameter is provided. This is useful when DC/OS is run in [strict](https://docs.mesosphere.com/latest/security/#security-modes) security mode. It must be a [client TLS](client_tls.md#client-tls) object. Note that the `clientAuth` config value will be unused, as DC/OS does not use mutual TLS.
 
 ### Marathon Path Parameters
 

--- a/namer/marathon/src/test/scala/io/buoyant/namer/marathon/MarathonTest.scala
+++ b/namer/marathon/src/test/scala/io/buoyant/namer/marathon/MarathonTest.scala
@@ -28,7 +28,7 @@ class MarathonTest extends FunSuite {
     // ensure it doesn't totally blowup
     // We use a name that resolves here
     val _ = MarathonConfig(Some("localhost"), None, None, None, None, None,
-      None).newNamer(Stack.Params.empty)
+      None, None).newNamer(Stack.Params.empty)
   }
 
   test("service registration") {
@@ -77,6 +77,39 @@ class MarathonTest extends FunSuite {
     assert(marathon._prefix.contains(Path.read("/io.l5d.marathon")))
     assert(marathon.ttlMs.contains(300))
     assert(marathon.jitterMs.isEmpty)
+    assert(!marathon.disabled)
+  }
+
+  test("parse config with tls") {
+    val yaml = s"""
+                  |kind:           io.l5d.marathon
+                  |prefix:         /io.l5d.marathon
+                  |host:           localhost
+                  |port:           80
+                  |uriPrefix:      /marathon
+                  |ttlMs:          300
+                  |useHealthCheck: false
+                  |tls:
+                  |  disableValidation: false
+                  |  commonName: master.mesos
+                  |  trustCerts:
+                  |    - /foo/caCert.pem
+      """.stripMargin
+
+    val mapper = Parser.objectMapper(yaml, Iterable(Seq(MarathonInitializer)))
+    val marathon = mapper.readValue[NamerConfig](yaml).asInstanceOf[MarathonConfig]
+    assert(marathon.host.contains("localhost"))
+    assert(marathon.port.contains(Port(80)))
+    assert(marathon.uriPrefix.contains("/marathon"))
+    assert(marathon._prefix.contains(Path.read("/io.l5d.marathon")))
+    assert(marathon.ttlMs.contains(300))
+    assert(marathon.jitterMs.isEmpty)
+
+    val tls = marathon.tls.get
+    assert(tls.disableValidation.contains(false))
+    assert(tls.commonName.contains("master.mesos"))
+    assert(tls.trustCerts.contains(List("/foo/caCert.pem")))
+
     assert(!marathon.disabled)
   }
 


### PR DESCRIPTION
For DC/OS clusters running in strict security mode, TLS is enforced for any calls to Marathon API endpoints, using certificates signed by the DC/OS Certificate Authority. Without being able to configure the relevant root certificate to be trusted, the Marathon namer cannot talk to the necessary Marathon endpoints. 

This change introduces the existing [TlsClientConfig](https://linkerd.io/config/1.1.1/linkerd/index.html#client-tls) to the Marathon namer configuration to enable TLS secured communication with Marathon, since it already has everything we need. The only caveat is that the clientAuth config section will remain unused, as DC/OS does not support mutual TLS. I've added a simple test to ensure that the TLS config is parsed from the config file correctly.

Fixes #1445