### PR TITLE
Reduce scariness of error message caused by misbehaving H2 clients

### DIFF
--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4DispatcherBase.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4DispatcherBase.scala
@@ -105,13 +105,12 @@ trait Netty4DispatcherBase[SendMsg <: Message, RecvMsg <: Message] {
         log.debug(e, "[%s] dispatcher closed", prefix)
         Future.exception(e)
 
-      case Throw(e: ChannelClosedException)
-        // if all streams have already been closed, then this just means that
-        // the client failed to send a GOAWAY frame...
-        if closed.get || streams.isEmpty =>
-          // ...so we don't need to propagate the exception
-          log.debug("[%s] client closed connection without sending GOAWAY frame", prefix)
-          Future.Unit
+      // if all streams have already been closed, then this just means that
+      // the client failed to send a GOAWAY frame...
+      case Throw(e: ChannelClosedException) if streams.isEmpty =>
+        // ...so we don't need to propagate the exception
+        log.debug("[%s] client closed connection without sending GOAWAY frame", prefix)
+        Future.Unit
 
       case Throw(e) =>
         log.error(e, "[%s] dispatcher failed", prefix)

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4DispatcherBase.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4DispatcherBase.scala
@@ -106,12 +106,12 @@ trait Netty4DispatcherBase[SendMsg <: Message, RecvMsg <: Message] {
         Future.exception(e)
 
       case Throw(e: ChannelClosedException)
-      // if all streams have already been closed, then this just means that
-      // the client failed to send a GOAWAY frame...
-      if closed.get || streams.keys.asScala.forall { _ <= closedId.get } =>
-        // ...so we don't need to propagate the exception
-        log.warning("[%s] client closed connection without sending GOAWAY frame", prefix)
-        Future.Unit
+        // if all streams have already been closed, then this just means that
+        // the client failed to send a GOAWAY frame...
+        if closed.get || streams.isEmpty =>
+          // ...so we don't need to propagate the exception
+          log.debug("[%s] client closed connection without sending GOAWAY frame", prefix)
+          Future.Unit
 
       case Throw(e) =>
         log.error(e, "[%s] dispatcher failed", prefix)

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4DispatcherBase.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4DispatcherBase.scala
@@ -108,7 +108,7 @@ trait Netty4DispatcherBase[SendMsg <: Message, RecvMsg <: Message] {
       case Throw(e: ChannelClosedException)
       // if all streams have already been closed, then this just means that
       // the client failed to send a GOAWAY frame...
-      if streams.keySet.asScala.max <= closedId.get || closed.get =>
+      if closed.get || streams.keys.asScala.forall { _ <= closedId.get } =>
         // ...so we don't need to propagate the exception
         log.warning("[%s] client closed connection without sending GOAWAY frame", prefix)
         Future.Unit


### PR DESCRIPTION
Some gRPC clients (including the grpc-go client we use in `linkerd-examples/docker/helloworld`) fail to send GOAWAY frames after closing the connection. This was causing linkerd to log an error message which gave the impression that servicing the request in question had failed, when it had actually been completed successfully.

I consulted the HTTP/2 spec and found the following: 

> Endpoints SHOULD always send a GOAWAY frame before closing a connection so that the remote peer can know whether a stream has been partially processed or not. For example, if an HTTP client sends a POST at the same time that a server closes a connection, the client cannot know if the server started to process that POST request if the server does not send a GOAWAY frame to indicate what streams it might have acted on.

Therefore, it occurs these clients are, in fact, acting erroneously by not sending a GOAWAY frame, so it seems reasonable for linkerd to log some kind of message. However, since the stack trace previously being printed was scary and didn't accurately describe what was going on, I intercepted the exception and downgraded the log entry to a warning with a more explanatory message. Additionally, I ensured that this warning is only logged if all the streams have already been closed, since a `ConnectionClosedException` occurring when there are still streams open could be indicative of a bigger problem and should still be propagated.

I reproduced the bug using the `helloworld` example and the linkerd configs provided by @klingerf in issue #1289. After applying my fix, the spurious log message no longer appears, and is replaced with
```
W 0712 20:30:18.821 UTC THREAD573: [S L:/127.0.0.1:4140 R:/127.0.0.1:54802] client closed connection without sending GOAWAY frame
```

Fixes #1289 