### PR TITLE
1.1.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,10 @@
-## In the next release...
+## 1.1.2 2017-07-12
 
+* Marathon Namer TLS support, for DC/OS strict mode.
 * We fixed an issue where requests that time out were not being retried.
+* HTTP 1.1 protocol fixes for chunked transfer encoding and `Content-Length`.
 * Improved memory allocation in InfluxDb and Prometheus telemeters.
+* Documentation fixes.
 
 ## 1.1.1 2017-07-10
 

--- a/project/Base.scala
+++ b/project/Base.scala
@@ -32,7 +32,7 @@ object Base {
 class Base extends Build {
   import Base._
 
-  val headVersion = "1.1.1"
+  val headVersion = "1.1.2"
 
   object Git {
     def git(arg: String, args: String*) = Process("git" +: arg +: args)


### PR DESCRIPTION
* Marathon Namer TLS support, for DC/OS strict mode.
* We fixed an issue where requests that time out were not being retried.
* HTTP 1.1 protocol fixes for chunked transfer encoding and `Content-Length`.
* Improved memory allocation in InfluxDb and Prometheus telemeters.
* Documentation fixes.