### PR TITLE
Add option to serve linkerd and namerd admin pages over TLS

### DIFF
--- a/admin/src/main/scala/io/buoyant/admin/Admin.scala
+++ b/admin/src/main/scala/io/buoyant/admin/Admin.scala
@@ -63,6 +63,7 @@ object Admin {
     .withMonitor(loggingMonitor)
     .withStatsReceiver(NullStatsReceiver)
     .withTracer(NullTracer)
+    .withParams(tls)
 
   val threadsJs = "<script src='files/js/threads.js'></script>"
 
@@ -112,7 +113,7 @@ class Admin(val address: SocketAddress, tlsCfg: Option[TlsServerConfig]) {
 
   private[this] val tls =
     tlsCfg.map(cfg => cfg.params(None, Netty4ServerEngineFactory()))
-          .getOrElse(Stack.Params.empty)
+      .getOrElse(Stack.Params.empty)
 
   private[this] val notFoundView = new NotFoundView()
   private[this] val server = makeServer(tls)

--- a/admin/src/main/scala/io/buoyant/admin/Admin.scala
+++ b/admin/src/main/scala/io/buoyant/admin/Admin.scala
@@ -118,12 +118,12 @@ class Admin(val address: SocketAddress, tlsCfg: Option[TlsServerConfig]) {
   /**
    * Whether or not this admin service was configured to serve over TLS
    */
-  lazy val isTls: Boolean = tlsCfg.isDefined
+  val isTls: Boolean = tlsCfg.isDefined
 
   /**
    * the name of the scheme the admin page is served over
    */
-  lazy val scheme: String = if (this.isTls) "https" else "http"
+  val scheme: String = if (this.isTls) "https" else "http"
 
   def mkService(app: TApp, extHandlers: Seq[Handler]): Service[Request, Response] = {
     val handlers = baseHandlers ++ appHandlers(app) ++ extHandlers

--- a/admin/src/main/scala/io/buoyant/admin/Admin.scala
+++ b/admin/src/main/scala/io/buoyant/admin/Admin.scala
@@ -11,6 +11,7 @@ import com.twitter.server.handler.{SummaryHandler => _, _}
 import com.twitter.server.view.{NotFoundView, TextBlockView}
 import com.twitter.util.Monitor
 import java.net.SocketAddress
+import com.twitter.finagle.buoyant.TlsServerConfig
 
 object Admin {
   val label = "adminhttp"
@@ -103,7 +104,7 @@ object Admin {
   }
 }
 
-class Admin(val address: SocketAddress) {
+class Admin(val address: SocketAddress, val tlsCfg: Option[TlsServerConfig]) {
   import Admin._
 
   private[this] val notFoundView = new NotFoundView()

--- a/admin/src/main/scala/io/buoyant/admin/Admin.scala
+++ b/admin/src/main/scala/io/buoyant/admin/Admin.scala
@@ -118,6 +118,16 @@ class Admin(val address: SocketAddress, tlsCfg: Option[TlsServerConfig]) {
   private[this] val notFoundView = new NotFoundView()
   private[this] val server = makeServer(tls)
 
+  /**
+   * Whether or not this admin service was configured to serve over TLS
+   */
+  lazy val isTls: Boolean = tlsCfg.isDefined
+
+  /**
+   * the name of the scheme the admin page is served over
+   */
+  lazy val scheme: String = if (this.isTls) "https" else "http"
+
   def mkService(app: TApp, extHandlers: Seq[Handler]): Service[Request, Response] = {
     val handlers = baseHandlers ++ appHandlers(app) ++ extHandlers
     val muxer = (handlers ++ indexHandlers(handlers)).foldLeft(new HttpMuxer) {

--- a/admin/src/main/scala/io/buoyant/admin/Admin.scala
+++ b/admin/src/main/scala/io/buoyant/admin/Admin.scala
@@ -1,22 +1,20 @@
 package io.buoyant.admin
 
+import java.net.SocketAddress
 import com.twitter.app.{App => TApp}
 import com.twitter.finagle._
-import com.twitter.finagle.http.{HttpMuxer, Request, Response}
+import com.twitter.finagle.buoyant._
 import com.twitter.finagle.http.filter.HeadFilter
+import com.twitter.finagle.http.{HttpMuxer, Request, Response}
+import com.twitter.finagle.netty4.ssl.server.Netty4ServerEngineFactory
 import com.twitter.finagle.stats.NullStatsReceiver
 import com.twitter.finagle.tracing.NullTracer
-import com.twitter.finagle.buoyant._
 import com.twitter.logging.Logger
 import com.twitter.server.handler.{SummaryHandler => _, _}
 import com.twitter.server.view.{NotFoundView, TextBlockView}
 import com.twitter.util.Monitor
-import java.net.SocketAddress
-import com.twitter.finagle.netty4.ssl.server.Netty4ServerEngineFactory
 
 object Admin {
-
-  import scala.language.implicitConversions
   val label = "adminhttp"
   private val log = Logger.get(label)
 

--- a/admin/src/main/scala/io/buoyant/admin/AdminConfig.scala
+++ b/admin/src/main/scala/io/buoyant/admin/AdminConfig.scala
@@ -2,17 +2,19 @@ package io.buoyant.admin
 
 import io.buoyant.config.types.Port
 import java.net.{InetAddress, InetSocketAddress}
+import com.twitter.finagle.buoyant.TlsServerConfig
 
 case class AdminConfig(
   ip: Option[InetAddress] = None,
   port: Option[Port] = None,
-  shutdownGraceMs: Option[Int] = None
+  shutdownGraceMs: Option[Int] = None,
+  tls: Option[TlsServerConfig] = None
 ) {
 
   def mk(defaultAddr: InetSocketAddress): Admin = {
     val adminIp = ip.getOrElse(defaultAddr.getAddress)
     val adminPort = port.map(_.port).getOrElse(defaultAddr.getPort)
     val addr = new InetSocketAddress(adminIp, adminPort)
-    new Admin(addr)
+    new Admin(addr, tls)
   }
 }

--- a/admin/src/main/scala/io/buoyant/admin/AdminConfig.scala
+++ b/admin/src/main/scala/io/buoyant/admin/AdminConfig.scala
@@ -1,8 +1,8 @@
 package io.buoyant.admin
 
-import io.buoyant.config.types.Port
-import java.net.{InetAddress, InetSocketAddress}
 import com.twitter.finagle.buoyant.TlsServerConfig
+import java.net.{InetAddress, InetSocketAddress}
+import io.buoyant.config.types.Port
 
 case class AdminConfig(
   ip: Option[InetAddress] = None,

--- a/finagle/buoyant/src/main/scala/com/twitter/finagle/buoyant/package.scala
+++ b/finagle/buoyant/src/main/scala/com/twitter/finagle/buoyant/package.scala
@@ -28,4 +28,13 @@ package object buoyant {
       }
     }
   }
+
+  implicit class MaybeTransform[A](val a: A) extends AnyVal {
+    def maybeTransform(f: Option[A => A]): A = {
+      f match {
+        case Some(f) => f(a)
+        case None => a
+      }
+    }
+  }
 }

--- a/finagle/buoyant/src/main/scala/com/twitter/finagle/buoyant/package.scala
+++ b/finagle/buoyant/src/main/scala/com/twitter/finagle/buoyant/package.scala
@@ -1,0 +1,20 @@
+package com.twitter.finagle
+
+package object buoyant {
+
+  implicit class ParamsMaybeWith(val params: Stack.Params) extends AnyVal {
+    def maybeWith[T: Stack.Param](p: Option[T]): Stack.Params = {
+      p match {
+        case Some(t) => params + t
+        case None => params
+      }
+    }
+
+    def maybeWith(ps: Option[Stack.Params]): Stack.Params = {
+      ps match {
+        case Some(ps) => params ++ ps
+        case None => params
+      }
+    }
+  }
+}

--- a/finagle/buoyant/src/main/scala/com/twitter/finagle/buoyant/package.scala
+++ b/finagle/buoyant/src/main/scala/com/twitter/finagle/buoyant/package.scala
@@ -1,5 +1,7 @@
 package com.twitter.finagle
 
+import com.twitter.finagle.Stack.Parameterized
+
 package object buoyant {
 
   implicit class ParamsMaybeWith(val params: Stack.Params) extends AnyVal {
@@ -14,6 +16,15 @@ package object buoyant {
       ps match {
         case Some(ps) => params ++ ps
         case None => params
+      }
+    }
+  }
+
+  implicit class ParameterizedMaybeWith[P <: Parameterized[P]](val self: P) extends AnyVal {
+    def maybeWith(ps: Option[Stack.Params]): P = {
+      ps match {
+        case Some(params) => self.withParams(params)
+        case None => self
       }
     }
   }

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/ClientConfig.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/ClientConfig.scala
@@ -6,6 +6,7 @@ import com.twitter.finagle.Stack
 import com.twitter.finagle.buoyant.{ClientAuth, PathMatcher, TlsClientConfig => FTlsClientConfig}
 import com.twitter.finagle.client.DefaultPool
 import com.twitter.finagle.service._
+import com.twitter.finagle.buoyant.ParamsMaybeWith
 import io.buoyant.router.RetryBudgetConfig
 import io.buoyant.router.RetryBudgetModule.param
 

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/Router.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/Router.scala
@@ -6,6 +6,7 @@ import com.twitter.finagle._
 import com.twitter.finagle.naming.buoyant.DstBindingFactory
 import com.twitter.finagle.naming.NameInterpreter
 import com.twitter.finagle.service._
+import com.twitter.finagle.buoyant.ParamsMaybeWith
 import com.twitter.util.Closable
 import io.buoyant.namer.{DefaultInterpreterConfig, InterpreterConfig}
 import io.buoyant.router.{ClassifiedRetries, Originator, RoutingFactory}

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/Server.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/Server.scala
@@ -4,11 +4,12 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import com.github.ghik.silencer.silent
 import com.twitter.concurrent.AsyncSemaphore
 import com.twitter.conversions.time._
-import com.twitter.finagle.buoyant.TlsServerConfig
+import com.twitter.finagle.buoyant.{TlsServerConfig, ParamsMaybeWith}
 import com.twitter.finagle.filter.RequestSemaphoreFilter
 import com.twitter.finagle.service.TimeoutFilter
 import com.twitter.finagle.ssl.server.{LegacyKeyServerEngineFactory, SslServerEngineFactory}
 import com.twitter.finagle.{ListeningServer, Path, Stack}
+import com.twitter.finagle.buoyant.ParamsMaybeWith
 import io.buoyant.config.types.Port
 import java.net.{InetAddress, InetSocketAddress}
 

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/SvcConfig.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/SvcConfig.scala
@@ -5,6 +5,7 @@ import com.twitter.conversions.time._
 import com.twitter.finagle.{param, Stack}
 import com.twitter.finagle.buoyant.TotalTimeout
 import com.twitter.finagle.service._
+import com.twitter.finagle.buoyant.ParamsMaybeWith
 import com.twitter.util.Duration
 import io.buoyant.config.PolymorphicConfig
 import io.buoyant.router.{ClassifiedRetries, RetryBudgetConfig}

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/package.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/package.scala
@@ -1,7 +1,4 @@
 package io.buoyant
-import com.twitter.finagle.Stack
-import com.twitter.finagle.buoyant.ParamsMaybeWith
-import scala.language.implicitConversions
 /**
  * Linkerd provides a modular & pluggable configuration layer to
  * support programmatic and configuration-driven initialization of
@@ -38,26 +35,4 @@ import scala.language.implicitConversions
  * configuration and initialization. ProtocolInitializer modules are
  * discovered at runtime with finagle's `LoadService` facility.
  */
-package object linkerd {
-  /**
-   * Reimport [[com.twitter.finagle.buoyant.ParamsMaybeWith ParamsMaybeWith]]
-   * so that it's globally visible in the `io.buoyant.linkerd` package.
-   * @param params a [[com.twitter.finagle.Stack.Params Stack.Params]] to
-   *               implicitly enhance with the `maybeWith()` function
-   * @return `params` enhanced with the
-   *        [[ParamsMaybeWith.maybeWith() maybeWith()]] function
-   */
-  @inline
-  final implicit def paramsMaybeWith(params: Stack.Params): ParamsMaybeWith =
-    ParamsMaybeWith(params)
-
-  implicit class MaybeTransform[A](val a: A) extends AnyVal {
-    def maybeTransform(f: Option[A => A]): A = {
-      f match {
-        case Some(f) => f(a)
-        case None => a
-      }
-    }
-  }
-
-}
+package object linkerd

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/package.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/package.scala
@@ -1,43 +1,42 @@
 package io.buoyant
 
-import com.twitter.finagle.Stack
 
 /**
- * Linkerd provides a modular & pluggable configuration layer to
- * support programmatic and configuration-driven initialization of
- * software routers.
- *
- * The library provides a family of configuration types:
- *
- * <pre>
- *      --------
- *     | Linker |
- *      --------
- *       |  --------
- *       |-| Router |
- *       |  --------
- *       |   |  --------
- *       |   |-| Server |
- *       |   |  --------
- *       |   `- ...
- *       `- ...
- * </pre>
- *
- *  * A [[io.buoyant.linkerd.Linker Linker]] represents the complete
- *    runtime configuration for a linkerd application (and not its
- *    virtual machine).  A linker must have one or more
- *    [[io.buoyant.linkerd.Router Routers]].
- *
- *  * A [[io.buoyant.linkerd.Router Router]] represents the complete
- *    runtime configuration for a router--the outbound client-side
- *    dispatching module--and its serving interfaces,
- *    [[io.buoyant.linkerd.Server Servers]].
- *
- * The [[io.buoyant.linkerd.ProtocolInitializer ProtocolInitializer]]
- * exposes a protocol-agnostic interface supporting protocol-aware
- * configuration and initialization. ProtocolInitializer modules are
- * discovered at runtime with finagle's `LoadService` facility.
- */
+  * Linkerd provides a modular & pluggable configuration layer to
+  * support programmatic and configuration-driven initialization of
+  * software routers.
+  *
+  * The library provides a family of configuration types:
+  *
+  * <pre>
+  *      --------
+  *     | Linker |
+  *      --------
+  *       |  --------
+  *       |-| Router |
+  *       |  --------
+  *       |   |  --------
+  *       |   |-| Server |
+  *       |   |  --------
+  *       |   `- ...
+  *       `- ...
+  * </pre>
+  *
+  *  * A [[io.buoyant.linkerd.Linker Linker]] represents the complete
+  *    runtime configuration for a linkerd application (and not its
+  *    virtual machine).  A linker must have one or more
+  *    [[io.buoyant.linkerd.Router Routers]].
+  *
+  *  * A [[io.buoyant.linkerd.Router Router]] represents the complete
+  *    runtime configuration for a router--the outbound client-side
+  *    dispatching module--and its serving interfaces,
+  *    [[io.buoyant.linkerd.Server Servers]].
+  *
+  * The [[io.buoyant.linkerd.ProtocolInitializer ProtocolInitializer]]
+  * exposes a protocol-agnostic interface supporting protocol-aware
+  * configuration and initialization. ProtocolInitializer modules are
+  * discovered at runtime with finagle's `LoadService` facility.
+  */
 package object linkerd {
   implicit class MaybeTransform[A](val a: A) extends AnyVal {
     def maybeTransform(f: Option[A => A]): A = {
@@ -48,19 +47,4 @@ package object linkerd {
     }
   }
 
-  implicit class ParamsMaybeWith(val params: Stack.Params) extends AnyVal {
-    def maybeWith[T: Stack.Param](p: Option[T]): Stack.Params = {
-      p match {
-        case Some(t) => params + t
-        case None => params
-      }
-    }
-
-    def maybeWith(ps: Option[Stack.Params]): Stack.Params = {
-      ps match {
-        case Some(ps) => params ++ ps
-        case None => params
-      }
-    }
-  }
 }

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/package.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/package.scala
@@ -1,43 +1,56 @@
 package io.buoyant
-
-
+import com.twitter.finagle.Stack
+import com.twitter.finagle.buoyant.ParamsMaybeWith
+import scala.language.implicitConversions
 /**
-  * Linkerd provides a modular & pluggable configuration layer to
-  * support programmatic and configuration-driven initialization of
-  * software routers.
-  *
-  * The library provides a family of configuration types:
-  *
-  * <pre>
-  *      --------
-  *     | Linker |
-  *      --------
-  *       |  --------
-  *       |-| Router |
-  *       |  --------
-  *       |   |  --------
-  *       |   |-| Server |
-  *       |   |  --------
-  *       |   `- ...
-  *       `- ...
-  * </pre>
-  *
-  *  * A [[io.buoyant.linkerd.Linker Linker]] represents the complete
-  *    runtime configuration for a linkerd application (and not its
-  *    virtual machine).  A linker must have one or more
-  *    [[io.buoyant.linkerd.Router Routers]].
-  *
-  *  * A [[io.buoyant.linkerd.Router Router]] represents the complete
-  *    runtime configuration for a router--the outbound client-side
-  *    dispatching module--and its serving interfaces,
-  *    [[io.buoyant.linkerd.Server Servers]].
-  *
-  * The [[io.buoyant.linkerd.ProtocolInitializer ProtocolInitializer]]
-  * exposes a protocol-agnostic interface supporting protocol-aware
-  * configuration and initialization. ProtocolInitializer modules are
-  * discovered at runtime with finagle's `LoadService` facility.
-  */
+ * Linkerd provides a modular & pluggable configuration layer to
+ * support programmatic and configuration-driven initialization of
+ * software routers.
+ *
+ * The library provides a family of configuration types:
+ *
+ * <pre>
+ *      --------
+ *     | Linker |
+ *      --------
+ *       |  --------
+ *       |-| Router |
+ *       |  --------
+ *       |   |  --------
+ *       |   |-| Server |
+ *       |   |  --------
+ *       |   `- ...
+ *       `- ...
+ * </pre>
+ *
+ *  * A [[io.buoyant.linkerd.Linker Linker]] represents the complete
+ *    runtime configuration for a linkerd application (and not its
+ *    virtual machine).  A linker must have one or more
+ *    [[io.buoyant.linkerd.Router Routers]].
+ *
+ *  * A [[io.buoyant.linkerd.Router Router]] represents the complete
+ *    runtime configuration for a router--the outbound client-side
+ *    dispatching module--and its serving interfaces,
+ *    [[io.buoyant.linkerd.Server Servers]].
+ *
+ * The [[io.buoyant.linkerd.ProtocolInitializer ProtocolInitializer]]
+ * exposes a protocol-agnostic interface supporting protocol-aware
+ * configuration and initialization. ProtocolInitializer modules are
+ * discovered at runtime with finagle's `LoadService` facility.
+ */
 package object linkerd {
+  /**
+   * Reimport [[com.twitter.finagle.buoyant.ParamsMaybeWith ParamsMaybeWith]]
+   * so that it's globally visible in the `io.buoyant.linkerd` package.
+   * @param params a [[com.twitter.finagle.Stack.Params Stack.Params]] to
+   *               implicitly enhance with the `maybeWith()` function
+   * @return `params` enhanced with the
+   *        [[ParamsMaybeWith.maybeWith() maybeWith()]] function
+   */
+  @inline
+  final implicit def paramsMaybeWith(params: Stack.Params): ParamsMaybeWith =
+    ParamsMaybeWith(params)
+
   implicit class MaybeTransform[A](val a: A) extends AnyVal {
     def maybeTransform(f: Option[A => A]): A = {
       f match {

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/TestProtocol.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/TestProtocol.scala
@@ -3,7 +3,7 @@ package io.buoyant.linkerd
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.twitter.finagle.Stack.Params
 import com.twitter.finagle._
-import com.twitter.finagle.buoyant.Dst
+import com.twitter.finagle.buoyant.{ParamsMaybeWith, Dst}
 import com.twitter.finagle.client.StackClient
 import com.twitter.finagle.server.StackServer
 import com.twitter.finagle.stack.Endpoint

--- a/linkerd/examples/admin-tls.yaml
+++ b/linkerd/examples/admin-tls.yaml
@@ -1,7 +1,4 @@
 # Config for serving linkerd admin page over TLS
-# localhost:9990 and localhost:4140/foo/ should display the same page.
-# when running namerd, localhost:9991 and localhost:4141/foo/ should display the same page.
-# Note, to run namerd in parallel, use `./sbt namerd-examples/basic:run`.
 
 admin:
   ip: 0.0.0.0
@@ -20,29 +17,6 @@ routers:
   label: linkerd-admin
   dtab: |
     /svc/* => /$/inet/127.1/9990;
-  identifier:
-    kind: io.l5d.path
-    segments: 1
-    consume: true
   servers:
   - port: 4140
-    ip: 0.0.0.0
-- protocol: http
-  label: namerd-admin
-  dtab: |
-    /svc/* => /$/inet/127.1/9991;
-  identifier:
-    kind: io.l5d.path
-    segments: 1
-    consume: true
-  servers:
-  - port: 4141
-    ip: 0.0.0.0
-- protocol: http
-  interpreter:
-    kind: io.l5d.namerd
-    dst: /$/inet/localhost/4100
-    namespace: default
-  servers:
-  - port: 4142
     ip: 0.0.0.0

--- a/linkerd/examples/admin-tls.yaml
+++ b/linkerd/examples/admin-tls.yaml
@@ -1,0 +1,48 @@
+# Config for serving linkerd admin page over TLS
+# localhost:9990 and localhost:4140/foo/ should display the same page.
+# when running namerd, localhost:9991 and localhost:4141/foo/ should display the same page.
+# Note, to run namerd in parallel, use `./sbt namerd-examples/basic:run`.
+
+admin:
+  ip: 0.0.0.0
+  port: 9990
+  tls:
+    certPath: finagle/h2/src/e2e/resources/linkerd-tls-e2e-cert.pem
+    keyPath: finagle/h2/src/e2e/resources/linkerd-tls-e2e-key.pem
+    caCertPath: finagle/h2/src/e2e/resources/cacert.pem
+
+telemetry:
+- kind: io.l5d.recentRequests
+  sampleRate: 1.0
+
+routers:
+- protocol: http
+  label: linkerd-admin
+  dtab: |
+    /svc/* => /$/inet/127.1/9990;
+  identifier:
+    kind: io.l5d.path
+    segments: 1
+    consume: true
+  servers:
+  - port: 4140
+    ip: 0.0.0.0
+- protocol: http
+  label: namerd-admin
+  dtab: |
+    /svc/* => /$/inet/127.1/9991;
+  identifier:
+    kind: io.l5d.path
+    segments: 1
+    consume: true
+  servers:
+  - port: 4141
+    ip: 0.0.0.0
+- protocol: http
+  interpreter:
+    kind: io.l5d.namerd
+    dst: /$/inet/localhost/4100
+    namespace: default
+  servers:
+  - port: 4142
+    ip: 0.0.0.0

--- a/linkerd/main/src/main/scala/io/buoyant/linkerd/Main.scala
+++ b/linkerd/main/src/main/scala/io/buoyant/linkerd/Main.scala
@@ -66,7 +66,7 @@ object Main extends App {
     linker: Linker
   ): Closable with Awaitable[Unit] = {
     val server = linker.admin.serve(this, LinkerdAdmin(config, linker))
-    log.info(s"serving http admin on %s", server.boundAddress)
+    log.info(s"serving ${linker.admin.scheme} admin on ${server.boundAddress}")
     server
   }
 

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/H2Config.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/H2Config.scala
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.core.{JsonParser, TreeNode}
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.databind.{DeserializationContext, JsonDeserializer, JsonNode}
 import com.twitter.conversions.storage._
-import com.twitter.finagle.buoyant.PathMatcher
+import com.twitter.finagle.buoyant.{PathMatcher, ParamsMaybeWith}
 import com.twitter.finagle.buoyant.h2._
 import com.twitter.finagle.buoyant.h2.param._
 import com.twitter.finagle.client.StackClient

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/HeaderPathIdentifier.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/HeaderPathIdentifier.scala
@@ -4,7 +4,7 @@ package h2
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.twitter.finagle.{Dtab, Path, Stack}
-import com.twitter.finagle.buoyant.Dst
+import com.twitter.finagle.buoyant.{Dst, ParamsMaybeWith}
 import com.twitter.finagle.buoyant.h2.{Request, Headers => H2Headers}
 import com.twitter.util.Future
 import io.buoyant.router.H2

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/HeaderTokenIdentifier.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/HeaderTokenIdentifier.scala
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import com.twitter.finagle.{Dtab, Path, Stack}
 import com.twitter.finagle.buoyant.Dst
 import com.twitter.finagle.buoyant.h2.{Headers, Request}
+import com.twitter.finagle.buoyant.ParamsMaybeWith
 import com.twitter.util.Future
 import io.buoyant.router.H2
 import io.buoyant.router.RoutingFactory._

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpConfig.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpConfig.scala
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.core.{JsonParser, TreeNode}
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.databind.{DeserializationContext, JsonDeserializer, JsonNode}
 import com.twitter.conversions.storage._
-import com.twitter.finagle.buoyant.PathMatcher
+import com.twitter.finagle.buoyant.{PathMatcher, ParamsMaybeWith}
 import com.twitter.finagle.buoyant.linkerd.{DelayedRelease, Headers, HttpEngine, HttpTraceInitializer}
 import com.twitter.finagle.client.{AddrMetadataExtraction, StackClient}
 import com.twitter.finagle.filter.DtabStatsFilter

--- a/linkerd/protocol/thrift/src/main/scala/io/buoyant/linkerd/protocol/ThriftInitializer.scala
+++ b/linkerd/protocol/thrift/src/main/scala/io/buoyant/linkerd/protocol/ThriftInitializer.scala
@@ -4,7 +4,7 @@ package protocol
 import com.fasterxml.jackson.annotation.{JsonIgnore, JsonProperty, JsonSubTypes, JsonTypeInfo}
 import com.twitter.finagle.Stack.Params
 import com.twitter.finagle.Thrift.param
-import com.twitter.finagle.buoyant.PathMatcher
+import com.twitter.finagle.buoyant.{PathMatcher, ParamsMaybeWith}
 import com.twitter.finagle.buoyant.linkerd.{ThriftClientPrep, ThriftServerPrep, ThriftTraceInitializer}
 import io.buoyant.config.types.ThriftProtocol
 import io.buoyant.router.Thrift

--- a/linkerd/protocol/thriftmux/src/main/scala/io/buoyant/linkerd/protocol/ThriftMuxInitializer.scala
+++ b/linkerd/protocol/thriftmux/src/main/scala/io/buoyant/linkerd/protocol/ThriftMuxInitializer.scala
@@ -6,6 +6,7 @@ import com.twitter.finagle.Stack
 import com.twitter.finagle.Thrift.param
 import com.twitter.finagle.buoyant.linkerd.{ThriftClientPrep, ThriftMuxServerPrep, ThriftTraceInitializer}
 import com.twitter.finagle.mux
+import com.twitter.finagle.buoyant.ParamsMaybeWith
 import io.buoyant.config.types.ThriftProtocol
 import io.buoyant.router.{Thrift, ThriftMux}
 

--- a/namerd/examples/tls.yaml
+++ b/namerd/examples/tls.yaml
@@ -7,6 +7,10 @@
 
 admin:
   port: 9991
+  tls:
+    certPath: finagle/h2/src/e2e/resources/linkerd-tls-e2e-cert.pem
+    keyPath: finagle/h2/src/e2e/resources/linkerd-tls-e2e-key.pem
+    caCertPath: finagle/h2/src/e2e/resources/cacert.pem
 storage:
   kind: io.l5d.inMemory
   namespaces:

--- a/namerd/main/src/main/scala/io/buoyant/namerd/Main.scala
+++ b/namerd/main/src/main/scala/io/buoyant/namerd/Main.scala
@@ -17,7 +17,7 @@ object Main extends App {
         val namerd = config.mk()
 
         val admin = namerd.admin.serve(this, NamerdAdmin(config, namerd))
-        log.info(s"serving http admin on ${admin.boundAddress}")
+        log.info(s"serving ${namerd.admin.scheme} on ${admin.boundAddress}")
 
         val servers = namerd.interfaces.map { iface =>
           val server = iface.serve()


### PR DESCRIPTION
In #1018, @sfroment requested that we add a feature to serve admin dashboards over TLS.

I've added an optional `TlsServerConfig` parameter to `Admin`, and a matching field to `AdminConfig`. The TLS server configuration is now added to the admin HTTP server stack, if it exists. I've moved the `ParamsMaybeWith` implicit class from `io.buoyant.linkerd` to `com.twitter.finagle.buoyant` in order to use it in the `admin` module (although I didn't actually end up using it here).

I've tested this by adding a new `admin-tls.yaml` example configuration in `linkerd/examples`, based on the existing `admin.yaml` example configuration. I've also modified `namerd/examples/tls.yaml` to serve the namerd admin page over TLS as well. 

As you can see, the admin dashboards are now served using HTTPS:
![screen shot 2017-07-13 at 11 02 00 am](https://user-images.githubusercontent.com/2796466/28176864-824e021e-67be-11e7-8c2e-a2cf446bb2af.png)
![screen shot 2017-07-13 at 11 02 08 am](https://user-images.githubusercontent.com/2796466/28176868-84099686-67be-11e7-9a88-b43d393097f7.png)

Closes #1018