### PR TITLE
Disable stacktraces when h2 transport is closed

### DIFF
--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4DispatcherBase.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4DispatcherBase.scala
@@ -187,7 +187,7 @@ trait Netty4DispatcherBase[SendMsg <: Message, RecvMsg <: Message] {
   }
 
   protected[this] val onTransportClose: Throwable => Unit = { e =>
-    log.debug(e, "[%s] transport closed", prefix)
+    log.debug("[%s] transport closed", prefix)
     resetStreams(Reset.Cancel); ()
   }
 }

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4DispatcherBase.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4DispatcherBase.scala
@@ -76,7 +76,7 @@ trait Netty4DispatcherBase[SendMsg <: Message, RecvMsg <: Message] {
         // The local side initiated a reset, so send a reset to
         // the remote.
         if (streams.replace(id, open, StreamLocalReset)) {
-          log.debug(e, "[%s S:%d] stream reset from local; resetting remote", prefix, id)
+          log.debug("[%s S:%d] stream reset from local; resetting remote: %s", prefix, id, e)
           val rst = e match {
             case rst: Reset => rst
             case _ => Reset.Cancel
@@ -102,7 +102,7 @@ trait Netty4DispatcherBase[SendMsg <: Message, RecvMsg <: Message] {
   protected[this] def demux(): Future[Unit] = {
     lazy val loop: Try[Http2Frame] => Future[Unit] = {
       case Throw(e) if closed.get =>
-        log.debug(e, "[%s] dispatcher closed", prefix)
+        log.debug("[%s] dispatcher closed: %s", prefix, e)
         Future.exception(e)
 
       // if all streams have already been closed, then this just means that
@@ -187,7 +187,7 @@ trait Netty4DispatcherBase[SendMsg <: Message, RecvMsg <: Message] {
   }
 
   protected[this] val onTransportClose: Throwable => Unit = { e =>
-    log.debug("[%s] transport closed", prefix)
+    log.debug("[%s] transport closed: %s", prefix, e)
     resetStreams(Reset.Cancel); ()
   }
 }

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4StreamTransport.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4StreamTransport.scala
@@ -189,23 +189,23 @@ private[h2] trait Netty4StreamTransport[SendMsg <: Message, RecvMsg <: Message] 
     // appropriate.
     remoteMsgP.setInterruptHandler {
       case err: Reset =>
-        log.debug(err, "[%s] remote message interrupted", prefix)
+        log.debug("[%s] remote message interrupted: %s", prefix, err)
         localReset(err)
 
       case Failure(Some(err: Reset)) =>
-        log.debug(err, "[%s] remote message interrupted", prefix)
+        log.debug("[%s] remote message interrupted: %s", prefix, err)
         localReset(err)
 
       case f@Failure(_) if f.isFlagged(Failure.Interrupted) =>
-        log.debug(f, "[%s] remote message interrupted", prefix)
+        log.debug("[%s] remote message interrupted: %s", prefix, f)
         localReset(Reset.Cancel)
 
       case f@Failure(_) if f.isFlagged(Failure.Rejected) =>
-        log.debug(f, "[%s] remote message interrupted", prefix)
+        log.debug("[%s] remote message interrupted: %s", prefix, f)
         localReset(Reset.Refused)
 
       case e =>
-        log.debug(e, "[%s] remote message interrupted", prefix)
+        log.debug("[%s] remote message interrupted: %s", prefix, e)
         localReset(Reset.InternalError)
     }
 
@@ -523,7 +523,7 @@ private[h2] trait Netty4StreamTransport[SendMsg <: Message, RecvMsg <: Message] 
           case rst: Reset => rst
           case _ => Reset.Cancel
         }
-        log.debug(e, "[%s] remote write failed: %s", prefix, rst)
+        log.debug("[%s] remote write failed: %s", prefix, rst)
         remoteReset(rst)
 
       case Throw(StreamError.Local(e)) =>
@@ -531,7 +531,7 @@ private[h2] trait Netty4StreamTransport[SendMsg <: Message, RecvMsg <: Message] 
           case rst: Reset => rst
           case _ => Reset.Cancel
         }
-        log.debug(e, "[%s] stream read failed: %s", prefix, rst)
+        log.debug("[%s] stream read failed: %s", prefix, rst)
         localReset(rst)
 
       case Throw(e) =>

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/ErrorResponder.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/ErrorResponder.scala
@@ -32,7 +32,7 @@ class ErrorResponder
             case _: TimeoutException | Failure(Some(_: TimeoutException)) =>
               Status.ServiceUnavailable
             case _ =>
-              log.error(e, "service failure")
+              log.error("service failure: %s", e)
               Status.BadGateway
           }
           val rsp = Headers.Err.respond(message, status)

--- a/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/ErrorResponderTest.scala
+++ b/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/ErrorResponderTest.scala
@@ -39,7 +39,7 @@ class ErrorResponderTest extends FunSuite with Awaits {
   val individualTimeoutService = mkService(Future.exception(new IndividualRequestTimeoutException(1.second)))
 
   val totalTimeoutService = mkService(Future.exception(new GlobalRequestTimeoutException(1.second)))
-  
+
   val malframedService = mkService(Future.exception(FramingException("malframed!")))
 
   test("returns BadRequest for UnknownDst exception") {


### PR DESCRIPTION
## Problem

In #1498, we stopped printing stacktraces at log level ERROR when gRPC clients fail to send GOAWAY after closing the connection. It turns out a stacktrace is still printed at log level DEBUG.

## Solution

Disable the DEBUG stacktrace too. Alternatively, we could print the stacktrace at TRACE, but the stacktrace itself (pasted below) doesn't seem particularly useful to me, whereas the "transport closed" message does.

## Validation

Before this change:

```
D 0714 21:50:41.408 UTC THREAD101 TraceId:5e1ea3044a82c103: [C L:/127.0.0.1:59553 R:localhost/127.0.0.1:50051 S:3] initialized stream
D 0714 21:50:41.463 UTC THREAD101 TraceId:5e1ea3044a82c103: [C L:/127.0.0.1:59553 R:localhost/127.0.0.1:50051 S:3] stream closed
D 0714 21:50:41.470 UTC THREAD96: [S L:/127.0.0.1:4140 R:/127.0.0.1:59552 S:3] stream closed
D 0714 21:50:41.477 UTC THREAD96: [S L:/127.0.0.1:4140 R:/127.0.0.1:59552] resetting all streams: Reset.Cancel
D 0714 21:50:41.492 UTC THREAD96: [S L:/127.0.0.1:4140 R:/127.0.0.1:59552] transport closed
com.twitter.finagle.ChannelClosedException: ChannelException at remote address: /127.0.0.1:59552. Remote Info: Not Available
	at com.twitter.finagle.netty4.transport.ChannelTransport$$anon$1.channelInactive(ChannelTransport.scala:186)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:245)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:231)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelInactive(AbstractChannelHandlerContext.java:224)
	...
```

After this change:

```
D 0714 22:01:20.107 UTC THREAD96 TraceId:3afcfdb0f21702b7: [C L:/127.0.0.1:59857 R:localhost/127.0.0.1:50051 S:3] initialized stream
D 0714 22:01:20.162 UTC THREAD96 TraceId:3afcfdb0f21702b7: [C L:/127.0.0.1:59857 R:localhost/127.0.0.1:50051 S:3] stream closed
D 0714 22:01:20.168 UTC THREAD94: [S L:/127.0.0.1:4140 R:/127.0.0.1:59856 S:3] stream closed
D 0714 22:01:20.175 UTC THREAD94: [S L:/127.0.0.1:4140 R:/127.0.0.1:59856] resetting all streams: Reset.Cancel
D 0714 22:01:20.185 UTC THREAD94: [S L:/127.0.0.1:4140 R:/127.0.0.1:59856] transport closed
```

## Open discussion

It looks like we print debug stacktraces elsewhere in the codebase, but almost entirely in the finagle/h2 project.

```bash
$ grep -r 'log\.debug(e' ./*
./finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/DebugHandler.scala:          case e => log.debug(e, s"$reqid $prefix.write.complete ${cf.channel} [$objstr] $cf")
./finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4DispatcherBase.scala:          log.debug(e, "[%s S:%d] stream reset from local; resetting remote", prefix, id)
./finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4DispatcherBase.scala:        log.debug(e, "[%s] dispatcher closed", prefix)
./finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4StreamTransport.scala:        log.debug(err, "[%s] remote message interrupted", prefix)
./finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4StreamTransport.scala:        log.debug(err, "[%s] remote message interrupted", prefix)
./finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4StreamTransport.scala:        log.debug(e, "[%s] remote message interrupted", prefix)
./finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4StreamTransport.scala:        log.debug(e, "[%s] remote write failed: %s", prefix, rst)
./finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4StreamTransport.scala:        log.debug(e, "[%s] stream read failed: %s", prefix, rst)
./linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/ErrorResponder.scala:          log.debug(e, "unknown dst")
```

I'm inclined to turn those off as well, provided the code recovers from the exception, but didn't want to do that without some discussion first.