### PR TITLE
Istio Request Redirect

### DIFF
--- a/k8s/src/main/scala/io/buoyant/k8s/istio/IstioIdentifierBase.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/istio/IstioIdentifierBase.scala
@@ -6,7 +6,7 @@ import io.buoyant.k8s.istio.ClusterCache.Cluster
 import istio.proxy.v1.config.StringMatch.OneofMatchType
 import istio.proxy.v1.config._
 
-trait IdentifierPreconditions[Req] {
+trait IstioIdentifierBase[Req] {
 
   /**
    * Defines a request's metadata for istio rules to match against
@@ -24,7 +24,7 @@ trait IdentifierPreconditions[Req] {
   def routeCache: RouteCache
   def pfx: Path
 
-  def redirectRequest[T](redir: HTTPRedirect, req: Req): Future[T]
+  def redirectRequest(redir: HTTPRedirect, req: Req): Future[Nothing]
   def rewriteRequest(uri: String, authority: Option[String], req: Req): Unit
   def reqToMeta(req: Req): IstioRequestMeta
 

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/ErrorReseter.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/ErrorReseter.scala
@@ -1,10 +1,13 @@
 package io.buoyant.linkerd.protocol.h2
 
 import com.twitter.finagle._
-import com.twitter.finagle.buoyant.h2.{Request, Response, Reset, LinkerdHeaders}
+import com.twitter.finagle.buoyant.h2.{Request, Reset, Response}
 import com.twitter.logging.Logger
 import com.twitter.util.Future
+import io.buoyant.linkerd.protocol.h2.ErrorReseter.H2ResponseException
 import io.buoyant.router.RoutingFactory
+import io.buoyant.router.RoutingFactory.ResponseException
+import scala.util.control.NoStackTrace
 
 /**
  * Coerces routing failures to the appropriate HTTP/2 error code
@@ -25,6 +28,8 @@ class ErrorReseter extends SimpleFilter[Request, Response] {
     case e: NoBrokersAvailableException =>
       log.info(e, "no available endpoints")
       RefusedF
+    case H2ResponseException(rsp) =>
+      Future.value(rsp)
   }
 }
 
@@ -42,4 +47,6 @@ object ErrorReseter {
       val description = "Lifts router errors to stream resets"
       def make(factory: ServiceFactory[Request, Response]) = filter.andThen(factory)
     }
+
+  case class H2ResponseException(rsp: Response) extends ResponseException(rsp)
 }

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/ErrorReseter.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/ErrorReseter.scala
@@ -2,7 +2,7 @@ package io.buoyant.linkerd.protocol.h2
 
 import com.twitter.finagle._
 import com.twitter.finagle.buoyant.h2.{Request, Reset, Response}
-import com.twitter.logging.Logger
+import com.twitter.logging.{Level, Logger}
 import com.twitter.util.Future
 import io.buoyant.linkerd.protocol.h2.ErrorReseter.H2ResponseException
 import io.buoyant.router.RoutingFactory
@@ -48,5 +48,7 @@ object ErrorReseter {
       def make(factory: ServiceFactory[Request, Response]) = filter.andThen(factory)
     }
 
-  case class H2ResponseException(rsp: Response) extends ResponseException(rsp)
+  case class H2ResponseException(rsp: Response) extends ResponseException {
+    val logLevel = Level.TRACE
+  }
 }

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/IstioIdentifier.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/IstioIdentifier.scala
@@ -6,7 +6,7 @@ import com.twitter.finagle.buoyant.h2._
 import com.twitter.finagle.{Dtab, Path, Stack}
 import com.twitter.util.Future
 import io.buoyant.config.types.Port
-import io.buoyant.k8s.istio.{ClusterCache, IdentifierPreconditions, RouteCache}
+import io.buoyant.k8s.istio.{ClusterCache, IstioIdentifierBase, RouteCache}
 import io.buoyant.linkerd.IdentifierInitializer
 import io.buoyant.linkerd.protocol.H2IdentifierConfig
 import io.buoyant.linkerd.protocol.h2.ErrorReseter.H2ResponseException
@@ -14,7 +14,7 @@ import io.buoyant.router.RoutingFactory.{BaseDtab, DstPrefix, IdentifiedRequest,
 import istio.proxy.v1.config.HTTPRedirect
 
 class IstioIdentifier(val pfx: Path, baseDtab: () => Dtab, val routeCache: RouteCache, val clusterCache: ClusterCache)
-  extends Identifier[Request] with IdentifierPreconditions[Request] {
+  extends Identifier[Request] with IstioIdentifierBase[Request] {
 
   override def apply(req: Request): Future[RequestIdentification[Request]] = {
     getIdentifiedPath(req).map { path =>
@@ -23,7 +23,7 @@ class IstioIdentifier(val pfx: Path, baseDtab: () => Dtab, val routeCache: Route
     }
   }
 
-  def redirectRequest[H2ResponseException](redir: HTTPRedirect, req: Request): Future[H2ResponseException] = {
+  def redirectRequest(redir: HTTPRedirect, req: Request): Future[Nothing] = {
     val resp = Response(Status.Found, Stream.empty())
     resp.headers.set(Headers.Path, redir.`uri`.getOrElse(req.path))
     resp.headers.set(Headers.Authority, redir.`authority`.getOrElse(req.authority))

--- a/linkerd/protocol/h2/src/test/scala/io/buoyant/linkerd/protocol/h2/ErrorReseterTest.scala
+++ b/linkerd/protocol/h2/src/test/scala/io/buoyant/linkerd/protocol/h2/ErrorReseterTest.scala
@@ -4,6 +4,7 @@ import com.twitter.io.Buf
 import com.twitter.finagle.{Failure, Service}
 import com.twitter.finagle.buoyant.h2._
 import com.twitter.util.{Future, Throw}
+import io.buoyant.linkerd.protocol.h2.ErrorReseter.H2ResponseException
 import io.buoyant.router.RoutingFactory
 import io.buoyant.test.Awaits
 import org.scalatest.FunSuite
@@ -17,6 +18,18 @@ class ErrorReseterTest extends FunSuite with Awaits {
 
     val req = Request("http", Method.Get, "hihost", "/", Stream.empty())
     assert(await(service(req).liftToTry) == Throw(Reset.Refused))
+  }
+
+  test("returns H2ResponseExceptions as responses") {
+    val service = ErrorReseter.filter.andThen(Service.mk[Request, Response] { _ =>
+      Future.exception(H2ResponseException(Response(Status.Cowabunga, Stream.empty())))
+    })
+
+    val req = Request("http", Method.Get, "hihost", "/", Stream.empty())
+    val rsp = await(service(req))
+    assert(rsp.status == Status.Cowabunga)
+    assert(!rsp.headers.contains("l5d-err"))
+    assert(rsp.stream.isEmpty)
   }
 
   test("passes through arbitrary exceptions") {

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/ErrorResponder.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/ErrorResponder.scala
@@ -6,6 +6,7 @@ import com.twitter.finagle.service.RetryPolicy.RetryableWriteException
 import com.twitter.finagle._
 import com.twitter.logging.Logger
 import io.buoyant.router.RoutingFactory
+import io.buoyant.router.RoutingFactory.ResponseException
 import scala.util.control.{NoStackTrace, NonFatal}
 
 class ErrorResponder extends SimpleFilter[Request, Response] {
@@ -48,5 +49,5 @@ object ErrorResponder {
         filter.andThen(factory)
     }
 
-  case class HttpResponseException(rsp: Response) extends NoStackTrace
+  case class HttpResponseException(rsp: Response) extends ResponseException(rsp)
 }

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/ErrorResponder.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/ErrorResponder.scala
@@ -4,7 +4,7 @@ import com.twitter.finagle.buoyant.linkerd._
 import com.twitter.finagle.http.{Request, Response, Status}
 import com.twitter.finagle.service.RetryPolicy.RetryableWriteException
 import com.twitter.finagle._
-import com.twitter.logging.Logger
+import com.twitter.logging.{Level, Logger}
 import io.buoyant.router.RoutingFactory
 import io.buoyant.router.RoutingFactory.ResponseException
 import scala.util.control.{NoStackTrace, NonFatal}
@@ -49,5 +49,7 @@ object ErrorResponder {
         filter.andThen(factory)
     }
 
-  case class HttpResponseException(rsp: Response) extends ResponseException(rsp)
+  case class HttpResponseException(rsp: Response) extends ResponseException {
+    val logLevel = Level.TRACE
+  }
 }

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/IstioIdentifier.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/IstioIdentifier.scala
@@ -5,7 +5,7 @@ import com.twitter.finagle.http.{Request, Response, Status}
 import com.twitter.finagle.{Dtab, Path}
 import com.twitter.util.Future
 import io.buoyant.config.types.Port
-import io.buoyant.k8s.istio.{ClusterCache, IdentifierPreconditions, RouteCache}
+import io.buoyant.k8s.istio.{ClusterCache, IstioIdentifierBase, RouteCache}
 import io.buoyant.linkerd.IdentifierInitializer
 import io.buoyant.linkerd.protocol.HttpIdentifierConfig
 import io.buoyant.linkerd.protocol.http.ErrorResponder.HttpResponseException
@@ -13,7 +13,7 @@ import io.buoyant.router.RoutingFactory.{IdentifiedRequest, Identifier, RequestI
 import istio.proxy.v1.config.HTTPRedirect
 
 class IstioIdentifier(val pfx: Path, baseDtab: () => Dtab, val routeCache: RouteCache, val clusterCache: ClusterCache)
-  extends Identifier[Request] with IdentifierPreconditions[Request] {
+  extends Identifier[Request] with IstioIdentifierBase[Request] {
 
   override def apply(req: Request): Future[RequestIdentification[Request]] = {
     req.host match {
@@ -30,7 +30,7 @@ class IstioIdentifier(val pfx: Path, baseDtab: () => Dtab, val routeCache: Route
     //TODO: match on request scheme
     IstioRequestMeta(req.path, "", req.method.toString, req.host.getOrElse(""), req.headerMap.get)
 
-  def redirectRequest[HttpResponseException](redir: HTTPRedirect, req: Request): Future[HttpResponseException] = {
+  def redirectRequest(redir: HTTPRedirect, req: Request): Future[Nothing] = {
     val redirect = Response(Status.Found)
     redirect.location = redir.`uri`.getOrElse(req.uri)
     redirect.host = redir.`authority`.orElse(req.host).getOrElse("")

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/IstioIngressIdentifier.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/IstioIngressIdentifier.scala
@@ -25,7 +25,7 @@ class IstioIngressIdentifier(
   annotationClass: String,
   val routeCache: RouteCache,
   val clusterCache: ClusterCache
-) extends Identifier[Request] with IdentifierPreconditions[Request] {
+) extends Identifier[Request] with IstioIdentifierBase[Request] {
 
   private[this] val ingressCache = new IngressCache(namespace, apiClient, annotationClass)
 
@@ -73,7 +73,7 @@ class IstioIngressIdentifier(
     //TODO: match on request scheme
     IstioRequestMeta(req.path, "", req.method.toString, req.host.getOrElse(""), req.headerMap.get)
 
-  def redirectRequest[HttpResponseException](redir: HTTPRedirect, req: Request): Future[HttpResponseException] = {
+  def redirectRequest(redir: HTTPRedirect, req: Request): Future[Nothing] = {
     val redirect = Response(Status.Found)
     redirect.location = redir.`uri`.getOrElse(req.uri)
     redirect.host = redir.`authority`.orElse(req.host).getOrElse("")

--- a/router/core/src/main/scala/io/buoyant/router/RoutingFactory.scala
+++ b/router/core/src/main/scala/io/buoyant/router/RoutingFactory.scala
@@ -53,6 +53,8 @@ object RoutingFactory {
 
   }
 
+  abstract class ResponseException[Rsp](rsp: Rsp) extends NoStackTrace
+
   /** The result of attempting to identify a request. */
   sealed trait RequestIdentification[Req]
 
@@ -165,7 +167,11 @@ class RoutingFactory[Req, Rsp](
             Future.exception(UnknownDst(req0, unidentified.reason))
           case Throw(e) =>
             Annotations.Failure.Identification.record(e.getMessage)
-            Future.exception(UnknownDst(req0, e.getMessage))
+            e match {
+              case e: ResponseException[Rsp] => Future.exception(e)
+              case _ => Future.exception(UnknownDst(req0, e.getMessage))
+            }
+
         }
 
         // Client acquisition failures are recorded within the

--- a/router/core/src/main/scala/io/buoyant/router/RoutingFactory.scala
+++ b/router/core/src/main/scala/io/buoyant/router/RoutingFactory.scala
@@ -4,6 +4,7 @@ import com.twitter.finagle.{param => _, _}
 import com.twitter.finagle.buoyant.Dst
 import com.twitter.finagle.naming.buoyant.DstBindingFactory
 import com.twitter.finagle.tracing.Trace
+import com.twitter.logging.HasLogLevel
 import com.twitter.util.{Future, Return, Throw, Time}
 import scala.util.control.NoStackTrace
 
@@ -53,7 +54,7 @@ object RoutingFactory {
 
   }
 
-  abstract class ResponseException[Rsp](rsp: Rsp) extends NoStackTrace
+  abstract class ResponseException extends NoStackTrace with HasLogLevel
 
   /** The result of attempting to identify a request. */
   sealed trait RequestIdentification[Req]
@@ -168,7 +169,7 @@ class RoutingFactory[Req, Rsp](
           case Throw(e) =>
             Annotations.Failure.Identification.record(e.getMessage)
             e match {
-              case e: ResponseException[Rsp] => Future.exception(e)
+              case e: ResponseException => Future.exception(e)
               case _ => Future.exception(UnknownDst(req0, e.getMessage))
             }
 

--- a/router/core/src/test/scala/io/buoyant/router/RoutingFactoryTest.scala
+++ b/router/core/src/test/scala/io/buoyant/router/RoutingFactoryTest.scala
@@ -5,6 +5,7 @@ import com.twitter.finagle.buoyant._
 import com.twitter.finagle.naming.buoyant.DstBindingFactory
 import com.twitter.finagle.tracing.Annotation.BinaryAnnotation
 import com.twitter.finagle.tracing._
+import com.twitter.logging.Level
 import com.twitter.util.{Future, Time}
 import io.buoyant.router.RoutingFactory.{IdentifiedRequest, ResponseException}
 import io.buoyant.test.FunSuite
@@ -70,7 +71,9 @@ class RoutingFactoryTest extends FunSuite {
 
   test("passes through ResponseExceptions") {
     val tracer = new TestTracer()
-    case class MyResponseException(rsp: Response) extends ResponseException(rsp)
+    case class MyResponseException(rsp: Response) extends ResponseException {
+      val logLevel = Level.TRACE
+    }
 
     Trace.letTracer(tracer) {
       val service = mkService(pathMk = (_: Request) => Future.exception(MyResponseException(Response())))

--- a/router/core/src/test/scala/io/buoyant/router/RoutingFactoryTest.scala
+++ b/router/core/src/test/scala/io/buoyant/router/RoutingFactoryTest.scala
@@ -6,7 +6,7 @@ import com.twitter.finagle.naming.buoyant.DstBindingFactory
 import com.twitter.finagle.tracing.Annotation.BinaryAnnotation
 import com.twitter.finagle.tracing._
 import com.twitter.util.{Future, Time}
-import io.buoyant.router.RoutingFactory.IdentifiedRequest
+import io.buoyant.router.RoutingFactory.{IdentifiedRequest, ResponseException}
 import io.buoyant.test.FunSuite
 
 class RoutingFactoryTest extends FunSuite {
@@ -64,6 +64,24 @@ class RoutingFactoryTest extends FunSuite {
       } catch {
         case e: Exception => assert(e.getMessage.contains(req.toString))
         case _: Throwable => assert(false)
+      }
+    }
+  }
+
+  test("passes through ResponseExceptions") {
+    val tracer = new TestTracer()
+    case class MyResponseException(rsp: Response) extends ResponseException(rsp)
+
+    Trace.letTracer(tracer) {
+      val service = mkService(pathMk = (_: Request) => Future.exception(MyResponseException(Response())))
+
+      val req = Request()
+      try {
+        await(service(req))
+        assert(false)
+      } catch {
+        case _: Exception => assert(false)
+        case e: Throwable => assert(e.isInstanceOf[MyResponseException])
       }
     }
   }


### PR DESCRIPTION
Redirects requests based on istio route-rules. Fixes #1419
Adds H2ResponseException to ErrorResetter to match HttpResponseException in Error Responder.
DRYs up identifiers by pushing more logic into IdentifierPreconditions