### PR TITLE
Add basic observability for H2

### DIFF
--- a/router/h2/src/main/scala/io/buoyant/router/h2/StreamStatsFilter.scala
+++ b/router/h2/src/main/scala/io/buoyant/router/h2/StreamStatsFilter.scala
@@ -47,9 +47,9 @@ class StreamStatsFilter(statsReceiver: StatsReceiver)
   private[this] val reqCount = statsReceiver.counter("requests")
 
   private[this] val reqStreamStats =
-    new StreamStats(statsReceiver.scope("request").scope("stream"))
+    new StreamStats(statsReceiver.scope("request", "stream"))
   private[this] val rspStreamStats =
-    new StreamStats(statsReceiver.scope("response").scope("stream"))
+    new StreamStats(statsReceiver.scope("response", "stream"))
   private[this] val totalStreamStats =
     new StreamStats(statsReceiver.scope("stream"),
                     durationName = Some("total_latency"))

--- a/router/h2/src/main/scala/io/buoyant/router/h2/StreamStatsFilter.scala
+++ b/router/h2/src/main/scala/io/buoyant/router/h2/StreamStatsFilter.scala
@@ -3,7 +3,7 @@ package io.buoyant.router.h2
 import com.twitter.finagle.{Status => _, _}
 import com.twitter.finagle.buoyant.h2.{Request, Response, Stream}
 import com.twitter.finagle.stats.StatsReceiver
-import com.twitter.util.{Future, Return, Stopwatch, Throw}
+import com.twitter.util._
 
 object StreamStatsFilter {
   val role = Stack.Role("StreamStatsFilter")
@@ -21,73 +21,50 @@ object StreamStatsFilter {
 class StreamStatsFilter(statsReceiver: StatsReceiver)
   extends SimpleFilter[Request, Response] {
 
+  class StreamStats(
+    scopes: Seq[String] = Nil,
+    durationName: Option[String] = None,
+    successName: Option[String] = None) {
+
+    private[this] val (durationMs, successes, failures) = {
+      val scope = scopes.foldLeft(statsReceiver){ (scope, name) => scope.scope(name) }
+      ( scope.stat(s"${durationName.getOrElse("stream_duration")}_ms")
+      , scope.counter(s"${successName.getOrElse("stream")}_successes")
+      , scope.counter(s"${successName.getOrElse("stream")}_failures"))
+    }
+
+    @inline def apply(startT: Stopwatch.Elapsed)(result: Try[_]): Unit = {
+      durationMs.add(startT().inMillis)
+      result match {
+        case Return(_) => successes.incr()
+        case Throw(_) => failures.incr()
+      }
+    }
+  }
+
   // total number of requests received
   private[this] val reqCount = statsReceiver.counter("stream", "requests")
-  // time from request until request stream completes (successfully or not)
-  private[this] val reqStreamTimeMs = statsReceiver.stat("stream", "request", "stream_duration_ms")
-  // time from response until response stream completes (successfully or not)
-  private[this] val rspStreamTimeMs = statsReceiver.stat("stream", "response", "stream_duration_ms")
 
-  // number of response futures that succeed
-  private[this] val rspSuccess = statsReceiver.counter("stream", "response", "response_success")
-  // number of response futures that fail
-  private[this] val rspFailures = statsReceiver.counter("stream", "response", "response_failures")
-  // number of request streams that fail
-  private[this] val reqStreamFailures = statsReceiver.counter("stream", "request", "stream_failures")
-  // number of request streams that succeed
-  private[this] val reqStreamSuccesses = statsReceiver.counter("stream", "request", "stream_success")
-  // number of response streams that fail
-  private[this] val rspStreamFailures = statsReceiver.counter("stream", "response", "stream_failures")
-  // number of response futures that succeed
-  private[this] val rspStreamSuccesses = statsReceiver.counter("stream", "response", "stream_success")
-  // number of times any stream fails
-  private[this] val streamFailures = statsReceiver.counter("stream", "failures")
-  // number of times both streams succeed
-  private[this] val streamSuccesses = statsReceiver.counter("stream", "success")
-
-
-  // time from request until response future completes (successfully or not)
-  private[this] val rspLatencyMs = statsReceiver.stat("stream", "response", "latency_ms")
-  // time from request until both streams complete (successfully or not)
-  private[this] val totalLatencyMs = statsReceiver.stat("stream", "total_latency_ms")
+  private[this] val reqStreamStats = new StreamStats(Seq("stream", "request"))
+  private[this] val rspStreamStats = new StreamStats(Seq("stream", "response"))
+  private[this] val totalStreamStats = new StreamStats(Seq("stream"), Some("total_latency"))
+  private[this] val rspFutureStats = new StreamStats(Seq("response"), Some("response_latency"), Some("response"))
 
   override def apply(req: Request, service: Service[Request, Response]): Future[Response] = {
     reqCount.incr()
     val reqT = Stopwatch.start()
 
-    req.stream.onEnd.respond { result =>
-      reqStreamTimeMs.add(reqT().inMillis)
-      result match {
-        case Return(_) => reqStreamSuccesses.incr()
-        case Throw(_) => reqStreamFailures.incr()
-      }
-    }
+    req.stream.onEnd.respond(reqStreamStats(reqT))
 
     service(req)
+      .respond(rspFutureStats(reqT))
       .onSuccess { rsp =>
-        rspLatencyMs.add(reqT().inMillis)
-        rspSuccess.incr()
-
         val rspT = Stopwatch.start()
-        rsp.stream.onEnd.respond { result =>
-          rspStreamTimeMs.add(rspT().inMillis)
-          result match {
-            case Throw(_) => rspStreamFailures.incr()
-            case Return(_) => rspStreamSuccesses.incr()
-          }
-        }
+        rsp.stream.onEnd.respond(rspStreamStats(rspT))
 
-        val _ = req.stream.onEnd.join(rsp.stream.onEnd).respond { result =>
-          totalLatencyMs.add(reqT().inMillis)
-          result match {
-            case Return(_) => streamSuccesses.incr()
-            case Throw(_) => streamFailures.incr()
-          }
-        }
-      }
-      .onFailure { err =>
-        rspLatencyMs.add(reqT().inMillis)
-        rspFailures.incr()
+        val _ = req.stream.onEnd
+          .join(rsp.stream.onEnd)
+          .respond(totalStreamStats(reqT))
       }
   }
 

--- a/router/h2/src/test/scala/io/buoyant/router/h2/StreamStatsFilterTest.scala
+++ b/router/h2/src/test/scala/io/buoyant/router/h2/StreamStatsFilterTest.scala
@@ -8,24 +8,24 @@ import io.buoyant.test.{Awaits, FunSuite}
 
 class StreamStatsFilterTest extends FunSuite with Awaits {
   val successCounters = Seq(
-    Seq("stream", "response", "stream_successes"),
-    Seq("stream", "request", "stream_successes"),
+    Seq("response", "stream", "stream_successes"),
+    Seq("request", "stream", "stream_successes"),
     Seq("stream", "stream_successes"),
-    Seq("response", "successes")
+    Seq("successes")
   )
   val failureCounters = Seq(
-    Seq("stream", "response", "stream_failures"),
-    Seq("stream", "request", "stream_failures"),
+    Seq("response", "stream", "stream_failures"),
+    Seq("request", "stream", "stream_failures"),
     Seq("stream", "stream_failures"),
-    Seq("response", "failures")
+    Seq("failures")
   )
   val requestCounter = Seq("requests")
   val allCounters = successCounters ++ failureCounters :+ requestCounter
   val latencyStats = Seq(
-    Seq("stream", "response", "stream_duration_ms"),
-    Seq("stream", "request", "stream_duration_ms"),
+    Seq("response", "stream", "stream_duration_ms"),
+    Seq("request", "stream", "stream_duration_ms"),
     Seq("stream", "total_latency_ms"),
-    Seq("response", "response_latency_ms")
+    Seq("request_latency_ms")
   )
 
   private[this] def setup(response: Request => Future[Response]) = {
@@ -95,8 +95,8 @@ class StreamStatsFilterTest extends FunSuite with Awaits {
     val req = Request("http", Method.Get, "hihost", "/", Stream.empty())
     val expectedCounters = Seq(
       requestCounter,
-      Seq("response", "failures"),
-      Seq("stream", "request", "stream_successes"))
+      Seq("failures"),
+      Seq("request", "stream", "stream_successes"))
 
     assertThrows[Throwable] { await(service(req)) }
     withClue("after first failure") {
@@ -150,7 +150,7 @@ class StreamStatsFilterTest extends FunSuite with Awaits {
     val req = Request("http", Method.Get, "hihost", "/", Stream.empty())
     assertThrows[Throwable] { await(service(req)) }
     withClue("after failure") {
-      for { stat <- latencyStats.filter(_ != Seq("stream", "response", "stream_duration_ms")) }
+      for { stat <- latencyStats.filter(_ != Seq("response", "stream", "stream_duration_ms")) }
         withClue(s"stat: $stat") { assert(stats.stats.isDefinedAt(stat)) }
     }
   }

--- a/router/h2/src/test/scala/io/buoyant/router/h2/StreamStatsFilterTest.scala
+++ b/router/h2/src/test/scala/io/buoyant/router/h2/StreamStatsFilterTest.scala
@@ -1,0 +1,157 @@
+package io.buoyant.router.h2
+
+import com.twitter.finagle.{Service, ServiceFactory, Stack, param}
+import com.twitter.finagle.buoyant.h2.{Method, Request, Response, Status, Stream}
+import com.twitter.finagle.stats.InMemoryStatsReceiver
+import com.twitter.util.Future
+import io.buoyant.test.{Awaits, FunSuite}
+
+class StreamStatsFilterTest extends FunSuite with Awaits {
+  val successCounters = Seq(
+    Seq("stream", "response", "stream_successes"),
+    Seq("stream", "request", "stream_successes"),
+    Seq("stream", "stream_successes"),
+    Seq("response", "successes")
+  )
+  val failureCounters = Seq(
+    Seq("stream", "response", "stream_failures"),
+    Seq("stream", "request", "stream_failures"),
+    Seq("stream", "stream_failures"),
+    Seq("response", "failures")
+  )
+  val requestCounter = Seq("requests")
+  val allCounters = successCounters ++ failureCounters :+ requestCounter
+  val latencyStats = Seq(
+    Seq("stream", "response", "stream_duration_ms"),
+    Seq("stream", "request", "stream_duration_ms"),
+    Seq("stream", "total_latency_ms"),
+    Seq("response", "response_latency_ms")
+  )
+
+  private[this] def setup(response: Request => Future[Response]) = {
+
+    val stats = new InMemoryStatsReceiver()
+    val svc = Service.mk[Request, Response] { response(_) }
+    val stk = StreamStatsFilter.module.toStack(
+      Stack.Leaf(StreamStatsFilter.role, ServiceFactory.const(svc))
+    )
+    val service = await(stk.make(Stack.Params.empty + param.Stats(stats))())
+
+    (stats, service)
+  }
+
+  test("increments success counters on success") {
+    val (stats, service) = setup { _ =>
+      Future.value(Response(Status.Ok, Stream.empty()))
+    }
+
+    // all counters should be empty before firing request
+    withClue("before request") {
+      for {counter <- allCounters}
+        withClue(s"stat: $counter") { assert(!stats.counters.isDefinedAt(counter)) }
+    }
+
+    val req = Request("http", Method.Get, "hihost", "/", Stream.empty())
+    await(service(req))
+
+    withClue("after first response") {
+      for { counter <- successCounters :+ requestCounter }
+        withClue(s"stat: $counter") { assert(stats.counters(counter) == 1) }
+    }
+
+    await(service(req))
+    withClue("after second response") {
+      for { counter <- successCounters :+ requestCounter }
+        withClue(s"stat: $counter") { assert(stats.counters(counter) == 2) }
+    }
+  }
+
+  test("does not increment failure counters after successes") {
+    val (stats, service) = setup { _ =>
+      Future.value(Response(Status.Ok, Stream.empty()))
+    }
+
+    val req = Request("http", Method.Get, "hihost", "/", Stream.empty())
+    await(service(req))
+
+    withClue("after first response") {
+      for { counter <- failureCounters }
+        withClue(s"stat: $counter") { assert(!stats.counters.isDefinedAt(counter)) }
+    }
+
+    await(service(req))
+    withClue("after second response") {
+      for { counter <- failureCounters }
+        withClue(s"stat: $counter") { assert(!stats.counters.isDefinedAt(counter)) }
+    }
+  }
+
+  object Thrown extends Throwable
+
+  test("increments correct failure counters after failure") {
+    val (stats, service) = setup { _ =>
+      Future.exception(Thrown)
+    }
+    val req = Request("http", Method.Get, "hihost", "/", Stream.empty())
+    val expectedCounters = Seq(
+      requestCounter,
+      Seq("response", "failures"),
+      Seq("stream", "request", "stream_successes"))
+
+    assertThrows[Throwable] { await(service(req)) }
+    withClue("after first failure") {
+      for { counter <- expectedCounters }
+        assert(stats.counters(counter) == 1)
+      // counters that should not be incremented on this failure
+      for { counter <- failureCounters if !expectedCounters.contains(counter) }
+        withClue(s"stat: $counter") { assert(!stats.counters.isDefinedAt(counter)) }
+
+    }
+
+    assertThrows[Throwable] { await(service(req)) }
+    withClue("after second failure") {
+      for { counter <- expectedCounters }
+        withClue(s"stat: $counter") { assert(stats.counters(counter) == 2) }
+
+      // counters that should not be incremented on this failure
+      for { counter <- failureCounters if !expectedCounters.contains(counter) }
+        withClue(s"stat: $counter") { assert(!stats.counters.isDefinedAt(counter)) }
+    }
+  }
+
+  test("stats are defined after success") {
+    val (stats, service) = setup { _ =>
+      Future.value(Response(Status.Ok, Stream.empty()))
+    }
+    withClue("before request") {
+      // stats undefined before request
+      for {stat <- latencyStats}
+        withClue(s"stat: $stat") { assert(!stats.stats.isDefinedAt(stat)) }
+    }
+
+    val req = Request("http", Method.Get, "hihost", "/", Stream.empty())
+    await(service(req))
+    withClue("after success") {
+      for {stat <- latencyStats}
+        withClue(s"stat: $stat") { assert(stats.stats.isDefinedAt(stat)) }
+    }
+  }
+
+  test("stats are defined after failure") {
+    val (stats, service) = setup { _ =>
+      Future.exception(Thrown)
+    }
+    withClue("before request") {
+      // stats undefined before request
+      for {stat <- latencyStats}
+        withClue(s"stat: $stat") {assert(!stats.stats.isDefinedAt(stat)) }
+    }
+
+    val req = Request("http", Method.Get, "hihost", "/", Stream.empty())
+    assertThrows[Throwable] { await(service(req)) }
+    withClue("after failure") {
+      for { stat <- latencyStats.filter(_ != Seq("stream", "response", "stream_duration_ms")) }
+        withClue(s"stat: $stat") { assert(stats.stats.isDefinedAt(stat)) }
+    }
+  }
+}


### PR DESCRIPTION
I've added a [`StreamStatsFilter`](https://github.com/linkerd/linkerd/blob/f55f26da233d83aaa11720013246ce63e20e9eb8/router/h2/src/main/scala/io/buoyant/router/h2/StreamStatsFilter.scala) in `io.buoyant.router.h2` that adds the following stats: 

- `stream/`
  + `successes`: total number of times all streams finished successfully
  + `failures:` total number of times any stream failed
  + `total_latency_ms`: total latency between receipt of request and closing of response stream (whether success or failure)
  + `request/`
    * `stream_successes`: number of times the request stream succeeded
    * `stream_failures`: number of times the request stream failed
    * `stream_duration_ms`: time between initial request and closing of request stream (whether failure or success)
  + `response/`
    * `stream_successes`: number of times the response stream succeeded
    * `stream_failures`: number of times the response stream failed
    * `stream_duration_ms`: time between when the response future finished and when the response stream closed (whether failure or success)
- `response/`
    + `successes`: number of times the response future succeeded
    + `failures`: number of times the response future failed
    + `response_latency_ms`: time between receipt of request and finishing of response future
- `requests`: total number of requests received

I've also written a fairly comprehensive [test class](https://github.com/linkerd/linkerd/blob/b19f15b662bf72dd1be33b8c1a32124925219957/router/h2/src/test/scala/io/buoyant/router/h2/StreamStatsFilterTest.scala) for the behavior of this filter.

Closes #1507 