### PR TITLE
Annotate thrift client method on native thrift requests

### DIFF
--- a/linkerd/protocol/thrift/src/main/scala/com/twitter/finagle/buoyant/linkerd/TTwitterClientFilter.scala
+++ b/linkerd/protocol/thrift/src/main/scala/com/twitter/finagle/buoyant/linkerd/TTwitterClientFilter.scala
@@ -104,10 +104,6 @@ class TTwitterClientFilter(
     request: ThriftClientRequest,
     service: Service[ThriftClientRequest, Array[Byte]]
   ): Future[Array[Byte]] = {
-    // Create a new span identifier for this request.
-    val msg = new InputBuffer(request.message, protocolFactory)().readMessageBegin()
-    Trace.recordRpc(msg.name)
-
     val thriftRequest =
       if (isUpgraded)
         mkTTwitterRequest(request)

--- a/router/h2/src/main/scala/io/buoyant/router/H2.scala
+++ b/router/h2/src/main/scala/io/buoyant/router/H2.scala
@@ -40,7 +40,6 @@ object H2 extends Router[Request, Response]
         .mkStack(FinagleH2.Client.newStack)
         .replace(StatsFilter.role, StreamStatsFilter.module)
 
-
     val defaultParams = StackRouter.defaultParams +
       param.ProtocolLibrary("h2")
   }

--- a/router/h2/src/main/scala/io/buoyant/router/h2/StreamStatsFilter.scala
+++ b/router/h2/src/main/scala/io/buoyant/router/h2/StreamStatsFilter.scala
@@ -51,12 +51,16 @@ class StreamStatsFilter(statsReceiver: StatsReceiver)
   private[this] val rspStreamStats =
     new StreamStats(statsReceiver.scope("response", "stream"))
   private[this] val totalStreamStats =
-    new StreamStats(statsReceiver.scope("stream"),
-                    durationName = Some("total_latency"))
+    new StreamStats(
+      statsReceiver.scope("stream"),
+      durationName = Some("total_latency")
+    )
   private[this] val rspFutureStats =
-    new StreamStats(statsReceiver,
-                    durationName = Some("request_latency"),
-                    successName = Some(""))
+    new StreamStats(
+      statsReceiver,
+      durationName = Some("request_latency"),
+      successName = Some("")
+    )
 
   override def apply(req: Request, service: Service[Request, Response]): Future[Response] = {
     reqCount.incr()
@@ -77,7 +81,6 @@ class StreamStatsFilter(statsReceiver: StatsReceiver)
         val rspT = Stopwatch.start()
         val _ = rsp.stream.onEnd.respond(rspStreamStats(rspT))
       }
-
 
   }
 

--- a/router/h2/src/test/scala/io/buoyant/router/h2/StreamStatsFilterTest.scala
+++ b/router/h2/src/test/scala/io/buoyant/router/h2/StreamStatsFilterTest.scala
@@ -47,7 +47,7 @@ class StreamStatsFilterTest extends FunSuite with Awaits {
 
     // all counters should be empty before firing request
     withClue("before request") {
-      for {counter <- allCounters}
+      for { counter <- allCounters }
         withClue(s"stat: $counter") { assert(!stats.counters.isDefinedAt(counter)) }
     }
 
@@ -96,7 +96,8 @@ class StreamStatsFilterTest extends FunSuite with Awaits {
     val expectedCounters = Seq(
       requestCounter,
       Seq("failures"),
-      Seq("request", "stream", "stream_successes"))
+      Seq("request", "stream", "stream_successes")
+    )
 
     assertThrows[Throwable] { await(service(req)) }
     withClue("after first failure") {
@@ -125,14 +126,14 @@ class StreamStatsFilterTest extends FunSuite with Awaits {
     }
     withClue("before request") {
       // stats undefined before request
-      for {stat <- latencyStats}
+      for { stat <- latencyStats }
         withClue(s"stat: $stat") { assert(!stats.stats.isDefinedAt(stat)) }
     }
 
     val req = Request("http", Method.Get, "hihost", "/", Stream.empty())
     await(service(req))
     withClue("after success") {
-      for {stat <- latencyStats}
+      for { stat <- latencyStats }
         withClue(s"stat: $stat") { assert(stats.stats.isDefinedAt(stat)) }
     }
   }
@@ -143,8 +144,8 @@ class StreamStatsFilterTest extends FunSuite with Awaits {
     }
     withClue("before request") {
       // stats undefined before request
-      for {stat <- latencyStats}
-        withClue(s"stat: $stat") {assert(!stats.stats.isDefinedAt(stat)) }
+      for { stat <- latencyStats }
+        withClue(s"stat: $stat") { assert(!stats.stats.isDefinedAt(stat)) }
     }
 
     val req = Request("http", Method.Get, "hihost", "/", Stream.empty())

--- a/router/http/src/main/scala/io/buoyant/router/Http.scala
+++ b/router/http/src/main/scala/io/buoyant/router/Http.scala
@@ -35,7 +35,7 @@ object Http extends Router[Request, Response] with FinagleServer[Request, Respon
      */
     val client: StackClient[Request, Response] = FinagleHttp.client
       .transformed(StackRouter.Client.mkStack(_))
-      .transformed(_.replace(http.TracingFilter.role, http.TracingFilter.module))
+      .transformed(_.replace(TracingFilter.role, TracingFilter.module))
       .transformed(_.remove(TlsFilter.role))
 
     val responseDiscarder = ResponseDiscarder[Response] { rsp =>
@@ -81,7 +81,7 @@ object Http extends Router[Request, Response] with FinagleServer[Request, Respon
   object Server {
     val stack: Stack[ServiceFactory[Request, Response]] =
       (AddForwardedHeader.module +: FinagleHttp.server.stack)
-        .insertBefore(http.TracingFilter.role, ProxyRewriteFilter.module)
+        .insertBefore(TracingFilter.role, ProxyRewriteFilter.module)
 
     private val serverResponseClassifier = ClassifiedRetries.orElse(
       ClassifierFilter.successClassClassifier,

--- a/router/thrift/src/e2e/scala/io/buoyant/router/ThriftEndToEndTest.scala
+++ b/router/thrift/src/e2e/scala/io/buoyant/router/ThriftEndToEndTest.scala
@@ -1,6 +1,5 @@
 package io.buoyant.router
 
-import com.twitter.conversions.time._
 import com.twitter.finagle.stats.NullStatsReceiver
 import com.twitter.finagle.thrift.ThriftClientRequest
 import com.twitter.finagle.tracing.{Annotation, BufferingTracer, NullTracer}
@@ -89,6 +88,8 @@ class ThriftEndToEndTest extends FunSuite with Awaits {
         val path = "/thrift"
         val bound = s"/$$/inet/127.1/${cat.port}"
         withAnnotations { anns =>
+          assert(anns.contains(Annotation.Rpc("ping")))
+          assert(anns.contains(Annotation.Rpc("thrift /thrift")))
           assert(anns.contains(Annotation.BinaryAnnotation("service", path)))
           assert(anns.contains(Annotation.BinaryAnnotation("client", bound)))
           assert(anns.contains(Annotation.BinaryAnnotation("residual", "/")))

--- a/router/thrift/src/main/scala/io/buoyant/router/Thrift.scala
+++ b/router/thrift/src/main/scala/io/buoyant/router/Thrift.scala
@@ -1,13 +1,10 @@
 package io.buoyant.router
 
-import com.twitter.finagle.{Thrift => FinagleThrift, Server => FinagleServer, _}
-import com.twitter.finagle.buoyant._
+import com.twitter.finagle.{Server => FinagleServer, Thrift => FinagleThrift, _}
 import com.twitter.finagle.client.StackClient
 import com.twitter.finagle.param.ProtocolLibrary
-import com.twitter.finagle.server.StackServer
 import com.twitter.finagle.thrift.ThriftClientRequest
-import com.twitter.util._
-import io.buoyant.router.thrift.Identifier
+import io.buoyant.router.thrift.{Identifier, TracingFilter}
 import java.net.SocketAddress
 
 object Thrift extends Router[ThriftClientRequest, Array[Byte]]
@@ -30,6 +27,7 @@ object Thrift extends Router[ThriftClientRequest, Array[Byte]]
     val client: StackClient[ThriftClientRequest, Array[Byte]] =
       FinagleThrift.client
         .transformed(StackRouter.Client.mkStack(_))
+        .transformed(_.replace(TracingFilter.role, TracingFilter.module))
 
     val defaultParams: Stack.Params =
       StackRouter.defaultParams +

--- a/router/thrift/src/main/scala/io/buoyant/router/thrift/TracingFilter.scala
+++ b/router/thrift/src/main/scala/io/buoyant/router/thrift/TracingFilter.scala
@@ -1,0 +1,42 @@
+package io.buoyant.router.thrift
+
+import com.twitter.finagle.Thrift.{param => tparam}
+import com.twitter.finagle.client.StackClient
+import com.twitter.finagle.thrift.ThriftClientRequest
+import com.twitter.finagle.tracing.Trace
+import com.twitter.finagle._
+import org.apache.thrift.protocol.TProtocolFactory
+import org.apache.thrift.transport.TMemoryInputTransport
+
+object TracingFilter {
+  val role = StackClient.Role.protoTracing
+  val module: Stackable[ServiceFactory[ThriftClientRequest, Array[Byte]]] =
+    new Stack.Module2[param.Tracer, tparam.ProtocolFactory, ServiceFactory[ThriftClientRequest, Array[Byte]]] {
+      val role = TracingFilter.role
+      val description = "Traces HTTP-specific request metadata"
+      def make(_tracer: param.Tracer, _pf: tparam.ProtocolFactory, next: ServiceFactory[ThriftClientRequest, Array[Byte]]) = {
+        val param.Tracer(tracer) = _tracer
+        if (tracer.isNull) next
+        else {
+          val tparam.ProtocolFactory(pf) = _pf
+          new TracingFilter(pf).andThen(next)
+        }
+      }
+    }
+}
+
+class TracingFilter(protocol: TProtocolFactory) extends SimpleFilter[ThriftClientRequest, Array[Byte]] {
+
+  def apply(req: ThriftClientRequest, service: Service[ThriftClientRequest, Array[Byte]]) = {
+    recordRequest(req)
+    service(req)
+  }
+
+  private[this] def recordRequest(req: ThriftClientRequest): Unit =
+    if (Trace.isActivelyTracing) {
+      val messageName = protocol.getProtocol(
+        new TMemoryInputTransport(req.message)
+      ).readMessageBegin().name
+      Trace.recordRpc(messageName)
+    }
+}

--- a/router/thrift/src/main/scala/io/buoyant/router/thrift/TracingFilter.scala
+++ b/router/thrift/src/main/scala/io/buoyant/router/thrift/TracingFilter.scala
@@ -13,7 +13,7 @@ object TracingFilter {
   val module: Stackable[ServiceFactory[ThriftClientRequest, Array[Byte]]] =
     new Stack.Module2[param.Tracer, tparam.ProtocolFactory, ServiceFactory[ThriftClientRequest, Array[Byte]]] {
       val role = TracingFilter.role
-      val description = "Traces HTTP-specific request metadata"
+      val description = "Traces Thrift-specific request metadata"
       def make(_tracer: param.Tracer, _pf: tparam.ProtocolFactory, next: ServiceFactory[ThriftClientRequest, Array[Byte]]) = {
         val param.Tracer(tracer) = _tracer
         if (tracer.isNull) next


### PR DESCRIPTION
## Problem

The thrift client stack only sets the thrift method name as the Rpc trace annotation if the request is TTwitterThrift.

## Solution

Introduce a separate thrift TracingFilter client module that will set the Rpc trace annotation for both native thrift and TTwitterThrift requests.

Note, this branch includes a few scalariform fixes in a separate commit.