### PR TITLE
Improve docs for the io.l5d.tracelog level field

### DIFF
--- a/linkerd/docs/config.md
+++ b/linkerd/docs/config.md
@@ -40,7 +40,6 @@ telemetry:
   sampleRate: 0.01
 - kind: io.l5d.tracelog
   sampleRate: 0.2
-  level: TRACE
 ```
 
 Welcome to the Configuration Reference for linkerd!
@@ -183,7 +182,7 @@ telemetry:
   sampleRate: 0.01
 - kind: io.l5d.tracelog
   sampleRate: 0.2
-  level: TRACE
+  level: INFO
 ```
 
 A telemeter may receive stats and trace annotations, i.e. to send to a collector

--- a/linkerd/docs/config.md
+++ b/linkerd/docs/config.md
@@ -40,6 +40,7 @@ telemetry:
   sampleRate: 0.01
 - kind: io.l5d.tracelog
   sampleRate: 0.2
+  level: TRACE
 ```
 
 Welcome to the Configuration Reference for linkerd!
@@ -182,7 +183,7 @@ telemetry:
   sampleRate: 0.01
 - kind: io.l5d.tracelog
   sampleRate: 0.2
-  level: INFO
+  level: TRACE
 ```
 
 A telemeter may receive stats and trace annotations, i.e. to send to a collector

--- a/linkerd/docs/telemetry.md
+++ b/linkerd/docs/telemetry.md
@@ -93,6 +93,7 @@ sampleRate | `0.01` | A value between 0.0 and 1.0 indicating what proportion of 
 telemetry:
 - kind: io.l5d.tracelog
   sampleRate: 0.2
+  level: TRACE
 ```
 
 kind: `io.l5d.tracelog`
@@ -103,7 +104,7 @@ Key | Default Value | Description
 --- | ------------- | -----------
 host | `localhost` | Host to send trace data to.
 sampleRate | `1.0` | A value between 0.0 and 1.0 indicating what proportion of traces to log.
-level | `INFO` | Log-level used to log traces. It should be equal (or greater) to the linkerd log level, set by the `-log.level` flag (defaults to `INFO`). It can have one of the following values: `ALL`, `CRITICAL`, `DEBUG`, `ERROR`, `FATAL`, `INFO`, `OFF`, `TRACE`, `WARNING`. For full details, see [TwitterServer's Logging documentation](https://twitter.github.io/twitter-server/Features.html#logging).
+level | `INFO` | Log-level used to log traces. It should be equal (or greater) to the linkerd log level, set by the `-log.level` flag or at runtime in the logging tab of the admin dashboard (defaults to `INFO`). Field can have one of the following values: `ALL`, `CRITICAL`, `DEBUG`, `ERROR`, `FATAL`, `INFO`, `OFF`, `TRACE`, `WARNING`. For full details, see [TwitterServer's Logging documentation](https://twitter.github.io/twitter-server/Features.html#logging).
 
 ## Recent Requests
 

--- a/linkerd/docs/telemetry.md
+++ b/linkerd/docs/telemetry.md
@@ -93,7 +93,6 @@ sampleRate | `0.01` | A value between 0.0 and 1.0 indicating what proportion of 
 telemetry:
 - kind: io.l5d.tracelog
   sampleRate: 0.2
-  level: TRACE
 ```
 
 kind: `io.l5d.tracelog`
@@ -104,7 +103,7 @@ Key | Default Value | Description
 --- | ------------- | -----------
 host | `localhost` | Host to send trace data to.
 sampleRate | `1.0` | A value between 0.0 and 1.0 indicating what proportion of traces to log.
-level | `INFO` | Log-level, one of: `ALL`, `CRITICAL`, `DEBUG`, `ERROR`, `FATAL`, `INFO`, `OFF`, `TRACE`, `WARNING`. For full details, see [com.twitter.logging.Level](http://twitter.github.io/util/docs/#com.twitter.logging.Level).
+level | `INFO` | Log-level used to log traces. It should be equal (or greater) to the linkerd log level, set by the `-log.level` flag (defaults to `INFO`). It can have one of the following values: `ALL`, `CRITICAL`, `DEBUG`, `ERROR`, `FATAL`, `INFO`, `OFF`, `TRACE`, `WARNING`. For full details, see [TwitterServer's Logging documentation](https://twitter.github.io/twitter-server/Features.html#logging).
 
 ## Recent Requests
 

--- a/linkerd/examples/tracelog.yaml
+++ b/linkerd/examples/tracelog.yaml
@@ -13,4 +13,4 @@ routers:
 telemetry:
 - kind: io.l5d.tracelog
   sampleRate: 0.2
-  level: TRACE
+  level: INFO

--- a/linkerd/examples/tracelog.yaml
+++ b/linkerd/examples/tracelog.yaml
@@ -13,4 +13,3 @@ routers:
 telemetry:
 - kind: io.l5d.tracelog
   sampleRate: 0.2
-  level: TRACE

--- a/linkerd/examples/tracelog.yaml
+++ b/linkerd/examples/tracelog.yaml
@@ -13,3 +13,4 @@ routers:
 telemetry:
 - kind: io.l5d.tracelog
   sampleRate: 0.2
+  level: TRACE


### PR DESCRIPTION
This change was originally authored by @sumit-vij-ck in #1373. I cherry-picked his commits and then made the changes requested from that PR.

## Problem

All of the examples in this repo that demonstrate how to configure the `io.l5d.tracelog` telemeter set the `level` field to `TRACE`. Since linkerd's default log level is `INFO`, none of the tracelog output will show up in linkerd's logs unless the log level is adjusted.

## Solution

Update the `level` field's documentation to clarify how that field relates to linkerd's configured log level.
