### PR TITLE
Fix build modules so that mesh-core will be published

### DIFF
--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -732,6 +732,7 @@ object LinkerdBuild extends Base {
       Namerd.all,
       Namerd.examples,
       Router.all,
-      Telemetry.all
+      Telemetry.all,
+      Mesh.all
     )
 }


### PR DESCRIPTION
Right now it's not published to Maven Central and I get:
```
sbt.ResolveException: unresolved dependency: io.buoyant#mesh-core_2.12;1.1.2: not found
```
when I try to use `interpreter-mesh`.