### PR TITLE
Add http identifier endpoint to linkerd

### DIFF
--- a/admin/src/main/scala/io/buoyant/admin/Admin.scala
+++ b/admin/src/main/scala/io/buoyant/admin/Admin.scala
@@ -1,6 +1,5 @@
 package io.buoyant.admin
 
-import java.net.SocketAddress
 import com.twitter.app.{App => TApp}
 import com.twitter.finagle._
 import com.twitter.finagle.buoyant._
@@ -13,6 +12,7 @@ import com.twitter.logging.Logger
 import com.twitter.server.handler.{SummaryHandler => _, _}
 import com.twitter.server.view.{NotFoundView, TextBlockView}
 import com.twitter.util.Monitor
+import java.net.SocketAddress
 
 object Admin {
   val label = "adminhttp"
@@ -135,4 +135,9 @@ class Admin(val address: SocketAddress, tlsCfg: Option[TlsServerConfig]) {
 
   def serve(app: TApp, extHandlers: Seq[Handler]): ListeningServer =
     server.serve(address, mkService(app, extHandlers))
+
+  def serveHandler(address: SocketAddress, handler: Handler): ListeningServer = {
+    val muxer = new HttpMuxer().withHandler(handler.url, handler.service)
+    makeServer(None).serve(address, muxer)
+  }
 }

--- a/admin/src/main/scala/io/buoyant/admin/Admin.scala
+++ b/admin/src/main/scala/io/buoyant/admin/Admin.scala
@@ -12,7 +12,8 @@ import com.twitter.logging.Logger
 import com.twitter.server.handler.{SummaryHandler => _, _}
 import com.twitter.server.view.{NotFoundView, TextBlockView}
 import com.twitter.util.Monitor
-import java.net.SocketAddress
+import io.buoyant.config.types.Port
+import java.net.{InetSocketAddress, SocketAddress}
 
 object Admin {
   val label = "adminhttp"
@@ -107,7 +108,7 @@ object Admin {
   }
 }
 
-class Admin(val address: SocketAddress, tlsCfg: Option[TlsServerConfig]) {
+class Admin(val address: InetSocketAddress, tlsCfg: Option[TlsServerConfig]) {
   import Admin._
 
   private[this] val notFoundView = new NotFoundView()
@@ -136,8 +137,9 @@ class Admin(val address: SocketAddress, tlsCfg: Option[TlsServerConfig]) {
   def serve(app: TApp, extHandlers: Seq[Handler]): ListeningServer =
     server.serve(address, mkService(app, extHandlers))
 
-  def serveHandler(address: SocketAddress, handler: Handler): ListeningServer = {
+  def serveHandler(port: Int, handler: Handler): ListeningServer = {
+    val addrWithPort = new InetSocketAddress(address.getAddress, port)
     val muxer = new HttpMuxer().withHandler(handler.url, handler.service)
-    makeServer(None).serve(address, muxer)
+    makeServer(tlsCfg).serve(addrWithPort, muxer)
   }
 }

--- a/admin/src/main/scala/io/buoyant/admin/AdminConfig.scala
+++ b/admin/src/main/scala/io/buoyant/admin/AdminConfig.scala
@@ -8,7 +8,8 @@ case class AdminConfig(
   ip: Option[InetAddress] = None,
   port: Option[Port] = None,
   shutdownGraceMs: Option[Int] = None,
-  tls: Option[TlsServerConfig] = None
+  tls: Option[TlsServerConfig] = None,
+  httpIdentifierPort: Option[Port] = None
 ) {
 
   def mk(defaultAddr: InetSocketAddress): Admin = {

--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/HttpIdentifierHandler.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/HttpIdentifierHandler.scala
@@ -1,0 +1,46 @@
+package io.buoyant.linkerd.admin
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
+import com.twitter.finagle.Service
+import com.twitter.finagle.http._
+import com.twitter.io.Buf
+import com.twitter.util.{Future, Return, Throw, Try}
+import io.buoyant.router.RoutingFactory
+import io.buoyant.router.RoutingFactory.{IdentifiedRequest, UnidentifiedRequest}
+
+case class IdResult(path: Option[String] = None, dtab: Option[String] = None, error: Option[String] = None)
+
+object Json {
+  private[this] val mapper = new ObjectMapper with ScalaObjectMapper
+  mapper.registerModule(DefaultScalaModule)
+
+  def write[T](t: T): Buf =
+    Buf.ByteArray.Owned(mapper.writeValueAsBytes(t))
+}
+
+class HttpIdentifierHandler(
+  identifiersByLabel: Map[String, RoutingFactory.Identifier[Request]]
+) extends Service[Request, Response] {
+
+  def apply(req: Request): Future[Response] = {
+    val results = identifiersByLabel.mapValues { id =>
+      id(req).transform {
+        case Return(IdentifiedRequest(dst, req1)) =>
+          Future.value(IdResult(Some(dst.path.show), Some(dst.dtab.show)))
+        case Return(unidentified: UnidentifiedRequest[Request]) =>
+          Future.value(IdResult(error = Some(unidentified.reason)))
+        case Throw(e) =>
+          Future.value(IdResult(error = Some(e.getMessage)))
+      }
+    }
+
+    Future.collect(results).map { r =>
+      val rsp = Response()
+      rsp.content = Json.write(r)
+      rsp.contentType = MediaType.Json
+      rsp
+    }
+  }
+}

--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/HttpIdentifierHandler.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/HttpIdentifierHandler.scala
@@ -1,5 +1,6 @@
 package io.buoyant.linkerd.admin
 
+import com.fasterxml.jackson.annotation.JsonInclude.Include
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
@@ -15,6 +16,7 @@ case class IdResult(path: Option[String] = None, dtab: Option[String] = None, er
 object Json {
   private[this] val mapper = new ObjectMapper with ScalaObjectMapper
   mapper.registerModule(DefaultScalaModule)
+  mapper.setSerializationInclusion(Include.NON_EMPTY)
 
   def write[T](t: T): Buf =
     Buf.ByteArray.Owned(mapper.writeValueAsBytes(t))

--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/LinkerdAdmin.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/LinkerdAdmin.scala
@@ -2,6 +2,7 @@ package io.buoyant.linkerd
 package admin
 
 import com.twitter.finagle._
+import com.twitter.finagle.http.Request
 import com.twitter.finagle.naming.buoyant.DstBindingFactory
 import com.twitter.finagle.naming.NameInterpreter
 import com.twitter.server.handler.ResourceHandler
@@ -9,7 +10,7 @@ import io.buoyant.admin.Admin.{Handler, NavItem}
 import io.buoyant.admin.names.{BoundNamesHandler, DelegateApiHandler, DelegateHandler}
 import io.buoyant.admin.{Admin, ConfigHandler, StaticFilter, _}
 import io.buoyant.namer.EnumeratingNamer
-import io.buoyant.router.RoutingFactory
+import io.buoyant.router.{Http, RoutingFactory}
 
 object LinkerdAdmin {
 
@@ -52,6 +53,20 @@ object LinkerdAdmin {
     Handler("/logging", new LoggingHandler(adminHandler)),
     Handler("/logging.json", new LoggingApiHandler())
   )
+
+  def identifierHandler(lc: Linker.LinkerConfig, linker: Linker): Handler = {
+    linker.routers.head.protocol.configId
+
+    val identifiers = linker.routers.collect {
+      case router if router.protocol.configId == "http" =>
+        val RoutingFactory.DstPrefix(pfx) = router.params[RoutingFactory.DstPrefix]
+        val RoutingFactory.BaseDtab(baseDtab) = router.params[RoutingFactory.BaseDtab]
+        val Http.param.HttpIdentifier(id) = router.params[Http.param.HttpIdentifier]
+        router.label -> id(pfx, baseDtab)
+    }.toMap
+
+    Handler("/", new HttpIdentifierHandler(identifiers))
+  }
 
   def apply(lc: Linker.LinkerConfig, linker: Linker): Seq[Handler] = {
     val navItems = Seq(

--- a/linkerd/docs/config.md
+++ b/linkerd/docs/config.md
@@ -83,6 +83,7 @@ Key | Default Value | Description
 --- | ------------- | -----------
 ip | `0.0.0.0` | IP for the admin interface.
 port | `9990` | Port for the admin interface.
+httpIdentifierPort | none | Port for the http identifier debug endpoint.
 tls | no tls | The admin interface will serve over TLS if this parameter is provided. see [TLS](#server-tls).
 
 #### Administrative endpoints
@@ -129,6 +130,12 @@ Endpoint | Description
 
 Note that in addition to a default set of admin endpoints, linkerd plugins may
 dynamically add their own endpoints.
+
+HTTP Identifier Endpoints (running on `httpIdentifierPort`):
+
+Endpoint | Description
+-------- | -----------
+`/` | identifies the request and returns a json map of identified results
 
 This administrative interface was originally based on
 [TwitterServer](https://twitter.github.io/twitter-server), more information may

--- a/linkerd/main/src/main/scala/io/buoyant/linkerd/Main.scala
+++ b/linkerd/main/src/main/scala/io/buoyant/linkerd/Main.scala
@@ -70,7 +70,8 @@ object Main extends App {
 
     config.admin.flatMap(_.httpIdentifierPort) match {
       case Some(p) =>
-        val idServer = linker.admin.serveHandler(new InetSocketAddress(p.port), LinkerdAdmin.identifierHandler(config, linker))
+        val idServer = linker.admin.serveHandler(p.port, LinkerdAdmin.identifierHandler(config, linker))
+        log.info(s"serving http identifier on ${idServer.boundAddress}")
         Seq(server, idServer)
       case None => Seq(server)
     }

--- a/linkerd/main/src/main/scala/io/buoyant/linkerd/Main.scala
+++ b/linkerd/main/src/main/scala/io/buoyant/linkerd/Main.scala
@@ -39,11 +39,11 @@ object Main extends App {
         closeOnExit(Closable.sequence(
           Closable.all(routers: _*),
           Closable.all(telemeters: _*),
-          admin
+          Closable.all(admin: _*)
         ))
         Await.all(routers: _*)
         Await.all(telemeters: _*)
-        Await.result(admin)
+        Await.all(admin: _*)
 
       case _ => exitOnError("usage: linkerd path/to/config")
     }
@@ -64,10 +64,16 @@ object Main extends App {
   private def initAdmin(
     config: Linker.LinkerConfig,
     linker: Linker
-  ): Closable with Awaitable[Unit] = {
+  ): Seq[Closable with Awaitable[Unit]] = {
     val server = linker.admin.serve(this, LinkerdAdmin(config, linker))
     log.info(s"serving ${linker.admin.scheme} admin on ${server.boundAddress}")
-    server
+
+    config.admin.flatMap(_.httpIdentifierPort) match {
+      case Some(p) =>
+        val idServer = linker.admin.serveHandler(new InetSocketAddress(p.port), LinkerdAdmin.identifierHandler(config, linker))
+        Seq(server, idServer)
+      case None => Seq(server)
+    }
   }
 
   private def initRouter(config: Router): Closable with Awaitable[Unit] = {

--- a/linkerd/protocol/http/src/e2e/scala/io/buoyant/linkerd/protocol/ResponseClassificationEndToEndTest.scala
+++ b/linkerd/protocol/http/src/e2e/scala/io/buoyant/linkerd/protocol/ResponseClassificationEndToEndTest.scala
@@ -55,8 +55,6 @@ class ResponseClassificationEndToEndTest extends FunSuite {
     req.host = "foo"
     await(client(req))
 
-    println("THIS IS WHAT IT IS YO")
-    println(stats.counters)
     assert(stats.counters(Seq("rt", "http", "client", s"$$/inet/127.1/${downstream.port}", "service", "svc/foo", "success")) == 1)
     assert(stats.counters(Seq("rt", "http", "service", "svc/foo", "success")) == 1)
     assert(stats.counters(Seq("rt", "http", "server", "127.0.0.1/0", "success")) == 1)

--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -522,7 +522,7 @@ object LinkerdBuild extends Base {
       .withTwitterLib(Deps.twitterServer)
       .withTests()
       .dependsOn(core % "compile->compile;test->test")
-      .dependsOn(LinkerdBuild.admin, Namer.core)
+      .dependsOn(LinkerdBuild.admin, Namer.core, Router.http)
       .dependsOn(Protocol.thrift % "test")
 
     val main = projectDir("linkerd/main")


### PR DESCRIPTION
Problem:
As identifiers increase in complexity (see IstioIngressIdentifier), it becomes more
difficult to debug them.

Solution:
Adds a config admin option `httpIdentifierPort` that, if set, serves a json endpoint
on that port. Given a request, the endpoint returns a map where the keys are
router labels and the values are identifier responses from the identifiers 
configured for those routers.

Example:
```json
$ curl -H "l5d-name: /hello"  -H "Host: world" localhost:4888 | jq
{
  "netty3": {
    "path": "/svc/hello",
    "dtab": "/svc=>/#/io.l5d.fs"
  },
  "netty4": {
    "path": "/svc/world",
    "dtab": "/svc=>/#/io.l5d.fs"
  }
}
```

I wasn't 100% sure what packages to put this stuff in.
We could do this for h2 as well.