### PR TITLE
Rename "successes" metric to "success"

### DIFF
--- a/router/h2/src/main/scala/io/buoyant/router/h2/StreamStatsFilter.scala
+++ b/router/h2/src/main/scala/io/buoyant/router/h2/StreamStatsFilter.scala
@@ -30,7 +30,7 @@ class StreamStatsFilter(statsReceiver: StatsReceiver)
     private[this] val durationMs =
       stats.stat(s"${durationName.getOrElse("stream_duration")}_ms")
     private[this] val successes =
-      stats.counter(s"${successName.getOrElse("stream_")}successes")
+      stats.counter(s"${successName.getOrElse("stream_")}success")
     private[this] val failures =
       stats.counter(s"${successName.getOrElse("stream_")}failures")
 

--- a/router/h2/src/test/scala/io/buoyant/router/h2/StreamStatsFilterTest.scala
+++ b/router/h2/src/test/scala/io/buoyant/router/h2/StreamStatsFilterTest.scala
@@ -8,10 +8,10 @@ import io.buoyant.test.{Awaits, FunSuite}
 
 class StreamStatsFilterTest extends FunSuite with Awaits {
   val successCounters = Seq(
-    Seq("response", "stream", "stream_successes"),
-    Seq("request", "stream", "stream_successes"),
-    Seq("stream", "stream_successes"),
-    Seq("successes")
+    Seq("response", "stream", "stream_success"),
+    Seq("request", "stream", "stream_success"),
+    Seq("stream", "stream_success"),
+    Seq("success")
   )
   val failureCounters = Seq(
     Seq("response", "stream", "stream_failures"),
@@ -96,7 +96,7 @@ class StreamStatsFilterTest extends FunSuite with Awaits {
     val expectedCounters = Seq(
       requestCounter,
       Seq("failures"),
-      Seq("request", "stream", "stream_successes")
+      Seq("request", "stream", "stream_success")
     )
 
     assertThrows[Throwable] { await(service(req)) }


### PR DESCRIPTION
Kevin pointed out that in order to remain backwards-compatible, we need to report success count metrics as `success`, rather than `successes`. I've fixed that.

Fixes #1521