### PR TITLE
Don't require port to be an Int in HostColonPort 

### DIFF
--- a/namer/core/src/main/scala/io/buoyant/hostport.scala
+++ b/namer/core/src/main/scala/io/buoyant/hostport.scala
@@ -17,7 +17,7 @@ private object HostColonPort {
     * this is based on the `DNS_LABEL` regex in Kubernetes:
     * https://github.com/kubernetes/kubernetes/blob/master/pkg/api/types.go#L40-L43
     */
-  private[this] val DnsLabel  = """[a-z0-9]([-a-z0-9]*[a-z0-9])?""".r
+  private[this] val DnsLabel  = """([a-z0-9][-a-z0-9]*[a-z0-9]?)""".r
 
   def unapply(s: String): Option[(String, String)] = s.split(":") match {
     case Array(host, DnsLabel(port))

--- a/namer/core/src/main/scala/io/buoyant/hostport.scala
+++ b/namer/core/src/main/scala/io/buoyant/hostport.scala
@@ -10,14 +10,19 @@ import com.twitter.finagle.Path
  */
 private object HostColonPort {
   /**
-    * regex for capturing the `port` part of a [[HostColonPort]].
+    * regex for capturing strings that conform to the definition
+    * of a "label" in RFCs 1035 and 1123, used for the `port` part
+    * of a [[HostColonPort]].
+    *
     * this is based on the `DNS_LABEL` regex in Kubernetes:
     * https://github.com/kubernetes/kubernetes/blob/master/pkg/api/types.go#L40-L43
     */
   private[this] val DnsLabel  = """[a-z0-9]([-a-z0-9]*[a-z0-9])?""".r
 
   def unapply(s: String): Option[(String, String)] = s.split(":") match {
-    case Array(host, DnsLabel(port)) if port.length <= 63 => Some((host, port))
+    case Array(host, DnsLabel(port))
+      // DNS labels may not exceed 63 characters in length
+      if port.length <= 63 => Some((host, port))
     case _ => None
   }
 }

--- a/namer/core/src/main/scala/io/buoyant/hostport.scala
+++ b/namer/core/src/main/scala/io/buoyant/hostport.scala
@@ -9,15 +9,15 @@ import com.twitter.finagle.Path
  * work in Paths as-is, due to bracket characters).
  */
 private object HostColonPort {
-  object PortStr {
-    def unapply(s: String): Option[Int] = {
-      val port = try s.toInt catch { case _: java.lang.NumberFormatException => -1 }
-      if (0 < port && port < math.pow(2, 16)) Some(port) else None
-    }
-  }
+  /**
+    * regex for capturing the `port` part of a [[HostColonPort]].
+    * this is based on the `DNS_LABEL` regex in Kubernetes:
+    * https://github.com/kubernetes/kubernetes/blob/master/pkg/api/types.go#L40-L43
+    */
+  private[this] val DnsLabel  = """[a-z0-9]([-a-z0-9]*[a-z0-9])?""".r
 
-  def unapply(s: String): Option[(String, Int)] = s.split(":") match {
-    case Array(host, PortStr(port)) => Some((host, port))
+  def unapply(s: String): Option[(String, String)] = s.split(":") match {
+    case Array(host, DnsLabel(port)) if port.length <= 63 => Some((host, port))
     case _ => None
   }
 }

--- a/namer/core/src/main/scala/io/buoyant/hostport.scala
+++ b/namer/core/src/main/scala/io/buoyant/hostport.scala
@@ -39,7 +39,7 @@ private object HostColonPort {
 class hostportPfx extends RewritingNamer {
   protected[this] def rewrite(path: Path) = path.take(2) match {
     case Path.Utf8(pfx, HostColonPort(host, port)) =>
-      Some(Path.Utf8(pfx, host, port.toString) ++ path.drop(2))
+      Some(Path.Utf8(pfx, host, port) ++ path.drop(2))
     case _ => None
   }
 }
@@ -56,7 +56,7 @@ class hostportPfx extends RewritingNamer {
 class porthostPfx extends RewritingNamer {
   protected[this] def rewrite(path: Path) = path.take(2) match {
     case Path.Utf8(pfx, HostColonPort(host, port)) =>
-      Some(Path.Utf8(pfx, port.toString, host) ++ path.drop(2))
+      Some(Path.Utf8(pfx, port, host) ++ path.drop(2))
     case _ => None
   }
 }

--- a/namer/core/src/test/scala/io/buoyant/HostPortTest.scala
+++ b/namer/core/src/test/scala/io/buoyant/HostPortTest.scala
@@ -28,4 +28,24 @@ class HostPortTest extends FunSuite {
     val path = Path.read("/$/io.buoyant.porthostPfx/ia/127.1:8080/etc")
     assert(lookup(path) == NameTree.Leaf(Name.Path(Path.Utf8("ia", "8080", "127.1", "etc"))))
   }
+
+  test("io.buoyant.hostportPfx matches HOST:PORT with string port") {
+    val path = Path.read("/$/io.buoyant.hostportPfx/ia/google.com:http/etc")
+    assert(lookup(path) == NameTree.Leaf(Name.Path(Path.Utf8("ia", "google.com", "http", "etc"))))
+  }
+
+  test("io.buoyant.hostportPfx matches IP:PORT with string port") {
+    val path = Path.read("/$/io.buoyant.hostportPfx/ia/127.1:http/etc")
+    assert(lookup(path) == NameTree.Leaf(Name.Path(Path.Utf8("ia", "127.1", "http", "etc"))))
+  }
+
+  test("io.buoyant.hostportPfx does not match HOST:PORT:ETC with string port") {
+    val path = Path.read("/$/io.buoyant.hostportPfx/ia/google.com:http:abcdef/etc")
+    assert(lookup(path) == NameTree.Neg)
+  }
+
+  test("io.buoyant.porthostPfx matches IP:PORT with string port") {
+    val path = Path.read("/$/io.buoyant.porthostPfx/ia/127.1:http/etc")
+    assert(lookup(path) == NameTree.Leaf(Name.Path(Path.Utf8("ia", "http", "127.1", "etc"))))
+  }
 }


### PR DESCRIPTION
As @adleong suggested in #1511, allowing Strings rather than Ints in the `HostColonPort` would allow us to accept port names like `:http`, so that ports can be specified in Host/Authority headers, rather than in dtabs.

I've rewritten the `HostColonPort` to use a regex that matches valid RFC 1035/1123 "label" strings. 

I added tests to `HostPortTest` to test the matcher with non-numeric port names.
