### PR TITLE
H2 IstioIngressIdentifier and IstioLogger

### DIFF
--- a/k8s/src/main/scala/io/buoyant/k8s/istio/IstioLoggerBase.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/istio/IstioLoggerBase.scala
@@ -1,0 +1,46 @@
+package io.buoyant.k8s.istio
+
+import com.twitter.finagle._
+import com.twitter.util.Duration
+
+trait IstioLoggerBase {
+  val unknown = "unknown"
+
+  // expected istioPath
+  // Path(%,io.l5d.k8s.daemonset,default,incoming,l5d,#,io.l5d.k8s.istio,reviews.default.svc.cluster.local,az:us-west::env:prod::version:v1,http)
+  val pathLength = 10
+  val pathServiceIndex = 7
+  val pathLabelsIndex = 8
+
+  def targetService(istioPath: Option[Path]): Option[String] = istioPath.map { path =>
+    path.showElems(pathServiceIndex)
+  }
+
+  def version(istioPath: Option[Path]): Option[String] = istioPath match {
+    case Some(path) =>
+      path.showElems(pathLabelsIndex).split("::").find {
+        e => e.startsWith("version:")
+      }.map { label => label.split(":").last }
+    case _ => None
+  }
+
+  // note that this should really come from the "app" label of the target pod.
+  // in most cases this will be the same value, but eventually the correct solution
+  // should be to get this directly from the label or the uid.
+  def targetLabelApp(targetService: Option[String]): Option[String] = targetService.flatMap(_.split('.').headOption)
+
+  def mixerClient: MixerClient
+
+  def report(istioPath: Option[Path], responseCode: Int, path: String, duration: Duration) = {
+    val tService = targetService(istioPath)
+    mixerClient.report(
+      responseCode,
+      path,
+      tService.getOrElse(unknown), // target in prom (~reviews.default.svc.cluster.local)
+      unknown, // source in prom (~productpage)
+      targetLabelApp(tService).getOrElse(unknown), // service in prom (~reviews)
+      version(istioPath).getOrElse(unknown), // version in prom (~v1)
+      duration
+    )
+  }
+}

--- a/linkerd/docs/protocol-h2.md
+++ b/linkerd/docs/protocol-h2.md
@@ -321,6 +321,39 @@ host | N/A | The host to send the request to.
 cluster | N/A | The cluster to send the request to.
 port | N/A | The port to send the request to.
 
+## HTTP/2 Loggers
+
+Loggers allow recording of arbitrary information about requests. Destination of
+information is specific to each logger. All HTTP/2 loggers have a `kind`. If a
+list of loggers is provided, they each log in the order they are defined.
+
+Key | Default Value | Description
+--- | ------------- | -----------
+kind | _required_ | Only [`io.l5d.k8s.istio`](#istio-logger) is currently supported.
+
+### HTTP/2 Istio Logger
+
+kind: `io.l5d.k8s.istio`.
+
+With this logger, all H2 requests are sent to an Istio Mixer for telemetry
+recording and aggregation.
+
+#### Logger Configuration:
+
+> Configuration example
+
+```yaml
+loggers:
+- kind: io.l5d.k8s.istio
+  mixerHost: istio-mixer
+  mixerPort: 9091
+```
+
+Key | Default Value | Description
+--- | ------------- | -----------
+mixerHost | `istio-mixer` | Hostname of the Istio Mixer server.
+mixerPort | `9091` | Port of the Mixer server.
+
 ## HTTP/2 Headers
 
 linkerd reads and sets several headers prefixed by `l5d-`, as is done

--- a/linkerd/docs/protocol-h2.md
+++ b/linkerd/docs/protocol-h2.md
@@ -267,8 +267,7 @@ namespace | N/A | The Kubernetes namespace.
 port | N/A | The port name.
 svc | N/A | The name of the service.
 
-<a href="istio-identifier"></a>
-### Istio Identifier
+### HTTP/2 Istio Identifier
 
 kind: `io.l5d.k8s.istio`
 
@@ -276,7 +275,7 @@ This identifier compares H2 requests to
 [istio route-rules](https://istio.io/docs/concepts/traffic-management/rules-configuration.html) and assigns a name based
 on those rules.
 
- #### Identifier Configuration:
+#### Identifier Configuration:
 
 ```yaml
 routers:

--- a/linkerd/protocol/h2/src/main/resources/META-INF/services/io.buoyant.linkerd.IdentifierInitializer
+++ b/linkerd/protocol/h2/src/main/resources/META-INF/services/io.buoyant.linkerd.IdentifierInitializer
@@ -2,3 +2,4 @@ io.buoyant.linkerd.protocol.h2.HeaderTokenIdentifierInitializer
 io.buoyant.linkerd.protocol.h2.HeaderPathIdentifierInitializer
 io.buoyant.linkerd.protocol.h2.IngressIdentifierInitializer
 io.buoyant.linkerd.protocol.h2.IstioIdentifierInitializer
+io.buoyant.linkerd.protocol.h2.IstioIngressIdentifierInitializer

--- a/linkerd/protocol/h2/src/main/resources/META-INF/services/io.buoyant.linkerd.LoggerInitializer
+++ b/linkerd/protocol/h2/src/main/resources/META-INF/services/io.buoyant.linkerd.LoggerInitializer
@@ -1,0 +1,1 @@
+io.buoyant.linkerd.protocol.h2.IstioLoggerInitializer

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/H2LoggerConfig.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/H2LoggerConfig.scala
@@ -1,0 +1,56 @@
+package io.buoyant.linkerd.protocol.h2
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.twitter.finagle.buoyant.h2.{Request, Response}
+import com.twitter.finagle.{Filter, ServiceFactory, Stack, Stackable}
+import com.twitter.finagle.stack.nilStack
+import io.buoyant.config.PolymorphicConfig
+
+abstract class H2LoggerConfig extends PolymorphicConfig { config =>
+
+  @JsonIgnore
+  def role: Stack.Role
+  @JsonIgnore
+  def description: String
+  @JsonIgnore
+  def parameters: Seq[Stack.Param[_]]
+
+  @JsonIgnore
+  def mk(params: Stack.Params): Filter[Request, Response, Request, Response]
+
+  @JsonIgnore
+  def module = new Stack.Module[ServiceFactory[Request, Response]] {
+    override def role: Stack.Role = config.role
+    override def description: String = config.description
+    override def parameters: Seq[Stack.Param[_]] = config.parameters
+
+    override def make(
+      params: Stack.Params,
+      next: Stack[ServiceFactory[Request, Response]]
+    ): Stack[ServiceFactory[Request, Response]] = {
+      val filter = mk(params)
+      Stack.Leaf(role, filter.andThen(next.make(params)))
+    }
+  }
+}
+
+object H2LoggerConfig {
+  object param {
+    case class Logger(loggerStack: Stack[ServiceFactory[Request, Response]])
+    implicit object Logger extends Stack.Param[Logger] {
+      val default = Logger(nilStack)
+    }
+  }
+
+  def module: Stackable[ServiceFactory[Request, Response]] =
+    new Stack.Module[ServiceFactory[Request, Response]] {
+      override val role = Stack.Role("H2Logger")
+      override val description = "H2 Logger"
+      override val parameters = Seq(implicitly[Stack.Param[param.Logger]])
+      def make(params: Stack.Params, next: Stack[ServiceFactory[Request, Response]]): Stack[ServiceFactory[Request, Response]] = {
+        val param.Logger(loggerStack) = params[param.Logger]
+        loggerStack ++ next
+      }
+    }
+}
+

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/IstioIngressIdentifier.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/IstioIngressIdentifier.scala
@@ -3,7 +3,7 @@ package io.buoyant.linkerd.protocol.h2
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.twitter.finagle.Stack.Params
 import com.twitter.finagle.buoyant.Dst
-import com.twitter.finagle.buoyant.h2.{Headers, Request, Response, Status}
+import com.twitter.finagle.buoyant.h2.{Headers, Request, Response, Status, Stream}
 import com.twitter.finagle.param.Label
 import com.twitter.finagle._
 import com.twitter.util.{Future, Try}
@@ -70,7 +70,7 @@ class IstioIngressIdentifier(
   }
 
   def redirectRequest(redir: HTTPRedirect, req: Request): Future[Nothing] = {
-    val resp = Response(Status.Found, Stream.empty(0))
+    val resp = Response(Status.Found, Stream.empty())
     resp.headers.set(Headers.Path, redir.`uri`.getOrElse(req.path))
     resp.headers.set(Headers.Authority, redir.`authority`.getOrElse(req.authority))
     Future.exception(H2ResponseException(resp))

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/IstioIngressIdentifier.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/IstioIngressIdentifier.scala
@@ -1,0 +1,128 @@
+package io.buoyant.linkerd.protocol.h2
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.twitter.finagle.Stack.Params
+import com.twitter.finagle.buoyant.Dst
+import com.twitter.finagle.buoyant.h2.{Headers, Request, Response, Status}
+import com.twitter.finagle.param.Label
+import com.twitter.finagle._
+import com.twitter.util.{Future, Try}
+import io.buoyant.config.types.Port
+import io.buoyant.k8s.istio.ClusterCache.Cluster
+import io.buoyant.k8s.istio._
+import io.buoyant.k8s.{ClientConfig, IngressCache}
+import io.buoyant.linkerd.IdentifierInitializer
+import io.buoyant.linkerd.protocol.H2IdentifierConfig
+import io.buoyant.linkerd.protocol.h2.ErrorReseter.H2ResponseException
+import io.buoyant.router.RoutingFactory.{BaseDtab, DstPrefix, IdentifiedRequest, Identifier, RequestIdentification, UnidentifiedRequest}
+import istio.proxy.v1.config.HTTPRedirect
+
+class IstioIngressIdentifier(
+  val pfx: Path,
+  baseDtab: () => Dtab,
+  namespace: Option[String],
+  apiClient: Service[http.Request, http.Response],
+  annotationClass: String,
+  val routeCache: RouteCache,
+  val clusterCache: ClusterCache
+) extends Identifier[Request] with IstioIdentifierBase[Request] {
+
+  private[this] val ingressCache = new IngressCache(namespace, apiClient, annotationClass)
+
+  override def apply(req: Request): Future[RequestIdentification[Request]] = {
+    val matchingPath = ingressCache.matchPath(Some(req.authority), req.path)
+    matchingPath.flatMap {
+      case None =>
+        Future.value(new UnidentifiedRequest(s"no ingress rule matches ${req.authority}:${req.path}"))
+      case Some(ingressPath) =>
+        val clusterName = s"${ingressPath.svc}.${ingressPath.namespace}.svc.cluster.local"
+
+        // use clusterCache to transform any port Int into a port name
+        val portName = Try(ingressPath.port.toInt).toOption match {
+          case Some(portNumber) => clusterCache.get(s"$clusterName:$portNumber").map {
+            case Some(Cluster(_, p)) => Some(p)
+            case None => None
+          }
+          case None => Future.value(Some(ingressPath.port))
+        }
+
+        Future.join(portName, routeCache.getRules).flatMap {
+          case (Some(port), rules) =>
+            val filteredRules = filterRules(rules, clusterName, reqToMeta(req))
+            (maxPrecedenceRule(filteredRules) match {
+              case Some((ruleName, rule)) =>
+                rule.`redirect` match {
+                  case Some(redir) => redirectRequest(redir, req)
+                  case None =>
+                    val (uri, authority) = httpRewrite(rule, reqToMeta(req))
+                    rewriteRequest(uri, authority, req)
+                    Future.value(pfx ++ Path.Utf8("route", ruleName, port))
+                }
+              //forward requests which have no matching rules to an empty label selector
+              case None => Future.value(pfx ++ Path.Utf8("dest", clusterName, "::", port))
+            }).map { path =>
+              val dst = Dst.Path(path, baseDtab(), Dtab.local)
+              new IdentifiedRequest(dst, req)
+            }
+          case _ => Future.value(new UnidentifiedRequest(s"ingress path ${ingressPath.svc}:${ingressPath.port} does not match any istio vhosts"))
+        }
+    }
+  }
+
+  def redirectRequest(redir: HTTPRedirect, req: Request): Future[Nothing] = {
+    val resp = Response(Status.Found, Stream.empty(0))
+    resp.headers.set(Headers.Path, redir.`uri`.getOrElse(req.path))
+    resp.headers.set(Headers.Authority, redir.`authority`.getOrElse(req.authority))
+    Future.exception(H2ResponseException(resp))
+  }
+
+  def rewriteRequest(uri: String, authority: Option[String], req: Request): Unit = {
+    req.headers.set(Headers.Path, uri)
+    req.headers.set(Headers.Authority, authority.getOrElse(""))
+  }
+
+  def reqToMeta(req: Request): IstioRequestMeta =
+    IstioRequestMeta(req.path, req.scheme, req.method.toString, req.authority, req.headers.get)
+
+}
+
+case class IstioIngressIdentifierConfig(
+  host: Option[String],
+  port: Option[Port],
+  namespace: Option[String],
+  discoveryHost: Option[String],
+  discoveryPort: Option[Port],
+  apiserverHost: Option[String],
+  apiserverPort: Option[Port]
+) extends H2IdentifierConfig with ClientConfig {
+  @JsonIgnore
+  override def portNum: Option[Int] = port.map(_.port)
+
+  override def newIdentifier(params: Stack.Params) = {
+    import io.buoyant.k8s.istio._
+
+    val DstPrefix(prefix) = params[DstPrefix]
+    val BaseDtab(baseDtab) = params[BaseDtab]
+    val k8sApiserverClient = mkClient(Params.empty).configured(Label("ingress-identifier"))
+    val host = apiserverHost.getOrElse(DefaultApiserverHost)
+    val port = apiserverPort.map(_.port).getOrElse(DefaultApiserverPort)
+    val routeCache = RouteCache.getManagerFor(host, port)
+    val discoveryClient = DiscoveryClient(
+      discoveryHost.getOrElse(DefaultDiscoveryHost),
+      discoveryPort.map(_.port).getOrElse(DefaultDiscoveryPort)
+    )
+    val clusterCache = new ClusterCache(discoveryClient)
+    new IstioIngressIdentifier(prefix, baseDtab, namespace, k8sApiserverClient.newService(dst), "istio", routeCache, clusterCache)
+  }
+}
+
+object IstioIngressIdentifierConfig {
+  val kind = "io.l5d.k8s.istio-ingress"
+}
+
+class IstioIngressIdentifierInitializer extends IdentifierInitializer {
+  val configClass = classOf[IstioIngressIdentifierConfig]
+  override val configId = IstioIngressIdentifierConfig.kind
+}
+
+object IstioIngressIdentifierInitializer extends IstioIngressIdentifierInitializer


### PR DESCRIPTION
These are largely copies of their http counterparts. 
Adds the concept of loggers to the h2 protocol. Fixes #1480 

Validation: Manually tested against hello world grpc.