### PR TITLE
Enforce maximum request size for thrift requests

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## In the next release...
+
+* Enforce a maximum request size for Thrift requests to prevent large requests
+  from causing Linkerd/Namerd to OOM.
+
 ## 1.1.2 2017-07-12
 
 * Marathon Namer TLS support, for DC/OS strict mode.

--- a/linkerd/docs/protocol-thrift.md
+++ b/linkerd/docs/protocol-thrift.md
@@ -38,6 +38,7 @@ Key | Default Value | Description
 dstPrefix | `/svc` | A path prefix used in `dtab`.
 thriftMethodInDst | `false` | If `true`, thrift method names are appended to destinations for outgoing requests.
 thriftProtocol | `binary` | Either `binary` (TBinaryProtocol) or `compact` (TCompactProtocol). Applies to both clients and servers.
+maxRequestSize | 1 megabyte | The maximum size, in bytes, of requests to accept.
 
 
 ## Thrift Server Parameters

--- a/linkerd/protocol/thrift/src/e2e/scala/io/buoyant/linkerd/protocol/ThriftEndToEndTest.scala
+++ b/linkerd/protocol/thrift/src/e2e/scala/io/buoyant/linkerd/protocol/ThriftEndToEndTest.scala
@@ -53,7 +53,7 @@ class ThriftEndToEndTest extends FunSuite {
   test("end-to-end echo routing") {
     val cat = Downstream.const("cat", "meow")
     val router = {
-      val config = new ThriftConfig(Some(true), None) {
+      val config = new ThriftConfig(Some(true), None, None) {
         dtab = Some(Dtab.read(s"""/svc/cat => /$$/inet/127.1/${cat.port} ;"""))
         servers = Seq(
           new ThriftServerConfig(None) {
@@ -88,7 +88,7 @@ class ThriftEndToEndTest extends FunSuite {
   test("multiple clients") {
     val cat = Downstream.const("cat", "meow")
     val router = {
-      val config = new ThriftConfig(Some(true), None) {
+      val config = new ThriftConfig(Some(true), None, None) {
         dtab = Some(Dtab.read(s"""/svc/cat => /$$/inet/127.1/${cat.port} ;"""))
         servers = Seq(
           new ThriftServerConfig(None) {
@@ -128,7 +128,7 @@ class ThriftEndToEndTest extends FunSuite {
   test("linker-to-linker echo routing") {
     val cat = Downstream.const("cat", "meow")
     val incoming = {
-      val config = new ThriftConfig(Some(true), None) {
+      val config = new ThriftConfig(Some(true), None, None) {
         _label = Some("incoming")
         dtab = Some(Dtab.read(s"""/svc/cat => /$$/inet/127.1/${cat.port} ;"""))
         servers = Seq(
@@ -144,7 +144,7 @@ class ThriftEndToEndTest extends FunSuite {
     }
 
     val outgoing = {
-      val config = new ThriftConfig(Some(true), None) {
+      val config = new ThriftConfig(Some(true), None, None) {
         _label = Some("outgoing")
         dtab = Some(Dtab.read(s"""/svc/cat => /$$/inet/127.1/${incoming.boundAddress.asInstanceOf[InetSocketAddress].getPort} ;"""))
         servers = Seq(

--- a/linkerd/protocol/thrift/src/main/scala/io/buoyant/config/types/ThriftProtocolDeserializer.scala
+++ b/linkerd/protocol/thrift/src/main/scala/io/buoyant/config/types/ThriftProtocolDeserializer.scala
@@ -7,16 +7,16 @@ import io.buoyant.config.{ConfigDeserializer, ConfigSerializer}
 import org.apache.thrift.protocol.{TCompactProtocol, TProtocolFactory}
 
 sealed trait ThriftProtocol {
-  def factory: TProtocolFactory
+  def factory(readLength: Int): TProtocolFactory
   def name: String
 }
 object ThriftProtocol {
   object Binary extends ThriftProtocol {
-    def factory = Protocols.binaryFactory()
+    def factory(readLength: Int) = Protocols.binaryFactory(readLength = readLength)
     val name = "binary"
   }
   object Compact extends ThriftProtocol {
-    def factory = new TCompactProtocol.Factory
+    def factory(readLength: Int) = new TCompactProtocol.Factory
     val name = "compact"
   }
 }

--- a/namerd/docs/interface.md
+++ b/namerd/docs/interface.md
@@ -34,6 +34,7 @@ ip | `0.0.0.0` | The local IP address on which to serve the namer interface.
 port | `4100` | The port number on which to serve the namer interface.
 retryBaseSecs | `600` | Base number of seconds to tell clients to wait before retrying after an error.
 retryJitterSecs | `60` | Maximum number of seconds to jitter retry time by.
+maxRequestSize | 1 megabyte | The maximum size, in bytes, of requests to accept.
 cache | see [cache](#cache) | Binding and address cache size configuration.
 tls | no tls | The namer interface will serve over TLS if this parameter is provided. See [Server TLS](https://linkerd.io/config/head/linkerd#server-tls).
 


### PR DESCRIPTION
If Linkerd/Namerd encountered a thrift request that advertised a very large
body, it would attempt to allocate a buffer of that size and immediately OOM.

Add a `maxRequestSize` property to the Thrift and Thriftmux routers and to
Namerd's thriftNameInterpreter.  If a message is encountered that advertises
too large of a body, the request will be rejected.

Fixes #1524