### PR TITLE
Set default TBinaryProtocol.readLength to 10MiB (#1524)

### DIFF
--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -214,6 +214,7 @@ object LinkerdBuild extends Base {
        |   -XX:-TieredCompilation                            \
        |   -XX:+UseStringDeduplication                       \
        |   -Dcom.twitter.util.events.sinkEnabled=false       \
+       |   -Dorg.apache.thrift.readLength=10485760           \
        |   ${LOCAL_JVM_OPTIONS:-}                            "
        |""".stripMargin
 


### PR DESCRIPTION
This is an alternative simpler approach to fix #1524 

Probably, can be even combined with the solution proposed by @adleong