### PR TITLE
Fix incorrect retries stat in router summary of admin dashboard

### DIFF
--- a/admin/src/main/resources/io/buoyant/admin/js/spec/RouterSummarySpec.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/spec/RouterSummarySpec.js
@@ -1,0 +1,87 @@
+"use strict";
+
+define([
+  'jQuery',
+  'lodash',
+  'src/router_summary',
+  'src/metrics_collector',
+  'spec/fixtures/metrics',
+  'template/compiled_templates'
+], function($, _, RouterSummary, MetricsCollector, metricsJson, templates) {
+  describe("RouterSummary", function() {
+    var $container;
+    var $summaryEl;
+    var $routerStatsEl;
+
+    var updatedMetrics = _.merge({}, metricsJson, {
+      rt: {
+        multiplier: {
+          "service": {
+            "svc": {
+              "retries": {
+                "total": {
+                  "counter": 481
+                }
+              }
+            }
+          },
+          client: {
+            "$/inet/127.1/9030": {
+              "retries": {
+                "requeues": {
+                  "counter": 100
+                }
+              }
+            }
+          },
+          server: {
+            "0.0.0.0/4116": {
+              "requests": {
+                counter: 1234
+              }
+            }
+          }
+        }
+      }
+    });
+
+    function extractRenderedValue($parent, dataKey) {
+      return $($parent.find("div[data-key='" + dataKey + "']")[0]).text().trim();
+    }
+
+    beforeEach(function () {
+      $container = $("<div />");
+      var containers = templates.router_container({ routers: ["multiplier"] });
+      $container.html(containers);
+
+      $summaryEl = $($container.find(".summary")[0]);
+      $routerStatsEl = $($container.find(".router-stats")[0]);
+    });
+
+    afterEach(function () {
+      $summaryEl.remove();
+      $summaryEl = null;
+      $routerStatsEl.remove();
+      $routerStatsEl = null;
+      $container.remove();
+      $container = null;
+    });
+
+    it("updates summary stats correctly", function() {
+      var collector = MetricsCollector(metricsJson);
+      RouterSummary(collector, $summaryEl, $routerStatsEl, "multiplier", null);
+      var summaryStats = $summaryEl.find(".router-summary-stat");
+
+      expect(summaryStats.length).toBe(5);
+      expect(extractRenderedValue(summaryStats, "requests")).toBe("0");
+      expect(extractRenderedValue(summaryStats, "retries")).toBe("0");
+
+      collector.__update__(updatedMetrics);
+
+      summaryStats = $summaryEl.find(".router-summary-stat");
+
+      expect(extractRenderedValue(summaryStats, "requests")).toBe("853");
+      expect(extractRenderedValue(summaryStats, "retries")).toBe("581"); // 481 + 100
+    });
+  });
+});

--- a/admin/src/main/resources/io/buoyant/admin/js/src/router_summary.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/router_summary.js
@@ -89,23 +89,23 @@ define([
     }
 
     function processResponses(data, routerName, metrics) {
-      function process(metric) {
+      function summarize(metric) {
         var m = metrics[metric];
         var datum = _(data).get(m.accessor);
 
-        return _.reduce(datum, function(mem, entityData) {
-          mem += _.get(entityData, m.metricAccessor) || 0;
-          return mem;
+        return _.reduce(datum, function(totalValue, entityData) {
+          totalValue += _.get(entityData, m.metricAccessor) || 0;
+          return totalValue;
         }, 0);
       }
 
       var result = {
         router: routerName,
-        load: process("load", true),
-        requests: process("requests"),
-        success: process("success"),
-        failures: process("failures"),
-        retries: process("pathRetries") + process("requeues")
+        load: summarize("load", true),
+        requests: summarize("requests"),
+        success: summarize("success"),
+        failures: summarize("failures"),
+        retries: summarize("pathRetries") + summarize("requeues")
       }
       var rates = getSuccessAndFailureRate(result);
       return  $.extend(result, rates);

--- a/admin/src/main/resources/io/buoyant/admin/js/src/router_summary.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/router_summary.js
@@ -53,7 +53,7 @@ define([
     function getMetrics(routerName) {
       var serverAccessor = ["rt", routerName, "server"];
       var clientAccessor = ["rt", routerName, "client"];
-      var pathAccessor = ["rt", routerName, "service", "svc"];
+      var pathAccessor = ["rt", routerName, "service"];
 
       return _.each({
         load: {
@@ -79,8 +79,7 @@ define([
         },
         pathRetries: {
           metricKey: ["retries", "total", "counter"],
-          accessor: pathAccessor,
-          isPath: true
+          accessor: pathAccessor
         },
       }, function(defn) {
         var key = _.clone(defn.metricKey);
@@ -94,14 +93,10 @@ define([
         var m = metrics[metric];
         var datum = _(data).get(m.accessor);
 
-        if(m.isPath) {
-          return _.get(datum, m.metricAccessor) || 0;
-        } else {
-          return _.reduce(datum, function(mem, entityData) {
-            mem += _.get(entityData, m.metricAccessor) || 0;
-            return mem;
-          }, 0);
-        }
+        return _.reduce(datum, function(mem, entityData) {
+          mem += _.get(entityData, m.metricAccessor) || 0;
+          return mem;
+        }, 0);
       }
 
       var result = {


### PR DESCRIPTION
Problem: we were only fetching stats for services named 'svc'
Solution: remove hardcoded service name from path stats accessor