### PR TITLE
Add H2 Classified Failure Accrual

### DIFF
--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/H2Classifiers.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/H2Classifiers.scala
@@ -1,6 +1,9 @@
 package io.buoyant.linkerd.protocol.h2
 
-import com.twitter.finagle.buoyant.h2.service.{H2Classifiers, H2Classifier}
+import com.twitter.finagle.buoyant.h2.Frame
+import com.twitter.finagle.buoyant.h2.service.{H2Classifier, H2Classifiers, H2ReqRep, H2ReqRepFrame}
+import com.twitter.finagle.service.ResponseClass
+import com.twitter.util.Return
 import io.buoyant.router.ClassifiedRetries
 
 class RetryableIdempotent5XXConfig extends H2ClassifierConfig {

--- a/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/H2FailureAccrualFactory.scala
+++ b/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/H2FailureAccrualFactory.scala
@@ -18,7 +18,7 @@ object H2FailureAccrualFactory {
 
   def module: Stackable[ServiceFactory[Request, Response]] =
     new Stack.ModuleParams[ServiceFactory[Request, Response]] {
-      val role: Role = FailureAccrualFactory.role
+      val role: Role = H2FailureAccrualFactory.role
       val description: String = "Backoff from hosts that we cannot successfully make requests to"
       override def parameters: Seq[Stack.Param[_]] = Seq(
         implicitly[Stack.Param[fParam.Stats]],
@@ -64,28 +64,6 @@ object H2FailureAccrualFactory {
         }
       }
     }
-
-  // The FailureAccrualFactory transitions between Alive, Dead, ProbeOpen,
-  // and ProbeClosed. The factory starts in the Alive state. After numFailures
-  // failures, the factory transitions to Dead. When it is revived,
-  // it transitions to ProbeOpen. After a request is received,
-  // it transitions to ProbeClosed and cannot accept any further requests until
-  // the initial request is satisfied. If the request is successful, it
-  // transitions back to Alive, otherwise Dead.
-  //
-  // The transitions can be visualized using the state diagram:
-  //
-  // ,<-----------.
-  // Alive        |
-  // |  ,---ProbeClosed
-  // ∨  ∨         ^
-  // Dead         |
-  //  `---> ProbeOpen
-  protected[finagle] sealed trait State
-  protected[finagle] object Alive extends State
-  protected[finagle] object Dead extends State
-  protected[finagle] object ProbeOpen extends State
-  protected[finagle] object ProbeClosed extends State
 }
 
 /**

--- a/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/H2FailureAccrualFactory.scala
+++ b/router/h2/src/main/scala/com/twitter/finagle/buoyant/h2/H2FailureAccrualFactory.scala
@@ -1,0 +1,276 @@
+package com.twitter.finagle.buoyant.h2
+
+import com.twitter.finagle.Stack.{Params, Role}
+import com.twitter.finagle.buoyant.h2.service.{H2Classifier, H2ReqRep, H2ReqRepFrame}
+import com.twitter.finagle.client.Transporter
+import com.twitter.finagle.liveness.{FailureAccrualFactory, FailureAccrualPolicy}
+import com.twitter.finagle.service.ResponseClass
+import com.twitter.finagle.stats.StatsReceiver
+import com.twitter.finagle.{Status => FStatus, param => fParam, _}
+import com.twitter.logging.Level
+import com.twitter.util._
+import io.buoyant.router.context.h2.H2ClassifierCtx
+
+/* Modified from https://github.com/twitter/finagle/blob/develop/finagle-core/src/main/scala/com/twitter/finagle/liveness/FailureAccrualFactory.scala */
+object H2FailureAccrualFactory {
+
+  val role = FailureAccrualFactory.role
+
+  def module: Stackable[ServiceFactory[Request, Response]] =
+    new Stack.ModuleParams[ServiceFactory[Request, Response]] {
+      val role: Role = FailureAccrualFactory.role
+      val description: String = "Backoff from hosts that we cannot successfully make requests to"
+      override def parameters: Seq[Stack.Param[_]] = Seq(
+        implicitly[Stack.Param[fParam.Stats]],
+        implicitly[Stack.Param[FailureAccrualFactory.Param]],
+        implicitly[Stack.Param[fParam.Timer]],
+        implicitly[Stack.Param[fParam.Label]],
+        implicitly[Stack.Param[fParam.Logger]],
+        implicitly[Stack.Param[Transporter.EndpointAddr]]
+      )
+
+      def make(params: Params, next: ServiceFactory[Request, Response]): ServiceFactory[Request, Response] = {
+        params[FailureAccrualFactory.Param] match {
+          case FailureAccrualFactory.Param.Configured(policy) =>
+            val timer = params[fParam.Timer].timer
+            val statsReceiver = params[fParam.Stats].statsReceiver
+
+            // extract some info useful for logging
+            val logger = params[fParam.Logger].log
+            val endpoint = params[Transporter.EndpointAddr].addr
+            val label = params[fParam.Label].label
+
+            new H2FailureAccrualFactory(
+              underlying = next,
+              policy = policy(),
+              timer = timer,
+              statsReceiver = statsReceiver.scope("failure_accrual")
+            ) {
+              override def didMarkDead(): Unit = {
+                logger.log(
+                  Level.INFO,
+                  s"""FailureAccrualFactory marking connection to "$label" as dead. """ +
+                    s"""Remote Address: $endpoint"""
+                )
+                super.didMarkDead()
+              }
+            }
+
+          case FailureAccrualFactory.Param.Replaced(f) =>
+            f(params[fParam.Timer].timer).andThen(next)
+
+          case FailureAccrualFactory.Param.Disabled =>
+            next
+        }
+      }
+    }
+
+  // The FailureAccrualFactory transitions between Alive, Dead, ProbeOpen,
+  // and ProbeClosed. The factory starts in the Alive state. After numFailures
+  // failures, the factory transitions to Dead. When it is revived,
+  // it transitions to ProbeOpen. After a request is received,
+  // it transitions to ProbeClosed and cannot accept any further requests until
+  // the initial request is satisfied. If the request is successful, it
+  // transitions back to Alive, otherwise Dead.
+  //
+  // The transitions can be visualized using the state diagram:
+  //
+  // ,<-----------.
+  // Alive        |
+  // |  ,---ProbeClosed
+  // ∨  ∨         ^
+  // Dead         |
+  //  `---> ProbeOpen
+  protected[finagle] sealed trait State
+  protected[finagle] object Alive extends State
+  protected[finagle] object Dead extends State
+  protected[finagle] object ProbeOpen extends State
+  protected[finagle] object ProbeClosed extends State
+}
+
+/**
+ * A modified version of [[com.twitter.finagle.liveness.FailureAccrualFactory]] for H2.
+ * This uses a H2Classifier to inform failure accrual at either response time, or when the stream
+ * is complete.
+ */
+class H2FailureAccrualFactory(
+  underlying: ServiceFactory[Request, Response],
+  policy: FailureAccrualPolicy,
+  timer: Timer,
+  statsReceiver: StatsReceiver
+)
+  extends ServiceFactory[Request, Response] { self =>
+  import FailureAccrualFactory._
+
+  // writes to `state` and `reviveTimerTask` are synchronized on `self`
+  @volatile private[this] var state: State = Alive
+  private[this] var reviveTimerTask: Option[TimerTask] = None
+
+  private[this] val removalCounter = statsReceiver.counter("removals")
+  private[this] val revivalCounter = statsReceiver.counter("revivals")
+  private[this] val probesCounter = statsReceiver.counter("probes")
+  private[this] val removedForCounter = statsReceiver.counter("removed_for_ms")
+
+  private[this] def didFail() = self.synchronized {
+    state match {
+      case Alive | ProbeClosed =>
+        policy.markDeadOnFailure() match {
+          case Some(duration) => markDeadFor(duration)
+          case None if state == ProbeClosed =>
+            // The probe request failed, but the policy tells us that we
+            // should not mark dead. We probe again in an attempt to
+            // resolve this ambiguity, but we could also mark dead for a
+            // fixed period of time, or even mark alive.
+            startProbing()
+          case None =>
+        }
+      case _ =>
+    }
+  }
+
+  private[this] val onServiceAcquisitionFailure: Throwable => Unit = self.synchronized { _ =>
+    stopProbing()
+    didFail()
+  }
+
+  protected def didSucceed(): Unit = self.synchronized {
+    // Only count revivals when the probe succeeds.
+    state match {
+      case ProbeClosed =>
+        revivalCounter.incr()
+        policy.revived()
+        state = Alive
+      case _ =>
+    }
+    policy.recordSuccess()
+  }
+
+  private[this] def markDeadFor(duration: Duration) = self.synchronized {
+    // In order to have symmetry with the revival counter, don't count removals
+    // when probing fails.
+    if (state == Alive) removalCounter.incr()
+
+    state = Dead
+
+    val timerTask = timer.schedule(duration.fromNow) { startProbing() }
+    reviveTimerTask = Some(timerTask)
+
+    removedForCounter.incr(duration.inMilliseconds.toInt)
+
+    didMarkDead()
+  }
+
+  /**
+   * Called by FailureAccrualFactory after marking an endpoint dead. Override
+   * this method to perform additional actions.
+   */
+  protected def didMarkDead() = {}
+
+  /**
+   * Enter 'Probing' state.
+   * The service must satisfy one request before accepting more.
+   */
+  protected def startProbing() = self.synchronized {
+    state = ProbeOpen
+    cancelReviveTimerTask()
+  }
+
+  /**
+   * Exit 'Probing' state (if necessary)
+   *
+   * The result of the subsequent request will determine whether the factory transitions to
+   * Alive (successful) or Dead (unsuccessful).
+   */
+  private[this] def stopProbing() = self.synchronized {
+    state match {
+      case ProbeOpen =>
+        probesCounter.incr()
+        state = ProbeClosed
+      case _ =>
+    }
+  }
+
+  private[this] def classifyResponse(classifier: H2Classifier, h2ReqRep: H2ReqRep): Try[Response] =
+    classifier.responseClassifier.lift(h2ReqRep) match {
+      case Some(ResponseClass.Successful(_)) =>
+        didSucceed()
+        h2ReqRep.response
+      case Some(ResponseClass.Failed(_)) =>
+        didFail()
+        h2ReqRep.response
+      case None =>
+        h2ReqRep.response match {
+          case Return(rep) =>
+            if (rep.stream.isEmpty) {
+              classifyStream(classifier, H2ReqRepFrame(h2ReqRep.request, Return((rep, None))))
+              Return(rep)
+            } else {
+              val stream = rep.stream.onFrame {
+                case Return(f) if f.isEnd =>
+                  classifyStream(classifier, H2ReqRepFrame(h2ReqRep.request, Return((rep, Some(Return(f))))))
+                case Throw(e) =>
+                  classifyStream(classifier, H2ReqRepFrame(h2ReqRep.request, Return((rep, Some(Throw(e))))))
+                case _ => ()
+              }
+              Return(Response(rep.headers, stream))
+            }
+          case Throw(e) =>
+            classifyStream(classifier, H2ReqRepFrame(h2ReqRep.request, Throw(e)))
+            Throw(e)
+        }
+    }
+
+  private[this] def classifyStream(classifier: H2Classifier, h2ReqRepFrame: H2ReqRepFrame): Unit =
+    classifier.streamClassifier(h2ReqRepFrame) match {
+      case ResponseClass.Successful(_) => didSucceed()
+      case ResponseClass.Failed(_) => didFail()
+    }
+
+  def apply(conn: ClientConnection) = {
+    underlying(conn).map { service =>
+      // N.B. the reason we can't simply filter the service factory is so that
+      // we can override the session status to reflect the broader endpoint status.
+      new Service[Request, Response] {
+        def apply(request: Request): Future[Response] = {
+          val param.H2Classifier(classifier) =
+            H2ClassifierCtx.current.getOrElse(param.H2Classifier.param.default)
+          // If service has just been revived, accept no further requests.
+          // Note: Another request may have come in before state transitions to
+          // ProbeClosed, so > 1 requests may be processing while in the
+          // ProbeClosed state. The result of first to complete will determine
+          // whether the factory transitions to Alive (successful) or Dead
+          // (unsuccessful).
+          stopProbing()
+
+          service(request).transform { rep =>
+            Future.const(classifyResponse(classifier, H2ReqRep(request, rep)))
+          }
+        }
+
+        override def close(deadline: Time): Future[Unit] = service.close(deadline)
+        override def status: FStatus = FStatus.worst(
+          service.status,
+          H2FailureAccrualFactory.this.status
+        )
+      }
+    }.onFailure(onServiceAcquisitionFailure)
+  }
+
+  override def status: FStatus = state match {
+    case Alive | ProbeOpen => underlying.status
+    case Dead | ProbeClosed => FStatus.Busy
+  }
+
+  protected[this] def getState: State = state
+
+  private[this] def cancelReviveTimerTask(): Unit = self.synchronized {
+    reviveTimerTask.foreach(_.cancel())
+    reviveTimerTask = None
+  }
+
+  def close(deadline: Time): Future[Unit] = underlying.close(deadline).ensure {
+    cancelReviveTimerTask()
+  }
+
+  override def toString = s"h2_failure_accrual_${underlying.toString}"
+}

--- a/router/h2/src/main/scala/io/buoyant/router/H2.scala
+++ b/router/h2/src/main/scala/io/buoyant/router/H2.scala
@@ -1,6 +1,6 @@
 package io.buoyant.router
 
-import com.twitter.finagle.buoyant.h2.{Request, Response, param => h2param}
+import com.twitter.finagle.buoyant.h2.{H2FailureAccrualFactory, Request, Response, param => h2param}
 import com.twitter.finagle.buoyant.{H2 => FinagleH2}
 import com.twitter.finagle.client.StackClient
 import com.twitter.finagle.{param, _}
@@ -8,6 +8,7 @@ import com.twitter.finagle.server.StackServer
 import com.twitter.util.Future
 import java.net.SocketAddress
 import com.twitter.finagle.buoyant.h2.service.H2Classifiers
+import com.twitter.finagle.liveness.FailureAccrualFactory
 import com.twitter.finagle.service.StatsFilter
 import io.buoyant.router.context.ResponseClassifierCtx
 import io.buoyant.router.context.h2.H2ClassifierCtx
@@ -47,6 +48,7 @@ object H2 extends Router[Request, Response]
       StackRouter.Client.mkStack(stk)
         .replace(PerDstPathStatsFilter.role, PerDstPathStreamStatsFilter.module)
         .replace(LocalClassifierStatsFilter.role, LocalClassifierStreamStatsFilter.module)
+        .replace(FailureAccrualFactory.role, H2FailureAccrualFactory.module)
     }
 
     val defaultParams = StackRouter.defaultParams +

--- a/router/h2/src/test/scala/com/twitter/finagle/buoyant/h2/H2FailureAccrualFactoryTest.scala
+++ b/router/h2/src/test/scala/com/twitter/finagle/buoyant/h2/H2FailureAccrualFactoryTest.scala
@@ -1,0 +1,107 @@
+package com.twitter.finagle.buoyant.h2
+
+import com.twitter.concurrent.AsyncQueue
+import com.twitter.finagle.buoyant.h2.service.{H2Classifier, H2ReqRep, H2ReqRepFrame}
+import com.twitter.finagle.context.Contexts
+import com.twitter.finagle.liveness.FailureAccrualPolicy
+import com.twitter.finagle.service.ResponseClass
+import com.twitter.finagle.stats.InMemoryStatsReceiver
+import com.twitter.finagle.{FactoryToService, Service, ServiceFactory, Status => FStatus}
+import com.twitter.util.{Duration, Future, MockTimer, Return}
+import io.buoyant.router.context.h2.H2ClassifierCtx
+import io.buoyant.test.FunSuite
+import java.util
+import scala.{Stream => SStream}
+
+class H2FailureAccrualFactoryTest extends FunSuite {
+
+  val timer = new MockTimer()
+
+  test("response failure accrual") {
+
+    val classifier = new H2Classifier {
+      override def responseClassifier: PartialFunction[H2ReqRep, ResponseClass] = {
+        case H2ReqRep(_, Return(rep)) =>
+          if (rep.headers.get(":status") == Some("200")) ResponseClass.Success
+          else ResponseClass.NonRetryableFailure
+        case _ =>
+          ResponseClass.NonRetryableFailure
+      }
+    }
+
+    val stats = new InMemoryStatsReceiver
+
+    val underlying = ServiceFactory.const(Service.mk { req: Request =>
+      Future.value(Response(Status.InternalServerError, Stream.empty()))
+    })
+
+    val fa = new H2FailureAccrualFactory(
+      underlying,
+      FailureAccrualPolicy.consecutiveFailures(5, SStream.continually(Duration.Top)),
+      timer,
+      stats
+    )
+
+    val svc = new FactoryToService(fa)
+
+    Contexts.local.let(H2ClassifierCtx, param.H2Classifier(classifier)) {
+      for (_ <- 1 to 4) {
+        await(svc(Request(Headers(":method" -> "GET"), Stream.empty())))
+        assert(fa.status == FStatus.Open)
+      }
+      await(svc(Request(Headers(":method" -> "GET"), Stream.empty())))
+      assert(fa.status == FStatus.Busy)
+    }
+  }
+
+  test("stream failure accrual") {
+
+    val classifier = new H2Classifier {
+      override def streamClassifier: PartialFunction[H2ReqRepFrame, ResponseClass] = {
+        case H2ReqRepFrame(_, Return((_, Some(Return(f: Frame.Trailers))))) =>
+          if (f.get("grpc-status") == Some("0")) ResponseClass.Success
+          else ResponseClass.NonRetryableFailure
+        case _ =>
+          ResponseClass.NonRetryableFailure
+      }
+    }
+
+    val stats = new InMemoryStatsReceiver
+
+    val serverLocalQs = new util.ArrayList[AsyncQueue[Frame]]()
+
+    val underlying = ServiceFactory.const(
+      Service.mk { req: Request =>
+        val q = new AsyncQueue[Frame]()
+        serverLocalQs.add(q)
+        Future.value(Response(Status.Ok, Stream(q)))
+      }
+    )
+
+    val fa = new H2FailureAccrualFactory(
+      underlying,
+      FailureAccrualPolicy.consecutiveFailures(5, SStream.continually(Duration.Top)),
+      timer,
+      stats
+    )
+
+    val svc = new FactoryToService(fa)
+
+    Contexts.local.let(H2ClassifierCtx, param.H2Classifier(classifier)) {
+      val rsps = for (_ <- 1 to 5) yield {
+        await(svc(Request(Headers(":method" -> "GET"), Stream.empty())))
+      }
+
+      assert(fa.status == FStatus.Open)
+
+      for (i <- 0 until 4) {
+        serverLocalQs.get(i).offer(Frame.Trailers("grpc-status" -> "1"))
+        await(rsps(i).stream.read())
+        assert(fa.status == FStatus.Open)
+      }
+      serverLocalQs.get(4).offer(Frame.Trailers("grpc-status" -> "1"))
+      await(rsps(4).stream.read())
+      assert(fa.status == FStatus.Busy)
+    }
+  }
+}


### PR DESCRIPTION
Finagle's FailureAccrualFactory does not use the configured H2Classifier.

Replace FailureAccrualFactory with a new H2FailureAccrualFactory that uses
the context local H2Classifier.