### PR TITLE
Use correct StatsFilter and Classifier for H2

### DIFF
--- a/router/core/src/main/scala/io/buoyant/router/LocalClassifierStatsFilter.scala
+++ b/router/core/src/main/scala/io/buoyant/router/LocalClassifierStatsFilter.scala
@@ -11,7 +11,7 @@ object LocalClassifierStatsFilter {
 
   def module[Req, Rsp]: Stackable[ServiceFactory[Req, Rsp]] =
     new Stack.Module3[param.Stats, param.ExceptionStatsHandler, StatsFilter.Param, ServiceFactory[Req, Rsp]] {
-      val role = StatsFilter.role
+      val role = LocalClassifierStatsFilter.role
       val description = "Report request statistics using local response classifier"
 
       def make(

--- a/router/h2/src/main/scala/io/buoyant/router/h2/LocalClassifierStreamStatsFilter.scala
+++ b/router/h2/src/main/scala/io/buoyant/router/h2/LocalClassifierStreamStatsFilter.scala
@@ -13,10 +13,13 @@ import io.buoyant.router.context.h2.H2ClassifierCtx
  */
 object LocalClassifierStreamStatsFilter {
 
+  val role: Stack.Role = LocalClassifierStatsFilter.role
+  val description = "Report request statistics using local H2 stream classifier"
+
   val module: Stackable[ServiceFactory[Request, Response]] =
     new Stack.Module3[param.Stats, param.ExceptionStatsHandler, StreamStatsFilter.Param, ServiceFactory[Request, Response]] {
-      val role: Stack.Role = LocalClassifierStatsFilter.role
-      val description = "Report request statistics using local H2 stream classifier"
+      val role: Stack.Role = LocalClassifierStreamStatsFilter.role
+      val description = LocalClassifierStreamStatsFilter.description
 
       override def make(
         statsP: param.Stats,

--- a/router/h2/src/main/scala/io/buoyant/router/h2/PerDstPathStreamStatsFilter.scala
+++ b/router/h2/src/main/scala/io/buoyant/router/h2/PerDstPathStreamStatsFilter.scala
@@ -28,13 +28,13 @@ object PerDstPathStreamStatsFilter {
         statsP match {
           case param.Stats(stats) if !stats.isNull =>
             val StreamStatsFilter.Param(timeUnit) = statsFilterP
-            val H2Classifier(classifier) =
-              H2ClassifierCtx.current.getOrElse(H2Classifier.param.default)
             val param.ExceptionStatsHandler(exHandler) = exHandlerP
 
             def mkScopedStatsFilter(path: Path): SimpleFilter[Request, Response] = {
               val name = path.show.stripPrefix("/")
               val scopedStats = stats.scope("service", name)
+              val H2Classifier(classifier) =
+                H2ClassifierCtx.current.getOrElse(H2Classifier.param.default)
               new StreamStatsFilter(scopedStats, classifier, exHandler, timeUnit)
             }
 

--- a/router/h2/src/test/scala/io/buoyant/router/H2Test.scala
+++ b/router/h2/src/test/scala/io/buoyant/router/H2Test.scala
@@ -1,0 +1,24 @@
+package io.buoyant.router
+
+import com.twitter.finagle.Stack
+import io.buoyant.router.h2.{LocalClassifierStreamStatsFilter, PerDstPathStreamStatsFilter}
+import io.buoyant.test.FunSuite
+
+class H2Test extends FunSuite {
+
+  def get[T](stk: Stack[T], role: Stack.Role): Option[Stack[T]] = {
+    var found: Option[Stack[T]] = None
+    stk.foreach { s =>
+      if (s.head.role == role) found = Some(s)
+    }
+    found
+  }
+
+  test("client stack contains classified stream filter") {
+    val statsModule = get(H2.router.client.stack, LocalClassifierStreamStatsFilter.role).get
+    assert(statsModule.head.description == LocalClassifierStreamStatsFilter.description)
+
+    val perDstStats = get(H2.router.client.stack, PerDstPathStreamStatsFilter.module.role).get
+    assert(perDstStats.head.description == "perdstpathstatsfilter, using H2 stream classification")
+  }
+}


### PR DESCRIPTION
Due to a discrepncy in the LocalClassifierStatsFilter role, the H2 client stack
did not include the LocalClassifierStreamStatsFilter.  This was causing the
success/failures stats to be incorrect at the client level.  Furthermore, the
PerDstPathStreamStatsFilter was reading the H2Classifier from the local context
outside of the request path which was causing the wrong classifier to be used.
This was causing the client/*/service success/failure stats to be incorrect.

Fix the LocalClassifierStatsFilter role so that
LocalClassifierStreamStatsFilter gets added to the H2 client stack.  Modify
PerDstPathStreamStatsFilter to read the H2Classifier in the request path.