### PR TITLE
Use request local classifier for failure accrual

### DIFF
--- a/router/core/src/main/scala/com/twitter/finagle/buoyant/FailureAccrualFactory.scala
+++ b/router/core/src/main/scala/com/twitter/finagle/buoyant/FailureAccrualFactory.scala
@@ -11,6 +11,10 @@ import com.twitter.logging.Level
 import com.twitter.util.Timer
 import io.buoyant.router.context.ResponseClassifierCtx
 
+/**
+ * A replacement for Finagle's FailureAccrualFactory that reads the respones classifier from the
+ * request local context.
+ */
 object FailureAccrualFactory {
 
   def module[Req, Rep]: Stackable[ServiceFactory[Req, Rep]] =

--- a/router/core/src/main/scala/com/twitter/finagle/buoyant/FailureAccrualFactory.scala
+++ b/router/core/src/main/scala/com/twitter/finagle/buoyant/FailureAccrualFactory.scala
@@ -1,0 +1,86 @@
+package com.twitter.finagle.buoyant
+
+import com.twitter.finagle.Stack.{Params, Role}
+import com.twitter.finagle.client.Transporter
+import com.twitter.finagle.liveness.{FailureAccrualPolicy, FailureAccrualFactory => FFailureAccrualFactory}
+import com.twitter.finagle.liveness.FailureAccrualFactory.Param
+import com.twitter.finagle.service.{ReqRep, ResponseClass, ResponseClassifier}
+import com.twitter.finagle.stats.StatsReceiver
+import com.twitter.finagle.{ServiceFactory, Stack, Stackable, param}
+import com.twitter.logging.Level
+import com.twitter.util.Timer
+import io.buoyant.router.context.ResponseClassifierCtx
+
+object FailureAccrualFactory {
+
+  def module[Req, Rep]: Stackable[ServiceFactory[Req, Rep]] =
+    new Stack.ModuleParams[ServiceFactory[Req, Rep]] {
+      val role: Role = FFailureAccrualFactory.role
+      val description: String = "Backoff from hosts that we cannot successfully make requests to using local response classifier"
+      override def parameters: Seq[Stack.Param[_]] = Seq(
+        implicitly[Stack.Param[param.Stats]],
+        implicitly[Stack.Param[Param]],
+        implicitly[Stack.Param[param.Timer]],
+        implicitly[Stack.Param[param.Label]],
+        implicitly[Stack.Param[param.Logger]],
+        implicitly[Stack.Param[Transporter.EndpointAddr]]
+      )
+
+      def make(params: Params, next: ServiceFactory[Req, Rep]): ServiceFactory[Req, Rep] = {
+        params[Param] match {
+          case Param.Configured(policy) =>
+            val timer = params[param.Timer].timer
+            val statsReceiver = params[param.Stats].statsReceiver
+
+            // extract some info useful for logging
+            val logger = params[param.Logger].log
+            val endpoint = params[Transporter.EndpointAddr].addr
+            val label = params[param.Label].label
+
+            new FailureAccrualFactory[Req, Rep](
+              underlying = next,
+              policy = policy(),
+              timer = timer,
+              statsReceiver = statsReceiver.scope("failure_accrual")
+            ) {
+              override def didMarkDead(): Unit = {
+                logger.log(
+                  Level.INFO,
+                  s"""FailureAccrualFactory marking connection to "$label" as dead. """ +
+                    s"""Remote Address: $endpoint"""
+                )
+                super.didMarkDead()
+              }
+            }
+
+          case Param.Replaced(f) =>
+            f(params[param.Timer].timer).andThen(next)
+
+          case Param.Disabled =>
+            next
+        }
+      }
+    }
+
+  val NullResponseClassifier: ResponseClassifier = {
+    case _ => throw new NotImplementedError()
+  }
+}
+
+class FailureAccrualFactory[Req, Rep](
+  underlying: ServiceFactory[Req, Rep],
+  policy: FailureAccrualPolicy,
+  timer: Timer,
+  statsReceiver: StatsReceiver
+) extends FFailureAccrualFactory[Req, Rep](
+  underlying, policy, FailureAccrualFactory.NullResponseClassifier, timer, statsReceiver
+) {
+  override protected def isSuccess(reqRep: ReqRep): Boolean = {
+    val param.ResponseClassifier(classifier) =
+      ResponseClassifierCtx.current.getOrElse(param.ResponseClassifier.param.default)
+    classifier.applyOrElse(reqRep, ResponseClassifier.Default) match {
+      case ResponseClass.Successful(_) => true
+      case ResponseClass.Failed(_) => false
+    }
+  }
+}

--- a/router/core/src/main/scala/io/buoyant/router/Router.scala
+++ b/router/core/src/main/scala/io/buoyant/router/Router.scala
@@ -3,6 +3,7 @@ package io.buoyant.router
 import com.twitter.finagle._
 import com.twitter.finagle.buoyant._
 import com.twitter.finagle.client._
+import com.twitter.finagle.liveness.{FailureAccrualFactory => FFailureAccrualFactory}
 import com.twitter.finagle.naming.buoyant.DstBindingFactory
 import com.twitter.finagle.server.StackServer
 import com.twitter.finagle.service.{FailFastFactory, Retries, StatsFilter}
@@ -314,6 +315,7 @@ object StackRouter {
         .insertBefore(StatsFilter.role, PerDstPathStatsFilter.module[Req, Rsp])
         .replace(StatsFilter.role, LocalClassifierStatsFilter.module[Req, Rsp])
         .insertBefore(Retries.Role, RetryBudgetModule.module[Req, Rsp])
+        .replace(FFailureAccrualFactory.role, FailureAccrualFactory.module[Req, Rsp])
   }
 
   def newPathStack[Req, Rsp]: Stack[ServiceFactory[Req, Rsp]] = {

--- a/router/h2/src/main/scala/io/buoyant/router/h2/StreamStatsFilter.scala
+++ b/router/h2/src/main/scala/io/buoyant/router/h2/StreamStatsFilter.scala
@@ -29,13 +29,7 @@ object StreamStatsFilter {
    * Creates a [[com.twitter.finagle.Stackable]] [[StreamStatsFilter]].
    */
   val module: Stackable[ServiceFactory[Request, Response]] =
-    new Stack.Module4[
-      param.Stats,
-      h2param.H2Classifier,
-      param.ExceptionStatsHandler,
-      Param,
-      ServiceFactory[Request, Response]
-    ] {
+    new Stack.Module4[param.Stats, h2param.H2Classifier, param.ExceptionStatsHandler, Param, ServiceFactory[Request, Response]] {
       override val role: Stack.Role = StreamStatsFilter.role
       override val description = "Record stats on h2 streams"
       override def make(


### PR DESCRIPTION
FailureAccrualFactory uses the response classifier configured on the stack
instead of the response classifier from the request local context.  This means
that circuit breakers will trip on different success criteria than is used for
stats reporting.

Replace Finagle's FailureAccrualFactory with a subclass which uses the response
classifier from the request local context.