### PR TITLE
Add counter for classification timeout

### DIFF
--- a/router/h2/src/main/scala/io/buoyant/router/h2/StreamStatsFilter.scala
+++ b/router/h2/src/main/scala/io/buoyant/router/h2/StreamStatsFilter.scala
@@ -29,13 +29,7 @@ object StreamStatsFilter {
    * Creates a [[com.twitter.finagle.Stackable]] [[StreamStatsFilter]].
    */
   val module: Stackable[ServiceFactory[Request, Response]] =
-    new Stack.Module4[
-      param.Stats,
-      h2param.H2Classifier,
-      param.ExceptionStatsHandler,
-      Param,
-      ServiceFactory[Request, Response]
-    ] {
+    new Stack.Module4[param.Stats, h2param.H2Classifier, param.ExceptionStatsHandler, Param, ServiceFactory[Request, Response]] {
       override val role: Stack.Role = StreamStatsFilter.role
       override val description = "Record stats on h2 streams"
       override def make(

--- a/router/h2/src/test/scala/io/buoyant/router/h2/ClassifiedRetryFilterTest.scala
+++ b/router/h2/src/test/scala/io/buoyant/router/h2/ClassifiedRetryFilterTest.scala
@@ -98,6 +98,7 @@ class ClassifiedRetryFilterTest extends FunSuite {
     assert(stats.stats(Seq("retries", "per_request")) == Seq(2f))
     assert(stats.counters.get(Seq("retries", "request_stream_too_long")) == None)
     assert(stats.counters.get(Seq("retries", "response_stream_too_long")) == None)
+    assert(stats.counters.get(Seq("retries", "classification_timeout")) == None)
   }
 
   test("response not retryable") {
@@ -122,6 +123,7 @@ class ClassifiedRetryFilterTest extends FunSuite {
     assert(stats.stats(Seq("retries", "per_request")) == Seq(0f))
     assert(stats.counters.get(Seq("retries", "request_stream_too_long")) == None)
     assert(stats.counters.get(Seq("retries", "response_stream_too_long")) == None)
+    assert(stats.counters.get(Seq("retries", "classification_timeout")) == None)
   }
 
   test("request stream too long to retry") {
@@ -152,6 +154,7 @@ class ClassifiedRetryFilterTest extends FunSuite {
     assert(stats.stats(Seq("retries", "per_request")) == Seq(0f))
     assert(stats.counters(Seq("retries", "request_stream_too_long")) == 1)
     assert(stats.counters.get(Seq("retries", "response_stream_too_long")) == None)
+    assert(stats.counters.get(Seq("retries", "classification_timeout")) == None)
   }
 
   test("response stream too long to retry") {
@@ -182,6 +185,7 @@ class ClassifiedRetryFilterTest extends FunSuite {
     assert(stats.stats(Seq("retries", "per_request")) == Seq(0f))
     assert(stats.counters.get(Seq("retries", "request_stream_too_long")) == None)
     assert(stats.counters(Seq("retries", "response_stream_too_long")) == 1)
+    assert(stats.counters.get(Seq("retries", "classification_timeout")) == None)
   }
 
   test("early classification") {
@@ -206,6 +210,7 @@ class ClassifiedRetryFilterTest extends FunSuite {
     assert(stats.stats(Seq("retries", "per_request")) == Seq(0f))
     assert(stats.counters.get(Seq("retries", "request_stream_too_long")) == None)
     assert(stats.counters.get(Seq("retries", "response_stream_too_long")) == None)
+    assert(stats.counters.get(Seq("retries", "classification_timeout")) == None)
   }
 
   test("classification timeout") {
@@ -245,5 +250,6 @@ class ClassifiedRetryFilterTest extends FunSuite {
     assert(stats.stats(Seq("retries", "per_request")) == Seq(0f))
     assert(stats.counters.get(Seq("retries", "request_stream_too_long")) == None)
     assert(stats.counters.get(Seq("retries", "response_stream_too_long")) == None)
+    assert(stats.counters(Seq("retries", "classification_timeout")) == 1)
   }
 }


### PR DESCRIPTION
If ClassifiedRetryFilter does not fully buffer a response within a certain
amount of time, it returns it to the caller and does not attempt to retry.
We have no visibility in to how often this happens.

Add a counter that keeps track of how often this happens.