### PR TITLE
Support for charset in Content-Type header in dtab REST API (#1536)

### DIFF
--- a/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/Json.scala
+++ b/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/Json.scala
@@ -25,7 +25,7 @@ object Json {
 }
 
 sealed trait DtabCodec {
-  def contentTypes: Set[String]
+  def mediaTypes: Set[String]
   def write(dtab: Dtab): Buf
   def read(buf: Buf): Try[Dtab]
 }
@@ -33,14 +33,14 @@ sealed trait DtabCodec {
 object DtabCodec {
 
   object JsonCodec extends DtabCodec {
-    val contentTypes = Set(MediaType.Json)
+    val mediaTypes = Set(MediaType.Json)
     def write(dtab: Dtab) = Json.write(dtab)
     def read(buf: Buf) =
       Json.read[IndexedSeq[Dentry]](buf).map(Dtab(_))
   }
 
   object TextCodec extends DtabCodec {
-    val contentTypes = Set("application/dtab", MediaType.Txt)
+    val mediaTypes = Set("application/dtab", MediaType.Txt)
     def write(dtab: Dtab) = Buf.Utf8(dtab.show)
     def read(buf: Buf) = {
       val Buf.Utf8(d) = buf
@@ -50,13 +50,13 @@ object DtabCodec {
 
   def accept(types: Seq[String]): Option[(String, DtabCodec)] =
     types.map(_.toLowerCase).foldLeft[Option[(String, DtabCodec)]](None) {
-      case (None, ct) => byContentType(ct).map(ct -> _)
+      case (None, mt) => byMediaType(mt).map(mt -> _)
       case (t, _) => t
     }
 
-  def byContentType(ct: String): Option[DtabCodec] =
-    if (JsonCodec.contentTypes(ct)) Some(DtabCodec.JsonCodec)
-    else if (TextCodec.contentTypes(ct)) Some(DtabCodec.TextCodec)
+  def byMediaType(ct: String): Option[DtabCodec] =
+    if (JsonCodec.mediaTypes(ct)) Some(DtabCodec.JsonCodec)
+    else if (TextCodec.mediaTypes(ct)) Some(DtabCodec.TextCodec)
     else None
 
   val default = (MediaType.Json, JsonCodec)

--- a/namerd/iface/control-http/src/test/scala/io/buoyant/namerd/iface/HttpControlServiceTest.scala
+++ b/namerd/iface/control-http/src/test/scala/io/buoyant/namerd/iface/HttpControlServiceTest.scala
@@ -159,15 +159,22 @@ class HttpControlServiceTest extends FunSuite with Awaits {
     rsp.reader.discard()
   }
 
-  for (ct <- Seq("application/dtab", MediaType.Txt))
-    test(s"GET /api/1/dtabs/ns exists; accept $ct") {
+  val acceptsAndMediaTypes = List(
+    ("application/dtab", "application/dtab"),
+    ("application/dtab;q=0.9", "application/dtab"),
+    (MediaType.Txt, MediaType.Txt),
+    (MediaType.Txt + ";q=0.9", MediaType.Txt)
+  )
+
+  for ((a, mt) <- acceptsAndMediaTypes)
+    test(s"GET /api/1/dtabs/ns exists; accept $a") {
       val req = Request()
       req.uri = "/api/1/dtabs/yeezus"
-      req.accept = Seq(ct, MediaType.Json)
+      req.accept = Seq(a, MediaType.Json)
       val service = newService()
       val rsp = Await.result(service(req), 1.second)
       assert(rsp.status == Status.Ok)
-      assert(rsp.contentType == Some(ct))
+      assert(rsp.contentType == Some(mt))
       assert(rsp.headerMap("ETag") == v1Stamp)
       assert(rsp.contentString == defaultDtabs("yeezus").show + "\n")
     }
@@ -204,6 +211,7 @@ class HttpControlServiceTest extends FunSuite with Awaits {
 
   val data = Map(
     MediaType.Json -> """[{"prefix":"/yeezy","dst":"/kanye"}]""",
+    MediaType.Json + ";charset=UTF-8" -> """[{"prefix":"/yeezy","dst":"/kanye"}]""",
     MediaType.Txt -> "/yeezy => /kanye",
     "application/dtab" -> "/yeezy => /kanye"
   )


### PR DESCRIPTION
This is a fix for #1536 