### PR TITLE
Remove deprecated sbt operators

### DIFF
--- a/project/Base.scala
+++ b/project/Base.scala
@@ -101,9 +101,9 @@ class Base extends Build {
           <url>https://buoyant.io/</url>
         </developer>
       </developers>,
-    publishTo <<= version { (v: String) =>
+    publishTo := {
       val nexus = "https://oss.sonatype.org/"
-      if (v.trim.endsWith("SNAPSHOT"))
+      if (version.value.trim.endsWith("SNAPSHOT"))
         Some("snapshots" at nexus + "content/repositories/snapshots")
       else
         Some("releases"  at nexus + "service/local/staging/deploy/maven2")
@@ -153,9 +153,9 @@ class Base extends Build {
 
   val appPackagingSettings = baseDockerSettings ++ appAssemblySettings ++ Seq(
     assemblyJarName in assembly := s"${name.value}-${version.value}-${configuration.value}-exec",
-    docker <<= docker dependsOn (assembly in configuration),
+    docker := (docker dependsOn (assembly in configuration)).value,
     dockerEnvPrefix := "",
-    dockerJavaImage <<= (dockerJavaImage in Global).?(_.getOrElse("openjdk:8u131-jre")),
+    dockerJavaImage := (dockerJavaImage in Global).?(_.getOrElse("openjdk:8u131-jre")).value,
     dockerfile in docker := new Dockerfile {
       val envPrefix = dockerEnvPrefix.value.toUpperCase
       val home = s"/${organization.value}/${name.value}/${version.value}"

--- a/project/Base.scala
+++ b/project/Base.scala
@@ -168,7 +168,9 @@ class Base extends Build {
       copy((assemblyOutputPath in assembly).value, exec)
       entryPoint(exec)
     },
-    dockerTag <<= (dockerTag in Global).or((version, configuration) { (v, c) => s"${v}-${c}" }),
+    dockerTag += (dockerTag in Global).or( initialize[String] { _ =>
+      s"$version-$configuration"
+    }).value,
     imageName in docker := ImageName(
       namespace = Some("buoyantio"),
       repository = name.value,

--- a/project/Base.scala
+++ b/project/Base.scala
@@ -279,11 +279,11 @@ class Base extends Build {
 
     /** Writes build metadata into the projects resources */
     def withBuildProperties(path: String): Project = project
-      .settings((resourceGenerators in Compile) <+=
-        (resourceManaged in Compile, name, version).map { (dir, name, ver) =>
+      .settings((resourceGenerators in Compile) += task[Seq[File]] {
+          val dir = (resourceManaged in Compile).value
           val rev = Git.revision
           val build = new java.text.SimpleDateFormat("yyyyMMdd-HHmmss").format(new java.util.Date)
-          val contents = s"name=$name\nversion=$ver\nbuild_revision=$rev\nbuild_name=$build"
+          val contents = s"name=${name.value}\nversion=${version.value}\nbuild_revision=$rev\nbuild_name=$build"
           val file = dir / path / "build.properties"
           IO.write(file, contents)
           Seq(file)

--- a/project/Base.scala
+++ b/project/Base.scala
@@ -171,11 +171,11 @@ class Base extends Build {
     dockerTag += (dockerTag in Global).or( initialize[String] { _ =>
       s"$version-$configuration"
     }).value,
-    imageName in docker := ImageName(
+    imageNames in docker := Seq(ImageName(
       namespace = Some("buoyantio"),
       repository = name.value,
       tag = Some(dockerTag.value)
-    )
+    ))
   )
 
   // Examples are named by a .yaml config file

--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -395,10 +395,10 @@ object LinkerdBuild extends Base {
       .configDependsOn(Dcos)(dcosBootstrap)
       .settings(inConfig(Dcos)(DcosSettings))
       .settings(
-        assembly <<= assembly in Bundle,
-        docker <<= docker in Bundle,
-        dockerBuildAndPush <<= dockerBuildAndPush in Bundle,
-        dockerPush <<= dockerPush in Bundle
+        assembly := (assembly in Bundle).value,
+        docker := (docker in Bundle).value,
+        dockerBuildAndPush := (dockerBuildAndPush in Bundle).value,
+        dockerPush := (dockerPush in Bundle).value
       )
 
     // Find example configurations by searching the examples directory for config files.
@@ -597,10 +597,10 @@ object LinkerdBuild extends Base {
       .configDependsOn(LowMem)(BundleProjects: _*)
       .settings(inConfig(LowMem)(LowMemSettings))
       .settings(
-        assembly <<= assembly in Bundle,
-        docker <<= docker in Bundle,
-        dockerBuildAndPush <<= dockerBuildAndPush in Bundle,
-        dockerPush <<= dockerPush in Bundle
+        assembly := (assembly in Bundle).value,
+        docker := (docker in Bundle).value,
+        dockerBuildAndPush := (dockerBuildAndPush in Bundle).value,
+        dockerPush := (dockerPush in Bundle).value
       )
 
     // Find example configurations by searching the examples directory for config files.


### PR DESCRIPTION
The key dependency operators (`<<=`, `<+=`, `<++=`) and tuple enrichments for `TaskKey`s and `SettingKey`s are [deprecated in sbt 0.13.13](http://www.scala-sbt.org/0.13/docs/Migrating-from-sbt-012x.html). Building Linkerd with sbt 0.13.13 currently generates a bunch of warnings due to our use of deprecated features. Furthermore, according to the sbt documentation, these features are slated for removal in sbt 1.0, so I thought we ought to remove them.

I've rewritten the parts of our build file that use these deprecated features to use the `.value` DSL instead.

I've ran our tests with the new build file, and everything appears to work correctly. Furthermore, I ran the `docker` task on my branch and compared the tags of the generated Docker images with those generated by the `docker` task on master, to ensure that the tag was still being generated correctly after my changes.