### PR TITLE
Grpc-Status code may come in H2 headers

### DIFF
--- a/grpc/runtime/src/main/scala/io/buoyant/grpc/runtime/Codec.scala
+++ b/grpc/runtime/src/main/scala/io/buoyant/grpc/runtime/Codec.scala
@@ -77,7 +77,7 @@ object Codec {
     def accum(orig: Buf): Future[(Buf, GrpcStatus)] =
       stream.read().flatMap {
         case t: h2.Frame.Trailers =>
-          val status = GrpcStatus.fromTrailers(t)
+          val status = GrpcStatus.fromHeaders(t)
           t.release()
           Future.value(orig -> status)
 

--- a/grpc/runtime/src/main/scala/io/buoyant/grpc/runtime/DecodingStream.scala
+++ b/grpc/runtime/src/main/scala/io/buoyant/grpc/runtime/DecodingStream.scala
@@ -109,7 +109,7 @@ object DecodingStream {
   ): Stream[T] = new DecodingStream[T] {
     protected[this] val frames: h2.Stream = rsp.stream
     protected[this] def decoder: ByteBuffer => T = decodeF
-    protected[this] val getStatus: h2.Frame.Trailers => GrpcStatus = GrpcStatus.fromTrailers(_)
+    protected[this] val getStatus: h2.Frame.Trailers => GrpcStatus = GrpcStatus.fromHeaders(_)
   }
 
   private sealed trait RecvState

--- a/grpc/runtime/src/test/scala/io/buoyant/grpc/runtime/DecodingStreamTest.scala
+++ b/grpc/runtime/src/test/scala/io/buoyant/grpc/runtime/DecodingStreamTest.scala
@@ -19,7 +19,7 @@ class DecodingStreamTest extends FunSuite {
         decodedLength += bb.remaining
         bb.remaining
       }
-      protected[this] val getStatus: h2.Frame.Trailers => GrpcStatus = GrpcStatus.fromTrailers(_)
+      protected[this] val getStatus: h2.Frame.Trailers => GrpcStatus = GrpcStatus.fromHeaders(_)
     }
 
     // We lay out 4 pseudo-messages across 3 frames:

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/grpc/GrpcClassifier.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/grpc/GrpcClassifier.scala
@@ -7,6 +7,9 @@ import io.buoyant.grpc.runtime.GrpcStatus
 import io.buoyant.grpc.runtime.GrpcStatus.{Ok, Unavailable}
 
 trait GrpcClassifier extends H2Classifier {
+
+  def retryable(status: GrpcStatus): Boolean
+
   /**
    * @inheritdoc
    * Since GRPC sends status codes in the
@@ -16,19 +19,19 @@ trait GrpcClassifier extends H2Classifier {
    */
   override val responseClassifier: PartialFunction[H2ReqRep, ResponseClass] = {
     case H2ReqRep(_, Throw(_)) => ResponseClass.NonRetryableFailure
+    case H2ReqRep(_, Return(GrpcStatus(Ok(_)))) => ResponseClass.Success
+    case H2ReqRep(_, Return(GrpcStatus(status))) =>
+      if (retryable(status)) ResponseClass.RetryableFailure
+      else ResponseClass.NonRetryableFailure
   }
 
-  private[this] val successClassifier: PartialFunction[H2ReqRepFrame, ResponseClass] = {
-    case H2ReqRepFrame(_, Return((_, Some(Return(GrpcStatus(Ok(_))))))) =>
-      ResponseClass.Success
+  override def streamClassifier: PartialFunction[H2ReqRepFrame, ResponseClass] = {
+    case H2ReqRepFrame(_, Return((_, Some(Return(GrpcStatus(Ok(_))))))) => ResponseClass.Success
+    case H2ReqRepFrame(_, Return((_, Some(Return(GrpcStatus(status)))))) =>
+      if (retryable(status)) ResponseClass.RetryableFailure
+      else ResponseClass.NonRetryableFailure
+    case _ => ResponseClass.NonRetryableFailure
   }
-
-  override def streamClassifier: PartialFunction[H2ReqRepFrame, ResponseClass] =
-    successClassifier.orElse(retryableClassifier).orElse {
-      case _ => ResponseClass.NonRetryableFailure
-    }
-
-  def retryableClassifier: PartialFunction[H2ReqRepFrame, ResponseClass]
 }
 
 /**
@@ -41,12 +44,7 @@ object GrpcClassifiers {
    * codes as [[ResponseClass.RetryableFailure]]
    */
   object AlwaysRetryable extends GrpcClassifier {
-
-    override val retryableClassifier: PartialFunction[H2ReqRepFrame, ResponseClass] = {
-      case H2ReqRepFrame(_, Return((_, Some(Return(GrpcStatus(_)))))) =>
-        ResponseClass.RetryableFailure
-    }
-
+    override def retryable(status: GrpcStatus): Boolean = true
   }
 
   /**
@@ -54,12 +52,7 @@ object GrpcClassifiers {
    * codes as [[ResponseClass.NonRetryableFailure]]
    */
   object NeverRetryable extends GrpcClassifier {
-
-    override val retryableClassifier: PartialFunction[H2ReqRepFrame, ResponseClass] = {
-      case H2ReqRepFrame(_, Return((_, Some(Return(GrpcStatus(_)))))) =>
-        ResponseClass.NonRetryableFailure
-    }
-
+    override def retryable(status: GrpcStatus): Boolean = false
   }
 
   /**
@@ -69,12 +62,10 @@ object GrpcClassifiers {
    * failures are marked as non-retryable.
    */
   object Default extends GrpcClassifier {
-
-    override val retryableClassifier: PartialFunction[H2ReqRepFrame, ResponseClass] = {
-      case H2ReqRepFrame(_, Return((_, Some(Return(GrpcStatus(Unavailable(_))))))) =>
-        ResponseClass.RetryableFailure
+    override def retryable(status: GrpcStatus): Boolean = status match {
+      case Unavailable(_) => true
+      case _ => false
     }
-
   }
 
   /**
@@ -83,10 +74,6 @@ object GrpcClassifiers {
    * @param retryableCodes a set of status codes which should be marked retryable
    */
   class RetryableStatusCodes(val retryableCodes: Set[Int]) extends GrpcClassifier {
-    override val retryableClassifier: PartialFunction[H2ReqRepFrame, ResponseClass] = {
-      case H2ReqRepFrame(_, Return((_, Some(Return(GrpcStatus(status)))))) if retryableCodes.contains(status.code) =>
-        ResponseClass.RetryableFailure
-    }
+    override def retryable(status: GrpcStatus): Boolean = retryableCodes(status.code)
   }
-
 }

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/grpc/GrpcClassifierConfig.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/grpc/GrpcClassifierConfig.scala
@@ -1,7 +1,5 @@
 package io.buoyant.linkerd.protocol.h2.grpc
 
-import com.fasterxml.jackson.annotation.JsonSubTypes
-import com.fasterxml.jackson.annotation.JsonSubTypes.Type
 import com.twitter.finagle.buoyant.h2.service.H2Classifier
 import io.buoyant.linkerd.protocol.h2._
 
@@ -17,7 +15,7 @@ class NeverRetryableInitializer extends H2ClassifierInitializer {
 object NeverRetryableInitializer extends NeverRetryableInitializer
 
 class AlwaysRetryableConfig extends H2ClassifierConfig {
-  override def mk: H2Classifier = GrpcClassifiers.NeverRetryable
+  override def mk: H2Classifier = GrpcClassifiers.AlwaysRetryable
 }
 
 class AlwaysRetryableInitializer extends H2ClassifierInitializer {


### PR DESCRIPTION
The grpc response classifiers assume that the grpc-status code will appear in
a trailers frame but this is not always the case.  If a response has no data
frames, the grpc-status may appear in the headers frame and the stream will be
empty.  The grpc response classifiers fail to correctly classify in this case.

Change the grpc response classifiers to check the headers frame for a
grpc-status code as part of early classification.