### PR TITLE
Fix retry budget widget on the admin dashboard

### DIFF
--- a/admin/src/main/resources/io/buoyant/admin/js/src/router_summary.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/router_summary.js
@@ -140,10 +140,15 @@ define([
       if (!config) return DEFAULT_BUDGET;
 
       var routerObj = _.find(config.routers, function(router) {
-        return router.label === routerName;
+        if (router.label) {
+            return router.label === routerName;
+        } else {
+            return router.protocol == routerName;
+        }
+
       });
 
-      return _.get(routerObj, 'client.retries.budget.percentCanRetry', DEFAULT_BUDGET);
+      return _.get(routerObj, 'service.retries.budget.percentCanRetry', DEFAULT_BUDGET);
     }
 
     return function(metricsCollector, $summaryEl, $barChartEl, routerName, routerConfig) {


### PR DESCRIPTION
The retry budget widget always showed a budget of 20% regardless of the actual
budget.

Update the code to read the retry budget from the correct location.