### PR TITLE
Ensure headers-only streams are closed

### DIFF
--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/H2.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/H2.scala
@@ -53,11 +53,9 @@ object H2 extends Client[Request, Response] with Server[Request, Response] {
     ): Client = copy(stack, params)
 
     private[this] lazy val param.Stats(statsReceiver) = params[param.Stats]
-    private[this] lazy val streamStats =
-      new Netty4StreamTransport.StatsReceiver(statsReceiver.scope("stream"))
 
     protected def newDispatcher(trans: Http2FrameTransport): Service[Request, Response] =
-      new Netty4ClientDispatcher(trans, streamStats)
+      new Netty4ClientDispatcher(trans, statsReceiver.scope("stream"))
   }
 
   val client = Client()
@@ -96,15 +94,13 @@ object H2 extends Client[Request, Response] with Server[Request, Response] {
       Netty4H2Listener.mk(params)
 
     private[this] lazy val statsReceiver = params[param.Stats].statsReceiver
-    private[this] lazy val streamStats =
-      new Netty4StreamTransport.StatsReceiver(statsReceiver.scope("stream"))
 
     /** A dispatcher is created for each inbound HTTP/2 connection. */
     protected def newDispatcher(
       trans: Http2FrameTransport,
       service: Service[Request, Response]
     ): Closable = {
-      new Netty4ServerDispatcher(trans, service, streamStats)
+      new Netty4ServerDispatcher(trans, service, statsReceiver.scope("stream"))
     }
   }
 

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4StreamTransport.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4StreamTransport.scala
@@ -510,7 +510,10 @@ private[h2] trait Netty4StreamTransport[SendMsg <: Message, RecvMsg <: Message] 
    */
   def send(msg: SendMsg): Future[Future[Unit]] = {
     val headersF = writeHeaders(msg.headers, msg.stream.isEmpty)
-    val streamFF = headersF.map(_ => writeStream(msg.stream))
+    val streamFF = headersF.map { _ =>
+      if (msg.stream.isEmpty) Future.Unit
+      else writeStream(msg.stream)
+    }
 
     val writeF = streamFF.flatten
     onReset.onFailure(writeF.raise(_))
@@ -615,7 +618,7 @@ object Netty4StreamTransport {
     override def read(): Future[Frame] = Future.exception(Reset.NoError)
   }
 
-  class StatsReceiver(underlying: FStatsReceiver) {
+  class StatsReceiver(val underlying: FStatsReceiver) {
     private[this] val local = underlying.scope("local")
     private[this] val localDataBytes = local.stat("data", "bytes")
     private[this] val localDataFrames = local.counter("data", "frames")

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4StreamTransport.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4StreamTransport.scala
@@ -542,7 +542,7 @@ private[h2] trait Netty4StreamTransport[SendMsg <: Message, RecvMsg <: Message] 
         localReset(Reset.InternalError)
     }
 
-    streamFF
+    localResetOnCancel(streamFF)
   }
 
   private[this] val writeHeaders: (Headers, Boolean) => Future[Unit] = { (hdrs, eos) =>

--- a/finagle/h2/src/test/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4ClientDispatcherTest.scala
+++ b/finagle/h2/src/test/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4ClientDispatcherTest.scala
@@ -36,8 +36,7 @@ class Netty4ClientDispatcherTest extends FunSuite {
     }
 
     val stats = new InMemoryStatsReceiver
-    val tstats = new Netty4StreamTransport.StatsReceiver(stats)
-    val dispatcher = new Netty4ClientDispatcher(transport, tstats)
+    val dispatcher = new Netty4ClientDispatcher(transport, stats)
     assert(dispatcher.status == SvcStatus.Open)
 
     var released = 0

--- a/finagle/h2/src/test/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4ServerDispatcherTest.scala
+++ b/finagle/h2/src/test/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4ServerDispatcherTest.scala
@@ -57,8 +57,7 @@ class Netty4ServerDispatcherTest extends FunSuite {
     }
 
     val stats = new InMemoryStatsReceiver
-    val tstats = new Netty4StreamTransport.StatsReceiver(stats)
-    val dispatcher = new Netty4ServerDispatcher(transport, service, tstats)
+    val dispatcher = new Netty4ServerDispatcher(transport, service, stats)
 
     assert(!bartmanCalled.get)
     assert(recvq.offer({

--- a/router/h2/src/main/scala/io/buoyant/router/h2/ClassifiedRetryFilter.scala
+++ b/router/h2/src/main/scala/io/buoyant/router/h2/ClassifiedRetryFilter.scala
@@ -76,11 +76,13 @@ class ClassifiedRetryFilter(
                 } else {
                   // Not enough retry budget to retry.
                   budgetExhausted.incr()
+                  consumeAll(s)
                   orElse
                 }
               case _ =>
                 // We ran out of retries.
                 backoffsExhausted.incr()
+                consumeAll(s)
                 orElse
             }
           case Throw(e) =>


### PR DESCRIPTION
When Netty4StreamTransport writes a message with an empty stream, it will
attempt to read frames off of the stream until it is empty before closing the
local side of the stream.  Since the stream is empty, it will never close
local and the stream will persist in the streams hashtable forever causing
a memory leak.

Do not attempt to read frames off of an empty stream, instead closing local
immediately after headers have been written.