### PR TITLE
1.1.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,24 @@
+## 1.1.3 2017-08-09
+
+The 1.1.3 release of Linkerd is mostly focused on improving our HTTP/2 support,
+including better support for gRPC.  Linkerd now supports automatic retires in
+HTTP/2 for retryable requests, even when there are (small) request or response
+bodies.
+
+* HTTP/2
+  * Cleaned up spurious errors messages in the Linkerd log output.
+  * Added a number of gRPC response classifiers that use the `grpc-status` code
+    to determine if the response was successful and if it should be retried.
+    See [the docs](https://linkerd.io/config/1.1.3/linkerd/index.html#grpc-response-classifiers)
+    for details.
+  * Added support for failure accrual and automatic retries to HTTP/2.
+  * Fixed a memory leak related to messages with only a headers frame.
+* Istio
+  * Added HTTP/2 support to the Istio integration: the `io.l5d.k8s.istio`
+    identifier can now be used in H2 router configs.
+  * Added support for HTTPRedirect Route Rules.
+* The Linkerd and Namerd admin sites can now be configured to require HTTPS.
+
 ## 1.1.2 2017-07-12
 
 * Marathon Namer TLS support, for DC/OS strict mode.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,8 +2,7 @@
 
 The 1.1.3 release of Linkerd is mostly focused on improving our HTTP/2 support,
 including better support for gRPC.  Linkerd now supports automatic retries in
-HTTP/2 for retryable requests, even when there are (small) request or response
-bodies.
+HTTP/2 for retryable requests.
 
 * HTTP/2
   * Cleaned up spurious errors messages in the Linkerd log output.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 ## 1.1.3 2017-08-09
 
 The 1.1.3 release of Linkerd is mostly focused on improving our HTTP/2 support,
-including better support for gRPC.  Linkerd now supports automatic retires in
+including better support for gRPC.  Linkerd now supports automatic retries in
 HTTP/2 for retryable requests, even when there are (small) request or response
 bodies.
 
@@ -9,8 +9,7 @@ bodies.
   * Cleaned up spurious errors messages in the Linkerd log output.
   * Added a number of gRPC response classifiers that use the `grpc-status` code
     to determine if the response was successful and if it should be retried.
-    See [the docs](https://linkerd.io/config/1.1.3/linkerd/index.html#grpc-response-classifiers)
-    for details.
+    See [the docs](https://linkerd.io/config/1.1.3/linkerd/index.html#grpc-response-classifiers) for details.
   * Added support for failure accrual and automatic retries to HTTP/2.
   * Fixed a memory leak related to messages with only a headers frame.
 * Istio

--- a/project/Base.scala
+++ b/project/Base.scala
@@ -32,7 +32,7 @@ object Base {
 class Base extends Build {
   import Base._
 
-  val headVersion = "1.1.2"
+  val headVersion = "1.1.3"
 
   object Git {
     def git(arg: String, args: String*) = Process("git" +: arg +: args)


### PR DESCRIPTION
The 1.1.3 release of Linkerd is mostly focused on improving our HTTP/2 support,
including better support for gRPC.  Linkerd now supports automatic retries in
HTTP/2 for retryable requests.

* HTTP/2
  * Cleaned up spurious errors messages in the Linkerd log output.
  * Added a number of gRPC response classifiers that use the `grpc-status` code
    to determine if the response was successful and if it should be retried.
    See [the docs](https://linkerd.io/config/1.1.3/linkerd/index.html#grpc-response-classifiers) for details.
  * Added support for failure accrual and automatic retries to HTTP/2.
  * Fixed a memory leak related to messages with only a headers frame.
* Istio
  * Added HTTP/2 support to the Istio integration: the `io.l5d.k8s.istio`
    identifier can now be used in H2 router configs.
  * Added support for HTTPRedirect Route Rules.
* The Linkerd and Namerd admin sites can now be configured to require HTTPS.