### PR TITLE
Fix for memory leak when using JsonStreamParser

### DIFF
--- a/config/src/main/scala/io/buoyant/config/JsonStreamParser.scala
+++ b/config/src/main/scala/io/buoyant/config/JsonStreamParser.scala
@@ -111,6 +111,7 @@ class JsonStreamParser(mapper: ObjectMapper with ScalaObjectMapper) {
     AsyncStream.fromFuture(read).flatMap {
       //Fake None element to get around scanLeft being one behind bug
       //Tracked in https://github.com/twitter/util/issues/195
+      //Can be removed once 195 is fixed
       case Some(buf) => Some(buf) +:: None +:: fromReaderJson(r, chunkSize)
       case None => AsyncStream.empty[Option[Buf]]
     }

--- a/config/src/main/scala/io/buoyant/config/JsonStreamParser.scala
+++ b/config/src/main/scala/io/buoyant/config/JsonStreamParser.scala
@@ -109,7 +109,8 @@ class JsonStreamParser(mapper: ObjectMapper with ScalaObjectMapper) {
     }
 
     AsyncStream.fromFuture(read).flatMap {
-      //Fake None element to get around scanLeft being one behind
+      //Fake None element to get around scanLeft being one behind bug
+      //Tracked in https://github.com/twitter/util/issues/195
       case Some(buf) => Some(buf) +:: None +:: fromReaderJson(r, chunkSize)
       case None => AsyncStream.empty[Option[Buf]]
     }


### PR DESCRIPTION
This fixes https://github.com/linkerd/linkerd/issues/1361. It's been tested in a live environment against kube-system and shows no memory leak (the original version hit 300mb usage within 30 minutes on the same environment).