### PR TITLE
Make k8s Ingress class used by Linkerd configurable  (#1433)

### DIFF
--- a/k8s/src/test/scala/io/buoyant/k8s/IngressCacheTest.scala
+++ b/k8s/src/test/scala/io/buoyant/k8s/IngressCacheTest.scala
@@ -1,11 +1,333 @@
 package io.buoyant.k8s
 
+import com.twitter.finagle.Service
+import com.twitter.io.Buf
+import com.twitter.util.Future
 import io.buoyant.test.Awaits
 import org.scalatest.FunSuite
+import com.twitter.finagle.http.{Request, Response}
 
 class IngressCacheTest extends FunSuite with Awaits {
   val host = Some("myhost")
   val ns = Some("ns")
+
+  val ingressResourceListWithManyAnnotatedIngresses =
+    """
+{
+  "kind": "IngressList",
+  "apiVersion": "extensions/v1beta1",
+  "metadata": {
+    "selfLink": "/apis/extensions/v1beta1/ingresses",
+    "resourceVersion": "58101"
+  },
+  "items": [
+    {
+      "metadata": {
+        "name": "istio-ingress",
+        "namespace": "default",
+        "selfLink": "/apis/extensions/v1beta1/namespaces/default/ingresses/istio-ingress",
+        "uid": "07900e6b-813d-11e7-b89b-080027a996b8",
+        "resourceVersion": "58098",
+        "generation": 1,
+        "creationTimestamp": "2017-08-14T22:07:57Z",
+        "annotations": {
+          "kubernetes.io/ingress.class": "istio"
+        }
+      },
+      "spec": {
+        "rules": [
+          {
+            "http": {
+              "paths": [
+                {
+                  "path": "/istio-only",
+                  "backend": {
+                    "serviceName": "httpbin",
+                    "servicePort": 6060
+                  }
+                },
+                {
+                  "path": "/shared",
+                  "backend": {
+                    "serviceName": "httpbin",
+                    "servicePort": 6061
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "metadata": {
+        "name": "linkerd-ingress",
+        "namespace": "default",
+        "selfLink": "/apis/extensions/v1beta1/namespaces/default/ingresses/linkerd-ingress",
+        "uid": "07948e8e-813d-11e7-b89b-080027a996b8",
+        "resourceVersion": "58099",
+        "generation": 1,
+        "creationTimestamp": "2017-08-14T22:07:57Z",
+        "annotations": {
+          "kubernetes.io/ingress.class": "linkerd"
+        }
+      },
+      "spec": {
+        "rules": [
+          {
+            "http": {
+              "paths": [
+                {
+                  "path": "/linkerd-only",
+                  "backend": {
+                    "serviceName": "echo",
+                    "servicePort": 7070
+                  }
+                },
+                {
+                  "path": "/shared",
+                  "backend": {
+                    "serviceName": "echo",
+                    "servicePort": 7071
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "metadata": {
+        "name": "nginx-ingress",
+        "namespace": "default",
+        "selfLink": "/apis/extensions/v1beta1/namespaces/default/ingresses/nginx-ingress",
+        "uid": "078c9288-813d-11e7-b89b-080027a996b8",
+        "resourceVersion": "58096",
+        "generation": 1,
+        "creationTimestamp": "2017-08-14T22:07:57Z",
+        "annotations": {
+          "kubernetes.io/ingress.class": "nginx",
+          "ingress.kubernetes.io/rewrite-target": "/"
+        }
+      },
+      "spec": {
+        "rules": [
+          {
+            "http": {
+              "paths": [
+                {
+                  "path": "/nginx-only",
+                  "backend": {
+                    "serviceName": "nginx",
+                    "servicePort": 8080
+                  }
+                },
+                {
+                  "path": "/shared",
+                  "backend": {
+                    "serviceName": "nginx",
+                    "servicePort": 8081
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    }
+  ]
+}"""
+
+  val ingressResourceListWithMoreThanOneLinkerdIngresses =
+    """
+{
+  "kind": "IngressList",
+  "apiVersion": "extensions/v1beta1",
+  "metadata": {
+    "selfLink": "/apis/extensions/v1beta1/ingresses",
+    "resourceVersion": "58101"
+  },
+  "items": [
+    {
+      "metadata": {
+        "name": "linkerd-ingress",
+        "namespace": "default",
+        "selfLink": "/apis/extensions/v1beta1/namespaces/default/ingresses/istio-ingress",
+        "uid": "07900e6b-813d-11e7-b89b-080027a996b8",
+        "resourceVersion": "58098",
+        "generation": 1,
+        "creationTimestamp": "2017-08-14T22:07:57Z",
+        "annotations": {
+          "kubernetes.io/ingress.class": "linkerd"
+        }
+      },
+      "spec": {
+        "rules": [
+          {
+            "http": {
+              "paths": [
+                {
+                  "path": "/linkerd-1",
+                  "backend": {
+                    "serviceName": "echo1",
+                    "servicePort": 6060
+                  }
+                },
+                {
+                  "path": "/shared",
+                  "backend": {
+                    "serviceName": "shared1",
+                    "servicePort": 6061
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "metadata": {
+        "name": "linkerd-ingress-2",
+        "namespace": "default",
+        "selfLink": "/apis/extensions/v1beta1/namespaces/default/ingresses/linkerd-ingress",
+        "uid": "07948e8e-813d-11e7-b89b-080027a996b8",
+        "resourceVersion": "58099",
+        "generation": 1,
+        "creationTimestamp": "2017-08-14T22:07:57Z",
+        "annotations": {
+          "kubernetes.io/ingress.class": "linkerd"
+        }
+      },
+      "spec": {
+        "rules": [
+          {
+            "http": {
+              "paths": [
+                {
+                  "path": "/linkerd-2",
+                  "backend": {
+                    "serviceName": "echo2",
+                    "servicePort": 7070
+                  }
+                },
+                {
+                  "path": "/shared",
+                  "backend": {
+                    "serviceName": "shared2",
+                    "servicePort": 7071
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    }
+  ]
+}"""
+
+  val ingressResourceListWithOneIngress =
+    """
+{
+  "kind": "IngressList",
+  "apiVersion": "extensions/v1beta1",
+  "metadata": {
+    "selfLink": "/apis/extensions/v1beta1/ingresses",
+    "resourceVersion": "58845"
+  },
+  "items": [
+    {
+      "metadata": {
+        "name": "the-ingress",
+        "namespace": "default",
+        "selfLink": "/apis/extensions/v1beta1/namespaces/default/ingresses/the-ingress",
+        "uid": "6c1466d7-813e-11e7-b89b-080027a996b8",
+        "resourceVersion": "58840",
+        "generation": 1,
+        "creationTimestamp": "2017-08-14T22:17:55Z"
+      },
+      "spec": {
+        "rules": [
+          {
+            "http": {
+              "paths": [
+                {
+                  "path": "/some-path",
+                  "backend": {
+                    "serviceName": "echo",
+                    "servicePort": 1010
+                  }
+                },
+                {
+                  "path": "/other-path",
+                  "backend": {
+                    "serviceName": "echo",
+                    "servicePort": 2021
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    }
+  ]
+}"""
+
+  val annotationClass = "linkerd"
+
+  def mkIngressApiServiceReturning(response: String) = Service.mk[Request, Response] {
+    case req if req.uri.contains("/apis/extensions/v1beta1/ingresses") =>
+      val rsp = Response()
+      rsp.content = Buf.Utf8(response)
+      Future.value(rsp)
+    case req =>
+      fail(s"unexpected request for [${req.uri}]: $req")
+  }
+
+  test("when multiple ingress resources, only adds one with desired annotation class") {
+    val service = mkIngressApiServiceReturning(ingressResourceListWithManyAnnotatedIngresses)
+    val cache = new IngressCache(None, service, annotationClass)
+    assert(await(cache.matchPath(host, "/istio-only")).isEmpty)
+    assert(await(cache.matchPath(host, "/nginx-only")).isEmpty)
+    assert(await(cache.matchPath(host, "/non-existing-path")).isEmpty)
+    assert(await(cache.matchPath(host, "/linkerd-only")).get.svc == "echo")
+  }
+
+  test("when multiple ingress resources with desired annotation class, matches based on path of either") {
+    val service = mkIngressApiServiceReturning(ingressResourceListWithMoreThanOneLinkerdIngresses)
+    val cache = new IngressCache(None, service, annotationClass)
+    assert(await(cache.matchPath(host, "/linkerd-1")).get.svc == "echo1")
+    assert(await(cache.matchPath(host, "/linkerd-2")).get.svc == "echo2")
+    assert(Set("shared1", "shared2").contains(await(cache.matchPath(host, "/shared")).get.svc))
+  }
+
+  test("when only one ingress configured, adds it irrespective of annotations") {
+    val service = mkIngressApiServiceReturning(ingressResourceListWithOneIngress)
+    val cache = new IngressCache(None, service, annotationClass)
+    assert(await(cache.matchPath(host, "/some-path")).get.svc == "echo")
+    assert(await(cache.matchPath(host, "/non-existing-path")).isEmpty)
+  }
 
   test("on multiple path matches, return first match") {
     val paths = Seq(

--- a/linkerd/docs/protocol-h2.md
+++ b/linkerd/docs/protocol-h2.md
@@ -263,6 +263,7 @@ spec:
 Key  | Default Value | Description
 ---- | ------------- | -----------
 namespace | (all) | The Kubernetes namespace where the ingress resources are deployed. If not specified, linkerd will watch all namespaces.
+ingressClassAnnotation | `linkerd` | When using [multiple ingress controllers](https://github.com/kubernetes/ingress/blob/master/docs/faq/README.md#how-do-i-run-multiple-ingress-controllers-in-the-same-cluster), Linkerd will only use the ingress resource annotated with this class.
 host | `localhost` | The Kubernetes master host.
 port | `8001` | The Kubernetes master port.
 

--- a/linkerd/docs/protocol-http.md
+++ b/linkerd/docs/protocol-http.md
@@ -342,6 +342,7 @@ spec:
 Key  | Default Value | Description
 ---- | ------------- | -----------
 namespace | (all) | The Kubernetes namespace where the ingress resources are deployed. If not specified, linkerd will watch all namespaces.
+ingressClassAnnotation | `linkerd` | When using [multiple ingress controllers](https://github.com/kubernetes/ingress/blob/master/docs/faq/README.md#how-do-i-run-multiple-ingress-controllers-in-the-same-cluster), Linkerd will only use the ingress resource annotated with this class.
 host | `localhost` | The Kubernetes master host.
 port | `8001` | The Kubernetes master port.
 

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/IngressIdentifier.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/IngressIdentifier.scala
@@ -41,7 +41,9 @@ class IngressIdentifier(
 case class IngressIdentifierConfig(
   host: Option[String],
   port: Option[Port],
-  namespace: Option[String]
+  namespace: Option[String],
+  ingressClassAnnotation: Option[String]
+
 ) extends H2IdentifierConfig with ClientConfig {
   override def portNum: Option[Int] = port.map(_.port)
 
@@ -50,7 +52,7 @@ case class IngressIdentifierConfig(
     val DstPrefix(pfx) = params[DstPrefix]
     val BaseDtab(baseDtab) = params[BaseDtab]
     val client = mkClient(params).configured(Label("ingress-identifier"))
-    new IngressIdentifier(pfx, baseDtab, namespace, client.newService(dst), "linkerd")
+    new IngressIdentifier(pfx, baseDtab, namespace, client.newService(dst), ingressClassAnnotation.getOrElse("linkerd"))
   }
 }
 

--- a/linkerd/protocol/h2/src/test/scala/io/buoyant/linkerd/protocol/h2/IngressIdentifierConfigTest.scala
+++ b/linkerd/protocol/h2/src/test/scala/io/buoyant/linkerd/protocol/h2/IngressIdentifierConfigTest.scala
@@ -1,0 +1,46 @@
+package io.buoyant.linkerd.protocol.h2
+
+import com.twitter.finagle.Stack.Params
+import io.buoyant.config.Parser
+import io.buoyant.config.types.Port
+import org.scalatest.FunSuite
+
+class IngressIdentifierConfigTest extends FunSuite {
+  test("sanity") {
+    val ingressConfig = new IngressIdentifierConfig(Some("example.org"), Some(Port(9090)), None, Some("linkerd-ingress"))
+    val _ = ingressConfig.newIdentifier(Params.empty)
+  }
+
+  test("parse simplest config") {
+    val yaml =
+      """|kind: io.l5d.ingress
+      """.stripMargin
+    val mapper = Parser.objectMapper(yaml, Iterable(Seq(IngressIdentifierInitializer)))
+    val ingress = mapper.readValue[IngressIdentifierConfig](yaml)
+    assert(ingress.namespace == None)
+    assert(ingress.ingressClassAnnotation == None)
+  }
+
+  test("parse config with namespace") {
+    val yaml =
+      """|kind: io.l5d.ingress
+         |namespace: "istio-ns"
+      """.stripMargin
+    val mapper = Parser.objectMapper(yaml, Iterable(Seq(IngressIdentifierInitializer)))
+    val ingress = mapper.readValue[IngressIdentifierConfig](yaml)
+    assert(ingress.namespace == Some("istio-ns"))
+    assert(ingress.ingressClassAnnotation == None)
+  }
+
+  test("parse config with namespace and ingress class") {
+    val yaml =
+      """|kind: io.l5d.ingress
+         |ingressClassAnnotation: "istio"
+         |namespace: "istio-ns"
+      """.stripMargin
+    val mapper = Parser.objectMapper(yaml, Iterable(Seq(IngressIdentifierInitializer)))
+    val ingress = mapper.readValue[IngressIdentifierConfig](yaml)
+    assert(ingress.namespace == Some("istio-ns"))
+    assert(ingress.ingressClassAnnotation == Some("istio"))
+  }
+}

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/IngressIdentifier.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/IngressIdentifier.scala
@@ -41,7 +41,9 @@ class IngressIdentifier(
 case class IngressIdentifierConfig(
   host: Option[String],
   port: Option[Port],
-  namespace: Option[String]
+  namespace: Option[String],
+  ingressClassAnnotation: Option[String]
+
 ) extends HttpIdentifierConfig with ClientConfig {
   @JsonIgnore
   override def portNum: Option[Int] = port.map(_.port)
@@ -51,7 +53,7 @@ case class IngressIdentifierConfig(
     baseDtab: () => Dtab = () => Dtab.base
   ): Identifier[Request] = {
     val client = mkClient(Params.empty).configured(Label("ingress-identifier"))
-    new IngressIdentifier(prefix, baseDtab, namespace, client.newService(dst), "linkerd")
+    new IngressIdentifier(prefix, baseDtab, namespace, client.newService(dst), ingressClassAnnotation.getOrElse("linkerd"))
   }
 }
 

--- a/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/IngressIdentifierConfigTest.scala
+++ b/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/IngressIdentifierConfigTest.scala
@@ -1,0 +1,46 @@
+package io.buoyant.linkerd.protocol.http
+
+import com.twitter.finagle.Path
+import io.buoyant.config.Parser
+import io.buoyant.config.types.Port
+import org.scalatest.FunSuite
+
+class IngressIdentifierConfigTest extends FunSuite {
+  test("sanity") {
+    val ingressConfig = new IngressIdentifierConfig(Some("example.org"), Some(Port(9090)), None, Some("linkerd-ingress"))
+    val _ = ingressConfig.newIdentifier(Path.empty)
+  }
+
+  test("parse simplest config") {
+    val yaml =
+      """|kind: io.l5d.ingress
+      """.stripMargin
+    val mapper = Parser.objectMapper(yaml, Iterable(Seq(IngressIdentifierInitializer)))
+    val ingress = mapper.readValue[IngressIdentifierConfig](yaml)
+    assert(ingress.namespace == None)
+    assert(ingress.ingressClassAnnotation == None)
+  }
+
+  test("parse config with namespace") {
+    val yaml =
+      """|kind: io.l5d.ingress
+         |namespace: "istio-ns"
+      """.stripMargin
+    val mapper = Parser.objectMapper(yaml, Iterable(Seq(IngressIdentifierInitializer)))
+    val ingress = mapper.readValue[IngressIdentifierConfig](yaml)
+    assert(ingress.namespace == Some("istio-ns"))
+    assert(ingress.ingressClassAnnotation == None)
+  }
+
+  test("parse config with namespace and ingress class") {
+    val yaml =
+      """|kind: io.l5d.ingress
+         |ingressClassAnnotation: "istio"
+         |namespace: "istio-ns"
+      """.stripMargin
+    val mapper = Parser.objectMapper(yaml, Iterable(Seq(IngressIdentifierInitializer)))
+    val ingress = mapper.readValue[IngressIdentifierConfig](yaml)
+    assert(ingress.namespace == Some("istio-ns"))
+    assert(ingress.ingressClassAnnotation == Some("istio"))
+  }
+}

--- a/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/IngressIdentifierTest.scala
+++ b/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/IngressIdentifierTest.scala
@@ -1,18 +1,18 @@
-package io.buoyant.linkerd.protocol.h2
+package io.buoyant.linkerd.protocol.http
 
 import com.twitter.finagle.buoyant.Dst
-import com.twitter.finagle.buoyant.h2._
-import com.twitter.finagle.http.{Request => H1Request, Response => H1Response}
+import com.twitter.finagle.http.{Method, Request, Response}
 import com.twitter.finagle.{Dtab, Path, Service}
 import com.twitter.io.Buf
 import com.twitter.util.Future
-import io.buoyant.router.RoutingFactory._
+import io.buoyant.router.RoutingFactory.{IdentifiedRequest, UnidentifiedRequest}
 import io.buoyant.test.Awaits
 import org.scalatest.FunSuite
 
 class IngressIdentifierTest extends FunSuite with Awaits {
 
-  val ingressListResource = Buf.Utf8("""{
+  val ingressListResource = Buf.Utf8(
+    """{
     "kind":"IngressList",
     "apiVersion":"extensions/v1beta",
     "items": [{
@@ -46,9 +46,9 @@ class IngressIdentifierTest extends FunSuite with Awaits {
     }]
   }""")
 
-  val service = Service.mk[H1Request, H1Response] {
+  val service = Service.mk[Request, Response] {
     case req if req.uri.contains("/apis/extensions/v1beta1/ingresses") =>
-      val rsp = H1Response()
+      val rsp = Response()
       rsp.content = ingressListResource
       Future.value(rsp)
     case req =>
@@ -57,7 +57,11 @@ class IngressIdentifierTest extends FunSuite with Awaits {
 
   test("identifies requests by host, without path") {
     val identifier = new IngressIdentifier(Path.Utf8("svc"), () => Dtab.empty, None, service, "linkerd")
-    val req0 = Request("http", Method.Get, "foo.bar.com", "/penguins", Stream.empty())
+    val req0 = Request()
+    req0.method = Method.Get
+    req0.uri = "/penguins"
+    req0.host = "foo.bar.com"
+
     await(identifier(req0)) match {
       case IdentifiedRequest(Dst.Path(name, base, local), req1) =>
         assert(name == Path.read("/svc/fooNamespace/fooHostPort/fooHostService"))
@@ -67,7 +71,11 @@ class IngressIdentifierTest extends FunSuite with Awaits {
 
   test("identifies requests by host & path") {
     val identifier = new IngressIdentifier(Path.Utf8("svc"), () => Dtab.empty, None, service, "linkerd")
-    val req0 = Request("http", Method.Get, "foo.bar.com", "/fooPath/penguins", Stream.empty())
+    val req0 = Request()
+    req0.method = Method.Get
+    req0.uri = "/fooPath/penguins"
+    req0.host = "foo.bar.com"
+
     await(identifier(req0)) match {
       case IdentifiedRequest(Dst.Path(name, base, local), req1) =>
         assert(name == Path.read("/svc/fooNamespace/fooPathPort/fooPathService"))
@@ -77,11 +85,15 @@ class IngressIdentifierTest extends FunSuite with Awaits {
 
   test("falls back to the default backend") {
     val identifier = new IngressIdentifier(Path.Utf8("svc"), () => Dtab.empty, None, service, "linkerd")
-    val req0 = Request("http", Method.Get, "authority", "/", Stream.empty())
+    val req0 = Request()
+    req0.method = Method.Get
+    req0.uri = "/fooPath/penguins"
+    req0.host = "authority"
     await(identifier(req0)) match {
       case IdentifiedRequest(Dst.Path(name, base, local), req1) =>
         assert(name == Path.read("/svc/fooNamespace/defaultPort/defaultService"))
       case id: UnidentifiedRequest[Request] => fail(s"unexpected identification: ${id.reason}")
     }
   }
+
 }


### PR DESCRIPTION
As per #1433 , sometimes one has many different Ingress Resource and Ingress Controller deployed. One common example seems to be when you have one Controller provided by a cloud (e.g. GCE), another one for Linkerd, and a third one provided by Istio. Linkerd, like most controllers,  will ignore any Ingress Resource not meant for it, and the way to indicate which one is meant for Linkerds is by using the `kubernetes.io/ingress.class` annotation.

Initially, Linkerd would always look for any Ingress annotated as `linkerd`. This change allows for users to  configure what annotation value Linkerd should look for.