### PR TITLE
add ISSUE_TEMPLATE to route to discourse/slack

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,30 @@
+# Thanks for your help improving the project! #
+
+## Getting Help ##
+
+Github issues are for bug reports and feature requests. For questions about
+linkerd, how to use it, or debugging assistance, start by
+[asking a question in the forums](https://discourse.linkerd.io/) or join us on
+[Slack](https://slack.linkerd.io/).
+
+Full details at [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Filing a linkerd issue ##
+
+Issue Type:
+
+- [ ] Bug report
+- [ ] Feature request
+
+**What happened**:
+
+**What you expected to happen**:
+
+**How to reproduce it (as minimally and precisely as possible)**:
+
+**Anything else we need to know?**:
+
+**Environment**:
+- linkerd/namerd version, config files:
+- Platform, version, and config files (Kubernetes, DC/OS, etc):
+- Cloud provider or hardware configuration:


### PR DESCRIPTION
Landing on the New Issue page, it's not clear to users that they should
start by asking questions in discourse and slack.

This change puts instructions directly into the description of a New
Issue.