### PR TITLE
Base Docker image is now openjdk-alpine (#1369)

### DIFF
--- a/project/Base.scala
+++ b/project/Base.scala
@@ -153,7 +153,7 @@ class Base extends Build {
     assemblyJarName in assembly := s"${name.value}-${version.value}-${configuration.value}-exec",
     docker := (docker dependsOn (assembly in configuration)).value,
     dockerEnvPrefix := "",
-    dockerJavaImage := (dockerJavaImage in Global).?(_.getOrElse("openjdk:8u131-jre")).value,
+    dockerJavaImage := (dockerJavaImage in Global).?(_.getOrElse("openjdk:8u131-jre-alpine")).value,
     dockerfile in docker := new Dockerfile {
       val envPrefix = dockerEnvPrefix.value.toUpperCase
       val home = s"/${organization.value}/${name.value}/${version.value}"


### PR DESCRIPTION
linkerd's Docker image is currently built on openjdk:8u131-jre,
which includes openssl.

linkerd no longer requires openssl, as PKCS#1 is no longer supported.
This change migrates linkerd to openjdk:8u131-jre-alpine.

Validated with unit tests and integration test suite.

fixes #1369