### PR TITLE
Improve Consul failure handling

### DIFF
--- a/namer/consul/src/main/scala/io/buoyant/namer/consul/SvcAddr.scala
+++ b/namer/consul/src/main/scala/io/buoyant/namer/consul/SvcAddr.scala
@@ -60,6 +60,7 @@ private[consul] object SvcAddr {
         if (stopped) Future.Unit
         else getAddresses(index0).transform {
           case Throw(Failure(Some(err: ConnectionFailedException))) =>
+            log.warning("consul connection failed, retrying: %s", err)
             // Drop the index, in case it's been reset by a consul restart
             loop(None)
           case Throw(e) =>
@@ -70,7 +71,7 @@ private[consul] object SvcAddr {
                 // try again.
                 state() = addr
                 log.warning("consul service observation error %s, falling back to last good state", e)
-                loop(None)
+                loop(index0)
               case None =>
                 // if no previous good state was seen, treat the exception
                 // as effectively fatal to the service observation.

--- a/namer/consul/src/test/scala/io/buoyant/namer/consul/ConsulNamerTest.scala
+++ b/namer/consul/src/test/scala/io/buoyant/namer/consul/ConsulNamerTest.scala
@@ -711,9 +711,5 @@ class ConsulNamerTest extends FunSuite with Awaits {
         "namer did not update after falling back"
       )
     }
-
-
-
-
   }
 }


### PR DESCRIPTION
Upon Consul failure Namerd produces `Addr.Fail` and isn't able to resolve any names. If it has seen valid responses from Consul before entering the failed state, it should instead continue to resolve names based on the observed known-good state.

I've  modified the`SvcAddr` in `io.buoyant.namer.consul` to cache the last observed good state, and fall back to that state when polling Consul fails. If no good state was previously observed, `SvcAddr` will still produce `Addr.Failed`. I've also added log messages to all failure cases in `SvcAddr`: it will log at the `WARNING` level when an error occurred but it fell back to a previous state, and it will log at the `ERROR` level when an error occurred but no fallback was possible (i.e. `Addr.Fail` was produced). 

I've also added calls to `Activity.stabilize()` on the Consul observation activities in `ConsulDtabStore`. This should prevent these activities from entering the `Failed` state if they have previously observed a good state, and fall back to that state on observing an error instead. Failures that are flagged as interruptions should still close the `Activity`. I've also added added error logging to these activities.

I've added some additional tests in `ConsulNamerTest` to ensure that the namer will fall back to the previous good state on errors, that the state the namer falls back to is the most recent observed good state, and that the namer will resume responding to good updates after falling back.

Closes #1593 