### PR TITLE
Ensure frames are released after classification timeout

### DIFF
--- a/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/IngressIdentifierTest.scala
+++ b/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/IngressIdentifierTest.scala
@@ -44,7 +44,8 @@ class IngressIdentifierTest extends FunSuite with Awaits {
         }]
       }
     }]
-  }""")
+  }"""
+  )
 
   val service = Service.mk[Request, Response] {
     case req if req.uri.contains("/apis/extensions/v1beta1/ingresses") =>


### PR DESCRIPTION
After a classification timeout in ClassifiedRetryFilter, an exception is
raised on the classification future to cancel it.  This has the effect that
any frames that had been read by the classification future but not yet released
when the future was cancelled would get dropped and remain un-released forever.
This would cause the flow control window to slowly fill up and eventually
cause frames to stop being sent.

Instead, we no longer use Future.raise and instead implement our own timeout
logic where, even in the case that a timeout exception is returned, processing
continues on the stream and ensures that all frames are released.

Closes #1613.