### PR TITLE
Support for Istio Mixer's Conditions Check (#1403) 

### DIFF
--- a/istio/src/main/scala/io/buoyant/k8s/istio/CurrentIstioPath.scala
+++ b/istio/src/main/scala/io/buoyant/k8s/istio/CurrentIstioPath.scala
@@ -6,26 +6,106 @@ import com.twitter.logging.Logger
 import io.buoyant.router.context.DstBoundCtx
 
 object CurrentIstioPath {
-  val log = Logger(this.getClass.getName)
-  private val pathLength = 10
+  val logger = Logger(this.getClass.getName)
 
   def apply(maybeBound: Option[Dst.Bound]): Option[Path] = {
     maybeBound.flatMap { bound =>
       bound.id match {
-        case path: Path if (path.elems.length == pathLength) => Some(path)
-        case _ => None
+        case path: Path => Some(path)
+        case other =>
+          logger.warning("Expected path, got %s", other)
+          None
       }
     }
   }
 
   /**
-   * Resolves a valid Istio [[Path]], if any exists for the current [[DstBoundCtx]]
-   */
+    * Returns the target service requested based on the supplied [[Path]].
+    *
+    * The service is expected to be specified in the third last element in the path. For example,
+    * in the path:
+    *
+    * `%,io.l5d.k8s.daemonset,default,incoming,l5d,#,io.l5d.k8s.istio,reviews.default.svc.cluster.local,az:us-west::env:prod::version:v1,http`
+    *
+    * The service is `reviews.default.svc.cluster.local`.
+    *
+    *
+    * @param istioPath
+    * @return
+    */
+  def targetServiceIn(istioPath: Path): Option[String] = {
+    val pathServiceIndex = istioPath.elems.size - 3
+    if (pathServiceIndex > 0) {
+      Some(istioPath.showElems(pathServiceIndex))
+    } else {
+      logger.warning(
+        "Tried parsing target service at index %s for Invalid Istio Path %s",
+        pathServiceIndex,
+        istioPath
+      )
+      None
+    }
+  }
+
+  /**
+    *
+    * Returns the target version of the app requested based on the supplied [[Path]].
+    *
+    * The version of the app is expected to be specified in the second last element in the path. For
+    * example, in the path:
+    *
+    * `%,io.l5d.k8s.daemonset,default,incoming,l5d,#,io.l5d.k8s.istio,reviews.default.svc.cluster.local,az:us-west::env:prod::version:v1,http`
+    *
+    * The version is contained in the segment `az:us-west::env:prod::version:v1`, and its value is `v1`.
+    *
+    * @param istioPath
+    * @return
+    */
+  def targetVersionIn(istioPath: Path): Option[String] = {
+    val pathLabelsIndex = istioPath.elems.size - 2
+    if (pathLabelsIndex >= 0) {
+      istioPath
+        .showElems(pathLabelsIndex).split("::")
+        .find { e => e.startsWith("version:") }
+        .map { label => label.split(":").last }
+    } else {
+      logger.warning(
+        "Tried parsing target version at index %s for Invalid Istio Path %s",
+        pathLabelsIndex,
+        istioPath
+      )
+      None
+    }
+  }
+
+  /**
+    * Returns the app requested based on the supplied [[Path]].
+    *
+    * The app is expected to be the first segment of the service as returned by [[targetServiceIn()]].
+    * For example, in the path:
+    *
+    * `%,io.l5d.k8s.daemonset,default,incoming,l5d,#,io.l5d.k8s.istio,reviews.default.svc.cluster.local,az:us-west::env:prod::version:v1,http`
+    *
+    * The service is `reviews.default.svc.cluster.local`, and the app is `reviews`.
+    *
+    * Note that this should really come from the "app" label of the target pod. in most cases this
+    * will be the same value, but eventually the correct solution should be to get this directly from
+    * the label or the uid.
+    *
+    * @param istioPath
+    * @return
+    */
+  def targetAppIn(istioPath: Path): Option[String] = targetServiceIn(istioPath)
+    .flatMap(_.split('.').headOption)
+
+  /**
+    * Resolves a valid Istio [[Path]], if any exists for the current [[DstBoundCtx]]
+    */
   def apply(): Option[Path] = {
     Option(DstBoundCtx) match {
       case Some(p) => apply(p.current)
       case None =>
-        log.warning(
+        logger.warning(
           "Couldn' find a bound %s for current context %s, found %s",
           getClass.getSimpleName,
           DstBoundCtx,

--- a/istio/src/main/scala/io/buoyant/k8s/istio/IstioRequest.scala
+++ b/istio/src/main/scala/io/buoyant/k8s/istio/IstioRequest.scala
@@ -1,9 +1,6 @@
 package io.buoyant.k8s.istio
 
 import com.twitter.finagle.Path
-import com.twitter.finagle.buoyant.Dst
-import com.twitter.logging.Logger
-import io.buoyant.router.context.DstBoundCtx
 
 /**
  * Defines a request's metadata for istio rules to match against
@@ -19,43 +16,27 @@ case class IstioRequest[Req](
   istioPath: Option[Path]
 ) {
   val unknown = "unknown"
-  // expected istioPath
-  // Path(%,io.l5d.k8s.daemonset,default,incoming,l5d,#,io.l5d.k8s.istio,reviews.default.svc.cluster.local,az:us-west::env:prod::version:v1,http)
-  private val pathServiceIndex = 7
-  private val pathLabelsIndex = 8
 
   val requestedPath: RequestPathIstioAttribute = RequestPathIstioAttribute(uri)
 
-  val targetService: TargetServiceIstioAttribute = TargetServiceIstioAttribute(findTargetService.getOrElse(unknown))
+  val targetService: TargetServiceIstioAttribute = {
+    val foundService = istioPath.flatMap(CurrentIstioPath.targetServiceIn(_))
+    TargetServiceIstioAttribute(foundService.getOrElse(unknown))
+  }
 
   val sourceLabel: SourceLabelIstioAttribute = SourceLabelIstioAttribute(Map(
     "app" -> unknown,
     "version" -> unknown
   ))
 
-  val targetLabel: TargetLabelsIstioAttribute = TargetLabelsIstioAttribute(Map(
-    "app" -> findTargetLabelApp.getOrElse(unknown),
-    "version" -> findTargetVersion.getOrElse(unknown)
-  ))
+  val targetLabel: TargetLabelsIstioAttribute = {
+    val app = istioPath.flatMap(CurrentIstioPath.targetAppIn(_))
+    val version = istioPath.flatMap(CurrentIstioPath.targetVersionIn(_))
 
-  private def findTargetService: Option[String] = {
-    istioPath.map { path =>
-      path.showElems(pathServiceIndex)
-    }
+    TargetLabelsIstioAttribute(Map(
+      "app" -> app.getOrElse(unknown),
+      "version" -> version.getOrElse(unknown)
+    ))
   }
-
-  private def findTargetVersion: Option[String] = istioPath match {
-    case Some(path) =>
-      path.showElems(pathLabelsIndex).split("::").find {
-        e => e.startsWith("version:")
-      }.map { label => label.split(":").last }
-    case _ => None
-  }
-
-  /* note that this should really come from the "app" label of the target pod.
-   in most cases this will be the same value, but eventually the correct solution
-   should be to get this directly from the label or the uid.
-   */
-  private def findTargetLabelApp: Option[String] = findTargetService.flatMap(_.split('.').headOption)
 }
 

--- a/istio/src/main/scala/io/buoyant/k8s/istio/IstioRequestAuthorizerFilter.scala
+++ b/istio/src/main/scala/io/buoyant/k8s/istio/IstioRequestAuthorizerFilter.scala
@@ -1,13 +1,35 @@
 package io.buoyant.k8s.istio
 
 import com.twitter.finagle.{Filter, Service}
-import com.twitter.util.{Duration, Stopwatch, Try}
+import com.twitter.logging.Logger
+import com.twitter.util.{Duration, Future, Stopwatch, Try}
 import io.buoyant.k8s.istio.mixer.MixerClient
 
 abstract class IstioRequestAuthorizerFilter[Req, Resp](mixerClient: MixerClient) extends Filter[Req, Resp, Req, Resp] {
+  val logger = Logger()
 
-  def report(request: IstioRequest[Req], response: IstioResponse[Resp], duration: Duration) = {
+  def toIstioRequest(req: Req): IstioRequest[Req]
 
+  def toIstioResponse(resp: Try[Resp], duration: Duration): IstioResponse[Resp]
+
+  def toFailedResponse(code: Int, reason: String): Resp
+
+  def apply(req: Req, svc: Service[Req, Resp]): Future[Resp] = {
+    val istioRequest = toIstioRequest(req)
+
+    logger.trace("checking Istio pre-conditions for request %s", istioRequest)
+    mixerClient.checkPreconditions(istioRequest).flatMap { status =>
+      if (status.success) {
+        logger.trace("Succesful pre-condition check for request: %s", istioRequest)
+        callService(req, svc, istioRequest)
+      } else {
+        logger.info("request [%s] failed Istio pre-condition check: %s", istioRequest, status)
+        Future.value(toFailedResponse(status.httpCode, status.reason))
+      }
+    }
+  }
+
+  def report(request: IstioRequest[Req], response: IstioResponse[Resp], duration: Duration): Future[Unit] = {
     mixerClient.report(
       response.responseCode,
       request.requestedPath,
@@ -18,13 +40,7 @@ abstract class IstioRequestAuthorizerFilter[Req, Resp](mixerClient: MixerClient)
     )
   }
 
-  def toIstioRequest(req: Req): IstioRequest[Req]
-
-  def toIstioResponse(resp: Try[Resp], duration: Duration): IstioResponse[Resp]
-
-  def apply(req: Req, svc: Service[Req, Resp]) = {
-    val istioRequest = toIstioRequest(req)
-
+  private def callService(req: Req, svc: Service[Req, Resp], istioRequest: IstioRequest[Req]) = {
     val elapsed = Stopwatch.start()
 
     svc(req).respond { resp =>

--- a/istio/src/test/scala/io/buoyant/k8s/istio/CurrentIstioPathTest.scala
+++ b/istio/src/test/scala/io/buoyant/k8s/istio/CurrentIstioPathTest.scala
@@ -6,18 +6,18 @@ import com.twitter.util.Var
 import io.buoyant.test.FunSuite
 
 class CurrentIstioPathTest extends FunSuite {
-  test("returns  when path has the expected number of segments") {
+  test("returns path when path has transformer prefix") {
     val id = Path.Utf8(
-      "1",
-      "2",
-      "3",
-      "4",
-      "5",
-      "6",
-      "7",
-      "8",
-      "9",
-      "10"
+      "%",
+      "io.l5d.k8s.daemonset",
+      "default",
+      "incoming",
+      "l5d",
+      "#",
+      "io.l5d.k8s.istio",
+      "reviews.default.svc.cluster.local",
+      "az:us-west::env:prod::version:v1",
+      "http"
     )
 
     val residual = Path.empty
@@ -31,7 +31,7 @@ class CurrentIstioPathTest extends FunSuite {
     assert(CurrentIstioPath(Some(bound)) == Some(id))
   }
 
-  test("returns null when not enough segments on path") {
+  test("returns path when path doesnt have the transfomer prefix because it came from the ingress") {
     val id = Path.Utf8(
       "#",
       "io.l5d.k8s.istio",
@@ -48,10 +48,112 @@ class CurrentIstioPathTest extends FunSuite {
       residual
     )
 
-    assert(CurrentIstioPath(Some(bound)) == None)
+    assert(CurrentIstioPath(Some(bound)) == Some(id))
   }
 
   test("returns null when no path bound") {
     assert(CurrentIstioPath(None) == None)
+  }
+
+  test("finds target service from path") {
+    val expectedTargetFromLongPath = "reviews.default.svc.cluster.local"
+    val targetFromLongPath = CurrentIstioPath.targetServiceIn(Path.Utf8(
+      "%",
+      "io.l5d.k8s.daemonset",
+      "default",
+      "incoming",
+      "l5d",
+      "#",
+      "io.l5d.k8s.istio",
+      expectedTargetFromLongPath,
+      "az:us-west::env:prod::version:v1",
+      "http"
+    ))
+
+    val expectedTargetFromShortPath = "productpage.default.svc.cluster.local"
+    val targetFromShortPath = CurrentIstioPath.targetServiceIn(Path.Utf8(
+      "#",
+      "io.l5d.k8s.istio",
+      expectedTargetFromShortPath,
+      "version:v1",
+      "http"
+    ))
+
+    val targetFromInvalidPath = CurrentIstioPath.targetServiceIn(Path.Utf8(
+      "#",
+      "http"
+    ))
+
+    assert(targetFromLongPath == Some(expectedTargetFromLongPath))
+    assert(targetFromShortPath == Some(expectedTargetFromShortPath))
+    assert(targetFromInvalidPath == None)
+  }
+
+  test("finds target version from path") {
+    val expectedTargetFromLongPath = "cda3f1bdc2d55e487bc76dd77020a45a0305b74b"
+    val targetFromLongPath = CurrentIstioPath.targetVersionIn(Path.Utf8(
+      "%",
+      "io.l5d.k8s.daemonset",
+      "default",
+      "incoming",
+      "l5d",
+      "#",
+      "io.l5d.k8s.istio",
+      "reviews.default.svc.cluster.local",
+      s"az:us-west::env:prod::version:$expectedTargetFromLongPath",
+      "http"
+    ))
+
+    val expectedTargetFromShortPath = "v42"
+    val targetFromShortPath = CurrentIstioPath.targetVersionIn(Path.Utf8(
+      "#",
+      "io.l5d.k8s.istio",
+      "productpage.default.svc.cluster.local",
+      s"version:$expectedTargetFromShortPath",
+      "http"
+    ))
+
+    val targetFromInvalidPath = CurrentIstioPath.targetVersionIn(Path.Utf8(
+      "#",
+      "http"
+    ))
+
+    assert(targetFromLongPath == Some(expectedTargetFromLongPath))
+    assert(targetFromShortPath == Some(expectedTargetFromShortPath))
+    assert(targetFromInvalidPath == None)
+  }
+
+  test("finds target app from path") {
+    val expectedTargetFromLongPath = "reviews"
+    val targetFromLongPath = CurrentIstioPath.targetAppIn(Path.Utf8(
+      "%",
+      "io.l5d.k8s.daemonset",
+      "default",
+      "incoming",
+      "l5d",
+      "#",
+      "io.l5d.k8s.istio",
+      s"${expectedTargetFromLongPath}.default.svc.cluster.local",
+      "az:us-west::env:prod::version:v1",
+      "http"
+    ))
+
+    val expectedTargetFromShortPath = "productpage"
+    val targetFromShortPath = CurrentIstioPath.targetAppIn(Path.Utf8(
+      "#",
+      "io.l5d.k8s.istio",
+      s"${expectedTargetFromShortPath}.default.svc.cluster.local",
+      "version:v1",
+      "http"
+    ))
+
+    val targetFromInvalidPath = CurrentIstioPath.targetAppIn(Path.Utf8(
+      "#",
+      "http"
+    ))
+
+    assert(targetFromLongPath == Some(expectedTargetFromLongPath))
+    assert(targetFromShortPath == Some(expectedTargetFromShortPath))
+    assert(targetFromInvalidPath == None)
   }
 }

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/istio/IstioRequestAuthorizer.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/istio/IstioRequestAuthorizer.scala
@@ -1,12 +1,13 @@
 package io.buoyant.linkerd.protocol.h2.istio
 
 import com.fasterxml.jackson.annotation.JsonIgnore
-import com.twitter.finagle._
-import com.twitter.finagle.buoyant.h2.{Request, Response}
+import com.twitter.finagle.{Filter, Stack}
+import com.twitter.finagle.buoyant.h2.{Request, Response, Status, Stream => H2Stream}
 import com.twitter.util.{Duration, Try}
 import io.buoyant.config.types.Port
 import io.buoyant.k8s.istio.mixer.MixerClient
-import io.buoyant.k8s.istio.{IstioRequestAuthorizerFilter, _}
+import io.buoyant.k8s.istio._
+import io.buoyant.k8s.istio.{CurrentIstioPath, IstioRequestAuthorizerFilter}
 import io.buoyant.linkerd.RequestAuthorizerInitializer
 import io.buoyant.linkerd.protocol.h2.H2RequestAuthorizerConfig
 
@@ -14,6 +15,8 @@ class IstioRequestAuthorizer(val mixerClient: MixerClient, params: Stack.Params)
   override def toIstioRequest(req: Request) = H2IstioRequest(req, CurrentIstioPath())
 
   override def toIstioResponse(resp: Try[Response], duration: Duration) = H2IstioResponse(resp, duration)
+
+  override def toFailedResponse(code: Int, reason: String) = Response(Status(code), H2Stream.const(reason))
 }
 
 case class IstioRequestAuthorizerConfig(

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/istio/IstioRequestAuthorizer.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/istio/IstioRequestAuthorizer.scala
@@ -1,8 +1,8 @@
 package io.buoyant.linkerd.protocol.http.istio
 
 import com.fasterxml.jackson.annotation.JsonIgnore
-import com.twitter.finagle._
-import com.twitter.finagle.http.{Request, Response}
+import com.twitter.finagle.{Filter, Stack}
+import com.twitter.finagle.http.{Request, Response, Status, Version}
 import com.twitter.util._
 import io.buoyant.config.types.Port
 import io.buoyant.k8s.istio.mixer.MixerClient
@@ -14,6 +14,8 @@ class IstioRequestAuthorizer(val mixerClient: MixerClient, params: Stack.Params)
   override def toIstioRequest(req: Request) = HttpIstioRequest(req, CurrentIstioPath())
 
   override def toIstioResponse(resp: Try[Response], duration: Duration) = HttpIstioResponse(resp, duration)
+
+  override def toFailedResponse(code: Int, reason: String) = Response(Version.Http11, Status(code))
 }
 
 case class IstioRequestAuthorizerInitializerConfig(


### PR DESCRIPTION
This implementation builds on the [original Istio integration work](https://github.com/linkerd/linkerd/pull/1473/files#diff-ec7d844511058df1c9ecb3491112b988), extending our Mixer integration to not only send reporting data but also checking for preconditions.

The initial design assumed that this check could be done at the `Identifier`, but it turns out that to get the `target.service` attribute we need it to be much later in the processing chain. We then refactored what was known as the `IstioLogger` into an `RequestAuthorization` that performs such check.

The actual check added:  https://github.com/linkerd/linkerd/commit/54ba9ad2ba1b4d3af6fb08b340d2deb9deb77376#diff-1d26b6a6caa59bb04f9815bbca98dd76R22

### Design Rationale
Istio allows for operators to define preconditions that must be met before a request is sent to a service. These preconditions are defined based on [attributes](https://istio.io/docs/concepts/policy-and-control/attributes.html). As per #1403, we want to add this feature to an Istio + Linkerd deployment.

The way this is supposed to work is that the proxy should send the request attributes to the [check request API](https://istio.io/docs/reference/api/mixer/mixer-service.html#checkrequest) and, depending on the result, either forward the request to the underlying service or reject the connection altogether.

The way Istio's vanilla proxy implements the check is [by first checking against a cache of pre-computed results](https://github.com/istio/mixerclient/blob/13460a96b4b3aa792ad47817d4fbf529b63c25e2/src/check_cache.cc#L78). The cache is indexed by [a hash of each attribute from the request](https://github.com/istio/mixerclient/blob/13460a96b4b3aa792ad47817d4fbf529b63c25e2/src/signature.cc#L30). The cache is only used to prevent calls that are known to *fail* the check, and not enabled by default. Our implementation currently doesn't cache anything.