### PR TITLE
Update default backend behavior and strip host ports

### DIFF
--- a/k8s/src/main/scala/io/buoyant/k8s/IngressCache.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/IngressCache.scala
@@ -14,17 +14,11 @@ case class IngressSpec(
 ) {
   def getMatchingPath(hostHeader: Option[String], requestPath: String): Option[IngressPath] = {
     val matchingPath = rules.find(_.matches(hostHeader, requestPath))
-    (matchingPath, fallbackBackend) match {
-      case (Some(path), _) =>
-        log.info("k8s found rule matching %s %s: %s", hostHeader.getOrElse(""), requestPath, path)
-        Some(path)
-      case (None, Some(default)) =>
-        log.info("k8s using default service %s for request %s %s", default, hostHeader.getOrElse(""), requestPath)
-        Some(default)
-      case _ =>
-        log.info("k8s no suitable rule found in %s for request %s %s", name.getOrElse(""), hostHeader.getOrElse(""), requestPath)
-        None
+    matchingPath match {
+      case Some(path) => log.info("k8s found rule matching %s %s: %s", hostHeader.getOrElse(""), requestPath, path)
+      case None => log.info("no ingress rule found for request %s %s", hostHeader.getOrElse(""), requestPath)
     }
+    matchingPath
   }
 }
 
@@ -59,12 +53,16 @@ object IngressCache {
   type IngressState = Activity.State[Seq[IngressSpec]]
   val annotationKey = "kubernetes.io/ingress.class"
 
-  private[k8s] def getMatchingPath(hostHeader: Option[String], requestPath: String, ingresses: Seq[IngressSpec]): Option[IngressPath] =
+  private[k8s] def iterateForMatch(ingresses: Seq[IngressSpec], fn: (IngressSpec) => Option[IngressPath]) =
     ingresses
       .toIterator // stop after we find a match
-      .flatMap(_.getMatchingPath(hostHeader, requestPath))
+      .flatMap(fn(_))
       .take(1)
       .toSeq.headOption
+
+  private[k8s] def getMatchingPath(hostHeader: Option[String], requestPath: String, ingresses: Seq[IngressSpec]): Option[IngressPath] =
+    iterateForMatch(ingresses, _.getMatchingPath(hostHeader, requestPath))
+      .orElse(iterateForMatch(ingresses, _.fallbackBackend))
 
 }
 
@@ -143,8 +141,16 @@ class IngressCache(namespace: Option[String], apiClient: Service[Request, Respon
     }
   }
 
-  def matchPath(hostHeader: Option[String], requestPath: String): Future[Option[IngressPath]] =
+  def matchPath(hostHeader: Option[String], requestPath: String): Future[Option[IngressPath]] = {
+    val hostHeaderSansPort = hostHeader.map {
+      _.split(":") match {
+        case Array(h: String, _) => h
+        case Array(h: String) => h
+        case _ => throw new IllegalArgumentException("unable to parse host for request")
+      }
+    }
     ingresses.map { cache: Seq[IngressSpec] =>
-      getMatchingPath(hostHeader, requestPath, cache)
+      getMatchingPath(hostHeaderSansPort, requestPath, cache)
     }.toFuture
+  }
 }

--- a/k8s/src/test/scala/io/buoyant/k8s/IngressCacheTest.scala
+++ b/k8s/src/test/scala/io/buoyant/k8s/IngressCacheTest.scala
@@ -376,6 +376,13 @@ class IngressCacheTest extends FunSuite with Awaits {
     assert(matchingPath.get.svc == "fallback")
   }
 
+  test("no matches") {
+    val resource1 = IngressSpec(Some("polar-bear1"), ns, None, Seq(IngressPath(host, None, ns.get, "svc1", "80")))
+    val resource2 = IngressSpec(Some("polar-bear2"), ns, None, Seq(IngressPath(host, None, ns.get, "svc2", "80")))
+    val matchingPath = IngressCache.getMatchingPath(Some("unknown host"), "/path", Seq(resource1, resource2))
+    assert(matchingPath == None)
+  }
+
   test("match on path regex") {
     val path = IngressPath(host, Some("/prefix/.*"), ns.get, "svc1", "80")
     assert(path.matches(host, "/prefix/and-other-stuff"))


### PR DESCRIPTION
Default backends are now only applied *after* searching through all ingress resources for available matches. Ports in the host header field are now stripped.

Fixes #1553 
Fixes #1566 