### PR TITLE
Add option to filter consul nodes by health statuses

### DIFF
--- a/consul/src/main/resources/META-INF/services/io.buoyant.config.ConfigDeserializer
+++ b/consul/src/main/resources/META-INF/services/io.buoyant.config.ConfigDeserializer
@@ -1,1 +1,2 @@
 io.buoyant.consul.v1.ConsistencyModeDeserializer
+io.buoyant.consul.v1.HealthStatusDeserializer

--- a/consul/src/main/resources/META-INF/services/io.buoyant.config.ConfigSerializer
+++ b/consul/src/main/resources/META-INF/services/io.buoyant.config.ConfigSerializer
@@ -1,1 +1,2 @@
 io.buoyant.consul.v1.ConsistencyModeSerializer
+io.buoyant.consul.v1.HealthStatusSerializer

--- a/consul/src/main/scala/io/buoyant/consul/v1/ConsulApi.scala
+++ b/consul/src/main/scala/io/buoyant/consul/v1/ConsulApi.scala
@@ -82,11 +82,12 @@ class CatalogApi(
 }
 
 object HealthApi {
-  def apply(c: Client): HealthApi = new HealthApi(c, s"/$versionString")
+  def apply(c: Client, statuses: Option[Set[HealthStatus.Value]]): HealthApi = new HealthApi(c, statuses, s"/$versionString")
 }
 
 class HealthApi(
   override val client: Client,
+  val statuses: Option[Set[HealthStatus.Value]],
   override val uriPrefix: String,
   override val backoffs: Stream[Duration] = Backoff.exponentialJittered(1.milliseconds, 5.seconds),
   override val stats: StatsReceiver = DefaultStatsReceiver
@@ -115,12 +116,14 @@ class HealthApi(
       "index" -> blockingIndex,
       "dc" -> datacenter,
       "tag" -> tag,
-      "passing" -> Some("true")
+      "passing" -> Some("false")
     )
     executeJson[Seq[ServiceHealth]](req, retry).map { indexed =>
       val result = indexed.value.map { health =>
         val service = health.Service
+        val checks = health.Checks.getOrElse(List()).flatMap(_.Status).map(HealthStatus.withNameSafe(_))
         val node = health.Node
+
         ServiceNode(
           node.flatMap(_.Node),
           node.flatMap(_.Address),
@@ -128,10 +131,16 @@ class HealthApi(
           service.flatMap(_.Service),
           service.flatMap(_.Tags),
           service.flatMap(_.Address),
-          service.flatMap(_.Port)
+          service.flatMap(_.Port),
+          checks.reduceOption(HealthStatus.worstCase)
         )
       }
-      Indexed[Seq[ServiceNode]](result, indexed.index)
+      val nodes = statuses match {
+        case None => result
+        case Some(x) if x contains HealthStatus.Any => result
+        case Some(x) => result.filter(x contains _.Status.getOrElse(HealthStatus.Passing))
+      }
+      Indexed[Seq[ServiceNode]](nodes, indexed.index)
     }
   }
 }
@@ -151,7 +160,12 @@ case class Service_(
 
 case class ServiceHealth(
   Node: Option[Node],
-  Service: Option[Service_]
+  Service: Option[Service_],
+  Checks: Option[Seq[Check]]
+)
+
+case class Check(
+  Status: Option[String]
 )
 
 case class ServiceNode(
@@ -161,5 +175,6 @@ case class ServiceNode(
   ServiceName: Option[String],
   ServiceTags: Option[Seq[String]],
   ServiceAddress: Option[String],
-  ServicePort: Option[Int]
+  ServicePort: Option[Int],
+  Status: Option[HealthStatus.Value]
 )

--- a/consul/src/main/scala/io/buoyant/consul/v1/ConsulApi.scala
+++ b/consul/src/main/scala/io/buoyant/consul/v1/ConsulApi.scala
@@ -87,7 +87,7 @@ object HealthApi {
 
 class HealthApi(
   override val client: Client,
-  val statuses: Option[Set[HealthStatus.Value]],
+  val statuses: Option[Set[HealthStatus.Value]] = None,
   override val uriPrefix: String,
   override val backoffs: Stream[Duration] = Backoff.exponentialJittered(1.milliseconds, 5.seconds),
   override val stats: StatsReceiver = DefaultStatsReceiver

--- a/consul/src/main/scala/io/buoyant/consul/v1/HealthStatus.scala
+++ b/consul/src/main/scala/io/buoyant/consul/v1/HealthStatus.scala
@@ -1,0 +1,45 @@
+package io.buoyant.consul.v1
+
+import com.fasterxml.jackson.core.{JsonGenerator, JsonParser}
+import com.fasterxml.jackson.databind.{DeserializationContext, SerializerProvider}
+import io.buoyant.config.{ConfigDeserializer, ConfigSerializer}
+
+object HealthStatus extends Enumeration {
+  type HealthStatus = Value
+  val Any, Passing, Warning, Critical, Maintenance = Value
+  def withNameSafe(name: String): Value =
+    values.find(_.toString.toLowerCase == name.toLowerCase()).getOrElse(Passing)
+  /* 
+   * worstCase returns the "worst" status of two health checks. Because a given
+   * entry may have many service and node-level health checks attached, this
+   * function can be used to determine the most representative status as a
+   * single enum value using the following heuristic:
+   *
+   *  maintenance > critical > warning > passing
+  */
+  def worstCase(s1: Value, s2: Value): Value = if (s1.id > s2.id) s1 else s2
+}
+
+class HealthStatusDeserializer extends ConfigDeserializer[HealthStatus.Value] {
+
+  override def deserialize(jp: JsonParser, ctxt: DeserializationContext): HealthStatus.Value =
+    catchMappingException(ctxt) {
+      _parseString(jp, ctxt) match {
+        case "passing" => HealthStatus.Passing
+        case "warning" => HealthStatus.Warning
+        case "critical" => HealthStatus.Critical
+        case "maintenance" => HealthStatus.Maintenance
+        case "any" => HealthStatus.Any
+        case unknown =>
+          throw new IllegalArgumentException(s"Illegal Consul health status: $unknown")
+      }
+    }
+}
+
+class HealthStatusSerializer extends ConfigSerializer[HealthStatus.Value] {
+  override def serialize(
+    mode: HealthStatus.Value,
+    jgen: JsonGenerator,
+    provider: SerializerProvider
+  ): Unit = jgen.writeString(mode.toString.toLowerCase)
+}

--- a/consul/src/main/scala/io/buoyant/consul/v1/HealthStatus.scala
+++ b/consul/src/main/scala/io/buoyant/consul/v1/HealthStatus.scala
@@ -6,10 +6,10 @@ import io.buoyant.config.{ConfigDeserializer, ConfigSerializer}
 
 object HealthStatus extends Enumeration {
   type HealthStatus = Value
-  val Any, Passing, Warning, Critical, Maintenance = Value
+  val Passing, Warning, Critical, Maintenance = Value
   def withNameSafe(name: String): Value =
     values.find(_.toString.toLowerCase == name.toLowerCase()).getOrElse(Passing)
-  /* 
+  /*
    * worstCase returns the "worst" status of two health checks. Because a given
    * entry may have many service and node-level health checks attached, this
    * function can be used to determine the most representative status as a
@@ -29,7 +29,6 @@ class HealthStatusDeserializer extends ConfigDeserializer[HealthStatus.Value] {
         case "warning" => HealthStatus.Warning
         case "critical" => HealthStatus.Critical
         case "maintenance" => HealthStatus.Maintenance
-        case "any" => HealthStatus.Any
         case unknown =>
           throw new IllegalArgumentException(s"Illegal Consul health status: $unknown")
       }

--- a/consul/src/main/scala/io/buoyant/consul/v1/HealthStatus.scala
+++ b/consul/src/main/scala/io/buoyant/consul/v1/HealthStatus.scala
@@ -8,7 +8,7 @@ object HealthStatus extends Enumeration {
   type HealthStatus = Value
   val Passing, Warning, Critical, Maintenance = Value
   def withNameSafe(name: String): Value =
-    values.find(_.toString.toLowerCase == name.toLowerCase()).getOrElse(Passing)
+    values.find(_.toString.toLowerCase == name.toLowerCase).getOrElse(Passing)
   /*
    * worstCase returns the "worst" status of two health checks. Because a given
    * entry may have many service and node-level health checks attached, this

--- a/consul/src/test/scala/io/buoyant/consul/v1/HealthApiTest.scala
+++ b/consul/src/test/scala/io/buoyant/consul/v1/HealthApiTest.scala
@@ -22,8 +22,9 @@ class HealthApiTest extends FunSuite with Awaits {
 
   test("serviceNodes endpoint returns a seq of ServiceNodes") {
     val service = stubService(nodesBuf)
+    val statuses = Some(Set(HealthStatus.Any))
 
-    val response = await(HealthApi(service).serviceNodes("hosted_web")).value
+    val response = await(HealthApi(service, statuses).serviceNodes("hosted_web")).value
     assert(response.size == 1)
     assert(response.head.ServiceName == Some("hosted_web"))
     assert(response.head.Node == Some("Sarahs-MBP-2"))
@@ -33,7 +34,8 @@ class HealthApiTest extends FunSuite with Awaits {
 
   test("serviceNodes endpoint supports consistency parameter") {
     val service = stubService(nodesBuf)
-    val api = HealthApi(service)
+    val statuses = Some(Set(HealthStatus.Any))
+    val api = HealthApi(service, statuses)
 
     await(api.serviceNodes("foo"))
     assert(!lastUri.contains("consistent"))

--- a/consul/src/test/scala/io/buoyant/consul/v1/HealthApiTest.scala
+++ b/consul/src/test/scala/io/buoyant/consul/v1/HealthApiTest.scala
@@ -72,36 +72,22 @@ class HealthApiTest extends FunSuite with Awaits {
     assert(responseCritical.size == 0)
   }
 
-  test("HealthApi supports filtering by health status `warning`") {
-    val service = stubService(nodesWithChecksBuf)
-    val api = HealthApi(service, Set(HealthStatus.Warning))
+  def filterTest(status: HealthStatus.Value, name: String) =
+    test(s"HealthApi supports filtering by health status `$name`") {
+      val service = stubService(nodesWithChecksBuf)
+      val api = HealthApi(service, Set(status))
 
-    val response = await(api.serviceNodes("hosted_web")).value
-    assert(response.size == 1)
-    assert(response.head.ServiceName == Some("hosted_web"))
-    assert(response.head.Node == Some("node-warning"))
-    assert(response.head.Status == Some(HealthStatus.Warning))
-  }
+      val response = await(api.serviceNodes("hosted_web")).value
+      assert(response.size == 1)
+      assert(response.head.ServiceName == Some("hosted_web"))
+      assert(response.head.Node == Some(s"node-$name"))
+      assert(response.head.Status == Some(status))
+    }
 
-  test("HealthApi supports filtering by health status `critical`") {
-    val service = stubService(nodesWithChecksBuf)
-    val api = HealthApi(service, Set(HealthStatus.Critical))
-
-    val response = await(api.serviceNodes("hosted_web")).value
-    assert(response.size == 1)
-    assert(response.head.ServiceName == Some("hosted_web"))
-    assert(response.head.Node == Some("node-critical"))
-    assert(response.head.Status == Some(HealthStatus.Critical))
-  }
-
-  test("HealthApi supports filtering by health status `maintenance`") {
-    val service = stubService(nodesWithChecksBuf)
-    val api = HealthApi(service, Set(HealthStatus.Maintenance))
-
-    val response = await(api.serviceNodes("hosted_web")).value
-    assert(response.size == 1)
-    assert(response.head.ServiceName == Some("hosted_web"))
-    assert(response.head.Node == Some("node-maintenance"))
-    assert(response.head.Status == Some(HealthStatus.Maintenance))
-  }
+  // No filterTest for health status `passing` as HealthApi is optmized to use
+  // consul API parameter `passing=true` to perform server side filtering when
+  // only passing nodes are required.
+  filterTest(HealthStatus.Warning, "warning")
+  filterTest(HealthStatus.Critical, "critical")
+  filterTest(HealthStatus.Maintenance, "maintenance")
 }

--- a/consul/src/test/scala/io/buoyant/consul/v1/HealthApiTest.scala
+++ b/consul/src/test/scala/io/buoyant/consul/v1/HealthApiTest.scala
@@ -28,9 +28,8 @@ class HealthApiTest extends FunSuite with Awaits {
 
   test("serviceNodes endpoint returns a seq of ServiceNodes") {
     val service = stubService(nodesBuf)
-    val statuses = Some(Set(HealthStatus.Any))
 
-    val response = await(HealthApi(service, statuses).serviceNodes("hosted_web")).value
+    val response = await(HealthApi(service, Set(HealthStatus.Passing)).serviceNodes("hosted_web")).value
     assert(response.size == 1)
     assert(response.head.ServiceName == Some("hosted_web"))
     assert(response.head.Node == Some("Sarahs-MBP-2"))
@@ -40,8 +39,7 @@ class HealthApiTest extends FunSuite with Awaits {
 
   test("serviceNodes endpoint supports consistency parameter") {
     val service = stubService(nodesBuf)
-    val statuses = Some(Set(HealthStatus.Any))
-    val api = HealthApi(service, statuses)
+    val api = HealthApi(service, Set(HealthStatus.Passing))
 
     await(api.serviceNodes("foo"))
     assert(!lastUri.contains("consistent"))
@@ -60,46 +58,23 @@ class HealthApiTest extends FunSuite with Awaits {
 
   test("Nodes without status are filtered as if `passing`") {
     val service = stubService(nodesBuf)
-    val statuses = Some(Set(HealthStatus.Passing))
 
-    val apiPassing = HealthApi(service, statuses)
+    val apiPassing = HealthApi(service, Set(HealthStatus.Passing))
     val responsePassing = await(apiPassing.serviceNodes("hosted_web")).value
 
     assert(responsePassing.size == 1)
     assert(responsePassing.head.ServiceName == Some("hosted_web"))
     assert(responsePassing.head.Node == Some("Sarahs-MBP-2"))
 
-    val apiCritical = HealthApi(service, Some(Set(HealthStatus.Critical)))
+    val apiCritical = HealthApi(service, Set(HealthStatus.Critical))
     val responseCritical = await(apiCritical.serviceNodes("hosted_web")).value
 
     assert(responseCritical.size == 0)
   }
 
-  test("HealthApi supports filtering by health status `any`") {
-    val service = stubService(nodesWithChecksBuf)
-    val statuses = Some(Set(HealthStatus.Any))
-    val api = HealthApi(service, statuses)
-
-    val response = await(api.serviceNodes("hosted_web")).value
-    assert(response.size == 4)
-  }
-
-  test("HealthApi supports filtering by health status `passing`") {
-    val service = stubService(nodesWithChecksBuf)
-    val statuses = Some(Set(HealthStatus.Passing))
-    val api = HealthApi(service, statuses)
-
-    val response = await(api.serviceNodes("hosted_web")).value
-    assert(response.size == 1)
-    assert(response.head.ServiceName == Some("hosted_web"))
-    assert(response.head.Node == Some("node-passing"))
-    assert(response.head.Status == Some(HealthStatus.Passing))
-  }
-
   test("HealthApi supports filtering by health status `warning`") {
     val service = stubService(nodesWithChecksBuf)
-    val statuses = Some(Set(HealthStatus.Warning))
-    val api = HealthApi(service, statuses)
+    val api = HealthApi(service, Set(HealthStatus.Warning))
 
     val response = await(api.serviceNodes("hosted_web")).value
     assert(response.size == 1)
@@ -110,8 +85,7 @@ class HealthApiTest extends FunSuite with Awaits {
 
   test("HealthApi supports filtering by health status `critical`") {
     val service = stubService(nodesWithChecksBuf)
-    val statuses = Some(Set(HealthStatus.Critical))
-    val api = HealthApi(service, statuses)
+    val api = HealthApi(service, Set(HealthStatus.Critical))
 
     val response = await(api.serviceNodes("hosted_web")).value
     assert(response.size == 1)
@@ -122,8 +96,7 @@ class HealthApiTest extends FunSuite with Awaits {
 
   test("HealthApi supports filtering by health status `maintenance`") {
     val service = stubService(nodesWithChecksBuf)
-    val statuses = Some(Set(HealthStatus.Maintenance))
-    val api = HealthApi(service, statuses)
+    val api = HealthApi(service, Set(HealthStatus.Maintenance))
 
     val response = await(api.serviceNodes("hosted_web")).value
     assert(response.size == 1)

--- a/consul/src/test/scala/io/buoyant/consul/v1/HealthApiTest.scala
+++ b/consul/src/test/scala/io/buoyant/consul/v1/HealthApiTest.scala
@@ -9,6 +9,12 @@ import org.scalatest.FunSuite
 
 class HealthApiTest extends FunSuite with Awaits {
   val nodesBuf = Buf.Utf8("""[{"Node":{"Node":"Sarahs-MBP-2","Address":"192.168.1.37"}, "Service": {"Service":"hosted_web","Tags":["master"],"Port":8084, "Address":""}}]""")
+  val nodesWithChecksBuf = Buf.Utf8("""[
+    {"Node":{"Node":"node-passing"}, "Service": {"Service":"hosted_web"}, "Checks": [{"Status":"passing"}]},
+    {"Node":{"Node":"node-warning"}, "Service": {"Service":"hosted_web"}, "Checks": [{"Status":"warning"}]},
+    {"Node":{"Node":"node-critical"}, "Service": {"Service":"hosted_web"}, "Checks": [{"Status":"critical"}]},
+    {"Node":{"Node":"node-maintenance"}, "Service": {"Service":"hosted_web"}, "Checks": [{"Status":"maintenance"}]}
+  ]""")
   var lastUri = ""
 
   def stubService(buf: Buf) = Service.mk[Request, Response] { req =>
@@ -50,5 +56,79 @@ class HealthApiTest extends FunSuite with Awaits {
 
     await(api.serviceNodes("foo", consistency = Some(ConsistencyMode.Consistent)))
     assert(lastUri.contains("consistent=true"))
+  }
+
+  test("Nodes without status are filtered as if `passing`") {
+    val service = stubService(nodesBuf)
+    val statuses = Some(Set(HealthStatus.Passing))
+
+    val apiPassing = HealthApi(service, statuses)
+    val responsePassing = await(apiPassing.serviceNodes("hosted_web")).value
+
+    assert(responsePassing.size == 1)
+    assert(responsePassing.head.ServiceName == Some("hosted_web"))
+    assert(responsePassing.head.Node == Some("Sarahs-MBP-2"))
+
+    val apiCritical = HealthApi(service, Some(Set(HealthStatus.Critical)))
+    val responseCritical = await(apiCritical.serviceNodes("hosted_web")).value
+
+    assert(responseCritical.size == 0)
+  }
+
+  test("HealthApi supports filtering by health status `any`") {
+    val service = stubService(nodesWithChecksBuf)
+    val statuses = Some(Set(HealthStatus.Any))
+    val api = HealthApi(service, statuses)
+
+    val response = await(api.serviceNodes("hosted_web")).value
+    assert(response.size == 4)
+  }
+
+  test("HealthApi supports filtering by health status `passing`") {
+    val service = stubService(nodesWithChecksBuf)
+    val statuses = Some(Set(HealthStatus.Passing))
+    val api = HealthApi(service, statuses)
+
+    val response = await(api.serviceNodes("hosted_web")).value
+    assert(response.size == 1)
+    assert(response.head.ServiceName == Some("hosted_web"))
+    assert(response.head.Node == Some("node-passing"))
+    assert(response.head.Status == Some(HealthStatus.Passing))
+  }
+
+  test("HealthApi supports filtering by health status `warning`") {
+    val service = stubService(nodesWithChecksBuf)
+    val statuses = Some(Set(HealthStatus.Warning))
+    val api = HealthApi(service, statuses)
+
+    val response = await(api.serviceNodes("hosted_web")).value
+    assert(response.size == 1)
+    assert(response.head.ServiceName == Some("hosted_web"))
+    assert(response.head.Node == Some("node-warning"))
+    assert(response.head.Status == Some(HealthStatus.Warning))
+  }
+
+  test("HealthApi supports filtering by health status `critical`") {
+    val service = stubService(nodesWithChecksBuf)
+    val statuses = Some(Set(HealthStatus.Critical))
+    val api = HealthApi(service, statuses)
+
+    val response = await(api.serviceNodes("hosted_web")).value
+    assert(response.size == 1)
+    assert(response.head.ServiceName == Some("hosted_web"))
+    assert(response.head.Node == Some("node-critical"))
+    assert(response.head.Status == Some(HealthStatus.Critical))
+  }
+
+  test("HealthApi supports filtering by health status `maintenance`") {
+    val service = stubService(nodesWithChecksBuf)
+    val statuses = Some(Set(HealthStatus.Maintenance))
+    val api = HealthApi(service, statuses)
+
+    val response = await(api.serviceNodes("hosted_web")).value
+    assert(response.size == 1)
+    assert(response.head.ServiceName == Some("hosted_web"))
+    assert(response.head.Node == Some("node-maintenance"))
+    assert(response.head.Status == Some(HealthStatus.Maintenance))
   }
 }

--- a/consul/src/test/scala/io/buoyant/consul/v1/HealthStatusTest.scala
+++ b/consul/src/test/scala/io/buoyant/consul/v1/HealthStatusTest.scala
@@ -7,10 +7,10 @@ import org.scalatest.FunSuite
 class HealthStatusTest extends FunSuite with Awaits {
 
   test("health statuses can be deserialized from lowercase names") {
-    val yaml = "[passing, warning, critical, maintenance, any]"
+    val yaml = "[passing, warning, critical, maintenance]"
     val mapper = Parser.objectMapper(yaml, Iterable.empty)
     val modes = mapper.readValue[Seq[HealthStatus.Value]](yaml)
-    assert(modes == Seq(HealthStatus.Passing, HealthStatus.Warning, HealthStatus.Critical, HealthStatus.Maintenance, HealthStatus.Any))
+    assert(modes == Seq(HealthStatus.Passing, HealthStatus.Warning, HealthStatus.Critical, HealthStatus.Maintenance))
   }
 
   test("health statuses can be compared by worst case") {

--- a/consul/src/test/scala/io/buoyant/consul/v1/HealthStatusTest.scala
+++ b/consul/src/test/scala/io/buoyant/consul/v1/HealthStatusTest.scala
@@ -13,9 +13,14 @@ class HealthStatusTest extends FunSuite with Awaits {
     assert(modes == Seq(HealthStatus.Passing, HealthStatus.Warning, HealthStatus.Critical, HealthStatus.Maintenance, HealthStatus.Any))
   }
 
-  test("health statuses can be aggregated by worst case") {
-    val statuses = Seq(HealthStatus.Passing, HealthStatus.Warning, HealthStatus.Critical)
-    assert(statuses.reduce(HealthStatus.worstCase) == HealthStatus.Critical)
+  test("health statuses can be compared by worst case") {
+    // HealthStatus order should be maintenance > critical > warning > passing
+    assert(HealthStatus.worstCase(HealthStatus.Maintenance, HealthStatus.Critical) == HealthStatus.Maintenance)
+    assert(HealthStatus.worstCase(HealthStatus.Critical, HealthStatus.Warning) == HealthStatus.Critical)
+    assert(HealthStatus.worstCase(HealthStatus.Warning, HealthStatus.Passing) == HealthStatus.Warning)
+
+    val statuses = Seq(HealthStatus.Passing, HealthStatus.Warning, HealthStatus.Critical, HealthStatus.Maintenance)
+    assert(statuses.reduce(HealthStatus.worstCase) == HealthStatus.Maintenance)
   }
 
 }

--- a/consul/src/test/scala/io/buoyant/consul/v1/HealthStatusTest.scala
+++ b/consul/src/test/scala/io/buoyant/consul/v1/HealthStatusTest.scala
@@ -1,0 +1,21 @@
+package io.buoyant.consul.v1
+
+import io.buoyant.config.Parser
+import io.buoyant.test.Awaits
+import org.scalatest.FunSuite
+
+class HealthStatusTest extends FunSuite with Awaits {
+
+  test("health statuses can be deserialized from lowercase names") {
+    val yaml = "[passing, warning, critical, maintenance, any]"
+    val mapper = Parser.objectMapper(yaml, Iterable.empty)
+    val modes = mapper.readValue[Seq[HealthStatus.Value]](yaml)
+    assert(modes == Seq(HealthStatus.Passing, HealthStatus.Warning, HealthStatus.Critical, HealthStatus.Maintenance, HealthStatus.Any))
+  }
+
+  test("health statuses can be aggregated by worst case") {
+    val statuses = Seq(HealthStatus.Passing, HealthStatus.Warning, HealthStatus.Critical)
+    assert(statuses.reduce(HealthStatus.worstCase) == HealthStatus.Critical)
+  }
+
+}

--- a/linkerd/docs/namer.md
+++ b/linkerd/docs/namer.md
@@ -189,8 +189,8 @@ prefix | `io.l5d.consul` | Resolves names with `/#/<prefix>`.
 host | `localhost` | The Consul host.
 port | `8500` | The Consul port.
 includeTag | `false` | If `true`, read a Consul tag from the path.
-useHealthCheck | `false` | If `true`, exclude app instances that are failing Consul health checks. Even if `false`, linkerd's built-in resiliency algorithms will still apply.
-healthStatuses | `any` | Exclude app instances which do not match one of the provided Consul health check statuses. Possible values are `passing`, `warning`, `critical`, `maintenance` and the wildcard status `any`. Note that if a service defines more than one health check per app instance then the most representative statuses is used (`maintenance` > `critical` > `warning` > `passing`). If `useHealthCheck` is `true` this parameter is overridden with `passing` and any values provided are ignored. Regardless of the statuses used to filter, linkerd's built-in resiliency algorithms will still apply.
+useHealthCheck | `false` | If `true`, exclude app instances that do not match one of the provided `healthStatuses`. Even if `false`, linkerd's built-in resiliency algorithms will still apply.
+healthStatuses | `passing` | List of statuses to used to filter Consul app instances by. Possible values are `passing`, `warning`, `critical`, `maintenance`. Note that if a service defines more than one health check per app instance then the most representative statuses is used (`maintenance` > `critical` > `warning` > `passing`). If `useHealthCheck` is `false` then this parameter has no effect. Regardless of the statuses used to filter, linkerd's built-in resiliency algorithms will still apply.
 token | no authentication | The auth token to use when making API calls.
 setHost | `false` | If `true`, HTTP requests resolved by Consul will have their Host header overwritten to `${serviceName}.service.${datacenter}.${domain}`. `$domain` is fetched from Consul.
 consistencyMode | `default` | Select between [Consul API consistency modes](https://www.consul.io/docs/agent/http.html) such as `default`, `stale` and `consistent`.

--- a/linkerd/docs/namer.md
+++ b/linkerd/docs/namer.md
@@ -166,7 +166,10 @@ namers:
   host: 127.0.0.1
   port: 2181
   includeTag: true
-  useHealthCheck: true
+  useHealthCheck: false
+  healthStatuses:
+    - "passing"
+    - "warning"
   setHost: true
   consistencyMode: stale
 ```
@@ -187,6 +190,7 @@ host | `localhost` | The Consul host.
 port | `8500` | The Consul port.
 includeTag | `false` | If `true`, read a Consul tag from the path.
 useHealthCheck | `false` | If `true`, exclude app instances that are failing Consul health checks. Even if `false`, linkerd's built-in resiliency algorithms will still apply.
+healthStatuses | `any` | Exclude app instances which do not match one of the provided Consul health check statuses. Possible values are `passing`, `warning`, `critical`, `maintenance` and the wildcard status `any`. Note that if a service defines more than one health check per app instance then the most representative statuses is used (`maintenance` > `critical` > `warning` > `passing`). If `useHealthCheck` is `true` this parameter is overridden with `passing` and any values provided are ignored. Regardless of the statuses used to filter, linkerd's built-in resiliency algorithms will still apply.
 token | no authentication | The auth token to use when making API calls.
 setHost | `false` | If `true`, HTTP requests resolved by Consul will have their Host header overwritten to `${serviceName}.service.${datacenter}.${domain}`. `$domain` is fetched from Consul.
 consistencyMode | `default` | Select between [Consul API consistency modes](https://www.consul.io/docs/agent/http.html) such as `default`, `stale` and `consistent`.

--- a/namer/consul/src/main/scala/io/buoyant/namer/consul/ConsulInitializer.scala
+++ b/namer/consul/src/main/scala/io/buoyant/namer/consul/ConsulInitializer.scala
@@ -20,9 +20,9 @@ import io.buoyant.namer.{NamerConfig, NamerInitializer}
  *   host: consul.site.biz
  *   port: 8600
  *   includeTag: true
- *   useHealthCheck: false
+ *   useHealthCheck: true
  *   healthStatuses:
- *   - any
+ *   - passing
  *   setHost: true
  *   token: some-consul-acl-token
  *   consistencyMode: default
@@ -78,8 +78,8 @@ case class ConsulConfig(
       .newService(s"/$$/inet/$getHost/$getPort")
 
     val consul = (useHealthCheck, healthStatuses) match {
-      case (Some(true), _) => v1.HealthApi(service, Some(Set(HealthStatus.Passing)))
-      case (_, Some(status)) => v1.HealthApi(service, Some(status))
+      case (Some(true), Some(status)) => v1.HealthApi(service, status)
+      case (Some(true), _) => v1.HealthApi(service, Set(HealthStatus.Passing))
       case _ => v1.CatalogApi(service)
     }
     val agent = v1.AgentApi(service)

--- a/namer/consul/src/test/scala/io/buoyant/namer/consul/ConsulNamerTest.scala
+++ b/namer/consul/src/test/scala/io/buoyant/namer/consul/ConsulNamerTest.scala
@@ -19,7 +19,8 @@ class ConsulNamerTest extends FunSuite with Awaits {
     Some("servicename"),
     Some(Seq.empty),
     Some(""),
-    Some(8080)
+    Some(8080),
+    Some(HealthStatus.Passing)
   )
   val testServiceNode2 = ServiceNode(
     Some("node2"),
@@ -28,7 +29,8 @@ class ConsulNamerTest extends FunSuite with Awaits {
     Some("servicename"),
     Some(Seq.empty),
     Some(""),
-    Some(8080)
+    Some(8080),
+    Some(HealthStatus.Passing)
   )
 
   def assertOnAddrs(
@@ -191,7 +193,7 @@ class ConsulNamerTest extends FunSuite with Awaits {
         retry: Boolean = false
       ): Future[Indexed[Seq[ServiceNode]]] = blockingIndex match {
         case Some("0") | None =>
-          val node = ServiceNode(Some("foobar"), None, None, None, None, Some("127.0.0.1"), Some(8888))
+          val node = ServiceNode(Some("foobar"), None, None, None, None, Some("127.0.0.1"), Some(8888), None)
           Future.value(Indexed(Seq(node), Some("1")))
         case _ => Future.never //don't respond to blocking index calls
       }

--- a/namer/consul/src/test/scala/io/buoyant/namer/consul/ConsulTest.scala
+++ b/namer/consul/src/test/scala/io/buoyant/namer/consul/ConsulTest.scala
@@ -39,7 +39,7 @@ class ConsulTest extends FunSuite {
                     |port: 8600
                     |token: some-token
                     |includeTag: true
-                    |useHealthCheck: false
+                    |useHealthCheck: true
                     |healthStatuses:
                     | - warning
                     |setHost: true
@@ -53,7 +53,7 @@ class ConsulTest extends FunSuite {
     assert(consul.host == Some("consul.site.biz"))
     assert(consul.port == Some(Port(8600)))
     assert(consul.token == Some("some-token"))
-    assert(consul.useHealthCheck == Some(false))
+    assert(consul.useHealthCheck == Some(true))
     assert(consul.healthStatuses == Some(Set(HealthStatus.Warning)))
     assert(consul.setHost == Some(true))
     assert(consul.includeTag == Some(true))

--- a/namer/consul/src/test/scala/io/buoyant/namer/consul/ConsulTest.scala
+++ b/namer/consul/src/test/scala/io/buoyant/namer/consul/ConsulTest.scala
@@ -5,6 +5,7 @@ import com.twitter.finagle.util.LoadService
 import io.buoyant.config.Parser
 import io.buoyant.config.types.Port
 import io.buoyant.consul.v1.ConsistencyMode
+import io.buoyant.consul.v1.HealthStatus
 import io.buoyant.namer.{NamerConfig, NamerInitializer}
 import org.scalatest.FunSuite
 
@@ -12,7 +13,7 @@ class ConsulTest extends FunSuite {
 
   test("sanity") {
     // ensure it doesn't totally blowup
-    val _ = ConsulConfig(None, None, None, None, None, None, None, None, None).newNamer(Stack.Params.empty)
+    val _ = ConsulConfig(None, None, None, None, None, None, None, None, None, None).newNamer(Stack.Params.empty)
   }
 
   test("service registration") {
@@ -38,6 +39,9 @@ class ConsulTest extends FunSuite {
                     |port: 8600
                     |token: some-token
                     |includeTag: true
+                    |useHealthCheck: false
+                    |healthStatuses:
+                    | - warning
                     |setHost: true
                     |consistencyMode: stale
                     |failFast: true
@@ -49,6 +53,8 @@ class ConsulTest extends FunSuite {
     assert(consul.host == Some("consul.site.biz"))
     assert(consul.port == Some(Port(8600)))
     assert(consul.token == Some("some-token"))
+    assert(consul.useHealthCheck == Some(false))
+    assert(consul.healthStatuses == Some(Set(HealthStatus.Warning)))
     assert(consul.setHost == Some(true))
     assert(consul.includeTag == Some(true))
     assert(consul.consistencyMode == Some(ConsistencyMode.Stale))


### PR DESCRIPTION
Adding the healthStatuses parameter to linkerd consul api #1601.

The only concern I have is the way the `healthStatuses` are used to filter the nodes are passed to `HealthApi`, I could move the parameter into the serviceNodes method but that would require also modifying `CatalogueApi` and a number of intermediate calls. There may be another approach that I am missing though.

A few other things are worth highlighting:

- Each consul node can have more than one health check associated with it, for this reason the checks for an individual node are aggregated into a single health status before the filtering is applied. This is the same approach as taken in [consul template](https://github.com/hashicorp/consul/blob/master/api/health.go) (in particular see line 42.)

- There is some conflict with the existing `useHealthChecks` parameter, for backwards compatibility my implementation currently makes `useHealthChecks = True` override the healthStatuses parameter to be just `passing`. There may be a better approach to this, such as throwing an exception if both are defined or deprecating `useHealthChecks` in favour of `healthStatuses`.

- If `healthStatuses` is passed as just `passing` (or if `useHealthChecks = True`) then we could 
still use the `passing` parameter of the consul api to filter on the server side. However this would complicate the code for potentially little/no real gain.

- While `healthStatuses` takes an array of statuses it also allows any `any` parameter for convenience, which is also the default parameter. If no value is provided to `healthStatuses` then
it defaults to `any` which is equivalent to the existing behaviour.
