### PR TITLE
add Namer for DNS SRV records

### DIFF
--- a/linkerd/docs/namer.md
+++ b/linkerd/docs/namer.md
@@ -178,7 +178,7 @@ dtab: |
   /svc => /#/io.l5d.consul/dc1/prod;
 ```
 
-linker provides support for service discovery via [Consul](https://www.consul.io/).
+linkerd provides support for service discovery via [Consul](https://www.consul.io/).
 
 Key | Default Value | Description
 --- | ------------- | -----------
@@ -479,7 +479,7 @@ port | `8080` | The port of the Istio-Manager.
 Key | Required | Description
 --- | -------- | -----------
 prefix | yes | Tells linkerd to resolve the request path using the Istio namer.
-port-name | yes | The port name.
+
 cluster | yes | The fully qualified name of the service.
 labels | yes | A `::` delimited list of `label:value` pairs.  Only endpoints that match all of these label selectors will be returned.
 
@@ -567,6 +567,58 @@ Further reading:
 * [Mesosphere Universe Repo](https://github.com/mesosphere/universe/search?utf8=%E2%9C%93&q=DCOS_SERVICE_ACCOUNT_CREDENTIAL)
 
 <a name="zkLeader"></a>
+
+## DNS SRV Records
+
+kind: `io.l5d.dnssrv`
+
+### DNS-SRV Configuration
+
+> Configure a DNS-SRV namer
+
+```yaml
+namers:
+- kind: io.l5d.dnssrv
+  experimental: true
+  refreshIntervalSeconds: 5
+  dnsHosts:
+  - ns0.example.org
+  - ns1.example.org
+```
+
+> Then reference the namer in the dtab to use it:
+```
+dtab: |
+  /dnssrv => /#/io.l5d.dnssrv
+  /svc/myservice =>
+    /dnssrv/myservice.srv.example.org &
+    /dnssrv/myservice2.srv.example.org;
+  /svc/other => 
+    /dnssrv/other.srv.example.org;
+
+```
+
+linkerd provides support for service discovery via DNS SRV records.
+
+Key | Default Value | Description
+--- | ------------- | -----------
+prefix | `io.l5d.dnssrv` | Resolves names with `/#/<prefix>`.
+experimental | `false` | Since the DNS-SRV namer is still considered experimental, this must be set to `true`.
+refreshIntervalSeconds | `5` | linkerd will perform a SRV lookup for each host every `refreshIntervalSeconds`.
+dnsHosts | `<empty list>` | If specified, linkerd will use these DNS servers to perform SRV lookups. If not specified, linkerd will use the default system resolver.
+ 
+### DNS-SRV Path Parameters
+
+> Dtab Path Format
+
+```
+/#/<prefix>/<address>
+```
+
+Key     | Required | Description
+prefix  | yes      | Tells linkerd to resolve the request path using the DNS-SRV namer.
+address |          | The DNS address of a SRV record. Linkerd resolves the record to one or more `address:port` tuples using a SRV lookup 
+
 ## ZooKeeper Leader
 
 kind: `io.l5d.zkLeader`

--- a/namer/dnssrv/src/integration/scala/io/buoyant/namer/dnssrv/DnsSrvNamerIntegrationTest.scala
+++ b/namer/dnssrv/src/integration/scala/io/buoyant/namer/dnssrv/DnsSrvNamerIntegrationTest.scala
@@ -1,17 +1,17 @@
 package io.buoyant.namer.dnssrv
 
-import com.twitter.finagle.{Addr, Name, NameTree, Path}
 import com.twitter.finagle.stats.NullStatsReceiver
+import com.twitter.finagle.{Addr, Name, NameTree, Path}
 import com.twitter.util.{Duration, NullTimer}
-import io.buoyant.test.FunSuite
+import io.buoyant.namer.RichActivity
+import io.buoyant.test.{Awaits, FunSuite}
 import org.scalatest.Matchers
 import org.xbill.DNS
 
-class DnsSrvNamerIntegrationTest extends FunSuite with Matchers {
+class DnsSrvNamerIntegrationTest extends FunSuite with Awaits with Matchers {
   test("can resolve some public SRV revord") {
     val namer = new DnsSrvNamer(Path.empty, new DNS.ExtendedResolver, new NullTimer, Duration.Zero, new NullStatsReceiver)
-    val result = namer.lookupSrv("_http._tcp.mxtoolbox.com.", Path.read("/foo"), Path.empty)
-    result.get().simplified match {
+    await(namer.lookup(Path.read("/_http._tcp.mxtoolbox.com.")).toFuture) match {
       case NameTree.Leaf(Name.Bound(varAddr)) => varAddr.sample() match {
         case Addr.Bound(addrs, _) => addrs should not be empty
         case addr => fail(s"unexpected addr: $addr")

--- a/namer/dnssrv/src/integration/scala/io/buoyant/namer/dnssrv/DnsSrvNamerIntegrationTest.scala
+++ b/namer/dnssrv/src/integration/scala/io/buoyant/namer/dnssrv/DnsSrvNamerIntegrationTest.scala
@@ -10,7 +10,7 @@ import org.xbill.DNS
 class DnsSrvNamerIntegrationTest extends FunSuite with Matchers {
   test("can resolve some public SRV revord") {
     val namer = new DnsSrvNamer(Path.empty, new DNS.ExtendedResolver, new NullTimer, Duration.Zero, new NullStatsReceiver)
-    val result = namer.lookupSrv("_http._tcp.mxtoolbox.com.", Path.read("/foo"), null)
+    val result = namer.lookupSrv("_http._tcp.mxtoolbox.com.", Path.read("/foo"))
     result.get().simplified match {
       case NameTree.Leaf(Name.Bound(varAddr)) => varAddr.sample() match {
         case Addr.Bound(addrs, _) => addrs should not be empty

--- a/namer/dnssrv/src/integration/scala/io/buoyant/namer/dnssrv/DnsSrvNamerIntegrationTest.scala
+++ b/namer/dnssrv/src/integration/scala/io/buoyant/namer/dnssrv/DnsSrvNamerIntegrationTest.scala
@@ -10,7 +10,7 @@ import org.xbill.DNS
 class DnsSrvNamerIntegrationTest extends FunSuite with Matchers {
   test("can resolve some public SRV revord") {
     val namer = new DnsSrvNamer(Path.empty, new DNS.ExtendedResolver, new NullTimer, Duration.Zero, new NullStatsReceiver)
-    val result = namer.lookupSrv("_http._tcp.mxtoolbox.com.", Path.read("/foo"))
+    val result = namer.lookupSrv("_http._tcp.mxtoolbox.com.", Path.read("/foo"), Path.empty)
     result.get().simplified match {
       case NameTree.Leaf(Name.Bound(varAddr)) => varAddr.sample() match {
         case Addr.Bound(addrs, _) => addrs should not be empty

--- a/namer/dnssrv/src/integration/scala/io/buoyant/namer/dnssrv/DnsSrvNamerIntegrationTest.scala
+++ b/namer/dnssrv/src/integration/scala/io/buoyant/namer/dnssrv/DnsSrvNamerIntegrationTest.scala
@@ -1,0 +1,22 @@
+package io.buoyant.namer.dnssrv
+
+import com.twitter.finagle.{Addr, Name, NameTree, Path}
+import com.twitter.finagle.stats.NullStatsReceiver
+import com.twitter.util.{Duration, NullTimer}
+import io.buoyant.test.FunSuite
+import org.scalatest.Matchers
+import org.xbill.DNS
+
+class DnsSrvNamerIntegrationTest extends FunSuite with Matchers {
+  test("can resolve some public SRV revord") {
+    val namer = new DnsSrvNamer(Path.empty, new DNS.ExtendedResolver, new NullTimer, Duration.Zero, new NullStatsReceiver)
+    val result = namer.lookupSrv("_http._tcp.mxtoolbox.com.", Path.read("/foo"), null)
+    result.get().simplified match {
+      case NameTree.Leaf(Name.Bound(varAddr)) => varAddr.sample() match {
+        case Addr.Bound(addrs, _) => addrs should not be empty
+        case addr => fail(s"unexpected addr: $addr")
+      }
+      case other => fail(s"unexpected result: $other")
+    }
+  }
+}

--- a/namer/dnssrv/src/integration/scala/io/buoyant/namer/dnssrv/DnsSrvNamerIntegrationTest.scala
+++ b/namer/dnssrv/src/integration/scala/io/buoyant/namer/dnssrv/DnsSrvNamerIntegrationTest.scala
@@ -1,8 +1,9 @@
 package io.buoyant.namer.dnssrv
 
 import com.twitter.finagle.stats.NullStatsReceiver
+import com.twitter.finagle.util.DefaultTimer
 import com.twitter.finagle.{Addr, Name, NameTree, Path}
-import com.twitter.util.{Duration, NullTimer}
+import com.twitter.util.{Duration, FuturePool}
 import io.buoyant.namer.RichActivity
 import io.buoyant.test.{Awaits, FunSuite}
 import org.scalatest.Matchers
@@ -10,7 +11,7 @@ import org.xbill.DNS
 
 class DnsSrvNamerIntegrationTest extends FunSuite with Awaits with Matchers {
   test("can resolve some public SRV revord") {
-    val namer = new DnsSrvNamer(Path.empty, new DNS.ExtendedResolver, new NullTimer, Duration.Zero, new NullStatsReceiver)
+    val namer = new DnsSrvNamer(Path.empty, new DNS.ExtendedResolver, Duration.Zero, new NullStatsReceiver, FuturePool.unboundedPool)(DefaultTimer)
     await(namer.lookup(Path.read("/_http._tcp.mxtoolbox.com.")).toFuture) match {
       case NameTree.Leaf(Name.Bound(varAddr)) => varAddr.sample() match {
         case Addr.Bound(addrs, _) => addrs should not be empty

--- a/namer/dnssrv/src/main/resources/META-INF/services/io.buoyant.namer.NamerInitializer
+++ b/namer/dnssrv/src/main/resources/META-INF/services/io.buoyant.namer.NamerInitializer
@@ -1,0 +1,1 @@
+io.buoyant.namer.dnssrv.DnsSrvNamerInitializer

--- a/namer/dnssrv/src/main/scala/io/buoyant/namer/dnssrv/DnsSrvNamer.scala
+++ b/namer/dnssrv/src/main/scala/io/buoyant/namer/dnssrv/DnsSrvNamer.scala
@@ -12,7 +12,13 @@ import com.twitter.util.Activity.State
 import com.twitter.util._
 import org.xbill.DNS
 
-class DnsSrvNamer(prefix: Path, resolver: DNS.Resolver, refreshInterval: Duration, stats: StatsReceiver, pool: FuturePool)(implicit val timer: Timer)
+class DnsSrvNamer(
+  prefix: Path,
+  resolver: DNS.Resolver,
+  refreshInterval: Duration,
+  stats: StatsReceiver,
+  pool: FuturePool
+)(implicit val timer: Timer)
   extends Namer {
 
   override def lookup(path: Path): Activity[NameTree[Name]] = memoizedLookup(path)

--- a/namer/dnssrv/src/main/scala/io/buoyant/namer/dnssrv/DnsSrvNamer.scala
+++ b/namer/dnssrv/src/main/scala/io/buoyant/namer/dnssrv/DnsSrvNamer.scala
@@ -32,7 +32,7 @@ class DnsSrvNamer(prefix: Path, resolver: DNS.Resolver, timer: Timer, refreshInt
     }
   }
 
-  private[dnssrv] def lookupSrv(address: String, id: Path, residual: Path): Try[NameTree[Name]] = {
+  private def lookupSrv(address: String, id: Path, residual: Path): Try[NameTree[Name]] = {
     val question = DNS.Record.newRecord(
       DNS.Name.fromString(address),
       DNS.Type.SRV,

--- a/namer/dnssrv/src/main/scala/io/buoyant/namer/dnssrv/DnsSrvNamer.scala
+++ b/namer/dnssrv/src/main/scala/io/buoyant/namer/dnssrv/DnsSrvNamer.scala
@@ -2,20 +2,26 @@ package io.buoyant.namer.dnssrv
 
 import java.io.IOException
 import java.net.InetSocketAddress
+import java.util.concurrent.TimeUnit
 
 import com.twitter.finagle._
-import com.twitter.finagle.stats.StatsReceiver
+import com.twitter.finagle.stats.{Stat, StatsReceiver}
 import com.twitter.logging.Logger
 import com.twitter.util.Activity.State
 import com.twitter.util._
 import org.xbill.DNS
 
-class DnsSrvNamer(prefix: Path, resolver: DNS.Resolver, timer: Timer, refreshInterval: Duration, stats: StatsReceiver)
+class DnsSrvNamer(prefix: Path, resolver: DNS.Resolver, timer: Timer,refreshInterval: Duration, stats: StatsReceiver)
   extends Namer {
 
   override def lookup(path: Path): Activity[NameTree[Name]] = memoizedLookup(path)
 
+  private val success = stats.counter("lookup_successes_total")
+  private val failure = stats.counter("lookup_failures_total")
+  private val zeroResults = stats.counter("lookup_zero_results_total")
+  private val latency = stats.stat("request_duration_seconds")
   private val log = Logger.get("dnssrv")
+
   private val memoizedLookup: (Path) => Activity[NameTree[Name]] = Memoize { path =>
     path.take(1) match {
       case id@Path.Utf8(address) =>
@@ -40,10 +46,11 @@ class DnsSrvNamer(prefix: Path, resolver: DNS.Resolver, timer: Timer, refreshInt
     )
     val query = DNS.Message.newQuery(question)
     log.debug("looking up %s", address)
-    Try(resolver.send(query)) flatMap { message =>
+    Try(Stat.time(latency, TimeUnit.SECONDS)(resolver.send(query))) flatMap { message =>
       message.getRcode match {
         case DNS.Rcode.NXDOMAIN =>
           log.trace("no results for %s", address)
+          failure.incr()
           Return(NameTree.Neg)
         case DNS.Rcode.NOERROR =>
           val hosts = message.getSectionArray(DNS.Section.ADDITIONAL).collect {
@@ -61,14 +68,17 @@ class DnsSrvNamer(prefix: Path, resolver: DNS.Resolver, timer: Timer, refreshInt
             // return NameTree.Neg because NameTree.Empty causes requests to fail,
             // even in the presence of load-balancing (NameTree.Union) and fail-over (NameTree.Alt)
             log.trace("empty response for %s", address)
+            zeroResults.incr()
             Return(NameTree.Neg)
           } else {
             log.trace("got %d results for %s", srvRecords.length, address)
+            success.incr()
             Return(NameTree.Leaf(Name.Bound(Var.value(Addr.Bound(srvRecords: _*)), id, residual)))
           }
         case code =>
           val msg = s"unexpected RCODE: ${DNS.Rcode.string(code)} for $address"
           log.warning(msg)
+          failure.incr()
           Throw(new IOException(msg))
       }
     }

--- a/namer/dnssrv/src/main/scala/io/buoyant/namer/dnssrv/DnsSrvNamer.scala
+++ b/namer/dnssrv/src/main/scala/io/buoyant/namer/dnssrv/DnsSrvNamer.scala
@@ -73,7 +73,7 @@ class DnsSrvNamer(prefix: Path, resolver: DNS.Resolver, timer: Timer, refreshInt
           NameTree.Leaf(Name.Bound(Var.value(Addr.Bound(srvRecords: _*)), id))
         }
       case code =>
-        log.trace("unexpected RCODE: %d for %s", code, address)
+        log.warning("unexpected RCODE: %s for %s", DNS.Rcode.string(code), address)
         NameTree.Fail
     }
   }

--- a/namer/dnssrv/src/main/scala/io/buoyant/namer/dnssrv/DnsSrvNamer.scala
+++ b/namer/dnssrv/src/main/scala/io/buoyant/namer/dnssrv/DnsSrvNamer.scala
@@ -26,7 +26,7 @@ class DnsSrvNamer(prefix: Path, resolver: DNS.Resolver, timer: Timer, refreshInt
         // This is ok, since the body is only run when something subscribes to the Var.
         Var.async[State[NameTree[Name]]](Activity.Pending) { state =>
           timer.schedule(refreshInterval) {
-            val next = lookupSrv(address, prefix ++ id, path.drop(2)) match {
+            val next = lookupSrv(address, prefix ++ id, path.drop(1)) match {
               case Return(nameTree) => Activity.Ok(nameTree)
               case Throw(e) => Activity.Failed(e)
             }

--- a/namer/dnssrv/src/main/scala/io/buoyant/namer/dnssrv/DnsSrvNamer.scala
+++ b/namer/dnssrv/src/main/scala/io/buoyant/namer/dnssrv/DnsSrvNamer.scala
@@ -1,0 +1,80 @@
+package io.buoyant.namer.dnssrv
+
+import java.net.InetSocketAddress
+
+import com.twitter.finagle._
+import com.twitter.finagle.stats.StatsReceiver
+import com.twitter.logging.Logger
+import com.twitter.util.Activity.State
+import com.twitter.util._
+import org.xbill.DNS
+
+import scala.collection.concurrent.TrieMap
+
+class DnsSrvNamer(prefix: Path, resolver: DNS.Resolver, timer: Timer, refreshInterval: Duration, stats: StatsReceiver)
+  extends Namer {
+
+  private val log = Logger.get("dnssrv")
+  private val cache = TrieMap.empty[Path, Var[State[NameTree[Name]]]]
+
+  override def lookup(path: Path): Activity[NameTree[Name]] = path.take(1) match {
+    case id@Path.Utf8(address) =>
+      log.trace("lookup %s", id)
+      val states = cache.getOrElseUpdate(
+        id,
+        // TrieMap may evaluate this unnecessarily in case of concurrent calls.
+        // This is ok, since the body is only run when something subscribes to the Var.
+        Var.async[State[NameTree[Name]]](Activity.Pending) { state =>
+          timer.schedule(refreshInterval) {
+            val next = lookupSrv(address, prefix ++ id, path.drop(2)) match {
+              case Return(nameTree) => Activity.Ok(nameTree)
+              case Throw(e) => Activity.Failed(e)
+            }
+            state.update(next)
+          }
+        }
+      )
+      Activity(states)
+    case _ => Activity.value(NameTree.Neg)
+  }
+
+  private[dnssrv] def lookupSrv(address: String, id: Path, residual: Path): Try[NameTree[Name]] = Try {
+    val question = DNS.Record.newRecord(
+      DNS.Name.fromString(address),
+      DNS.Type.SRV,
+      DNS.DClass.IN
+    )
+    val query = DNS.Message.newQuery(question)
+    log.debug("looking up %s", address)
+    val m = resolver.send(query)
+    log.debug("got response %s", address)
+    m.getRcode match {
+      case DNS.Rcode.NXDOMAIN =>
+        log.trace("no results for %s", address)
+        NameTree.Neg
+      case DNS.Rcode.NOERROR =>
+        val hosts = m.getSectionArray(DNS.Section.ADDITIONAL).collect {
+          case a: DNS.ARecord => a.getName -> a.getAddress
+        }.toMap
+        val srvRecords = m.getSectionArray(DNS.Section.ANSWER).collect {
+          case srv: DNS.SRVRecord =>
+            hosts.get(srv.getTarget) match {
+              case Some(inetAddress) => Address(new InetSocketAddress(inetAddress, srv.getPort))
+              case None => Address(srv.getTarget.toString, srv.getPort)
+            }
+        }
+        if (srvRecords.isEmpty) {
+          // valid DNS entry, but no instances.
+          // for some reason, NameTree.Empty doesn't work right
+          log.trace("empty response for %s", address)
+          NameTree.Neg
+        } else {
+          log.trace("got %d results for %s", srvRecords.length, address)
+          NameTree.Leaf(Name.Bound(Var.value(Addr.Bound(srvRecords: _*)), id))
+        }
+      case code =>
+        log.trace("unexpected RCODE: %d for %s", code, address)
+        NameTree.Fail
+    }
+  }
+}

--- a/namer/dnssrv/src/main/scala/io/buoyant/namer/dnssrv/DnsSrvNamer.scala
+++ b/namer/dnssrv/src/main/scala/io/buoyant/namer/dnssrv/DnsSrvNamer.scala
@@ -41,7 +41,6 @@ class DnsSrvNamer(prefix: Path, resolver: DNS.Resolver, timer: Timer, refreshInt
     val query = DNS.Message.newQuery(question)
     log.debug("looking up %s", address)
     Try(resolver.send(query)) flatMap { message =>
-      log.debug("got response %s", address)
       message.getRcode match {
         case DNS.Rcode.NXDOMAIN =>
           log.trace("no results for %s", address)
@@ -59,7 +58,8 @@ class DnsSrvNamer(prefix: Path, resolver: DNS.Resolver, timer: Timer, refreshInt
           }
           if (srvRecords.isEmpty) {
             // valid DNS entry, but no instances.
-            // for some reason, NameTree.Empty doesn't work right
+            // return NameTree.Neg because NameTree.Empty causes requests to fail,
+            // even in the presence of load-balancing (NameTree.Union) and fail-over (NameTree.Alt)
             log.trace("empty response for %s", address)
             Return(NameTree.Neg)
           } else {

--- a/namer/dnssrv/src/main/scala/io/buoyant/namer/dnssrv/DnsSrvNamerInitializer.scala
+++ b/namer/dnssrv/src/main/scala/io/buoyant/namer/dnssrv/DnsSrvNamerInitializer.scala
@@ -40,7 +40,7 @@ case class DnsSrvNamerConfig(refreshIntervalSeconds: Option[Int], dnsHosts: Opti
     )
     val timer = params[param.Timer].timer
     val refreshInterval = refreshIntervalSeconds.getOrElse(5).seconds
-    new DnsSrvNamer(prefix, resolver, timer, refreshInterval, stats)
+    new DnsSrvNamer(prefix, resolver, timer, refreshInterval, stats.scope("dnssrv"))
   }
 }
 object DnsSrvNamerConfig {

--- a/namer/dnssrv/src/main/scala/io/buoyant/namer/dnssrv/DnsSrvNamerInitializer.scala
+++ b/namer/dnssrv/src/main/scala/io/buoyant/namer/dnssrv/DnsSrvNamerInitializer.scala
@@ -7,6 +7,8 @@ import com.twitter.conversions.time._
 import com.twitter.finagle.Stack.Params
 import com.twitter.finagle._
 import io.buoyant.namer.{NamerConfig, NamerInitializer}
+import org.xbill.DNS
+import DnsSrvNamerConfig.Edns
 
 class DnsSrvNamerInitializer extends NamerInitializer {
   override val configClass = classOf[DnsSrvNamerConfig]
@@ -21,8 +23,6 @@ case class DnsSrvNamerConfig(refreshIntervalSeconds: Option[Int], dnsHosts: Opti
 
   @JsonIgnore
   override def newNamer(params: Params): Namer = {
-    import org.xbill.DNS
-    import DnsSrvNamerConfig.Edns
 
     val stats = params[param.Stats].statsReceiver.scope(prefix.show.stripPrefix("/"))
     val resolver = dnsHosts match {

--- a/namer/dnssrv/src/main/scala/io/buoyant/namer/dnssrv/DnsSrvNamerInitializer.scala
+++ b/namer/dnssrv/src/main/scala/io/buoyant/namer/dnssrv/DnsSrvNamerInitializer.scala
@@ -9,6 +9,7 @@ import com.twitter.finagle._
 import io.buoyant.namer.{NamerConfig, NamerInitializer}
 import org.xbill.DNS
 import DnsSrvNamerConfig.Edns
+import com.twitter.util.FuturePool
 
 class DnsSrvNamerInitializer extends NamerInitializer {
   override val configClass = classOf[DnsSrvNamerConfig]
@@ -40,7 +41,8 @@ case class DnsSrvNamerConfig(refreshIntervalSeconds: Option[Int], dnsHosts: Opti
     )
     val timer = params[param.Timer].timer
     val refreshInterval = refreshIntervalSeconds.getOrElse(5).seconds
-    new DnsSrvNamer(prefix, resolver, timer, refreshInterval, stats.scope("dnssrv"))
+    val pool = FuturePool.unboundedPool
+    new DnsSrvNamer(prefix, resolver, refreshInterval, stats.scope("dnssrv"), pool)(timer)
   }
 }
 object DnsSrvNamerConfig {

--- a/namer/dnssrv/src/main/scala/io/buoyant/namer/dnssrv/DnsSrvNamerInitializer.scala
+++ b/namer/dnssrv/src/main/scala/io/buoyant/namer/dnssrv/DnsSrvNamerInitializer.scala
@@ -19,6 +19,9 @@ object DnsSrvNamerInitializer extends DnsSrvNamerInitializer
 case class DnsSrvNamerConfig(refreshIntervalSeconds: Option[Int], dnsHosts: Option[Seq[String]]) extends NamerConfig {
 
   @JsonIgnore
+  override def experimentalRequired = true
+
+  @JsonIgnore
   override def defaultPrefix: Path = Path.read("/io.l5d.dnssrv")
 
   @JsonIgnore

--- a/namer/dnssrv/src/test/scala/io/buoyant/namer/dnssrv/DnsSrvNamerTest.scala
+++ b/namer/dnssrv/src/test/scala/io/buoyant/namer/dnssrv/DnsSrvNamerTest.scala
@@ -1,14 +1,11 @@
 package io.buoyant.namer.dnssrv
 
 import com.twitter.finagle._
-import com.twitter.finagle.stats.NullStatsReceiver
 import com.twitter.finagle.util.LoadService
-import com.twitter.util.{Duration, NullTimer}
 import io.buoyant.config.Parser
 import io.buoyant.namer.{NamerConfig, NamerInitializer}
 import io.buoyant.test.FunSuite
 import org.scalatest.Matchers
-import org.xbill.DNS
 
 class DnsSrvNamerTest extends FunSuite with Matchers {
 
@@ -34,20 +31,8 @@ class DnsSrvNamerTest extends FunSuite with Matchers {
       """.stripMargin
 
     val mapper = Parser.objectMapper(yaml, Iterable(Seq(DnsSrvNamerInitializer)))
-    val curator = mapper.readValue[NamerConfig](yaml).asInstanceOf[DnsSrvNamerConfig]
-    assert(curator.refreshIntervalSeconds === Some(60))
-    assert(curator.dnsHosts === Some(Seq("localhost")))
-  }
-
-  test("can resolve some public SRV revord") {
-    val namer = new DnsSrvNamer(Path.empty, new DNS.ExtendedResolver, new NullTimer, Duration.Zero, new NullStatsReceiver)
-    val result = namer.lookupSrv("_http._tcp.mxtoolbox.com.", Path.read("/foo"), null)
-    result.get().simplified match {
-      case NameTree.Leaf(Name.Bound(varAddr)) => varAddr.sample() match {
-        case Addr.Bound(addrs, _) => addrs should not be empty
-        case a => fail(s"unexpected addr: $a")
-      }
-      case x => fail(s"unexpected result: $x")
-    }
+    val config = mapper.readValue[NamerConfig](yaml).asInstanceOf[DnsSrvNamerConfig]
+    assert(config.refreshIntervalSeconds === Some(60))
+    assert(config.dnsHosts === Some(Seq("localhost")))
   }
 }

--- a/namer/dnssrv/src/test/scala/io/buoyant/namer/dnssrv/DnsSrvNamerTest.scala
+++ b/namer/dnssrv/src/test/scala/io/buoyant/namer/dnssrv/DnsSrvNamerTest.scala
@@ -1,0 +1,53 @@
+package io.buoyant.namer.dnssrv
+
+import com.twitter.finagle._
+import com.twitter.finagle.stats.NullStatsReceiver
+import com.twitter.finagle.util.LoadService
+import com.twitter.util.{Duration, NullTimer}
+import io.buoyant.config.Parser
+import io.buoyant.namer.{NamerConfig, NamerInitializer}
+import io.buoyant.test.FunSuite
+import org.scalatest.Matchers
+import org.xbill.DNS
+
+class DnsSrvNamerTest extends FunSuite with Matchers {
+
+  test("sanity") {
+    // ensure it doesn't totally blowup
+    val _ = DnsSrvNamerConfig(
+      Some(15),
+      Some(List("localhost"))
+    ).newNamer(Stack.Params.empty)
+  }
+
+  test("service registration") {
+    assert(LoadService[NamerInitializer]().exists(_.isInstanceOf[DnsSrvNamerInitializer]))
+  }
+
+  test("parse config") {
+    val yaml = s"""
+                  |kind: io.l5d.dnssrv
+                  |experimental: true
+                  |refreshIntervalSeconds: 60
+                  |dnsHosts:
+                  |- localhost
+      """.stripMargin
+
+    val mapper = Parser.objectMapper(yaml, Iterable(Seq(DnsSrvNamerInitializer)))
+    val curator = mapper.readValue[NamerConfig](yaml).asInstanceOf[DnsSrvNamerConfig]
+    assert(curator.refreshIntervalSeconds === Some(60))
+    assert(curator.dnsHosts === Some(Seq("localhost")))
+  }
+
+  test("can resolve some public SRV revord") {
+    val namer = new DnsSrvNamer(Path.empty, new DNS.ExtendedResolver, new NullTimer, Duration.Zero, new NullStatsReceiver)
+    val result = namer.lookupSrv("_http._tcp.mxtoolbox.com.", Path.read("/foo"), null)
+    result.get().simplified match {
+      case NameTree.Leaf(Name.Bound(varAddr)) => varAddr.sample() match {
+        case Addr.Bound(addrs, _) => addrs should not be empty
+        case a => fail(s"unexpected addr: $a")
+      }
+      case x => fail(s"unexpected result: $x")
+    }
+  }
+}

--- a/namer/dnssrv/src/test/scala/io/buoyant/namer/dnssrv/DnsSrvNamerTest.scala
+++ b/namer/dnssrv/src/test/scala/io/buoyant/namer/dnssrv/DnsSrvNamerTest.scala
@@ -34,5 +34,6 @@ class DnsSrvNamerTest extends FunSuite with Matchers {
     val config = mapper.readValue[NamerConfig](yaml).asInstanceOf[DnsSrvNamerConfig]
     assert(config.refreshIntervalSeconds === Some(60))
     assert(config.dnsHosts === Some(Seq("localhost")))
+    assert(config.disabled === false)
   }
 }

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -68,4 +68,7 @@ object Deps {
 
   // statsd client
   val statsd = "com.datadoghq" % "java-dogstatsd-client" % "2.3"
+
+  // dnsjava
+  val dnsJava = "dnsjava" % "dnsjava" % "2.1.8"
 }

--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -125,7 +125,7 @@ object LinkerdBuild extends Base {
     val dnssrv = projectDir("namer/dnssrv")
       .dependsOn(core)
       .withLibs(Deps.dnsJava)
-      .withTests()
+      .withTests().withIntegration()
 
     val fs = projectDir("namer/fs")
       .dependsOn(core % "compile->compile;test->test")

--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -122,6 +122,11 @@ object LinkerdBuild extends Base {
       .withLibs(Deps.curatorFramework, Deps.curatorClient, Deps.curatorDiscovery)
       .withTests()
 
+    val dnssrv = projectDir("namer/dnssrv")
+      .dependsOn(core)
+      .withLibs(Deps.dnsJava)
+      .withTests()
+
     val fs = projectDir("namer/fs")
       .dependsOn(core % "compile->compile;test->test")
       .withTests()
@@ -145,7 +150,7 @@ object LinkerdBuild extends Base {
       .withLib(Deps.zkCandidate)
       .withTests()
 
-    val all = aggregateDir("namer", core, consul, curator, fs, k8s, marathon, serversets, zkLeader)
+    val all = aggregateDir("namer", core, consul, curator, dnssrv, fs, k8s, marathon, serversets, zkLeader)
   }
 
   val admin = projectDir("admin")
@@ -327,7 +332,7 @@ object LinkerdBuild extends Base {
     val BundleProjects = Seq[ProjectReference](
       core, main, Namer.fs, Storage.inMemory, Router.http,
       Iface.controlHttp, Iface.interpreterThrift, Iface.mesh,
-      Namer.consul, Namer.k8s, Namer.marathon, Namer.serversets, Namer.zkLeader,
+      Namer.consul, Namer.k8s, Namer.marathon, Namer.serversets, Namer.zkLeader, Namer.dnssrv,
       Iface.mesh,
       Interpreter.perHost, Interpreter.k8s,
       Storage.etcd, Storage.inMemory, Storage.k8s, Storage.zk, Storage.consul,
@@ -573,7 +578,7 @@ object LinkerdBuild extends Base {
 
     val BundleProjects = Seq[ProjectReference](
       admin, core, main, configCore,
-      Namer.consul, Namer.fs, Namer.k8s, Namer.marathon, Namer.serversets, Namer.zkLeader, Namer.curator,
+      Namer.consul, Namer.fs, Namer.k8s, Namer.marathon, Namer.serversets, Namer.zkLeader, Namer.curator, Namer.dnssrv,
       Interpreter.fs, Interpreter.k8s, Interpreter.mesh, Interpreter.namerd, Interpreter.perHost, Interpreter.subnet,
       Protocol.h2, Protocol.http, Protocol.mux, Protocol.thrift, Protocol.thriftMux,
       Announcer.serversets,
@@ -664,6 +669,7 @@ object LinkerdBuild extends Base {
   val namerCore = Namer.core
   val namerConsul = Namer.consul
   val namerCurator = Namer.curator
+  val namerDnsSrv = Namer.dnssrv
   val namerFs = Namer.fs
   val namerK8s = Namer.k8s
   val namerMarathon = Namer.marathon


### PR DESCRIPTION
This adds a plugin that allows linkerd to use SRV records for service discovery. A `linkerd.yaml` file using the plugin might contain something like this:

```yaml
routers:
- protocol: http
  dtab: |
    /dnssrv => /#/io.l5d.dnssrv;
    /svc/myservice =>
               /dnssrv/myservice.srv.example.org &
               /dnssrv/myservice2.srv.example.org;
    /svc/other => 
               /dnssrv/other.srv.example.org;

namers:
- kind: io.l5d.dnssrv
  experimental: true
```

Fixes #1610