### PR TITLE
Document disableValidation/clientAuth incompatibility

### DIFF
--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/ClientConfig.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/ClientConfig.scala
@@ -3,10 +3,9 @@ package io.buoyant.linkerd
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.twitter.conversions.time._
 import com.twitter.finagle.Stack
-import com.twitter.finagle.buoyant.{ClientAuth, PathMatcher, TlsClientConfig => FTlsClientConfig}
+import com.twitter.finagle.buoyant.{ClientAuth, ParamsMaybeWith, PathMatcher, TlsClientConfig => FTlsClientConfig}
 import com.twitter.finagle.client.DefaultPool
 import com.twitter.finagle.service._
-import com.twitter.finagle.buoyant.ParamsMaybeWith
 import io.buoyant.router.RetryBudgetConfig
 import io.buoyant.router.RetryBudgetModule.param
 
@@ -42,6 +41,10 @@ case class TlsClientConfig(
   trustCerts: Option[Seq[String]] = None,
   clientAuth: Option[ClientAuth] = None
 ) {
+  require (
+    !disableValidation.getOrElse(false) || clientAuth.isEmpty,
+    "disableValidation: true is incompatible with clientAuth"
+  )
   def params(vars: Map[String, String]): Stack.Params =
     FTlsClientConfig(
       disableValidation,

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/ClientConfigTest.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/ClientConfigTest.scala
@@ -1,0 +1,40 @@
+package io.buoyant.linkerd
+
+import com.fasterxml.jackson.databind.JsonMappingException
+import io.buoyant.config.Parser
+import io.buoyant.test.FunSuite
+
+class ClientConfigTest extends FunSuite {
+
+  test("disableValidation: true incompatible with clientAuth") {
+    val yaml =
+      """
+        |commonName: foo
+        |disableValidation: true
+        |clientAuth:
+        |  certPath: cert.pem
+        |  keyPath: key.pem
+      """.stripMargin
+    val exception =
+      intercept[JsonMappingException] {
+        Parser.objectMapper(yaml, Nil).readValue[TlsClientConfig](yaml)
+      }
+    assert(exception.getCause.isInstanceOf[IllegalArgumentException])
+    assert(exception.getCause.getMessage ==
+      "requirement failed: disableValidation: true is incompatible with clientAuth")
+  }
+
+  test("disableValidation: false compatible with clientAuth") {
+    val yaml =
+      """
+        |commonName: foo
+        |disableValidation: false
+        |clientAuth:
+        |  certPath: cert.pem
+        |  keyPath: key.pem
+      """.stripMargin
+    Parser.objectMapper(yaml, Nil).readValue[TlsClientConfig](yaml)
+
+  }
+
+}

--- a/linkerd/docs/client_tls.md
+++ b/linkerd/docs/client_tls.md
@@ -53,7 +53,7 @@ to destination services.
 
 Key               | Default Value                              | Description
 ----------------- | ------------------------------------------ | -----------
-disableValidation | false                                      | Enable this to skip hostname validation (unsafe).
+disableValidation | false                                      | Enable this to skip hostname validation (unsafe). Setting `disableValidation: true` is incompatible with `clientAuth`.
 commonName        | _required_ unless disableValidation is set | The common name to use for all TLS requests.
 trustCerts        | empty list                                 | A list of file paths of CA certs to use for common name validation.
 clientAuth        | none                                       | A client auth object used to sign requests.
@@ -64,6 +64,10 @@ Key      | Default Value | Description
 ---------|---------------|-------------
 certPath | _required_    | File path to the TLS certificate file.
 keyPath  | _required_    | File path to the TLS key file.  Must be in PKCS#8 format.
+
+<aside class="warning">
+Setting `disableValidation: true` will force the use of the JDK SSL provider which does not support client auth. Therefore, `disableValidation: true` and `clientAuth` are incompatible.
+</aside>
 
 Any variables captured from the client prefix may be used in the common name.
 


### PR DESCRIPTION
As @adleong said in https://github.com/linkerd/linkerd/issues/1581#issuecomment-327284668, disabling TLS validation will force the use of the JDK SSL provider is thus incompatible with clientAuth.

I've confirmed this in the `linux-test` GCE instance I set up to reproduce issue #1581 – if `disableValidation` is set to `false`, everything works fine.

I've updated the docs to reflect this.

Closes #1581 