### PR TITLE
Handle K8s Delete Events Correctly

### DIFF
--- a/k8s/src/main/scala/io/buoyant/k8s/IngressCache.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/IngressCache.scala
@@ -90,10 +90,8 @@ class IngressCache(namespace: Option[String], apiClient: Service[Request, Respon
             mkIngress(m)
               .map { item => ingresses.filterNot(isNameEqual(_, item)) :+ item }
               .getOrElse(ingresses)
-          case v1beta1.IngressDeleted(d) =>
-            mkIngress(d)
-              .map { item => ingresses.filterNot(isNameEqual(_, item)) }
-              .getOrElse(ingresses)
+          case v1beta1.IngressDeleted(_) =>
+            Seq.empty
           case v1beta1.IngressError(e) =>
             log.error("k8s watch error: %s", e)
             ingresses

--- a/k8s/src/main/scala/io/buoyant/k8s/ServiceNamer.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/ServiceNamer.scala
@@ -83,13 +83,12 @@ class ServiceNamer(
           logEvent.modification(portMappings, svc.portMappings)
           logEvent.modification(ports, svc.ports)
           svc
-        case v1.ServiceDeleted(deleted) =>
-          val Svc(deletedPorts, deletedMappings) = Svc(deleted)
-          logEvent.deletion(deletedPorts)
-          logEvent.deletion(deletedMappings)
+        case v1.ServiceDeleted(_) =>
+          logEvent.deletion(ports)
+          logEvent.deletion(portMappings)
           this.copy(
-            ports = ports -- deletedPorts.keys,
-            portMappings = portMappings -- deletedMappings.keys
+            ports = Map.empty,
+            portMappings = Map.empty
           )
         case v1.ServiceError(error) =>
           log.warning(


### PR DESCRIPTION
When Linkerd receives a DELETE event from the Kubernetes API, it treats the
contents of the event as the new state.  However, the semantics of the API are
that the contents of the event are the previous state and the resource should
be deleted entirely.  This causes Linkerd to get stuck in a bad state when
watching a resource as it is being deleted.

Treat DELETE events as total deletions and ignore the contents of the event.

Manually tested on Minikube.