### PR TITLE
Deprecate StatsD telemeter

### DIFF
--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/BufferedStream.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/BufferedStream.scala
@@ -1,13 +1,13 @@
 package com.twitter.finagle.buoyant.h2
 
-import com.twitter.conversions.storage._
+import java.util.concurrent.atomic.AtomicBoolean
 import com.twitter.concurrent.AsyncQueue
+import com.twitter.conversions.storage._
 import com.twitter.finagle.buoyant.h2.BufferedStream.{RefCountedDataFrame, RefCountedFrame, RefCountedTrailersFrame, State}
 import com.twitter.finagle.buoyant.h2.Stream.AsyncQueueReader
 import com.twitter.finagle.util.AsyncLatch
 import com.twitter.io.Buf
 import com.twitter.util._
-import java.util.concurrent.atomic.AtomicBoolean
 import scala.collection.mutable
 import scala.util.control.NoStackTrace
 
@@ -103,9 +103,9 @@ class BufferedStream(underlying: Stream, bufferCapacity: Long = 8.kilobytes.byte
   @volatile private[this] var pullState: PullState = Idle
 
   /**
-    * Read a Frame from the underlying Stream and write it into the buffer and offer it to the child
-    * Streams.
-    */
+   * Read a Frame from the underlying Stream and write it into the buffer and offer it to the child
+   * Streams.
+   */
   private[this] def pull(): Future[Unit] = {
     if (underlying.isEmpty) {
       Future.Unit

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/ClientConfig.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/ClientConfig.scala
@@ -41,7 +41,7 @@ case class TlsClientConfig(
   trustCerts: Option[Seq[String]] = None,
   clientAuth: Option[ClientAuth] = None
 ) {
-  require (
+  require(
     !disableValidation.getOrElse(false) || clientAuth.isEmpty,
     "disableValidation: true is incompatible with clientAuth"
   )

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/ClientTest.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/ClientTest.scala
@@ -111,6 +111,8 @@ class ClientTest extends FunSuite {
       .failureAccrualPolicy()
     assert(policy.toString == "FooFailureAccrual")
   }
+
+
 }
 
 class FooFailureAccrual extends FailureAccrualInitializer {

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/ClientTest.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/ClientTest.scala
@@ -111,8 +111,6 @@ class ClientTest extends FunSuite {
       .failureAccrualPolicy()
     assert(policy.toString == "FooFailureAccrual")
   }
-
-
 }
 
 class FooFailureAccrual extends FailureAccrualInitializer {

--- a/linkerd/docs/telemetry.md
+++ b/linkerd/docs/telemetry.md
@@ -76,6 +76,10 @@ connects to a given StatsD server via UDP. Counters and timers/histograms are
 exported immediately, based on sample rate. Gauge export interval is
 configurable.
 
+<aside class="warning">
+The StatsD telemeter is unsupported. Due to how StatsD samples counter increments, this telemeter may cause loss of data for important events (such as failures). While the `sampleRate` property can be increased to decrease data loss, doing so will lead to higher Linkerd latency.
+</aside>
+
 Key | Default Value | Description
 --- | ------------- | -----------
 experimental | _required_ | Because this telemeter is still considered experimental, you must set this to `true` to use it.

--- a/telemetry/statsd/src/main/scala/io/buoyant/telemetry/StatsDInitializer.scala
+++ b/telemetry/statsd/src/main/scala/io/buoyant/telemetry/StatsDInitializer.scala
@@ -32,6 +32,11 @@ case class StatsDConfig(
   @JsonDeserialize(contentAs = classOf[java.lang.Double]) sampleRate: Option[Double]
 ) extends TelemeterConfig {
   import StatsDConfig._
+  log.warning(
+    """|Warning, you're using the `io.l5d.statsd` telemeter, which is unsupported and probably
+       | won't do what you expect. Use of this telemeter may lead to poor performance or decreased
+       | quality of data.""".stripMargin
+  )
 
   @JsonIgnore override val experimentalRequired = true
 

--- a/telemetry/statsd/src/main/scala/io/buoyant/telemetry/StatsDInitializer.scala
+++ b/telemetry/statsd/src/main/scala/io/buoyant/telemetry/StatsDInitializer.scala
@@ -32,18 +32,14 @@ case class StatsDConfig(
   @JsonDeserialize(contentAs = classOf[java.lang.Double]) sampleRate: Option[Double]
 ) extends TelemeterConfig {
   import StatsDConfig._
-  log.warning(
-    """|Warning, you're using the `io.l5d.statsd` telemeter, which is unsupported and probably
-       | won't do what you expect. Use of this telemeter may lead to poor performance or decreased
-       | quality of data.""".stripMargin
-  )
 
   @JsonIgnore private[this] val log = Logger.get("io.l5d.statsd")
 
   log.warning(
     "Warning, you're using the `io.l5d.statsd` telemeter, which is unsupported " +
       "and probably won't do what you expect. Use of this telemeter may lead to" +
-      " poor performance or decreased data quality."
+      " poor performance or decreased data quality.\n" +
+      "Please see https://discourse.linkerd.io/t/deprecating-the-statsd-telemeter for more information."
   )
 
   @JsonIgnore override val experimentalRequired = true

--- a/telemetry/statsd/src/main/scala/io/buoyant/telemetry/StatsDInitializer.scala
+++ b/telemetry/statsd/src/main/scala/io/buoyant/telemetry/StatsDInitializer.scala
@@ -32,15 +32,16 @@ case class StatsDConfig(
   @JsonDeserialize(contentAs = classOf[java.lang.Double]) sampleRate: Option[Double]
 ) extends TelemeterConfig {
   import StatsDConfig._
+
+  @JsonIgnore private[this] val log = Logger.get("io.l5d.statsd")
+
   log.warning(
-    """|Warning, you're using the `io.l5d.statsd` telemeter, which is unsupported and probably
-       | won't do what you expect. Use of this telemeter may lead to poor performance or decreased
-       | quality of data.""".stripMargin
+    "Warning, you're using the `io.l5d.statsd` telemeter, which is unsupported " +
+      "and probably won't do what you expect. Use of this telemeter may lead to" +
+      " poor performance or decreased data quality."
   )
 
   @JsonIgnore override val experimentalRequired = true
-
-  @JsonIgnore private[this] val log = Logger.get("io.l5d.statsd")
 
   @JsonIgnore private[this] val statsDPrefix = prefix.getOrElse(DefaultPrefix)
   @JsonIgnore private[this] val statsDHost = hostname.getOrElse(DefaultHostname)


### PR DESCRIPTION
Added a warning message when the StatsD telemeter is initialized. The warning message links to [this thread](https://discourse.linkerd.io/t/deprecating-the-statsd-telemeter/268?u=eliza) on Discourse.

Closes #1578 