### PR TITLE
Fix formatting issue with linkerd docs

### DIFF
--- a/linkerd/docs/namer.md
+++ b/linkerd/docs/namer.md
@@ -37,7 +37,7 @@ namers:
 
 > Then reference the namer in the dtab to use it:
 
-```
+```yaml
 dtab: |
   /svc => /#/io.l5d.fs
 ```
@@ -176,7 +176,7 @@ namers:
 
 > Then reference the namer in the dtab to use it:
 
-```
+```yaml
 dtab: |
   /svc => /#/io.l5d.consul/dc1/prod;
 ```
@@ -238,7 +238,7 @@ namers:
 
 > Then reference the namer in the dtab to use it:
 
-```
+```yaml
 dtab: |
   /svc => /#/io.l5d.k8s/prod/http;
 ```
@@ -289,7 +289,7 @@ namers:
 
 > Then reference the namer in the dtab to use it:
 
-```
+```yaml
 dtab: |
   /svc => /#/io.l5d.k8s.external/prod/http;
 ```
@@ -457,7 +457,7 @@ namers:
 
 > Then reference the namer in the dtab to use it:
 
-```
+```yaml
 dtab: |
   /svc/reviews => /#/io.l5d.k8s.istio/version:v1/http/reviews;
 ```
@@ -508,7 +508,7 @@ namers:
 ```
 > Then reference the namer in the dtab to use it:
 
-```
+```yaml
 dtab: |
   /marathonId => /#/io.l5d.marathon;
   /host       => /$/io.buoyant.http.domainToPathPfx/marathonId;
@@ -578,7 +578,7 @@ kind: `io.l5d.dnssrv`
 
 ### DNS-SRV Configuration
 
-> Configure a DNS-SRV namer
+> Configure a DNS-SRV namer:
 
 ```yaml
 namers:
@@ -591,13 +591,14 @@ namers:
 ```
 
 > Then reference the namer in the dtab to use it:
-```
+
+```yaml
 dtab: |
   /dnssrv => /#/io.l5d.dnssrv
   /svc/myservice =>
     /dnssrv/myservice.srv.example.org &
     /dnssrv/myservice2.srv.example.org;
-  /svc/other => 
+  /svc/other =>
     /dnssrv/other.srv.example.org;
 
 ```
@@ -610,18 +611,19 @@ prefix | `io.l5d.dnssrv` | Resolves names with `/#/<prefix>`.
 experimental | `false` | Since the DNS-SRV namer is still considered experimental, this must be set to `true`.
 refreshIntervalSeconds | `5` | linkerd will perform a SRV lookup for each host every `refreshIntervalSeconds`.
 dnsHosts | `<empty list>` | If specified, linkerd will use these DNS servers to perform SRV lookups. If not specified, linkerd will use the default system resolver.
- 
+
 ### DNS-SRV Path Parameters
 
 > Dtab Path Format
 
-```
+```yaml
 /#/<prefix>/<address>
 ```
 
-Key     | Required | Description
-prefix  | yes      | Tells linkerd to resolve the request path using the DNS-SRV namer.
-address |          | The DNS address of a SRV record. Linkerd resolves the record to one or more `address:port` tuples using a SRV lookup 
+Key | Required | Description
+--- | -------- | -----------
+prefix | yes | Tells linkerd to resolve the request path using the marathon namer.
+address | yes | The DNS address of a SRV record. Linkerd resolves the record to one or more `address:port` tuples using a SRV lookup.
 
 ## ZooKeeper Leader
 
@@ -699,7 +701,7 @@ namers:
 
 > Then reference the namer in the dtab to use it:
 
-```
+```yaml
 dtab: |
   /svc => /#/rewrite
 ```

--- a/linkerd/docs/telemetry.md
+++ b/linkerd/docs/telemetry.md
@@ -11,7 +11,7 @@ regardless of kind. Telemeters may also have kind-specific parameters.
 
 Key | Default Value | Description
 --- | ------------- | -----------
-kind | _required_ | Either [`io.l5d.prometheus`](#prometheus), [`io.l5d.statsd`](#statsd-experimental), [`io.l5d.tracelog`](#tracelog), [`io.l5d.recentRequests`](#recent-requests), or [`io.l5d.zipkin`](#zipkin-telemeter).
+kind | _required_ | Either [`io.l5d.prometheus`](#prometheus), [`io.l5d.influxdb`](#influxdb), [`io.l5d.statsd`](#statsd-experimental), [`io.l5d.tracelog`](#tracelog), [`io.l5d.recentRequests`](#recent-requests), or [`io.l5d.zipkin`](#zipkin-telemeter).
 experimental | `false` | Set this to `true` to enable the telemeter if it is experimental.
 
 ## Prometheus


### PR DESCRIPTION
The DNS SRV Records documentation had a few issues that were causing our API docs to render improperly. Also applying a few other misc fixes while I'm here.