### PR TITLE
make path for prometheus metrics configurable

### DIFF
--- a/telemetry/prometheus/src/main/scala/io/buoyant/telemetry/prometheus/PrometheusTelemeter.scala
+++ b/telemetry/prometheus/src/main/scala/io/buoyant/telemetry/prometheus/PrometheusTelemeter.scala
@@ -14,7 +14,7 @@ import io.buoyant.telemetry.{Metric, MetricsTree, Telemeter}
  * histogram summaries directly off of the MetricsTree and assumes that stats
  * are being snapshotted at some appropriate interval.
  */
-class PrometheusTelemeter(metrics: MetricsTree, handlerPath: String) extends Telemeter with Admin.WithHandlers {
+class PrometheusTelemeter(metrics: MetricsTree, private[prometheus] val handlerPath: String) extends Telemeter with Admin.WithHandlers {
 
   private[prometheus] val handler = Service.mk { request: Request =>
     val response = Response()

--- a/telemetry/prometheus/src/main/scala/io/buoyant/telemetry/prometheus/PrometheusTelemeter.scala
+++ b/telemetry/prometheus/src/main/scala/io/buoyant/telemetry/prometheus/PrometheusTelemeter.scala
@@ -14,7 +14,7 @@ import io.buoyant.telemetry.{Metric, MetricsTree, Telemeter}
  * histogram summaries directly off of the MetricsTree and assumes that stats
  * are being snapshotted at some appropriate interval.
  */
-class PrometheusTelemeter(metrics: MetricsTree) extends Telemeter with Admin.WithHandlers {
+class PrometheusTelemeter(metrics: MetricsTree, handlerPath: String) extends Telemeter with Admin.WithHandlers {
 
   private[prometheus] val handler = Service.mk { request: Request =>
     val response = Response()
@@ -27,7 +27,7 @@ class PrometheusTelemeter(metrics: MetricsTree) extends Telemeter with Admin.Wit
   }
 
   val adminHandlers: Seq[Admin.Handler] = Seq(
-    Admin.Handler("/admin/metrics/prometheus", handler)
+    Admin.Handler(handlerPath, handler)
   )
 
   val stats = NullStatsReceiver

--- a/telemetry/prometheus/src/main/scala/io/buoyant/telemetry/prometheus/PrometheusTelemeterInitializer.scala
+++ b/telemetry/prometheus/src/main/scala/io/buoyant/telemetry/prometheus/PrometheusTelemeterInitializer.scala
@@ -12,6 +12,10 @@ class PrometheusTelemeterInitializer extends TelemeterInitializer {
 
 object PrometheusTelemeterInitializer extends PrometheusTelemeterInitializer
 
-class PrometheusConfig extends TelemeterConfig {
-  @JsonIgnore def mk(params: Stack.Params): Telemeter = new PrometheusTelemeter(params[MetricsTree])
+class PrometheusConfig(path: Option[String]) extends TelemeterConfig {
+  @JsonIgnore def mk(params: Stack.Params): Telemeter =
+    new PrometheusTelemeter(
+      params[MetricsTree],
+      path.getOrElse("/admin/metrics/prometheus")
+    )
 }

--- a/telemetry/prometheus/src/test/scala/io/buoyant/telemetry/prometheus/PrometheusTelemeterInitializerTest.scala
+++ b/telemetry/prometheus/src/test/scala/io/buoyant/telemetry/prometheus/PrometheusTelemeterInitializerTest.scala
@@ -11,6 +11,7 @@ class PrometheusTelemeterInitializerTest extends FunSuite {
   test("io.l5d.prometheus telemeter loads") {
     val yaml =
       """|kind: io.l5d.prometheus
+         |path: /metrics
          |""".stripMargin
 
     val config = Parser.objectMapper(yaml, Seq(LoadService[TelemeterInitializer]))

--- a/telemetry/prometheus/src/test/scala/io/buoyant/telemetry/prometheus/PrometheusTelemeterInitializerTest.scala
+++ b/telemetry/prometheus/src/test/scala/io/buoyant/telemetry/prometheus/PrometheusTelemeterInitializerTest.scala
@@ -22,4 +22,16 @@ class PrometheusTelemeterInitializerTest extends FunSuite {
     assert(telemeter.stats.isNull)
     assert(telemeter.tracer.isNull)
   }
+
+  test("io.l5d.prometheus telemeter default path") {
+    val yaml =
+      """|kind: io.l5d.prometheus
+         |""".stripMargin
+
+    val config = Parser.objectMapper(yaml, Seq(LoadService[TelemeterInitializer]))
+      .readValue[TelemeterConfig](yaml)
+
+    val telemeter = config.mk(Stack.Params.empty).asInstanceOf[PrometheusTelemeter]
+    assert(telemeter.handlerPath === "/admin/metrics/prometheus")
+  }
 }

--- a/telemetry/prometheus/src/test/scala/io/buoyant/telemetry/prometheus/PrometheusTelemeterTest.scala
+++ b/telemetry/prometheus/src/test/scala/io/buoyant/telemetry/prometheus/PrometheusTelemeterTest.scala
@@ -1,17 +1,17 @@
 package io.buoyant.telemetry.prometheus
 
-import com.twitter.conversions.time._
 import com.twitter.finagle.http.Request
-import com.twitter.util.{MockTimer, Time}
 import io.buoyant.telemetry.{Metric, MetricsTree, MetricsTreeStatsReceiver}
 import io.buoyant.test.FunSuite
 
 class PrometheusTelemeterTest extends FunSuite {
 
+  private val prometheusPath = "/admin/metrics/prometheus"
+
   def statsAndHandler = {
     val metrics = MetricsTree()
     val stats = new MetricsTreeStatsReceiver(metrics)
-    val telemeter = new PrometheusTelemeter(metrics)
+    val telemeter = new PrometheusTelemeter(metrics, prometheusPath)
     val handler = telemeter.handler
     (stats, handler)
   }
@@ -20,10 +20,10 @@ class PrometheusTelemeterTest extends FunSuite {
     val (stats, handler) = statsAndHandler
     val counter = stats.scope("foo", "bar").counter("bas")
     counter.incr()
-    val rsp1 = await(handler(Request("/admin/metrics/prometheus"))).contentString
+    val rsp1 = await(handler(Request(prometheusPath))).contentString
     assert(rsp1 == "foo:bar:bas 1\n")
     counter.incr()
-    val rsp2 = await(handler(Request("/admin/metrics/prometheus"))).contentString
+    val rsp2 = await(handler(Request(prometheusPath))).contentString
     assert(rsp2 == "foo:bar:bas 2\n")
   }
 
@@ -31,10 +31,10 @@ class PrometheusTelemeterTest extends FunSuite {
     val (stats, handler) = statsAndHandler
     var v = 1.0f
     val gauge = stats.scope("foo", "bar").addGauge("bas")(v)
-    val rsp1 = await(handler(Request("/admin/metrics/prometheus"))).contentString
+    val rsp1 = await(handler(Request(prometheusPath))).contentString
     assert(rsp1 == "foo:bar:bas 1.0\n")
     v = 2.0f
-    val rsp2 = await(handler(Request("/admin/metrics/prometheus"))).contentString
+    val rsp2 = await(handler(Request(prometheusPath))).contentString
     assert(rsp2 == "foo:bar:bas 2.0\n")
   }
 
@@ -48,12 +48,12 @@ class PrometheusTelemeterTest extends FunSuite {
     stat.add(1.0f)
 
     // endpoint should return no data before first snapshot
-    val rsp0 = await(handler(Request("/admin/metrics/prometheus"))).contentString
+    val rsp0 = await(handler(Request(prometheusPath))).contentString
     assert(rsp0 == "")
 
     metricsTreeStat.snapshot()
 
-    val rsp1 = await(handler(Request("/admin/metrics/prometheus"))).contentString
+    val rsp1 = await(handler(Request(prometheusPath))).contentString
     assert(rsp1 == """foo:bar:bas_count 1
                      |foo:bar:bas_sum 1
                      |foo:bar:bas_avg 1.0
@@ -71,7 +71,7 @@ class PrometheusTelemeterTest extends FunSuite {
     stat.add(2.0f)
     metricsTreeStat.snapshot()
 
-    val rsp2 = await(handler(Request("/admin/metrics/prometheus"))).contentString
+    val rsp2 = await(handler(Request(prometheusPath))).contentString
     assert(rsp2 == """foo:bar:bas_count 2
                      |foo:bar:bas_sum 3
                      |foo:bar:bas_avg 1.5
@@ -90,7 +90,7 @@ class PrometheusTelemeterTest extends FunSuite {
     val (stats, handler) = statsAndHandler
     val counter = stats.scope("rt", "incoming", "service", """\x5b\x31\x32\x33\x2e\x31\x32\x33\x2e\x31\x32\x33\x2e\x31\x32\x33\x5dun"esc""").counter("requests")
     counter.incr()
-    val rsp = await(handler(Request("/admin/metrics/prometheus"))).contentString
+    val rsp = await(handler(Request(prometheusPath))).contentString
     assert(rsp == """rt:service:requests{rt="incoming", service="\\x5b\\x31\\x32\\x33\\x2e\\x31\\x32\\x33\\x2e\\x31\\x32\\x33\\x2e\\x31\\x32\\x33\\x5dun\\esc"} 1
 """)
   }
@@ -99,14 +99,14 @@ class PrometheusTelemeterTest extends FunSuite {
     val (stats, handler) = statsAndHandler
     val counter = stats.scope("rt", "incoming", "service", "/svc/foo").counter("requests")
     counter.incr()
-    val rsp = await(handler(Request("/admin/metrics/prometheus"))).contentString
+    val rsp = await(handler(Request(prometheusPath))).contentString
     assert(rsp == "rt:service:requests{rt=\"incoming\", service=\"/svc/foo\"} 1\n")
   }
 
   test("bound stats are labelled") {
     val (stats, handler) = statsAndHandler
     stats.scope("rt", "incoming", "client", "/#/bar").counter("requests").incr()
-    val rsp = await(handler(Request("/admin/metrics/prometheus"))).contentString
+    val rsp = await(handler(Request(prometheusPath))).contentString
     assert(rsp ==
       "rt:client:requests{rt=\"incoming\", client=\"/#/bar\"} 1\n")
   }
@@ -114,7 +114,7 @@ class PrometheusTelemeterTest extends FunSuite {
   test("bound stats with path scope are labelled") {
     val (stats, handler) = statsAndHandler
     stats.scope("rt", "incoming", "client", "/#/bar", "service", "/svc/foo").counter("requests").incr()
-    val rsp = await(handler(Request("/admin/metrics/prometheus"))).contentString
+    val rsp = await(handler(Request(prometheusPath))).contentString
     assert(rsp ==
       "rt:client:service:requests{rt=\"incoming\", client=\"/#/bar\", service=\"/svc/foo\"} 1\n")
   }
@@ -123,7 +123,7 @@ class PrometheusTelemeterTest extends FunSuite {
     val (stats, handler) = statsAndHandler
     val counter = stats.scope("rt", "incoming", "server", "127.0.0.1/4141").counter("requests")
     counter.incr()
-    val rsp = await(handler(Request("/admin/metrics/prometheus"))).contentString
+    val rsp = await(handler(Request(prometheusPath))).contentString
     assert(rsp == "rt:server:requests{rt=\"incoming\", server=\"127.0.0.1/4141\"} 1\n")
   }
 }


### PR DESCRIPTION
The [default path][1] where Prometheus expects to scrape metrics is `/metrics`.

To ease integration in environments that rely on this default,
this makes the path under which linkerd exports Prometheus metrics
configurable.

[1]: https://prometheus.io/docs/operating/configuration/#scrape_config

Fixes #1633