### PR TITLE
dnssrv: ensure that DNS names in SRV queries are absolute

### DIFF
--- a/linkerd/docs/namer.md
+++ b/linkerd/docs/namer.md
@@ -585,6 +585,7 @@ namers:
 - kind: io.l5d.dnssrv
   experimental: true
   refreshIntervalSeconds: 5
+  domain: srv.dc-1.example.org
   dnsHosts:
   - ns0.example.org
   - ns1.example.org
@@ -595,12 +596,10 @@ namers:
 ```yaml
 dtab: |
   /dnssrv => /#/io.l5d.dnssrv
+  /svc => /dnssrv
   /svc/myservice =>
-    /dnssrv/myservice.srv.example.org &
-    /dnssrv/myservice2.srv.example.org;
-  /svc/other =>
-    /dnssrv/other.srv.example.org;
-
+    /dnssrv/myservice |
+    /dnssrv/myservice.srv.dc-2.example.org.;
 ```
 
 linkerd provides support for service discovery via DNS SRV records.
@@ -610,6 +609,7 @@ Key | Default Value | Description
 prefix | `io.l5d.dnssrv` | Resolves names with `/#/<prefix>`.
 experimental | `false` | Since the DNS-SRV namer is still considered experimental, this must be set to `true`.
 refreshIntervalSeconds | `5` | linkerd will perform a SRV lookup for each host every `refreshIntervalSeconds`.
+domain | `.` | Domain to use to expand relative addresses in the dtab into absolute addresses. Absolute addresses ending in `.` will not be expanded. The default value treats all addresses as absolute.
 dnsHosts | `<empty list>` | If specified, linkerd will use these DNS servers to perform SRV lookups. If not specified, linkerd will use the default system resolver.
 
 ### DNS-SRV Path Parameters
@@ -623,7 +623,7 @@ dnsHosts | `<empty list>` | If specified, linkerd will use these DNS servers to 
 Key | Required | Description
 --- | -------- | -----------
 prefix | yes | Tells linkerd to resolve the request path using the marathon namer.
-address | yes | The absolute DNS address of a SRV record. Linkerd resolves the record to one or more `address:port` tuples using a SRV lookup.
+address | yes | The DNS address of a SRV record. Linkerd resolves the record to one or more `address:port` tuples using a SRV lookup. Relative addresses not ending in `.` are resolved relative to `searchDomain`; absolute addresses ending in `.` are treated as-is.
 
 ## ZooKeeper Leader
 

--- a/linkerd/docs/namer.md
+++ b/linkerd/docs/namer.md
@@ -623,7 +623,7 @@ dnsHosts | `<empty list>` | If specified, linkerd will use these DNS servers to 
 Key | Required | Description
 --- | -------- | -----------
 prefix | yes | Tells linkerd to resolve the request path using the marathon namer.
-address | yes | The DNS address of a SRV record. Linkerd resolves the record to one or more `address:port` tuples using a SRV lookup.
+address | yes | The absolute DNS address of a SRV record. Linkerd resolves the record to one or more `address:port` tuples using a SRV lookup.
 
 ## ZooKeeper Leader
 

--- a/namer/dnssrv/src/integration/scala/io/buoyant/namer/dnssrv/DnsSrvNamerIntegrationTest.scala
+++ b/namer/dnssrv/src/integration/scala/io/buoyant/namer/dnssrv/DnsSrvNamerIntegrationTest.scala
@@ -10,9 +10,16 @@ import org.scalatest.Matchers
 import org.xbill.DNS
 
 class DnsSrvNamerIntegrationTest extends FunSuite with Awaits with Matchers {
-  test("can resolve some public SRV revord") {
-    val namer = new DnsSrvNamer(Path.empty, new DNS.ExtendedResolver, Duration.Zero, new NullStatsReceiver, FuturePool.unboundedPool)(DefaultTimer)
-    await(namer.lookup(Path.read("/_http._tcp.mxtoolbox.com")).toFuture) match {
+  test("can resolve some public SRV record") {
+    val namer = new DnsSrvNamer(
+      Path.empty,
+      new DNS.ExtendedResolver,
+      DNS.Name.fromString("mxtoolbox.com", DNS.Name.root),
+      Duration.Zero,
+      new NullStatsReceiver,
+      FuturePool.unboundedPool
+    )(DefaultTimer)
+    await(namer.lookup(Path.read("/_http._tcp")).toFuture) match {
       case NameTree.Leaf(Name.Bound(varAddr)) => varAddr.sample() match {
         case Addr.Bound(addrs, _) => addrs should not be empty
         case addr => fail(s"unexpected addr: $addr")

--- a/namer/dnssrv/src/integration/scala/io/buoyant/namer/dnssrv/DnsSrvNamerIntegrationTest.scala
+++ b/namer/dnssrv/src/integration/scala/io/buoyant/namer/dnssrv/DnsSrvNamerIntegrationTest.scala
@@ -12,7 +12,7 @@ import org.xbill.DNS
 class DnsSrvNamerIntegrationTest extends FunSuite with Awaits with Matchers {
   test("can resolve some public SRV revord") {
     val namer = new DnsSrvNamer(Path.empty, new DNS.ExtendedResolver, Duration.Zero, new NullStatsReceiver, FuturePool.unboundedPool)(DefaultTimer)
-    await(namer.lookup(Path.read("/_http._tcp.mxtoolbox.com.")).toFuture) match {
+    await(namer.lookup(Path.read("/_http._tcp.mxtoolbox.com")).toFuture) match {
       case NameTree.Leaf(Name.Bound(varAddr)) => varAddr.sample() match {
         case Addr.Bound(addrs, _) => addrs should not be empty
         case addr => fail(s"unexpected addr: $addr")

--- a/namer/dnssrv/src/main/scala/io/buoyant/namer/dnssrv/DnsSrvNamer.scala
+++ b/namer/dnssrv/src/main/scala/io/buoyant/namer/dnssrv/DnsSrvNamer.scala
@@ -14,6 +14,7 @@ import org.xbill.DNS
 class DnsSrvNamer(
   prefix: Path,
   resolver: DNS.Resolver,
+  origin: DNS.Name,
   refreshInterval: Duration,
   stats: StatsReceiver,
   pool: FuturePool
@@ -65,7 +66,7 @@ class DnsSrvNamer(
 
   private def lookupSrv(address: String, id: Path, residual: Path): Future[NameTree[Name]] = {
     val question = DNS.Record.newRecord(
-      DNS.Name.fromString(address, DNS.Name.root),
+      DNS.Name.fromString(address, origin),
       DNS.Type.SRV,
       DNS.DClass.IN
     )

--- a/namer/dnssrv/src/main/scala/io/buoyant/namer/dnssrv/DnsSrvNamer.scala
+++ b/namer/dnssrv/src/main/scala/io/buoyant/namer/dnssrv/DnsSrvNamer.scala
@@ -65,7 +65,7 @@ class DnsSrvNamer(
 
   private def lookupSrv(address: String, id: Path, residual: Path): Future[NameTree[Name]] = {
     val question = DNS.Record.newRecord(
-      DNS.Name.fromString(address),
+      DNS.Name.fromString(address, DNS.Name.root),
       DNS.Type.SRV,
       DNS.DClass.IN
     )

--- a/namer/dnssrv/src/main/scala/io/buoyant/namer/dnssrv/DnsSrvNamerInitializer.scala
+++ b/namer/dnssrv/src/main/scala/io/buoyant/namer/dnssrv/DnsSrvNamerInitializer.scala
@@ -15,9 +15,14 @@ class DnsSrvNamerInitializer extends NamerInitializer {
   override val configClass = classOf[DnsSrvNamerConfig]
   override def configId: String = "io.l5d.dnssrv"
 }
+
 object DnsSrvNamerInitializer extends DnsSrvNamerInitializer
 
-case class DnsSrvNamerConfig(refreshIntervalSeconds: Option[Int], dnsHosts: Option[Seq[String]]) extends NamerConfig {
+case class DnsSrvNamerConfig(
+  refreshIntervalSeconds: Option[Int],
+  domain: Option[String],
+  dnsHosts: Option[Seq[String]]
+) extends NamerConfig {
 
   @JsonIgnore
   override def experimentalRequired = true
@@ -39,17 +44,25 @@ case class DnsSrvNamerConfig(refreshIntervalSeconds: Option[Int], dnsHosts: Opti
       Edns.Flags,
       Edns.Options
     )
+    val origin = domain match {
+      // always treat domain as absolute, even if trailing `.` is missing in config
+      case Some(str) => DNS.Name.fromString(str, DNS.Name.root)
+      case None => DNS.Name.root
+    }
     val timer = params[param.Timer].timer
     val refreshInterval = refreshIntervalSeconds.getOrElse(5).seconds
     val pool = FuturePool.unboundedPool
-    new DnsSrvNamer(prefix, resolver, refreshInterval, stats.scope("dnssrv"), pool)(timer)
+    new DnsSrvNamer(prefix, resolver, origin, refreshInterval, stats.scope("dnssrv"), pool)(timer)
   }
 }
+
 object DnsSrvNamerConfig {
+
   object Edns {
     val Level = 0
     val MaxPayloadSize = 2048
     val Flags = 0
     val Options = Collections.EMPTY_LIST
   }
+
 }

--- a/namer/dnssrv/src/main/scala/io/buoyant/namer/dnssrv/DnsSrvNamerInitializer.scala
+++ b/namer/dnssrv/src/main/scala/io/buoyant/namer/dnssrv/DnsSrvNamerInitializer.scala
@@ -52,7 +52,7 @@ case class DnsSrvNamerConfig(
     val timer = params[param.Timer].timer
     val refreshInterval = refreshIntervalSeconds.getOrElse(5).seconds
     val pool = FuturePool.unboundedPool
-    new DnsSrvNamer(prefix, resolver, origin, refreshInterval, stats.scope("dnssrv"), pool)(timer)
+    new DnsSrvNamer(prefix, resolver, origin, refreshInterval, stats, pool)(timer)
   }
 }
 

--- a/namer/dnssrv/src/test/scala/io/buoyant/namer/dnssrv/DnsSrvNamerTest.scala
+++ b/namer/dnssrv/src/test/scala/io/buoyant/namer/dnssrv/DnsSrvNamerTest.scala
@@ -12,8 +12,9 @@ class DnsSrvNamerTest extends FunSuite with Matchers {
   test("sanity") {
     // ensure it doesn't totally blowup
     val _ = DnsSrvNamerConfig(
-      Some(15),
-      Some(List("localhost"))
+      refreshIntervalSeconds = Some(15),
+      domain = None,
+      dnsHosts = Some(List("localhost"))
     ).newNamer(Stack.Params.empty)
   }
 
@@ -25,6 +26,7 @@ class DnsSrvNamerTest extends FunSuite with Matchers {
     val yaml = s"""
                   |kind: io.l5d.dnssrv
                   |experimental: true
+                  |domain: srv.example.org
                   |refreshIntervalSeconds: 60
                   |dnsHosts:
                   |- localhost
@@ -35,5 +37,6 @@ class DnsSrvNamerTest extends FunSuite with Matchers {
     assert(config.refreshIntervalSeconds === Some(60))
     assert(config.dnsHosts === Some(Seq("localhost")))
     assert(config.disabled === false)
+    assert(config.domain === Some("srv.example.org"))
   }
 }


### PR DESCRIPTION
the target of SRV queries must be an absolute DNS name (ending
with a `.`). If the dtab specifies a relative name, treat it as
absolute.