### PR TITLE
Make ConfigMapInterpreter handle errors gracefully

### DIFF
--- a/interpreter/k8s/src/main/scala/io/buoyant/interpreter/k8s/ConfigMapInterpreterInitializer.scala
+++ b/interpreter/k8s/src/main/scala/io/buoyant/interpreter/k8s/ConfigMapInterpreterInitializer.scala
@@ -26,19 +26,11 @@ case class ConfigMapInterpreterConfig(
   port: Option[Port],
   namespace: Option[String],
   name: String,
-  filename: String,
-  mkApi: Option[() => NsApi] = None
+  filename: String
 ) extends InterpreterConfig with ClientConfig {
   require(name != null, "ConfigMap name is required!")
   require(filename != null, "ConfigMap dtab filename is required!")
 
-  @JsonIgnore
-  @inline
-  private[this] val mkDefaultApi: () => NsApi = { () =>
-    val client = mkClient(Params.empty).configured(Label("configMapInterpreter"))
-    val nsOrDefault = namespace.getOrElse(DefaultNamespace)
-    Api(client.newService(dst)).withNamespace(nsOrDefault)
-  }
 
   @JsonIgnore
   override def experimentalRequired = true
@@ -50,7 +42,11 @@ case class ConfigMapInterpreterConfig(
   private[this] val log = Logger()
 
   @JsonIgnore
-  val api = mkApi.getOrElse(mkDefaultApi)()
+  def api = {
+    val client = mkClient(Params.empty).configured(Label("configMapInterpreter"))
+    val nsOrDefault = namespace.getOrElse(DefaultNamespace)
+    Api(client.newService(dst)).withNamespace(nsOrDefault)
+  }
 
   @JsonIgnore
   val act = api.configMap(name)

--- a/interpreter/k8s/src/main/scala/io/buoyant/interpreter/k8s/ConfigMapInterpreterInitializer.scala
+++ b/interpreter/k8s/src/main/scala/io/buoyant/interpreter/k8s/ConfigMapInterpreterInitializer.scala
@@ -42,7 +42,7 @@ case class ConfigMapInterpreterConfig(
   private[this] val log = Logger()
 
   @JsonIgnore
-  def api = {
+  val api = {
     val client = mkClient(Params.empty).configured(Label("configMapInterpreter"))
     val nsOrDefault = namespace.getOrElse(DefaultNamespace)
     Api(client.newService(dst)).withNamespace(nsOrDefault)

--- a/interpreter/k8s/src/test/scala/io/buoyant/interpreter/k8s/ConfigMapInterpreterTest.scala
+++ b/interpreter/k8s/src/test/scala/io/buoyant/interpreter/k8s/ConfigMapInterpreterTest.scala
@@ -1,25 +1,41 @@
 package io.buoyant.interpreter.k8s
 
-import com.twitter.finagle.Dtab
+import com.twitter.finagle.http.{Request, Response}
+import com.twitter.finagle.{Dtab, Service}
 import com.twitter.finagle.util.LoadService
+import com.twitter.io.Writer
+import com.twitter.util.{Promise, Return}
 import io.buoyant.config.Parser
 import io.buoyant.config.types.Port
+import io.buoyant.k8s.v1
 import io.buoyant.k8s.v1.ConfigMap
 import io.buoyant.namer.{InterpreterConfig, InterpreterInitializer}
 import io.buoyant.test.FunSuite
-import org.scalatest.{Inside, OptionValues}
+import org.scalatest.{Inside, OptionValues, TryValues}
 
 class ConfigMapInterpreterTest extends FunSuite
-  with Inside {
+  with Inside
+  with TryValues {
+
+  trait Fixtures {
+    @volatile var writer: Writer = null
+
+    val service = Service.mk[Request, Response] {
+      ???
+    }
+
+    val api = v1.Api(service)
+  }
 
   test("interpreter registration") {
     assert(LoadService[InterpreterInitializer]()
       .exists(_.isInstanceOf[ConfigMapInterpreterInitializer]))
   }
 
-  private[this] def parse(yaml: String): ConfigMapInterpreterConfig = Parser.objectMapper(yaml, Iterable(Seq(ConfigMapInterpreterInitializer)))
-    .readValue[InterpreterConfig](yaml)
-    .asInstanceOf[ConfigMapInterpreterConfig]
+  private[this] def parse(yaml: String): ConfigMapInterpreterConfig =
+    Parser.objectMapper(yaml, Iterable(Seq(ConfigMapInterpreterInitializer)))
+      .readValue[InterpreterConfig](yaml)
+      .asInstanceOf[ConfigMapInterpreterConfig]
 
   test("parse config") {
     val yaml =
@@ -32,7 +48,7 @@ class ConfigMapInterpreterTest extends FunSuite
           |""".stripMargin
     val config = parse(yaml)
     inside(config) {
-      case ConfigMapInterpreterConfig(host, port, namespace, name, filename) =>
+      case ConfigMapInterpreterConfig(host, port, namespace, name, filename, _) =>
         assert(host.contains("foo"))
         assert(port.contains(Port(8888)))
         assert(namespace.contains("my-great-namespace"))
@@ -64,6 +80,8 @@ class ConfigMapInterpreterTest extends FunSuite
       "test.dtab" -> dtab,
       "otherTest.dtab" -> "quux => quuux"
     ))
-    assert(config.getDtab(configMap) == Dtab.read(dtab))
+    assert(config.getDtab(configMap) == Return(Dtab.read(dtab)))
   }
+
+
 }

--- a/interpreter/k8s/src/test/scala/io/buoyant/interpreter/k8s/ConfigMapInterpreterTest.scala
+++ b/interpreter/k8s/src/test/scala/io/buoyant/interpreter/k8s/ConfigMapInterpreterTest.scala
@@ -160,12 +160,11 @@ class ConfigMapInterpreterTest extends FunSuite
         throw new TestFailedException(s"Unexpected request $req", 1)
     }
 
-    object TestConfigMapInterpreterConfig
-    extends ConfigMapInterpreterConfig(
+    object TestConfigMapInterpreterConfig extends {
+      override val api = v1.Api(service).withNamespace("test")
+    } with ConfigMapInterpreterConfig(
       None, None, Some("test"), "test-config", "test.dtab"
-    ) {
-      override def api = v1.Api(service).withNamespace("test")
-    }
+    )
 
     val interpreter = TestConfigMapInterpreterConfig.newInterpreter(Params.empty)
 


### PR DESCRIPTION
When a `ConfigMapInterpreter` receives a `MODIFIED` event containing an invalid dtab, it falls back to the last good observed dtab, as intended. However, after falling back to the last good dtab, Linkerd currently refuses to honor any future `MODIFIED` events to the ConfigMap, even if they contain valid dtabs.

I've modified `ConfigMapInterpreterInitializer` to rectify this behavior. The `getDtab` function now returns a `Try`, rather than throwing an exception.

I've added a unit test reproducing #1639 with real Kubernetes events I generated using our GKE cluster. Previously, there were no unit tests for `ConfigMapInterpreter`'s event handling, only for the correct initialization of the interpreter. I've rectified this situation by adding several other tests for the correctness of the interpreter's event handling as well. In order to write these tests, I also had to modify the `ConfigMapInterpreterInitializer` to allow a mock Kubernetes API object to be injected.

Fixes #1639