### PR TITLE
1.2.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,15 @@
+## 1.2.1 2017-09-14
+
+Hotfix for an issue where Kubernetes namers would continue to route to old
+endpoints after a service was deleted and re-created, or scaled down to 0 and
+then scaled back up.
+
+Also includes:
+* The path on which the Prometheus telemeter serves metrics can now be
+  set in the config file.
+* Minor documentation fixes.
+
+
 ## 1.2.0 2017-09-07
 
 * **Breaking Change**: `io.l5d.mesh`, `io.l5d.thriftNameInterpreter`, linkerd

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 ## 1.2.1 2017-09-14
 
-Hotfix for an issue where Kubernetes namers would continue to route to old
+Fix for an issue where Kubernetes namers would continue to route to old
 endpoints after a service was deleted and re-created, or scaled down to 0 and
 then scaled back up.
 

--- a/project/Base.scala
+++ b/project/Base.scala
@@ -32,7 +32,7 @@ object Base {
 class Base extends Build {
   import Base._
 
-  val headVersion = "1.2.0"
+  val headVersion = "1.2.1"
 
   object Git {
     def git(arg: String, args: String*) = Process("git" +: arg +: args)


### PR DESCRIPTION
## 1.2.1 2017-09-14

Fix for an issue where Kubernetes namers would continue to route to old
endpoints after a service was deleted and re-created, or scaled down to 0 and
then scaled back up.

Also includes:
* The path on which the Prometheus telemeter serves metrics can now be
  set in the config file.
* Minor documentation fixes.
