### PR TITLE
document the `path` setting for Prometheus telemetry

### DIFF
--- a/linkerd/docs/telemetry.md
+++ b/linkerd/docs/telemetry.md
@@ -21,6 +21,7 @@ experimental | `false` | Set this to `true` to enable the telemeter if it is exp
 ```yaml
 telemetry:
 - kind: io.l5d.prometheus
+  path: /admin/metrics/prometheus
 ```
 
 kind: `io.l5d.prometheus`
@@ -29,7 +30,9 @@ Exposes admin endpoints:
 
 * `/admin/metrics/prometheus`: retrieve all metrics in [Prometheus](https://prometheus.io) format
 
-This telemeter has no additional parameters.
+Key | Default Value | Description
+--- | ------------- | -----------
+path | `/admin/metrics/prometheus` | HTTP path where linkerd exposes Prometheus metrics
 
 ## InfluxDB
 


### PR DESCRIPTION
#1634 didn't update the docs to reflect the new `path` setting for Prometheus metrics. Thanks to [Amit Saha](https://twitter.com/echorand) for [pointing it out](https://twitter.com/echorand/status/908526271243489280) on Twitter.