### PR TITLE
Simplify K8s event handling

### DIFF
--- a/k8s/src/main/scala/io/buoyant/k8s/Api.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/Api.scala
@@ -181,17 +181,6 @@ object Watch {
     def resourceVersion = None
   }
 
-  /**
-   * Extractor allowing `Added` and `Modified` events --- which contain a new
-   * state --- to be handled in one match arm.
-   */
-  object NewState {
-    def unapply[O <: KubeObject](event: Watch[O]): Option[O] = event match {
-      case added: Added[O] => Some(added.`object`)
-      case modified: Modified[O] => Some(modified.`object`)
-      case _ => None
-    }
-  }
 }
 
 case class Status(

--- a/k8s/src/main/scala/io/buoyant/k8s/Api.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/Api.scala
@@ -171,6 +171,7 @@ object Watch {
     @JsonIgnore
     def resourceVersion = `object`.metadata.flatMap(_.resourceVersion)
   }
+
   trait Added[O <: KubeObject] extends WithObject[O]
   trait Modified[O <: KubeObject] extends WithObject[O]
   trait Deleted[O <: KubeObject] extends WithObject[O]
@@ -178,6 +179,20 @@ object Watch {
     def status: Status
     @JsonIgnore
     def resourceVersion = None
+  }
+
+
+  /**
+   * Extractor allowing `Added` and `Modified` events --- which contain a new
+   * state --- to be handled in one match arm.
+   */
+  object NewState {
+    def unapply[O <: KubeObject](event: Watch[O]): Option[O]
+    = event match {
+      case added: Added[O] => Some(added.`object`)
+      case modified: Modified[O] => Some(modified.`object`)
+      case _ => None
+    }
   }
 }
 

--- a/k8s/src/main/scala/io/buoyant/k8s/Api.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/Api.scala
@@ -181,14 +181,12 @@ object Watch {
     def resourceVersion = None
   }
 
-
   /**
    * Extractor allowing `Added` and `Modified` events --- which contain a new
    * state --- to be handled in one match arm.
    */
   object NewState {
-    def unapply[O <: KubeObject](event: Watch[O]): Option[O]
-    = event match {
+    def unapply[O <: KubeObject](event: Watch[O]): Option[O] = event match {
       case added: Added[O] => Some(added.`object`)
       case modified: Modified[O] => Some(modified.`object`)
       case _ => None

--- a/k8s/src/main/scala/io/buoyant/k8s/EndpointsNamer.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/EndpointsNamer.scala
@@ -149,22 +149,22 @@ abstract class EndpointsNamer(
             _.map(_.portMappings).getOrElse(Map.empty),
             labelSelector = labelSelector
           ) {
-            case (oldMap, NewState(service)) =>
-              val newMap = service.portMappings
-              logEvent.addition(newMap -- oldMap.keys)
-              logEvent.deletion(oldMap -- newMap.keys)
-              logEvent.modification(oldMap, newMap)
-              newMap
-            case (oldMap, v1.ServiceDeleted(_)) =>
-              logEvent.deletion(oldMap)
-              Map.empty
-            case (oldMap, v1.ServiceError(error)) =>
-              log.warning(
-                "k8s ns %s service %s watch error %s",
-                nsName, serviceName, error
-              )
-              oldMap
-          }
+              case (oldMap, NewState(service)) =>
+                val newMap = service.portMappings
+                logEvent.addition(newMap -- oldMap.keys)
+                logEvent.deletion(oldMap -- newMap.keys)
+                logEvent.modification(oldMap, newMap)
+                newMap
+              case (oldMap, v1.ServiceDeleted(_)) =>
+                logEvent.deletion(oldMap)
+                Map.empty
+              case (oldMap, v1.ServiceError(error)) =>
+                log.warning(
+                  "k8s ns %s service %s watch error %s",
+                  nsName, serviceName, error
+                )
+                oldMap
+            }
     })
 
   private[this] val serviceEndpoints: (String, String, Option[String]) => Activity[ServiceEndpoints] =
@@ -358,7 +358,7 @@ object EndpointsNamer {
     }
   }
 
-  object Subsets {
+  private[EndpointsNamer] object Subsets {
     def unapply(endpoints: v1.Endpoints): Option[(Set[Endpoint], PortMap)] =
       Some(endpoints.subsets.toEndpointsAndPorts)
   }

--- a/k8s/src/main/scala/io/buoyant/k8s/IngressCache.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/IngressCache.scala
@@ -4,7 +4,6 @@ import com.twitter.finagle.Service
 import com.twitter.finagle.http.{Request, Response}
 import com.twitter.util._
 import java.util.concurrent.atomic.AtomicReference
-import io.buoyant.k8s.Watch.NewState
 import io.buoyant.namer.RichActivity
 
 case class IngressSpec(

--- a/k8s/src/main/scala/io/buoyant/k8s/IngressCache.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/IngressCache.scala
@@ -4,6 +4,7 @@ import com.twitter.finagle.Service
 import com.twitter.finagle.http.{Request, Response}
 import com.twitter.util._
 import java.util.concurrent.atomic.AtomicReference
+import io.buoyant.k8s.Watch.NewState
 import io.buoyant.namer.RichActivity
 
 case class IngressSpec(
@@ -83,19 +84,13 @@ class IngressCache(namespace: Option[String], apiClient: Service[Request, Respon
 
   private[this] lazy val ingresses: Activity[Seq[IngressSpec]] = {
     val act = api.activity(unpackIngressList) {
-      (ingresses, watchEvent) =>
-        watchEvent match {
-          case v1beta1.IngressAdded(a) => ingresses ++ mkIngress(a)
-          case v1beta1.IngressModified(m) =>
-            mkIngress(m)
-              .map { item => ingresses.filterNot(isNameEqual(_, item)) :+ item }
-              .getOrElse(ingresses)
-          case v1beta1.IngressDeleted(_) =>
-            Seq.empty
-          case v1beta1.IngressError(e) =>
-            log.error("k8s watch error: %s", e)
-            ingresses
-        }
+      case (oldIngresses, NewState(ingress: v1beta1.Ingress)) =>
+        mkIngress(ingress).getOrElse(oldIngresses)
+      case (_, v1beta1.IngressDeleted(_)) =>
+        Seq.empty
+      case (oldIngresses, v1beta1.IngressError(e)) =>
+        log.error("k8s watch error: %s", e)
+        oldIngresses
     }
     val _ = act.states.respond(_ => ()) // register a listener forever to keep the Activity open
     act

--- a/k8s/src/main/scala/io/buoyant/k8s/ServiceNamer.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/ServiceNamer.scala
@@ -6,7 +6,6 @@ import com.twitter.finagle.service.Backoff
 import com.twitter.finagle.util.DefaultTimer
 import com.twitter.finagle.{Service => _, _}
 import com.twitter.util._
-import io.buoyant.k8s.Watch.NewState
 import io.buoyant.k8s.v1._
 import scala.Function.untupled
 import scala.collection.mutable
@@ -61,6 +60,7 @@ class ServiceNamer(
         address <- ports.get(portName)
       } yield address
 
+
     /**
      * Update this `Svc` with a [[v1.ServiceWatch]] watch event
      * @param logEvent an event logger with which to log changes to this
@@ -68,16 +68,21 @@ class ServiceNamer(
      * @param event the [[v1.ServiceWatch]] watch event that occurred.
      * @return an updated `Svc` representing the watched service.
      */
-    def update(logEvent: EventLogging, event: v1.ServiceWatch): Svc =
+    def update(logEvent: EventLogging, event: v1.ServiceWatch): Svc = {
+      @inline def newState(svc: Svc): Svc = {
+        logEvent.addition(svc.portMappings -- portMappings.keys)
+        logEvent.addition(svc.ports -- ports.keys)
+        logEvent.deletion(portMappings -- svc.portMappings.keys)
+        logEvent.deletion(ports -- svc.ports.keys)
+        logEvent.modification(portMappings, svc.portMappings)
+        logEvent.modification(ports, svc.ports)
+        svc
+      }
       event match {
-        case NewState(Svc(svc)) =>
-          logEvent.addition(svc.portMappings -- portMappings.keys)
-          logEvent.addition(svc.ports -- ports.keys)
-          logEvent.deletion(portMappings -- svc.portMappings.keys)
-          logEvent.deletion(ports -- svc.ports.keys)
-          logEvent.modification(portMappings, svc.portMappings)
-          logEvent.modification(ports, svc.ports)
-          svc
+        case v1.ServiceAdded(Svc(svc)) =>
+          newState(svc)
+        case v1.ServiceModified(Svc(svc)) =>
+          newState(svc)
         case v1.ServiceDeleted(_) =>
           logEvent.deletion(ports)
           logEvent.deletion(portMappings)
@@ -89,6 +94,8 @@ class ServiceNamer(
           )
           this
       }
+    }
+
   }
 
   private[this] object Svc {


### PR DESCRIPTION
Since the semantics of Kubernetes `ADDED` and `MODIFIED` events call for us
to completely replace the currently-held state with the new state
contained in the event (rather than only making more granular changes to
our current state based on the event type), we can collapse the handling
of these events into a single case.