### PR TITLE
Workaround for K8s watch events with incorrect status codes

### DIFF
--- a/k8s/src/main/scala/io/buoyant/k8s/Watchable.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/Watchable.scala
@@ -149,6 +149,7 @@ private[k8s] abstract class Watchable[O <: KubeObject: TypeReference, W <: Watch
             // 3. The watch fails
             //
             // We need to reload the initial information to ensure we are "caught up," and then watch again.
+            log.info("k8s restarting watch on %s, resource version %s was too old", watchPath, resourceVersion)
             AsyncStream.fromFuture {
               restartWatches(labelSelector, fieldSelector).map {
                 case (ws, ver) => AsyncStream.fromSeq(ws) ++ _watch(ver)

--- a/k8s/src/main/scala/io/buoyant/k8s/Watchable.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/Watchable.scala
@@ -110,6 +110,24 @@ private[k8s] abstract class Watchable[O <: KubeObject: TypeReference, W <: Watch
         Future.Unit
       })
 
+      @inline
+      def _resourceVersionTooOld() = {
+        // Gone is returned by k8s to indicate the requested resource version is too old to watch. A common scenario
+        // that exhibits this error is:
+        //
+        // 1. Kubernetes kills a connection or the connection is lost
+        // 2. We try to re-establish the watch from the last received version, but because we are only watching a
+        //    subset of resources, that version was a while ago
+        // 3. The watch fails
+        //
+        // We need to reload the initial information to ensure we are "caught up," and then watch again.
+        log.trace("k8s restarting watch on %s, resource version %s was too old", watchPath, resourceVersion)
+        AsyncStream.fromFuture {
+          restartWatches(labelSelector, fieldSelector).map {
+            case (ws, ver) => AsyncStream.fromSeq(ws) ++ _watch(ver)
+          }
+        }.flatten
+      }
       AsyncStream.fromFuture(initialState).flatMap { rsp =>
         rsp.status match {
           // NOTE: 5xx-class statuses will be retried by the infiniteRetryFilter above.
@@ -123,6 +141,23 @@ private[k8s] abstract class Watchable[O <: KubeObject: TypeReference, W <: Watch
               }
             })
             val watchStream = Json.readStream[W](rsp.reader, Api.BufSize)
+              // it would be nice to not have to flat map over the watch stream, but this is
+              // necessary to handle the K8s bug where erorrs have the incorrect status code.
+              // hopefully this hack can eventually be removed...
+              .flatMap {
+                // special case to handle Kubernetes bug where "too old resource version" errors
+                // are returned with status code 200 rather than status code 410.
+                // see https://github.com/kubernetes/kubernetes/issues/35068 for details.
+                case e: Watch.Error[O] if e.status.message.exists(_.startsWith("too old resource version")) =>
+                  log.warning(
+                    """k8s returned 'too old resource version' error with incorrect HTTP status code.
+                      |         everything is fine, but your Kubernetes version is probably outdated.
+                      |         see https://github.com/kubernetes/kubernetes/issues/35068 for more details.
+                      |""".stripMargin
+                  )
+                  _resourceVersionTooOld()
+                case event => AsyncStream.fromOption(Some(event))
+              }
             watchStream ++ // if the stream ends (k8s will kill connections after ~30m), restart it)
               AsyncStream.fromFuture {
                 // It's safe to call lastOption here, because we're after the `++` operator, so
@@ -140,21 +175,7 @@ private[k8s] abstract class Watchable[O <: KubeObject: TypeReference, W <: Watch
               }.flatten
 
           case http.Status.Gone =>
-            // Gone is returned by k8s to indicate the requested resource version is too old to watch. A common scenario
-            // that exhibits this error is:
-            //
-            // 1. Kubernetes kills a connection or the connection is lost
-            // 2. We try to re-establish the watch from the last received version, but because we are only watching a
-            //    subset of resources, that version was a while ago
-            // 3. The watch fails
-            //
-            // We need to reload the initial information to ensure we are "caught up," and then watch again.
-            log.info("k8s restarting watch on %s, resource version %s was too old", watchPath, resourceVersion)
-            AsyncStream.fromFuture {
-              restartWatches(labelSelector, fieldSelector).map {
-                case (ws, ver) => AsyncStream.fromSeq(ws) ++ _watch(ver)
-              }
-            }.flatten
+            _resourceVersionTooOld()
 
           case status =>
             close.set(Closable.nop)

--- a/k8s/src/test/scala/io/buoyant/k8s/v1/ApiTest.scala
+++ b/k8s/src/test/scala/io/buoyant/k8s/v1/ApiTest.scala
@@ -338,7 +338,6 @@ class ApiTest extends FunSuite
             val rsp = Response()
             rsp.version = req.version
             rsp.status = Status.Gone
-            //            val msg = Buf.Utf8("""{"type":"ERROR","object":{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"401: The event in requested index is outdated and cleared (the requested history has been cleared [4770862/4659254]) [4771861]"}}""")
             val msg = Buf.Utf8("""{"type":"ERROR","object":{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"too old resource version: 62033480 (62353773)","reason":"Gone","code":410}}""")
             rsp.writer.write(msg).ensure {
               val _ = rsp.writer.close()

--- a/k8s/src/test/scala/io/buoyant/k8s/v1/ApiTest.scala
+++ b/k8s/src/test/scala/io/buoyant/k8s/v1/ApiTest.scala
@@ -410,7 +410,7 @@ class ApiTest extends FunSuite
             val rsp = Response()
             rsp.version = req.version
             rsp.status = Status.Ok
-            val msg = Buf.Utf8("""{"type":"ERROR","object":{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"too old resource version: 62033480 (62353773)","reason":"Gone","code":200}}""")
+            val msg = Buf.Utf8("""{"type":"ERROR","object":{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"too old resource version: 62033480 (62353773)","reason":"Gone","code":410}}""")
             rsp.writer.write(msg).ensure {
               val _ = rsp.writer.close()
             }

--- a/k8s/src/test/scala/io/buoyant/k8s/v1/ApiTest.scala
+++ b/k8s/src/test/scala/io/buoyant/k8s/v1/ApiTest.scala
@@ -338,7 +338,80 @@ class ApiTest extends FunSuite
             val rsp = Response()
             rsp.version = req.version
             rsp.status = Status.Gone
-            val msg = Buf.Utf8("""{"type":"ERROR","object":{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"401: The event in requested index is outdated and cleared (the requested history has been cleared [4770862/4659254]) [4771861]"}}""")
+            //            val msg = Buf.Utf8("""{"type":"ERROR","object":{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"401: The event in requested index is outdated and cleared (the requested history has been cleared [4770862/4659254]) [4771861]"}}""")
+            val msg = Buf.Utf8("""{"type":"ERROR","object":{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"too old resource version: 62033480 (62353773)","reason":"Gone","code":410}}""")
+            rsp.writer.write(msg).ensure {
+              val _ = rsp.writer.close()
+            }
+            Future.value(rsp)
+          case 2 =>
+            assert(req.uri == "/api/v1/watch/namespaces/srv/endpoints")
+            val rsp = Response()
+            rsp.version = req.version
+            rsp.setContentTypeJson()
+            rsp.headerMap("Transfer-Encoding") = "chunked"
+
+            rsp.writer.write(endpointsList) before rsp.writer.close()
+            Future.value(rsp)
+          case 3 =>
+            assert(req.uri == "/api/v1/watch/namespaces/srv/endpoints?resourceVersion=17575669") // this is the top-level resource version
+
+            Future.never
+
+          case _ => // ignore
+            Future.never
+        }
+      } catch {
+        case up: TestFailedException => throw up
+        case e: Throwable =>
+          failure = e
+          Future.exception(e)
+      }
+    }
+    val api = Api(service)
+
+    val (stream, closable) = api.withNamespace("srv").endpoints.watch(resourceVersion = Some(ver))
+    try {
+      await(stream.uncons) match {
+        case Some((EndpointsModified(mod), stream)) =>
+          assert(mod.metadata.get.resourceVersion.contains("17147786"))
+          assert(mod.subsets.get.head.addresses.contains(Seq(EndpointAddress("10.248.9.109", None, Some(ObjectReference(Some("Pod"), Some("greg-test"), Some("accounts-h5zht"), Some("0b598c6e-9f9b-11e5-94e8-42010af00045"), None, Some("17147785"), None))))))
+          await(stream().uncons) match {
+            case Some((EndpointsModified(mod), stream)) =>
+              assert(mod.metadata.get.resourceVersion.contains("17147808"))
+              assert(mod.subsets.get.head.addresses.contains(List(EndpointAddress("10.248.4.134", None, Some(ObjectReference(Some("Pod"), Some("greg-test"), Some("auth-54q3e"), Some("0d5d0a2d-9f9b-11e5-94e8-42010af00045"), None, Some("17147807"), None))))))
+              await(stream().uncons) match {
+                case Some((EndpointsModified(mod), stream)) =>
+                  assert(mod.metadata.get.resourceVersion.contains("27147808"))
+                  assert(mod.subsets.isEmpty)
+                  val next = stream().uncons
+                  await(closable.close())
+                  assert(!next.isDefined)
+                case event => fail(s"unexpected event: $event")
+              }
+            case event => fail(s"unexpected event: $event")
+          }
+        case event => fail(s"unexpected event: $event")
+      }
+    } finally await(closable.close())
+    if (failure != null) throw failure
+  }
+
+  test("watch too old with incorrect status code (kubernetes#35068)") {
+    // reproduction for Linkerd issue #1636, caused by Kubernetes issue #35068.
+    val ver = "4659253"
+    @volatile var reqCount = 0
+    @volatile var failure: Throwable = null
+    val service = FService.mk[Request, Response] { req =>
+      reqCount += 1
+      try {
+        reqCount match {
+          case 1 =>
+            assert(req.uri == s"/api/v1/watch/namespaces/srv/endpoints?resourceVersion=$ver")
+            val rsp = Response()
+            rsp.version = req.version
+            rsp.status = Status.Ok
+            val msg = Buf.Utf8("""{"type":"ERROR","object":{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"too old resource version: 62033480 (62353773)","reason":"Gone","code":200}}""")
             rsp.writer.write(msg).ensure {
               val _ = rsp.writer.close()
             }


### PR DESCRIPTION
Due to a regression in some versions of Kubernetes (kubernetes/kubernetes#35068), the "resource version too old" watch event sometimes has HTTP status code 200, rather than status code 410. This event is not a fatal error and simply indicates that a watch should be restarted – k8s will fire this event for any watch that has been open for longer than thirty minutes. In Linkerd,`Watchable` currently detects this event by matching the HTTP status code of the watch event, and restarts the watch when it occurs. However, when the event is fired with the incorrect status code, the error is not handled in `Watchable` and passed downstream – in the case of issue #1636, to `EndpointsNamer`, which does not know how to handle this event. This leads to namers intermittently failing to resolve k8s endpoints.

Although this issue seems to have been fixed upstream in kubernetes/kubernetes#25369, many users of Linkerd are running versions of Kubernetes where it still occurs. Therefore,  I've added a workaround in `Watchable` to detect "resource version too old" events with status code 200 and restart the watch rather than passing these events downstream. When this occurs, Linkerd now logs a warning indicating that, although the error was handled, Kubernetes behaved erroneously. 

I've added a test to `v1.ApiTest` that replicates the Kubernetes bug.

Fixes #1636