### PR TITLE
Add Prefix Option to Prometheus Telemetry Config

### DIFF
--- a/linkerd/docs/telemetry.md
+++ b/linkerd/docs/telemetry.md
@@ -22,6 +22,7 @@ experimental | `false` | Set this to `true` to enable the telemeter if it is exp
 telemetry:
 - kind: io.l5d.prometheus
   path: /admin/metrics/prometheus
+  prefix: linkerd_
 ```
 
 kind: `io.l5d.prometheus`
@@ -33,6 +34,7 @@ Exposes admin endpoints:
 Key | Default Value | Description
 --- | ------------- | -----------
 path | `/admin/metrics/prometheus` | HTTP path where linkerd exposes Prometheus metrics
+path | No prefix | Prefix for exposed Prometheus metrics
 
 ## InfluxDB
 

--- a/linkerd/docs/telemetry.md
+++ b/linkerd/docs/telemetry.md
@@ -34,7 +34,7 @@ Exposes admin endpoints:
 Key | Default Value | Description
 --- | ------------- | -----------
 path | `/admin/metrics/prometheus` | HTTP path where linkerd exposes Prometheus metrics
-path | No prefix | Prefix for exposed Prometheus metrics
+prefix | No prefix | Prefix for exposed Prometheus metrics
 
 ## InfluxDB
 

--- a/telemetry/prometheus/src/main/scala/io/buoyant/telemetry/prometheus/PrometheusTelemeter.scala
+++ b/telemetry/prometheus/src/main/scala/io/buoyant/telemetry/prometheus/PrometheusTelemeter.scala
@@ -14,7 +14,7 @@ import io.buoyant.telemetry.{Metric, MetricsTree, Telemeter}
  * histogram summaries directly off of the MetricsTree and assumes that stats
  * are being snapshotted at some appropriate interval.
  */
-class PrometheusTelemeter(metrics: MetricsTree, private[prometheus] val handlerPath: String) extends Telemeter with Admin.WithHandlers {
+class PrometheusTelemeter(metrics: MetricsTree, private[prometheus] val handlerPath: String, private[prometheus] val handlerPrefix: String) extends Telemeter with Admin.WithHandlers {
 
   private[prometheus] val handler = Service.mk { request: Request =>
     val response = Response()
@@ -80,7 +80,7 @@ class PrometheusTelemeter(metrics: MetricsTree, private[prometheus] val handlerP
       case _ => (prefix0, labels0)
     }
 
-    val key = escapeKey(prefix1.mkString(":"))
+    val key = escapeKey(handlerPrefix + prefix1.mkString(":"))
 
     tree.metric match {
       case c: Metric.Counter =>

--- a/telemetry/prometheus/src/main/scala/io/buoyant/telemetry/prometheus/PrometheusTelemeterInitializer.scala
+++ b/telemetry/prometheus/src/main/scala/io/buoyant/telemetry/prometheus/PrometheusTelemeterInitializer.scala
@@ -12,10 +12,11 @@ class PrometheusTelemeterInitializer extends TelemeterInitializer {
 
 object PrometheusTelemeterInitializer extends PrometheusTelemeterInitializer
 
-class PrometheusConfig(path: Option[String]) extends TelemeterConfig {
+class PrometheusConfig(path: Option[String], prefix: Option[String]) extends TelemeterConfig {
   @JsonIgnore def mk(params: Stack.Params): Telemeter =
     new PrometheusTelemeter(
       params[MetricsTree],
-      path.getOrElse("/admin/metrics/prometheus")
+      path.getOrElse("/admin/metrics/prometheus"),
+      prefix.getOrElse("")
     )
 }

--- a/telemetry/prometheus/src/test/scala/io/buoyant/telemetry/prometheus/PrometheusTelemeterInitializerTest.scala
+++ b/telemetry/prometheus/src/test/scala/io/buoyant/telemetry/prometheus/PrometheusTelemeterInitializerTest.scala
@@ -12,6 +12,7 @@ class PrometheusTelemeterInitializerTest extends FunSuite {
     val yaml =
       """|kind: io.l5d.prometheus
          |path: /metrics
+         |prefix: some_prefix_
          |""".stripMargin
 
     val config = Parser.objectMapper(yaml, Seq(LoadService[TelemeterInitializer]))
@@ -33,5 +34,43 @@ class PrometheusTelemeterInitializerTest extends FunSuite {
 
     val telemeter = config.mk(Stack.Params.empty).asInstanceOf[PrometheusTelemeter]
     assert(telemeter.handlerPath === "/admin/metrics/prometheus")
+  }
+
+  test("io.l5d.prometheus telemeter path") {
+    val yaml =
+      """|kind: io.l5d.prometheus
+         |path: /some/path
+         |""".stripMargin
+
+    val config = Parser.objectMapper(yaml, Seq(LoadService[TelemeterInitializer]))
+      .readValue[TelemeterConfig](yaml)
+
+    val telemeter = config.mk(Stack.Params.empty).asInstanceOf[PrometheusTelemeter]
+    assert(telemeter.handlerPath === "/some/path")
+  }
+
+  test("io.l5d.prometheus telemeter default prefix") {
+    val yaml =
+      """|kind: io.l5d.prometheus
+         |""".stripMargin
+
+    val config = Parser.objectMapper(yaml, Seq(LoadService[TelemeterInitializer]))
+      .readValue[TelemeterConfig](yaml)
+
+    val telemeter = config.mk(Stack.Params.empty).asInstanceOf[PrometheusTelemeter]
+    assert(telemeter.handlerPrefix === "")
+  }
+
+  test("io.l5d.prometheus telemeter prefix") {
+    val yaml =
+      """|kind: io.l5d.prometheus
+         |prefix: some_prefix_
+         |""".stripMargin
+
+    val config = Parser.objectMapper(yaml, Seq(LoadService[TelemeterInitializer]))
+      .readValue[TelemeterConfig](yaml)
+
+    val telemeter = config.mk(Stack.Params.empty).asInstanceOf[PrometheusTelemeter]
+    assert(telemeter.handlerPrefix === "some_prefix_")
   }
 }


### PR DESCRIPTION
prometheus: Add the ability to configure a prefix #1655.

The new config key is optional and can be used like this:

```yaml
telemetry:
- kind: io.l5d.prometheus
  path: /admin/metrics/prometheus
  prefix: linkerd_
```

By default, the `prefix` value is an empty string and so no prefix will be attached to the exported Prometheus metrics. 

Also worth noting, currently the prefix will be inserted as is, with no delimeter. So if the prefix value is `linkerd_`, as above, then the exported metrics will look like: `linkerd_foo:bar...`. 