### PR TITLE
Add New Relic telemeter

### DIFF
--- a/linkerd/docs/telemetry.md
+++ b/linkerd/docs/telemetry.md
@@ -11,7 +11,7 @@ regardless of kind. Telemeters may also have kind-specific parameters.
 
 Key | Default Value | Description
 --- | ------------- | -----------
-kind | _required_ | Either [`io.l5d.prometheus`](#prometheus), [`io.l5d.influxdb`](#influxdb), [`io.l5d.statsd`](#statsd-experimental), [`io.l5d.tracelog`](#tracelog), [`io.l5d.recentRequests`](#recent-requests), or [`io.l5d.zipkin`](#zipkin-telemeter).
+kind | _required_ | Either [`io.l5d.prometheus`](#prometheus), [`io.l5d.influxdb`](#influxdb), [`io.l5d.statsd`](#statsd-experimental), [`io.l5d.tracelog`](#tracelog), [`io.l5d.recentRequests`](#recent-requests), [`io.l5d.zipkin`](#zipkin-telemeter), or [`io.l5d.newrelic`](#new-relic-experimental)
 experimental | `false` | Set this to `true` to enable the telemeter if it is experimental.
 
 ## Prometheus
@@ -170,3 +170,28 @@ Key | Default Value | Description
 host | `localhost` | Host to send trace data to.
 port | `9410` | Port to send trace data to (must be the Scribe collector port).
 sampleRate | `0.001` | A value between 0.0 and 1.0 indicating what proportion of requests to trace.
+
+
+## New Relic (experimental)
+
+> Example New Relic config
+
+```yaml
+telemetry:
+- kind: io.l5d.newrelic
+  experimental: true
+  license_key: $NEW_RELIC_LICENSE_KEY
+```
+
+kind: `io.l5d.newrelic`
+
+[New Relic](https://www.newrelic.com/) plugin metrics reporting. This telemeter
+will report metrics to the Linkerd new relic plugin. A New Relic account license key is required.
+
+Key | Default Value | Description
+--- | ------------- | -----------
+experimental | _required_ | Because this telemeter is still considered experimental, you must set this to `true` to use it
+license_key | _required_ | New Relic license key
+prefix | `Linkerd` | String to prefix all exported metric names with.
+host | `127.0.0.1` | The hostname reporting the metrics.
+dst | `/$/inet/platform-api.newrelic.com/443` | Path to the New Relic API server.

--- a/linkerd/examples/newrelic.yaml
+++ b/linkerd/examples/newrelic.yaml
@@ -1,0 +1,13 @@
+namers:
+- kind: io.l5d.fs
+  rootDir: linkerd/examples/io.l5d.fs
+
+routers:
+- protocol: http
+  dtab: /svc => /#/io.l5d.fs;
+  servers:
+  - port: 4140
+
+telemetry:
+- kind: io.l5d.newrelic
+  license_key:

--- a/linkerd/examples/newrelic.yaml
+++ b/linkerd/examples/newrelic.yaml
@@ -10,4 +10,5 @@ routers:
 
 telemetry:
 - kind: io.l5d.newrelic
+  experimental: true
   license_key:

--- a/linkerd/examples/newrelic.yaml
+++ b/linkerd/examples/newrelic.yaml
@@ -11,4 +11,5 @@ routers:
 telemetry:
 - kind: io.l5d.newrelic
   experimental: true
-  license_key:
+  # put your New Relic account license key here!
+  license_key: not_a_real_newrelic_license_key

--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -187,6 +187,11 @@ object LinkerdBuild extends Base {
       .withTwitterLibs(Deps.finagle("core"), Deps.finagle("stats"))
       .withTests()
 
+    val newrelic = projectDir("telemetry/newrelic")
+      .dependsOn(LinkerdBuild.admin, core)
+      .withTwitterLibs(Deps.finagle("core"), Deps.finagle("stats"))
+      .withTests()
+
     val prometheus = projectDir("telemetry/prometheus")
       .dependsOn(LinkerdBuild.admin, core)
       .withTwitterLibs(Deps.finagle("core"), Deps.finagle("stats"))
@@ -209,7 +214,7 @@ object LinkerdBuild extends Base {
       .dependsOn(core, Router.core)
       .withTests()
 
-    val all = aggregateDir("telemetry", adminMetricsExport, core, influxdb, prometheus, recentRequests, statsd, tracelog, zipkin)
+    val all = aggregateDir("telemetry", adminMetricsExport, core, influxdb, newrelic, prometheus, recentRequests, statsd, tracelog, zipkin)
   }
 
   val ConfigFileRE = """^(.*)\.yaml$""".r
@@ -347,7 +352,7 @@ object LinkerdBuild extends Base {
       Iface.mesh,
       Interpreter.perHost, Interpreter.k8s,
       Storage.etcd, Storage.inMemory, Storage.k8s, Storage.zk, Storage.consul,
-      Telemetry.adminMetricsExport, Telemetry.core, Telemetry.influxdb, Telemetry.prometheus, Telemetry.recentRequests, Telemetry.statsd, Telemetry.tracelog, Telemetry.zipkin
+      Telemetry.adminMetricsExport, Telemetry.core, Telemetry.influxdb, Telemetry.newrelic, Telemetry.prometheus, Telemetry.recentRequests, Telemetry.statsd, Telemetry.tracelog, Telemetry.zipkin
     )
 
     val LowMemSettings = BundleSettings ++ Seq(
@@ -597,7 +602,7 @@ object LinkerdBuild extends Base {
       Interpreter.fs, Interpreter.k8s, Interpreter.istio, Interpreter.mesh, Interpreter.namerd, Interpreter.perHost, Interpreter.subnet,
       Protocol.h2, Protocol.http, Protocol.mux, Protocol.thrift, Protocol.thriftMux,
       Announcer.serversets,
-      Telemetry.adminMetricsExport, Telemetry.core, Telemetry.influxdb, Telemetry.prometheus, Telemetry.recentRequests, Telemetry.statsd, Telemetry.tracelog, Telemetry.zipkin,
+      Telemetry.adminMetricsExport, Telemetry.core, Telemetry.influxdb, Telemetry.newrelic, Telemetry.prometheus, Telemetry.recentRequests, Telemetry.statsd, Telemetry.tracelog, Telemetry.zipkin,
       tls,
       failureAccrual
     )
@@ -674,6 +679,7 @@ object LinkerdBuild extends Base {
   val telemetryAdminMetricsExport = Telemetry.adminMetricsExport
   val telemetryCore = Telemetry.core
   val telemetryInfluxDb = Telemetry.influxdb
+  val telemetryNewrelic = Telemetry.newrelic
   val telemetryPrometheus = Telemetry.prometheus
   val telemetryRecentRequests = Telemetry.recentRequests
   val telemetryStatsD = Telemetry.statsd

--- a/telemetry/admin-metrics-export/src/main/scala/io/buoyant/telemetry/admin/AdminMetricsExportTelemeter.scala
+++ b/telemetry/admin-metrics-export/src/main/scala/io/buoyant/telemetry/admin/AdminMetricsExportTelemeter.scala
@@ -108,8 +108,8 @@ class AdminMetricsExportTelemeter(
     if (pretty) jg.setPrettyPrinter(new DefaultPrettyPrinter())
     jg.writeStartObject()
     val flattened =
-      if (pretty) flattenMetricsTree(tree).sortBy(_._1)
-      else flattenMetricsTree(tree)
+      if (pretty) MetricsTree.flatten(tree).sortBy(_._1)
+      else MetricsTree.flatten(tree)
     flattened.foreach(writeJsonMetric(jg, _))
     jg.writeEndObject()
     jg.close()
@@ -133,21 +133,6 @@ class AdminMetricsExportTelemeter(
       writeJsonTree(jg, child)
     }
     jg.writeEndObject()
-  }
-
-  private[this] def flattenMetricsTree(
-    tree: MetricsTree,
-    prefix: String = "",
-    acc: mutable.Buffer[(String, Metric)] = mutable.Buffer()
-  ): Seq[(String, Metric)] = {
-    acc += (prefix -> tree.metric)
-    for ((name, child) <- tree.children) {
-      if (prefix.isEmpty)
-        flattenMetricsTree(child, name, acc)
-      else
-        flattenMetricsTree(child, s"$prefix/$name", acc)
-    }
-    acc.toSeq
   }
 
   /** Snapshot histograms to produce histogram summaries, resetting as we go. */

--- a/telemetry/core/src/main/scala/io/buoyant/telemetry/MetricsTree.scala
+++ b/telemetry/core/src/main/scala/io/buoyant/telemetry/MetricsTree.scala
@@ -6,6 +6,7 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicReference
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._
+import scala.collection.mutable
 
 trait MetricsTree {
   def children: Map[String, MetricsTree]
@@ -119,5 +120,20 @@ object MetricsTree {
       trees.clear()
       metricRef.set(Metric.None)
     }
+  }
+
+  def flatten(
+    tree: MetricsTree,
+    prefix: String = "",
+    acc: mutable.Buffer[(String, Metric)] = mutable.Buffer()
+  ): Seq[(String, Metric)] = {
+    acc += (prefix -> tree.metric)
+    for ((name, child) <- tree.children) {
+      if (prefix.isEmpty)
+        flatten(child, name, acc)
+      else
+        flatten(child, s"$prefix/$name", acc)
+    }
+    acc
   }
 }

--- a/telemetry/core/src/main/scala/io/buoyant/telemetry/MetricsTree.scala
+++ b/telemetry/core/src/main/scala/io/buoyant/telemetry/MetricsTree.scala
@@ -152,7 +152,7 @@ object MetricsTree {
       case metric => acc += prefix -> tree.metric
     }
 
-    for ((name, child) <- tree.children ) {
+    for ((name, child) <- tree.children) {
       if (prefix.isEmpty)
         flattenNones(child, name, acc)
       else

--- a/telemetry/core/src/main/scala/io/buoyant/telemetry/MetricsTree.scala
+++ b/telemetry/core/src/main/scala/io/buoyant/telemetry/MetricsTree.scala
@@ -122,25 +122,10 @@ object MetricsTree {
     }
   }
 
-  def flatten(
-    tree: MetricsTree,
-    prefix: String = "",
-    acc: mutable.Buffer[(String, Metric)] = mutable.Buffer()
-  ): Seq[(String, Metric)] = {
-    acc += (prefix -> tree.metric)
-    for ((name, child) <- tree.children) {
-      if (prefix.isEmpty)
-        flatten(child, name, acc)
-      else
-        flatten(child, s"$prefix/$name", acc)
-    }
-    acc
-  }
-
   /**
    * Flatten `tree`, skipping empty scopes.
    */
-  def flattenNones(
+  def flatten(
     tree: MetricsTree,
     prefix: String = "",
     acc: mutable.Buffer[(String, Metric)] = mutable.Buffer()
@@ -154,9 +139,9 @@ object MetricsTree {
 
     for ((name, child) <- tree.children) {
       if (prefix.isEmpty)
-        flattenNones(child, name, acc)
+        flatten(child, name, acc)
       else
-        flattenNones(child, s"$prefix/$name", acc)
+        flatten(child, s"$prefix/$name", acc)
     }
     acc
   }

--- a/telemetry/core/src/main/scala/io/buoyant/telemetry/MetricsTree.scala
+++ b/telemetry/core/src/main/scala/io/buoyant/telemetry/MetricsTree.scala
@@ -136,4 +136,28 @@ object MetricsTree {
     }
     acc
   }
+
+  /**
+   * Flatten `tree`, skipping empty scopes.
+   */
+  def flattenNones(
+    tree: MetricsTree,
+    prefix: String = "",
+    acc: mutable.Buffer[(String, Metric)] = mutable.Buffer()
+  ): Seq[(String, Metric)] = {
+    // This method could also have been implemented as
+    // `flatten(...).filter(...)` but this seems more performant.
+    tree.metric match {
+      case Metric.None =>
+      case metric => acc += prefix -> tree.metric
+    }
+
+    for ((name, child) <- tree.children ) {
+      if (prefix.isEmpty)
+        flattenNones(child, name, acc)
+      else
+        flattenNones(child, s"$prefix/$name", acc)
+    }
+    acc
+  }
 }

--- a/telemetry/core/src/test/scala/io/buoyant/telemetry/MetricsTreeTest.scala
+++ b/telemetry/core/src/test/scala/io/buoyant/telemetry/MetricsTreeTest.scala
@@ -6,24 +6,21 @@ import org.scalatest.Matchers
 
 class MetricsTreeTest extends FunSuite with Matchers {
 
-  test("flattening an empty MetricsTree returns Metric.None") {
+  test("flattening an empty MetricsTree is empty") {
     val emptyTree = MetricsTree()
-    MetricsTree.flatten(emptyTree) should contain only (("", Metric.None))
+    MetricsTree.flatten(emptyTree) shouldBe 'empty
   }
 
-  test("flattening an empty MetricsTree with a prefix returns Metric.None with prefix") {
+  test("flattening an empty MetricsTree with a prefix is empty") {
     val emptyTree = MetricsTree()
-    val flat = MetricsTree.flatten(emptyTree, "my great prefix")
-    flat should contain only (("my great prefix", Metric.None))
+    MetricsTree.flatten(emptyTree, "my great prefix") shouldBe 'empty
   }
 
   test("flattening a MetricsTree with a single item") {
     val tree = MetricsTree()
     val scope = tree.resolve(Seq("my", "great", "scope"))
     val stat = scope.mkStat(Verbosity.Default)
-    MetricsTree.flatten(tree) should contain allOf (
-      "my" -> Metric.None,
-      "my/great" -> Metric.None,
+    MetricsTree.flatten(tree) should contain only (
       "my/great/scope" -> stat
     )
   }
@@ -34,8 +31,8 @@ class MetricsTreeTest extends FunSuite with Matchers {
     val tree = MetricsTree()
     val stat = tree.resolve(Seq("stat")).mkStat(Verbosity.Default)
     val counter = tree.resolve(Seq("counter")).mkCounter(Verbosity.Default)
-    MetricsTree.flatten(tree) should contain allOf (
-      "stat" -> stat, "counter" -> counter, "" -> Metric.None
+    MetricsTree.flatten(tree) should contain only (
+      "stat" -> stat, "counter" -> counter
     )
   }
 
@@ -50,60 +47,7 @@ class MetricsTreeTest extends FunSuite with Matchers {
     val counter1 = scope1.resolve(Seq("counter")).mkCounter(Verbosity.Default)
     val stat2 = scope2.resolve(Seq("stat")).mkStat(Verbosity.Default)
     val counter2 = scope2.resolve(Seq("counter")).mkCounter(Verbosity.Default)
-    MetricsTree.flatten(tree) should contain allOf (
-      "this" -> Metric.None,
-      "this/is" -> Metric.None,
-      "this/is/the" -> Metric.None,
-      "this/is/the/stat" -> stat0,
-      "this/is/the/first/stat" -> stat1,
-      "this/is/the/first/counter" -> counter1,
-      "this/is/the/second/stat" -> stat2,
-      "this/is/the/second/counter" -> counter2
-    )
-  }
-
-  test("flattening an empty MetricsTree ignoring None is empty") {
-    val emptyTree = MetricsTree()
-    MetricsTree.flattenNones(emptyTree) shouldBe 'empty
-  }
-
-  test("flattening an empty MetricsTree with a prefix ignoring None is empty") {
-    val emptyTree = MetricsTree()
-    MetricsTree.flattenNones(emptyTree, "my great prefix") shouldBe 'empty
-  }
-
-  test("flattening a MetricsTree with a single item, ignoring None") {
-    val tree = MetricsTree()
-    val scope = tree.resolve(Seq("my", "great", "scope"))
-    val stat = scope.mkStat(Verbosity.Default)
-    MetricsTree.flattenNones(tree) should contain only (
-      "my/great/scope" -> stat
-    )
-  }
-
-  test("flattening a MetricsTree with multiple items, ignoring None") {
-    // not adding a gauge because the gauge won't be returned & it's tricky to test
-    // gauge equality...
-    val tree = MetricsTree()
-    val stat = tree.resolve(Seq("stat")).mkStat(Verbosity.Default)
-    val counter = tree.resolve(Seq("counter")).mkCounter(Verbosity.Default)
-    MetricsTree.flattenNones(tree) should contain only (
-      "stat" -> stat, "counter" -> counter
-    )
-  }
-
-  test("flattening a MetricsTree with multiple scopes, ignoring None") {
-    // TODO: ScalaCheck test with arbitrary metrics trees?
-    val tree = MetricsTree()
-    val scope = tree.resolve(Seq("this","is","the"))
-    val scope1 = scope.resolve(Seq("first"))
-    val scope2 = scope.resolve(Seq("second"))
-    val stat0 = scope.resolve(Seq("stat")).mkStat(Verbosity.Default)
-    val stat1 = scope1.resolve(Seq("stat")).mkStat(Verbosity.Default)
-    val counter1 = scope1.resolve(Seq("counter")).mkCounter(Verbosity.Default)
-    val stat2 = scope2.resolve(Seq("stat")).mkStat(Verbosity.Default)
-    val counter2 = scope2.resolve(Seq("counter")).mkCounter(Verbosity.Default)
-    MetricsTree.flattenNones(tree) should contain only (
+    MetricsTree.flatten(tree) should contain only (
       "this/is/the/stat" -> stat0,
       "this/is/the/first/stat" -> stat1,
       "this/is/the/first/counter" -> counter1,

--- a/telemetry/core/src/test/scala/io/buoyant/telemetry/MetricsTreeTest.scala
+++ b/telemetry/core/src/test/scala/io/buoyant/telemetry/MetricsTreeTest.scala
@@ -1,0 +1,115 @@
+package io.buoyant.telemetry
+
+import com.twitter.finagle.stats.Verbosity
+import io.buoyant.test.FunSuite
+import org.scalatest.Matchers
+
+class MetricsTreeTest extends FunSuite with Matchers {
+
+  test("flattening an empty MetricsTree returns Metric.None") {
+    val emptyTree = MetricsTree()
+    MetricsTree.flatten(emptyTree) should contain only (("", Metric.None))
+  }
+
+  test("flattening an empty MetricsTree with a prefix returns Metric.None with prefix") {
+    val emptyTree = MetricsTree()
+    val flat = MetricsTree.flatten(emptyTree, "my great prefix")
+    flat should contain only (("my great prefix", Metric.None))
+  }
+
+  test("flattening a MetricsTree with a single item") {
+    val tree = MetricsTree()
+    val scope = tree.resolve(Seq("my", "great", "scope"))
+    val stat = scope.mkStat(Verbosity.Default)
+    MetricsTree.flatten(tree) should contain allOf (
+      "my" -> Metric.None,
+      "my/great" -> Metric.None,
+      "my/great/scope" -> stat
+    )
+  }
+
+  test("flattening a MetricsTree with multiple items") {
+    // not adding a gauge because the gauge won't be returned & it's tricky to test
+    // gauge equality...
+    val tree = MetricsTree()
+    val stat = tree.resolve(Seq("stat")).mkStat(Verbosity.Default)
+    val counter = tree.resolve(Seq("counter")).mkCounter(Verbosity.Default)
+    MetricsTree.flatten(tree) should contain allOf (
+      "stat" -> stat, "counter" -> counter, "" -> Metric.None
+    )
+  }
+
+  test("flattening a MetricsTree with multiple scopes") {
+    // TODO: ScalaCheck test with arbitrary metrics trees?
+    val tree = MetricsTree()
+    val scope = tree.resolve(Seq("this","is","the"))
+    val scope1 = scope.resolve(Seq("first"))
+    val scope2 = scope.resolve(Seq("second"))
+    val stat0 = scope.resolve(Seq("stat")).mkStat(Verbosity.Default)
+    val stat1 = scope1.resolve(Seq("stat")).mkStat(Verbosity.Default)
+    val counter1 = scope1.resolve(Seq("counter")).mkCounter(Verbosity.Default)
+    val stat2 = scope2.resolve(Seq("stat")).mkStat(Verbosity.Default)
+    val counter2 = scope2.resolve(Seq("counter")).mkCounter(Verbosity.Default)
+    MetricsTree.flatten(tree) should contain allOf (
+      "this" -> Metric.None,
+      "this/is" -> Metric.None,
+      "this/is/the" -> Metric.None,
+      "this/is/the/stat" -> stat0,
+      "this/is/the/first/stat" -> stat1,
+      "this/is/the/first/counter" -> counter1,
+      "this/is/the/second/stat" -> stat2,
+      "this/is/the/second/counter" -> counter2
+    )
+  }
+
+  test("flattening an empty MetricsTree ignoring None is empty") {
+    val emptyTree = MetricsTree()
+    MetricsTree.flattenNones(emptyTree) shouldBe 'empty
+  }
+
+  test("flattening an empty MetricsTree with a prefix ignoring None is empty") {
+    val emptyTree = MetricsTree()
+    MetricsTree.flattenNones(emptyTree, "my great prefix") shouldBe 'empty
+  }
+
+  test("flattening a MetricsTree with a single item, ignoring None") {
+    val tree = MetricsTree()
+    val scope = tree.resolve(Seq("my", "great", "scope"))
+    val stat = scope.mkStat(Verbosity.Default)
+    MetricsTree.flattenNones(tree) should contain only (
+      "my/great/scope" -> stat
+    )
+  }
+
+  test("flattening a MetricsTree with multiple items, ignoring None") {
+    // not adding a gauge because the gauge won't be returned & it's tricky to test
+    // gauge equality...
+    val tree = MetricsTree()
+    val stat = tree.resolve(Seq("stat")).mkStat(Verbosity.Default)
+    val counter = tree.resolve(Seq("counter")).mkCounter(Verbosity.Default)
+    MetricsTree.flattenNones(tree) should contain only (
+      "stat" -> stat, "counter" -> counter
+    )
+  }
+
+  test("flattening a MetricsTree with multiple scopes, ignoring None") {
+    // TODO: ScalaCheck test with arbitrary metrics trees?
+    val tree = MetricsTree()
+    val scope = tree.resolve(Seq("this","is","the"))
+    val scope1 = scope.resolve(Seq("first"))
+    val scope2 = scope.resolve(Seq("second"))
+    val stat0 = scope.resolve(Seq("stat")).mkStat(Verbosity.Default)
+    val stat1 = scope1.resolve(Seq("stat")).mkStat(Verbosity.Default)
+    val counter1 = scope1.resolve(Seq("counter")).mkCounter(Verbosity.Default)
+    val stat2 = scope2.resolve(Seq("stat")).mkStat(Verbosity.Default)
+    val counter2 = scope2.resolve(Seq("counter")).mkCounter(Verbosity.Default)
+    MetricsTree.flattenNones(tree) should contain only (
+      "this/is/the/stat" -> stat0,
+      "this/is/the/first/stat" -> stat1,
+      "this/is/the/first/counter" -> counter1,
+      "this/is/the/second/stat" -> stat2,
+      "this/is/the/second/counter" -> counter2
+    )
+  }
+
+}

--- a/telemetry/newrelic/src/main/resources/META-INF/services/io.buoyant.telemetry.TelemeterInitializer
+++ b/telemetry/newrelic/src/main/resources/META-INF/services/io.buoyant.telemetry.TelemeterInitializer
@@ -1,0 +1,1 @@
+io.buoyant.telemetry.newrelic.NewRelicTelemeterInitializer

--- a/telemetry/newrelic/src/main/scala/io/buoyant/telemetry/newrelic/NewRelicTelemeter.scala
+++ b/telemetry/newrelic/src/main/scala/io/buoyant/telemetry/newrelic/NewRelicTelemeter.scala
@@ -57,7 +57,7 @@ class NewRelicTelemeter(
     }
   }
 
-  private[this] def mkMetrics(): Map[String, Metric] = {
+  private[this] def mkMetrics(): Map[String, Metric] =
     MetricsTree.flattenNones(metrics).toMap.mapValues {
       case counter: Counter => ScalarIntegerMetric(counter.get)
       case gauge: Gauge => ScalarDecimalMetric(gauge.get)
@@ -66,8 +66,12 @@ class NewRelicTelemeter(
         DistributionMetric(summary.sum, summary.count, summary.min, summary.max)
       case None =>
         throw new Exception("metric tree should not have contained Nones!")
+    }.filter {
+      // TODO: handle this better
+      case (_, null) => false
+      case _ => true
     }
-  }
+
 }
 
 object NewRelicTelemeter {

--- a/telemetry/newrelic/src/main/scala/io/buoyant/telemetry/newrelic/NewRelicTelemeter.scala
+++ b/telemetry/newrelic/src/main/scala/io/buoyant/telemetry/newrelic/NewRelicTelemeter.scala
@@ -70,14 +70,12 @@ class NewRelicTelemeter(
         case counter: Counter => Option(counter.get).map { ScalarIntegerMetric }
         case gauge: Gauge => Option(gauge.get).map { ScalarDecimalMetric }
         case stat: Stat =>
-          // TODO: this requires a sum_of_squares field...
-          //          Option(stat.snapshottedSummary).map { summary =>
-          //            DistributionMetric(summary.sum, summary.count, summary.min, summary.max)
-          //          }
-          None
+          Option(stat.snapshottedSummary).map { summary =>
+            DistributionMetric(summary.sum, summary.count, summary.min, summary.max)
+          }
         case MetricNone => None
       }
-    } yield key -> newRelicMetric
+    } yield s"Component/Linkerd/$key" -> newRelicMetric
 
 }
 
@@ -96,10 +94,12 @@ case class Agent(host: String, version: String)
 case class Component(name: String, guid: String, duration: Long, metrics: Map[String, Metric])
 
 sealed trait Metric
+
 @JsonFormat(shape = JsonFormat.Shape.NUMBER)
 case class ScalarIntegerMetric(value: Long) extends Metric {
   @JsonValue def integer: Long = value
 }
+
 @JsonFormat(shape = JsonFormat.Shape.NUMBER)
 case class ScalarDecimalMetric(@JsonValue value: Float) extends Metric {
   @JsonValue def decimal: Float = value

--- a/telemetry/newrelic/src/main/scala/io/buoyant/telemetry/newrelic/NewRelicTelemeter.scala
+++ b/telemetry/newrelic/src/main/scala/io/buoyant/telemetry/newrelic/NewRelicTelemeter.scala
@@ -1,0 +1,82 @@
+package io.buoyant.telemetry.newrelic
+
+import com.fasterxml.jackson.annotation.JsonValue
+import com.twitter.conversions.time._
+import com.twitter.finagle.Service
+import com.twitter.finagle.http.{Method, Request, Response}
+import com.twitter.finagle.stats.NullStatsReceiver
+import com.twitter.finagle.tracing.NullTracer
+import com.twitter.util._
+import io.buoyant.config.Parser
+import io.buoyant.telemetry.Metric.{Counter, Gauge, Stat}
+import io.buoyant.telemetry.{MetricsTree, Telemeter}
+import java.util.concurrent.atomic.AtomicBoolean
+
+class NewRelicTelemeter(
+  metrics: MetricsTree,
+  client: Service[Request, Response],
+  licenseKey: String,
+  host: String,
+  timer: Timer
+) extends Telemeter {
+  import NewRelicTelemeter._
+
+  private[this] val agent = Agent(host, NewRelicTelemeter.Version)
+  private[this] val json = Parser.jsonObjectMapper(Nil)
+
+  val stats = NullStatsReceiver
+  def tracer = NullTracer
+
+  private[this] val started = new AtomicBoolean(false)
+  // only run at most once
+  def run(): Closable with Awaitable[Unit] =
+    if (started.compareAndSet(false, true)) run0()
+    else Telemeter.nopRun
+
+  private[this] def run0() = {
+    val task = timer.schedule(NewRelicTelemeter.Interval) {
+      sendMetrics()
+    }
+
+    new Closable with CloseAwaitably {
+      override def close(deadline: Time): Future[Unit] = closeAwaitably(task.close(deadline))
+    }
+  }
+
+  private[this] def sendMetrics(): Unit = {
+    val payload = MetricsPayload(agent, Seq(Component(Name, Guid, Interval.inSeconds, mkMetrics())))
+    val req = Request(Method.Post, NewRelicUri)
+    req.headerMap.add(LicenseKeyHeader, licenseKey)
+    req.withOutputStream(json.writeValue(_, payload))
+    val _ = client(req) // Fire-and-forget
+  }
+
+  private[this] def mkMetrics(): Map[String, Metric] = {
+    MetricsTree.flatten(metrics).toMap.mapValues {
+      case counter: Counter => ScalarIntegerMetric(counter.get)
+      case gauge: Gauge => ScalarDecimalMetric(gauge.get)
+      case stat: Stat => {
+        val summary = stat.snapshottedSummary
+        DistributionMetric(summary.sum, summary.count, summary.min, summary.max)
+      }
+    }
+  }
+}
+
+object NewRelicTelemeter {
+  val NewRelicUri = "platform/v1/metrics"
+  val LicenseKeyHeader = "X-License-Key"
+  val Version = "1.0.0" // New Relic plugin version (distinct from Linkerd version)
+  val Interval = 1.minute
+  val Guid = "io.l5d.newrelic"
+  val Name = "Linkerd"
+}
+
+case class MetricsPayload(agent: Agent, components: Seq[Component])
+case class Agent(host: String, version: String)
+case class Component(name: String, guid: String, duration: Long, metrics: Map[String, Metric])
+
+sealed trait Metric
+case class ScalarIntegerMetric(@JsonValue value: Long) extends Metric
+case class ScalarDecimalMetric(@JsonValue value: Float) extends Metric
+case class DistributionMetric(total: Long, count: Long, min: Long, max: Long) extends Metric

--- a/telemetry/newrelic/src/main/scala/io/buoyant/telemetry/newrelic/NewRelicTelemeter.scala
+++ b/telemetry/newrelic/src/main/scala/io/buoyant/telemetry/newrelic/NewRelicTelemeter.scala
@@ -52,17 +52,14 @@ class NewRelicTelemeter(
   }
 
   private[this] def mkMetrics(): Map[String, Metric] = {
-    MetricsTree.flatten(metrics).toMap.filter {
-      case (_, None) => false
-      case _ => true
-    }.mapValues {
+    MetricsTree.flattenNones(metrics).toMap.mapValues {
       case counter: Counter => ScalarIntegerMetric(counter.get)
       case gauge: Gauge => ScalarDecimalMetric(gauge.get)
-      case stat: Stat => {
+      case stat: Stat =>
         val summary = stat.snapshottedSummary
         DistributionMetric(summary.sum, summary.count, summary.min, summary.max)
-      }
-      case None => null
+      case None =>
+        throw new Exception("metric tree should not have contained Nones!")
     }
   }
 }

--- a/telemetry/newrelic/src/main/scala/io/buoyant/telemetry/newrelic/NewRelicTelemeter.scala
+++ b/telemetry/newrelic/src/main/scala/io/buoyant/telemetry/newrelic/NewRelicTelemeter.scala
@@ -14,12 +14,12 @@ import java.util.concurrent.atomic.AtomicBoolean
 import com.twitter.logging.Logger
 
 class NewRelicTelemeter(
-  metrics: MetricsTree,
-  client: Service[Request, Response],
-  licenseKey: String,
-  host: String,
-  name: String,
-  timer: Timer
+  private[this] val  metrics: MetricsTree,
+  private[this] val client: Service[Request, Response],
+  private[this] val licenseKey: String,
+  private[this] val host: String,
+  private[this] val name: String,
+  private[this] val timer: Timer
 ) extends Telemeter {
   import NewRelicTelemeter._
 

--- a/telemetry/newrelic/src/main/scala/io/buoyant/telemetry/newrelic/NewRelicTelemeter.scala
+++ b/telemetry/newrelic/src/main/scala/io/buoyant/telemetry/newrelic/NewRelicTelemeter.scala
@@ -18,6 +18,7 @@ class NewRelicTelemeter(
   client: Service[Request, Response],
   licenseKey: String,
   host: String,
+  name: String,
   timer: Timer
 ) extends Telemeter {
   import NewRelicTelemeter._
@@ -54,7 +55,7 @@ class NewRelicTelemeter(
   }
 
   private[this] def sendMetrics(): Future[Response] = {
-    val payload = MetricsPayload(agent, Seq(Component(Name, Guid, Interval.inSeconds, mkMetrics())))
+    val payload = MetricsPayload(agent, Seq(Component(name, Guid, Interval.inSeconds, mkMetrics())))
     val req = Request(Method.Post, NewRelicUri)
     req.headerMap.add(LicenseKeyHeader, licenseKey)
     req.mediaType = ContentType
@@ -75,7 +76,7 @@ class NewRelicTelemeter(
           }
         case MetricNone => None
       }
-    } yield s"Component/Linkerd/$key" -> newRelicMetric
+    } yield s"Component/$name/$key" -> newRelicMetric
 
 }
 
@@ -85,7 +86,6 @@ object NewRelicTelemeter {
   val Version = "1.0.0" // New Relic plugin version (distinct from Linkerd version)
   val Interval = 1.minute
   val Guid = "io.l5d.linkerd"
-  val Name = "Linkerd"
   val ContentType = MediaType.Json
 }
 

--- a/telemetry/newrelic/src/main/scala/io/buoyant/telemetry/newrelic/NewRelicTelemeter.scala
+++ b/telemetry/newrelic/src/main/scala/io/buoyant/telemetry/newrelic/NewRelicTelemeter.scala
@@ -1,6 +1,6 @@
 package io.buoyant.telemetry.newrelic
 
-import com.fasterxml.jackson.annotation.JsonValue
+import com.fasterxml.jackson.annotation.{JsonFormat, JsonValue}
 import com.twitter.conversions.time._
 import com.twitter.finagle.Service
 import com.twitter.finagle.http.{Method, Request, Response}
@@ -8,7 +8,7 @@ import com.twitter.finagle.stats.NullStatsReceiver
 import com.twitter.finagle.tracing.NullTracer
 import com.twitter.util._
 import io.buoyant.config.Parser
-import io.buoyant.telemetry.Metric.{Counter, Gauge, None => MetricNone, Stat}
+import io.buoyant.telemetry.Metric.{Counter, Gauge, Stat, None => MetricNone}
 import io.buoyant.telemetry.{MetricsTree, Telemeter}
 import java.util.concurrent.atomic.AtomicBoolean
 import com.twitter.logging.Logger
@@ -87,6 +87,12 @@ case class Agent(host: String, version: String)
 case class Component(name: String, guid: String, duration: Long, metrics: Map[String, Metric])
 
 sealed trait Metric
-case class ScalarIntegerMetric(@JsonValue value: Long) extends Metric
-case class ScalarDecimalMetric(@JsonValue value: Float) extends Metric
+@JsonFormat(shape = JsonFormat.Shape.NUMBER)
+case class ScalarIntegerMetric(value: Long) extends Metric {
+  @JsonValue def integer: Long = value
+}
+@JsonFormat(shape = JsonFormat.Shape.NUMBER)
+case class ScalarDecimalMetric(@JsonValue value: Float) extends Metric {
+  @JsonValue def decimal: Float = value
+}
 case class DistributionMetric(total: Long, count: Long, min: Long, max: Long) extends Metric

--- a/telemetry/newrelic/src/main/scala/io/buoyant/telemetry/newrelic/NewRelicTelemeter.scala
+++ b/telemetry/newrelic/src/main/scala/io/buoyant/telemetry/newrelic/NewRelicTelemeter.scala
@@ -14,12 +14,12 @@ import java.util.concurrent.atomic.AtomicBoolean
 import com.twitter.logging.Logger
 
 class NewRelicTelemeter(
-  private[this] val  metrics: MetricsTree,
-  private[this] val client: Service[Request, Response],
-  private[this] val licenseKey: String,
-  private[this] val host: String,
-  private[this] val name: String,
-  private[this] val timer: Timer
+  val  metrics: MetricsTree,
+  val client: Service[Request, Response],
+  val licenseKey: String,
+  val host: String,
+  val name: String,
+  val timer: Timer
 ) extends Telemeter {
   import NewRelicTelemeter._
 

--- a/telemetry/newrelic/src/main/scala/io/buoyant/telemetry/newrelic/NewRelicTelemeterInitializer.scala
+++ b/telemetry/newrelic/src/main/scala/io/buoyant/telemetry/newrelic/NewRelicTelemeterInitializer.scala
@@ -15,7 +15,12 @@ class NewRelicTelemeterInitializer extends TelemeterInitializer {
 
 object NewRelicTelemeterInitializer extends NewRelicTelemeterInitializer
 
-case class NewRelicConfig(license_key: String, host: Option[String], dst: Option[Path]) extends TelemeterConfig {
+case class NewRelicConfig(
+  license_key: String,
+  host: Option[String],
+  dst: Option[Path],
+  prefix: Option[String]
+) extends TelemeterConfig {
   import NewRelicConfig._
   assert(license_key != null, "License key must be provided.")
 
@@ -34,6 +39,7 @@ case class NewRelicConfig(license_key: String, host: Option[String], dst: Option
       client,
       license_key,
       host.getOrElse(InetAddress.getLocalHost.getCanonicalHostName),
+      prefix.getOrElse("Linkerd"),
       DefaultTimer
     )
   }

--- a/telemetry/newrelic/src/main/scala/io/buoyant/telemetry/newrelic/NewRelicTelemeterInitializer.scala
+++ b/telemetry/newrelic/src/main/scala/io/buoyant/telemetry/newrelic/NewRelicTelemeterInitializer.scala
@@ -18,7 +18,7 @@ object NewRelicTelemeterInitializer extends NewRelicTelemeterInitializer
 case class NewRelicConfig(license_key: String, host: Option[String], dst: Option[Path]) extends TelemeterConfig {
   import NewRelicConfig._
 
-  assert(license_key != null)
+  assert(license_key != null, "License key must be provided.")
 
   @JsonIgnore def mk(params: Stack.Params): Telemeter = {
     val client = Http.client

--- a/telemetry/newrelic/src/main/scala/io/buoyant/telemetry/newrelic/NewRelicTelemeterInitializer.scala
+++ b/telemetry/newrelic/src/main/scala/io/buoyant/telemetry/newrelic/NewRelicTelemeterInitializer.scala
@@ -19,6 +19,8 @@ case class NewRelicConfig(license_key: String, host: Option[String], dst: Option
   import NewRelicConfig._
   assert(license_key != null, "License key must be provided.")
 
+  @JsonIgnore override val experimentalRequired = true
+
   @JsonIgnore def mk(params: Stack.Params): Telemeter = {
     val client = Http.client
       .withParams(Http.client.params ++ params)

--- a/telemetry/newrelic/src/main/scala/io/buoyant/telemetry/newrelic/NewRelicTelemeterInitializer.scala
+++ b/telemetry/newrelic/src/main/scala/io/buoyant/telemetry/newrelic/NewRelicTelemeterInitializer.scala
@@ -17,7 +17,6 @@ object NewRelicTelemeterInitializer extends NewRelicTelemeterInitializer
 
 case class NewRelicConfig(license_key: String, host: Option[String], dst: Option[Path]) extends TelemeterConfig {
   import NewRelicConfig._
-
   assert(license_key != null, "License key must be provided.")
 
   @JsonIgnore def mk(params: Stack.Params): Telemeter = {
@@ -26,6 +25,7 @@ case class NewRelicConfig(license_key: String, host: Option[String], dst: Option
       .withSessionQualifier.noFailureAccrual
       .withSessionQualifier.noFailFast
       .withTracer(NullTracer)
+      .withTls("platform-api.newrelic.com")
       .newService(Name.Path(dst.getOrElse(DefaultDst)), "newrelic")
     new NewRelicTelemeter(
       params[MetricsTree],
@@ -38,5 +38,5 @@ case class NewRelicConfig(license_key: String, host: Option[String], dst: Option
 }
 
 object NewRelicConfig {
-  val DefaultDst = Path.read("/$/inet/platform-api.newrelic.com/80")
+  val DefaultDst = Path.read("/$/inet/platform-api.newrelic.com/443")
 }

--- a/telemetry/newrelic/src/main/scala/io/buoyant/telemetry/newrelic/NewRelicTelemeterInitializer.scala
+++ b/telemetry/newrelic/src/main/scala/io/buoyant/telemetry/newrelic/NewRelicTelemeterInitializer.scala
@@ -1,0 +1,42 @@
+package io.buoyant.telemetry.newrelic
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.twitter.finagle.tracing.NullTracer
+import com.twitter.finagle.util.DefaultTimer
+import com.twitter.finagle.{Http, Name, Path, Stack}
+import io.buoyant.telemetry.{MetricsTree, Telemeter, TelemeterConfig, TelemeterInitializer}
+import java.net.InetAddress
+
+class NewRelicTelemeterInitializer extends TelemeterInitializer {
+  type Config = NewRelicConfig
+  val configClass = classOf[NewRelicConfig]
+  override val configId = "io.l5d.newrelic"
+}
+
+object NewRelicTelemeterInitializer extends NewRelicTelemeterInitializer
+
+case class NewRelicConfig(license_key: String, host: Option[String], dst: Option[Path]) extends TelemeterConfig {
+  import NewRelicConfig._
+
+  assert(license_key != null)
+
+  @JsonIgnore def mk(params: Stack.Params): Telemeter = {
+    val client = Http.client
+      .withParams(Http.client.params ++ params)
+      .withSessionQualifier.noFailureAccrual
+      .withSessionQualifier.noFailFast
+      .withTracer(NullTracer)
+      .newService(Name.Path(dst.getOrElse(DefaultDst)), "newrelic")
+    new NewRelicTelemeter(
+      params[MetricsTree],
+      client,
+      license_key,
+      host.getOrElse(InetAddress.getLocalHost.getCanonicalHostName),
+      DefaultTimer
+    )
+  }
+}
+
+object NewRelicConfig {
+  val DefaultDst = Path.read("/$/inet/platform-api.newrelic.com/80")
+}

--- a/telemetry/newrelic/src/test/scala/NewRelicTelemeterInitializerTest.scala
+++ b/telemetry/newrelic/src/test/scala/NewRelicTelemeterInitializerTest.scala
@@ -1,0 +1,93 @@
+package io.buoyant.telemetry.newrelic
+
+import java.net.InetAddress
+import com.fasterxml.jackson.databind.JsonMappingException
+import com.twitter.finagle.Stack
+import com.twitter.finagle.util.LoadService
+import io.buoyant.config.Parser
+import io.buoyant.telemetry.{TelemeterConfig, TelemeterInitializer}
+import io.buoyant.test.FunSuite
+
+class NewRelicTelemeterInitializerTest extends FunSuite {
+
+  test("io.l5d.newrelic telemeter loads") {
+    val yaml =
+      """|kind: io.l5d.newrelic
+         |license_key: foo
+         |""".stripMargin
+
+    val config = Parser.objectMapper(yaml, Seq(LoadService[TelemeterInitializer]))
+      .readValue[TelemeterConfig](yaml)
+
+    val telemeter = config.mk(Stack.Params.empty)
+    assert(telemeter.isInstanceOf[NewRelicTelemeter])
+    assert(telemeter.stats.isNull)
+    assert(telemeter.tracer.isNull)
+  }
+
+  test("io.l5d.newrelic telemeter default host") {
+    val yaml =
+      """|kind: io.l5d.newrelic
+         |license_key: foo
+         |""".stripMargin
+
+    val config = Parser.objectMapper(yaml, Seq(LoadService[TelemeterInitializer]))
+      .readValue[TelemeterConfig](yaml)
+
+    val telemeter = config.mk(Stack.Params.empty).asInstanceOf[NewRelicTelemeter]
+    assert(telemeter.host == InetAddress.getLocalHost.getCanonicalHostName)
+  }
+
+  test("io.l5d.newrelic telemeter license key") {
+    val yaml =
+      """|kind: io.l5d.newrelic
+         |license_key: foo
+         |""".stripMargin
+
+    val config = Parser.objectMapper(yaml, Seq(LoadService[TelemeterInitializer]))
+      .readValue[TelemeterConfig](yaml)
+
+    val telemeter = config.mk(Stack.Params.empty).asInstanceOf[NewRelicTelemeter]
+    assert(telemeter.licenseKey === "foo")
+  }
+
+  test("io.l5d.newrelic telemeter default prefix") {
+    val yaml =
+      """|kind: io.l5d.newrelic
+         |license_key: foo
+         |""".stripMargin
+
+    val config = Parser.objectMapper(yaml, Seq(LoadService[TelemeterInitializer]))
+      .readValue[TelemeterConfig](yaml)
+
+    val telemeter = config.mk(Stack.Params.empty).asInstanceOf[NewRelicTelemeter]
+    assert(telemeter.name === "Linkerd")
+  }
+
+  test("io.l5d.newrelic telemeter prefix") {
+    val yaml =
+      """|kind: io.l5d.newrelic
+         |license_key: foo
+         |prefix: some_prefix_
+         |""".stripMargin
+
+    val config = Parser.objectMapper(yaml, Seq(LoadService[TelemeterInitializer]))
+      .readValue[TelemeterConfig](yaml)
+
+    val telemeter = config.mk(Stack.Params.empty).asInstanceOf[NewRelicTelemeter]
+    assert(telemeter.name === "some_prefix_")
+  }
+
+  test("io.l5d.newrelic telemeter throws an exception with no license key") {
+    val yaml =
+      """|kind: io.l5d.newrelic
+         |""".stripMargin
+
+    assertThrows[JsonMappingException] {
+      val config = Parser.objectMapper(yaml, Seq(LoadService[TelemeterInitializer]))
+        .readValue[TelemeterConfig](yaml)
+
+      val telemeter = config.mk(Stack.Params.empty).asInstanceOf[NewRelicTelemeter]
+    }
+  }
+}


### PR DESCRIPTION
This PR adds an experimental telemeter for reporting metrics to New Relic. 

A New Relic plugin which ingests these metrics and displays them on the New Relic dashboard is in the works.