### PR TITLE
Call non-watch endpoint first when restarting watches

### DIFF
--- a/k8s/src/main/scala/io/buoyant/k8s/Watchable.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/Watchable.scala
@@ -45,12 +45,11 @@ private[k8s] abstract class Watchable[O <: KubeObject: TypeReference, W <: Watch
     labelSelector: Option[String] = None,
     fieldSelector: Option[String] = None,
     resourceVersion: Option[String] = None,
-    retryIndefinitely: Boolean = false,
-    watch: Boolean = false
+    retryIndefinitely: Boolean = false
   ): Future[Option[G]] = {
     val req = Api.mkreq(
       http.Method.Get,
-      if (watch) watchPath else path,
+      path,
       None,
       LabelSelectorKey -> labelSelector,
       FieldSelectorKey -> fieldSelector,
@@ -168,8 +167,7 @@ private[k8s] abstract class Watchable[O <: KubeObject: TypeReference, W <: Watch
                   case None =>
                     // In this case, we want to try loading the initial information instead before watching again.
                     restartWatches(labelSelector, fieldSelector).map {
-                      case (ws, ver) =>
-                        AsyncStream.fromSeq(ws) ++ _watch(ver)
+                      case (ws, ver) => AsyncStream.fromSeq(ws) ++ _watch(ver)
                     }
                 }
               }.flatten

--- a/k8s/src/test/scala/io/buoyant/k8s/v1/ApiTest.scala
+++ b/k8s/src/test/scala/io/buoyant/k8s/v1/ApiTest.scala
@@ -223,13 +223,10 @@ class ApiTest extends FunSuite
             }
             Future.value(rsp)
           case 2 =>
-            assert(req.uri == "/api/v1/watch/namespaces/srv/endpoints")
+            assert(req.uri == "/api/v1/namespaces/srv/endpoints")
             val rsp = Response()
             rsp.version = req.version
-            rsp.setContentTypeJson()
-            rsp.headerMap("Transfer-Encoding") = "chunked"
-
-            rsp.writer.write(endpointsList) before rsp.writer.close()
+            rsp.content = endpointsList
             Future.value(rsp)
           case 3 =>
             assert(req.uri == "/api/v1/watch/namespaces/srv/endpoints?resourceVersion=17575669") // this is the top-level resource version
@@ -344,13 +341,10 @@ class ApiTest extends FunSuite
             }
             Future.value(rsp)
           case 2 =>
-            assert(req.uri == "/api/v1/watch/namespaces/srv/endpoints")
+            assert(req.uri == "/api/v1/namespaces/srv/endpoints")
             val rsp = Response()
             rsp.version = req.version
-            rsp.setContentTypeJson()
-            rsp.headerMap("Transfer-Encoding") = "chunked"
-
-            rsp.writer.write(endpointsList) before rsp.writer.close()
+            rsp.content = endpointsList
             Future.value(rsp)
           case 3 =>
             assert(req.uri == "/api/v1/watch/namespaces/srv/endpoints?resourceVersion=17575669") // this is the top-level resource version
@@ -416,13 +410,10 @@ class ApiTest extends FunSuite
             }
             Future.value(rsp)
           case 2 =>
-            assert(req.uri == "/api/v1/watch/namespaces/srv/endpoints")
+            assert(req.uri == "/api/v1/namespaces/srv/endpoints")
             val rsp = Response()
             rsp.version = req.version
-            rsp.setContentTypeJson()
-            rsp.headerMap("Transfer-Encoding") = "chunked"
-
-            rsp.writer.write(endpointsList) before rsp.writer.close()
+            rsp.content = endpointsList
             Future.value(rsp)
           case 3 =>
             assert(req.uri == "/api/v1/watch/namespaces/srv/endpoints?resourceVersion=17575669") // this is the top-level resource version


### PR DESCRIPTION
## Problem

When restarting Kubernetes watches after the previous watch has died, it's possible that the newly established watch creation is delayed, causing Linkerd's representation of the watch data to become stale. This is caused by our watch code seeding the new watch by calling the Kubernetes watch endpoint for the resource, which might not return immediately in some Kubernetes environments.

## Solution

When restarting Kubernetes watches, seed the watch by first calling the non-watch endoint, which returns immediately.

Fixes #1668. Fixes #1669.