### PR TITLE
dnssd: respect system search-domain configuration

### DIFF
--- a/linkerd/docs/namer.md
+++ b/linkerd/docs/namer.md
@@ -585,7 +585,6 @@ namers:
 - kind: io.l5d.dnssrv
   experimental: true
   refreshIntervalSeconds: 5
-  domain: srv.dc-1.example.org
   dnsHosts:
   - ns0.example.org
   - ns1.example.org
@@ -609,7 +608,6 @@ Key | Default Value | Description
 prefix | `io.l5d.dnssrv` | Resolves names with `/#/<prefix>`.
 experimental | `false` | Since the DNS-SRV namer is still considered experimental, this must be set to `true`.
 refreshIntervalSeconds | `5` | linkerd will perform a SRV lookup for each host every `refreshIntervalSeconds`.
-domain | `.` | Domain to use to expand relative addresses in the dtab into absolute addresses. Absolute addresses ending in `.` will not be expanded. The default value treats all addresses as absolute.
 dnsHosts | `<empty list>` | If specified, linkerd will use these DNS servers to perform SRV lookups. If not specified, linkerd will use the default system resolver.
 
 ### DNS-SRV Path Parameters
@@ -623,7 +621,7 @@ dnsHosts | `<empty list>` | If specified, linkerd will use these DNS servers to 
 Key | Required | Description
 --- | -------- | -----------
 prefix | yes | Tells linkerd to resolve the request path using the marathon namer.
-address | yes | The DNS address of a SRV record. Linkerd resolves the record to one or more `address:port` tuples using a SRV lookup. Relative addresses not ending in `.` are resolved relative to `searchDomain`; absolute addresses ending in `.` are treated as-is.
+address | yes | The DNS address of a SRV record. Linkerd resolves the record to one or more `address:port` tuples using a SRV lookup.
 
 ## ZooKeeper Leader
 

--- a/namer/dnssrv/src/integration/scala/io/buoyant/namer/dnssrv/DnsSrvNamerIntegrationTest.scala
+++ b/namer/dnssrv/src/integration/scala/io/buoyant/namer/dnssrv/DnsSrvNamerIntegrationTest.scala
@@ -14,12 +14,11 @@ class DnsSrvNamerIntegrationTest extends FunSuite with Awaits with Matchers {
     val namer = new DnsSrvNamer(
       Path.empty,
       new DNS.ExtendedResolver,
-      DNS.Name.fromString("mxtoolbox.com", DNS.Name.root),
       Duration.Zero,
       new NullStatsReceiver,
       FuturePool.unboundedPool
     )(DefaultTimer)
-    await(namer.lookup(Path.read("/_http._tcp")).toFuture) match {
+    await(namer.lookup(Path.read("/_http._tcp.mxtoolbox.com")).toFuture) match {
       case NameTree.Leaf(Name.Bound(varAddr)) => varAddr.sample() match {
         case Addr.Bound(addrs, _) => addrs should not be empty
         case addr => fail(s"unexpected addr: $addr")

--- a/namer/dnssrv/src/main/scala/io/buoyant/namer/dnssrv/DnsSrvNamerInitializer.scala
+++ b/namer/dnssrv/src/main/scala/io/buoyant/namer/dnssrv/DnsSrvNamerInitializer.scala
@@ -20,7 +20,6 @@ object DnsSrvNamerInitializer extends DnsSrvNamerInitializer
 
 case class DnsSrvNamerConfig(
   refreshIntervalSeconds: Option[Int],
-  domain: Option[String],
   dnsHosts: Option[Seq[String]]
 ) extends NamerConfig {
 
@@ -44,15 +43,10 @@ case class DnsSrvNamerConfig(
       Edns.Flags,
       Edns.Options
     )
-    val origin = domain match {
-      // always treat domain as absolute, even if trailing `.` is missing in config
-      case Some(str) => DNS.Name.fromString(str, DNS.Name.root)
-      case None => DNS.Name.root
-    }
     val timer = params[param.Timer].timer
     val refreshInterval = refreshIntervalSeconds.getOrElse(5).seconds
     val pool = FuturePool.unboundedPool
-    new DnsSrvNamer(prefix, resolver, origin, refreshInterval, stats, pool)(timer)
+    new DnsSrvNamer(prefix, resolver, refreshInterval, stats, pool)(timer)
   }
 }
 

--- a/namer/dnssrv/src/test/scala/io/buoyant/namer/dnssrv/DnsSrvNamerTest.scala
+++ b/namer/dnssrv/src/test/scala/io/buoyant/namer/dnssrv/DnsSrvNamerTest.scala
@@ -13,7 +13,6 @@ class DnsSrvNamerTest extends FunSuite with Matchers {
     // ensure it doesn't totally blowup
     val _ = DnsSrvNamerConfig(
       refreshIntervalSeconds = Some(15),
-      domain = None,
       dnsHosts = Some(List("localhost"))
     ).newNamer(Stack.Params.empty)
   }
@@ -26,7 +25,6 @@ class DnsSrvNamerTest extends FunSuite with Matchers {
     val yaml = s"""
                   |kind: io.l5d.dnssrv
                   |experimental: true
-                  |domain: srv.example.org
                   |refreshIntervalSeconds: 60
                   |dnsHosts:
                   |- localhost
@@ -37,6 +35,5 @@ class DnsSrvNamerTest extends FunSuite with Matchers {
     assert(config.refreshIntervalSeconds === Some(60))
     assert(config.dnsHosts === Some(Seq("localhost")))
     assert(config.disabled === false)
-    assert(config.domain === Some("srv.example.org"))
   }
 }


### PR DESCRIPTION
use the `Lookup` API in `dnsjava` so that DNS lookups respect the system
resolver configuration. This removes the need for the `domain` setting
in the linkerd yaml configuration and matches user expectations.

This is a follow-up of #1637 resulting from discussions with production engineering at SoundCloud.