### PR TITLE
1.3.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,13 @@
+## 1.3.1 2017-10-24
+
+* Kubernetes
+  * Fixed a failure to update routing data after restarting watches (#1674).
+  * Ensured that Kubernetes API watch events earlier than the current state are ignored (#1681).
+* Added support for Istio Mixer precondition checks (#1606).
+* Removed spurious error message logging from Consul namer (#1682).
+* Changed DNS SRV record namer to use system DNS resolver configuration (#1679).
+* Added `timestampHeader` configuration to support New Relic request queue (#1672).
+
 
 ## 1.3.0 2017-10-06
 

--- a/project/Base.scala
+++ b/project/Base.scala
@@ -32,7 +32,7 @@ object Base {
 class Base extends Build {
   import Base._
 
-  val headVersion = "1.3.1-rc1"
+  val headVersion = "1.3.1"
 
   object Git {
     def git(arg: String, args: String*) = Process("git" +: arg +: args)


### PR DESCRIPTION
## 1.3.1 2017-10-24
* Kubernetes 
  * Fixed a failure to update routing data after restarting watches (#1674).
  * Ensured that Kubernetes API watch events earlier than the current state are ignored (#1681).
* Added support for Istio Mixer precondition checks (#1606).
* Removed spurious error message logging from Consul namer (#1682).
* Changed DNS SRV record namer to use system DNS resolver configuration (#1679).
* Added `timestampHeader` configuration to support New Relic request queue (#1672).
