### PR TITLE
Add test for TLS certificate reloading

### DIFF
--- a/linkerd/protocol/http/src/integration/scala/io/buoyant/linkerd/protocol/TlsCertReloadingTest.scala
+++ b/linkerd/protocol/http/src/integration/scala/io/buoyant/linkerd/protocol/TlsCertReloadingTest.scala
@@ -1,17 +1,15 @@
 package io.buoyant.linkerd.protocol
 
-import java.net.InetSocketAddress
-
 import com.twitter.finagle.http.{Request, Status}
 import io.buoyant.linkerd.Linker
-import io.buoyant.linkerd.protocol.TlsUtils.{Certs, Downstream}
 import io.buoyant.test.{Awaits, FunSuite}
+import java.net.InetSocketAddress
 
 class TlsCertReloadingTest extends FunSuite with Awaits {
 
   test("cert reloading") {
     TlsUtils.withCerts("foo", "bar") { certs =>
-      val downstream = Downstream.const("foo", "foo")
+      val downstream = TlsUtils.Downstream.const("foo", "foo")
 
       val fooCerts = certs.serviceCerts("foo")
       val barCerts = certs.serviceCerts("bar")
@@ -69,8 +67,8 @@ class TlsCertReloadingTest extends FunSuite with Awaits {
 
         // move the "bar" certs to the "foo" certs' path
         withClue("renaming certs") {
-          assert(fooCerts.delete().isReturn)
-          assert(barCerts.renameTo("foo").isReturn)
+          fooCerts.delete()
+          barCerts.renameTo("foo")
         }
 
         // now, the request should succeed

--- a/linkerd/protocol/http/src/integration/scala/io/buoyant/linkerd/protocol/TlsCertReloadingTest.scala
+++ b/linkerd/protocol/http/src/integration/scala/io/buoyant/linkerd/protocol/TlsCertReloadingTest.scala
@@ -1,0 +1,94 @@
+package io.buoyant.linkerd.protocol
+
+import java.net.InetSocketAddress
+
+import com.twitter.finagle.http.{Request, Status}
+import io.buoyant.linkerd.Linker
+import io.buoyant.linkerd.protocol.TlsUtils.{Certs, Downstream}
+import io.buoyant.test.{Awaits, FunSuite}
+
+class TlsCertReloadingTest extends FunSuite with Awaits {
+
+  test("cert reloading") {
+    TlsUtils.withCerts("foo", "bar") { certs =>
+      val downstream = Downstream.const("foo", "foo")
+
+      val fooCerts = certs.serviceCerts("foo")
+      val barCerts = certs.serviceCerts("bar")
+
+      val incomingConfig =
+        s"""
+        |namers: []
+        |
+        |routers:
+        |- protocol: http
+        |  dtab: /svc/* => /$$/inet/127.1/${downstream.port} ;
+        |  servers:
+        |  - port: 0
+        |    tls:
+        |      certPath: ${fooCerts.cert.getPath}
+        |      keyPath: ${fooCerts.key.getPath}
+        |      caCertPath: ${certs.caCert.getPath}
+      """.stripMargin
+      val incomingLinker = Linker.load(incomingConfig)
+      val incomingRouter = incomingLinker.routers.head.initialize()
+      val incomingServer = incomingRouter.servers.head.serve()
+      val serverPort = incomingServer.boundAddress.asInstanceOf[InetSocketAddress].getPort
+
+
+      val outgoingConfig = s"""
+        |namers: []
+        |
+        |routers:
+        |- protocol: http
+        |  dtab: /svc/* => /$$/inet/127.1/$serverPort ;
+        |  servers:
+        |  - port: 0
+        |  client:
+        |   tls:
+        |     commonName: bar
+        |     trustCerts:
+        |     - ${certs.caCert.getPath}
+       """.stripMargin
+      val outgoingLinker = Linker.load(outgoingConfig)
+      val outgoingRouter = outgoingLinker.routers.head.initialize()
+      val outgoingServer = outgoingRouter.servers.head.serve()
+
+      val upstream = TlsUtils.upstream(outgoingServer)
+
+      try {
+        // build request
+        val req = Request()
+        req.host = "foo"
+
+        // request before the certs are renamed should fail
+        withClue("before renaming certs") {
+          val rsp = await(upstream(req))
+          assert(rsp.status == Status.BadGateway)
+        }
+
+        // move the "bar" certs to the "foo" certs' path
+        withClue("renaming certs") {
+          assert(fooCerts.delete().isReturn)
+          assert(barCerts.renameTo("foo").isReturn)
+        }
+
+        // now, the request should succeed
+        withClue("after renaming certs") {
+          val rsp = await(upstream(req))
+          assert(rsp.status == Status.Ok)
+          assert(rsp.contentString == "foo")
+        }
+        ()
+      } finally {
+        await(upstream.close())
+        await(outgoingServer.close())
+        await(outgoingRouter.close())
+        await(incomingServer.close())
+        await(incomingRouter.close())
+        await(downstream.server.close())
+      }
+    }
+  }
+
+}

--- a/linkerd/protocol/http/src/integration/scala/io/buoyant/linkerd/protocol/TlsUtils.scala
+++ b/linkerd/protocol/http/src/integration/scala/io/buoyant/linkerd/protocol/TlsUtils.scala
@@ -1,20 +1,19 @@
 package io.buoyant.linkerd.protocol
 
 import com.twitter.finagle.http.{Request, Response, TlsFilter}
+import com.twitter.finagle.{Http => FinagleHttp, _}
 import com.twitter.finagle.ssl.server.SslServerConfiguration
-import com.twitter.finagle.ssl.{KeyCredentials, Ssl}
+import com.twitter.finagle.ssl.KeyCredentials
 import com.twitter.finagle.stats.NullStatsReceiver
 import com.twitter.finagle.tracing.NullTracer
 import com.twitter.finagle.transport.Transport
-import com.twitter.util.{Future, Try, Var}
+import com.twitter.util.{Future, Var}
 import java.io.{File, FileInputStream}
-import java.net.{InetSocketAddress, SocketAddress}
+import java.net.{InetSocketAddress}
 import java.security.KeyStore
 import java.security.cert.CertificateFactory
 import javax.net.ssl.{SSLContext, TrustManagerFactory}
-
 import scala.sys.process._
-import com.twitter.finagle.{Http => FinagleHttp, _}
 
 object TlsUtils {
 
@@ -25,13 +24,14 @@ object TlsUtils {
   def run(p: ProcessBuilder): Int = p ! DevNull
 
   case class ServiceCert(cert: File, key: File) {
-    def delete(): Try[Unit] =
-      Try(assert(cert.delete()))
-        .flatMap(_ => Try(assert(key.delete())))
+    def delete() { assert(cert.delete() && key.delete()) }
 
-    def renameTo(name: String): Try[Unit] =
-      Try(assert(cert.renameTo(new File(cert.getParentFile, s"${name}_cert.pem"))))
-        .flatMap(_ => Try(assert(key.renameTo(new File(key.getParentFile, s"${name}_pk8.pem")))))
+    def renameTo(name: String) {
+      val newCert = new File(cert.getParentFile, s"${name}_cert.pem")
+      val newKey = new File(key.getParentFile, s"${name}_pk8.pem")
+      assert(cert.renameTo(newCert) && key.renameTo(newKey))
+    }
+
   }
   case class Certs(caCert: File, serviceCerts: Map[String, ServiceCert])
   def withCerts(names: String*)(f: Certs => Unit): Unit = {


### PR DESCRIPTION
I've added a test class to `linkerd/protocol/http/integration` which exercises the reloading of TLS certificates. The test prepares 2 different cert-key pairs: one with `commonName = foo `and one with `commonName = bar`. It configures an incoming Linkerd router with server TLS and points it at the "foo" cert and key, and an outgoing Linkerd router with client TLS and set it to expect `commonName = bar`.

The test sends a request through and asserts that it should fail validation because the cert has commonName foo instead of bar. Then, it replaces the bar cert and key with the foo cert and key, and sends another request, asserting that this request succeeds. If the incoming Linkerd reloads the cert and key, the second request should succeed. 