### PR TITLE
Properly handle cancellation in ThirftNamerInterface

### DIFF
--- a/k8s/src/main/scala/io/buoyant/k8s/Watchable.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/Watchable.scala
@@ -145,19 +145,19 @@ private[k8s] abstract class Watchable[O <: KubeObject: TypeReference, W <: Watch
               // stream, but this is necessary to handle the K8s bug where
               // erorrs have the incorrect status code.
               .flatMap {
-              // special case to handle Kubernetes bug where "too old
-              // resource version" errors are returned with status code 200
-              // rather than status code 410.
-              // see https://github.com/kubernetes/kubernetes/issues/35068
-              // for details.
-              case e: Watch.Error[O] if e.status.code.contains(410) =>
-                log.debug(
-                  "k8s returned 'too old resource version' error with " +
-                    "incorrect HTTP status code, restarting watch"
-                )
-                _resourceVersionTooOld()
-              case event => AsyncStream.fromOption(Some(event))
-            }
+                // special case to handle Kubernetes bug where "too old
+                // resource version" errors are returned with status code 200
+                // rather than status code 410.
+                // see https://github.com/kubernetes/kubernetes/issues/35068
+                // for details.
+                case e: Watch.Error[O] if e.status.code.contains(410) =>
+                  log.debug(
+                    "k8s returned 'too old resource version' error with " +
+                      "incorrect HTTP status code, restarting watch"
+                  )
+                  _resourceVersionTooOld()
+                case event => AsyncStream.fromOption(Some(event))
+              }
             watchStream ++ // if the stream ends (k8s will kill connections after ~30m), restart it)
               AsyncStream.fromFuture {
                 // It's safe to call lastOption here, because we're after the `++` operator, so
@@ -172,7 +172,7 @@ private[k8s] abstract class Watchable[O <: KubeObject: TypeReference, W <: Watch
                     }
                 }
               }
-                .flatten
+              .flatten
 
           case http.Status.Gone =>
             _resourceVersionTooOld()
@@ -184,8 +184,8 @@ private[k8s] abstract class Watchable[O <: KubeObject: TypeReference, W <: Watch
             AsyncStream.fromFuture(f)
         }
       }
-      // Ignore any cases where we receive a resource version lower
-      // than the last received resource version.
+        // Ignore any cases where we receive a resource version lower
+        // than the last received resource version.
         .increasingOnly
 
     }
@@ -285,10 +285,10 @@ object Watchable {
   implicit class IncreasingOnlyAsyncStream[T](as: AsyncStream[T])(implicit ord: Ordering[T]) {
     import ord.mkOrderingOps
     /**
-      * Filter out values less than the previous value.
-      * @return a new stream, consisting of this stream with all
-      *         values less than their predecessor removed.
-      */
+     * Filter out values less than the previous value.
+     * @return a new stream, consisting of this stream with all
+     *         values less than their predecessor removed.
+     */
     def increasingOnly: AsyncStream[T] =
       as.scanLeft[(Option[T], Boolean)]((None, false)) {
         // TODO: this would be much less ugly if the type of the scan was [W, Boolean]
@@ -298,7 +298,5 @@ object Watchable {
         case ((None, _), next) => (Some(next), true)
       }.filter(_._2).map(_._1.get)
   }
-
-
 
 }

--- a/k8s/src/main/scala/io/buoyant/k8s/v1.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/v1.scala
@@ -112,7 +112,7 @@ package object v1 {
   implicit private val configMapWatch = new TypeReference[ConfigMapWatch] {}
 
   implicit private val configMapWatchIsOrdered =
-    new ResourceVersionOrdering[ConfigMap, ConfigMapWatch]{}
+    new ResourceVersionOrdering[ConfigMap, ConfigMapWatch] {}
   implicit private val endpointsWatchIsOrdered =
     new ResourceVersionOrdering[Endpoints, EndpointsWatch] {}
   implicit private val serviceWatchIsOrdered =

--- a/k8s/src/test/scala/io/buoyant/k8s/WatchableTest.scala
+++ b/k8s/src/test/scala/io/buoyant/k8s/WatchableTest.scala
@@ -4,7 +4,6 @@ import com.twitter.concurrent.AsyncStream
 import io.buoyant.test.FunSuite
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
 
-
 class WatchableTest extends FunSuite
   with GeneratorDrivenPropertyChecks {
   test("items in AsyncStream.increasingOnly always greater than prior items") {

--- a/linkerd/protocol/h2/src/test/scala/io/buoyant/linkerd/protocol/h2/Downstream.scala
+++ b/linkerd/protocol/h2/src/test/scala/io/buoyant/linkerd/protocol/h2/Downstream.scala
@@ -18,7 +18,7 @@ case class Downstream(name: String, server: ListeningServer) {
 }
 
 object Downstream {
-  def mk(name: String)(f: Request=>Future[Response]): Downstream = {
+  def mk(name: String)(f: Request => Future[Response]): Downstream = {
     val service = Service.mk { req: Request => f(req) }
     val server = H2.server
       .configured(fparam.Label(name))

--- a/linkerd/tls/src/main/scala/io/buoyant/linkerd/tls/TlsUtils.scala
+++ b/linkerd/tls/src/main/scala/io/buoyant/linkerd/tls/TlsUtils.scala
@@ -26,7 +26,7 @@ object TlsUtils {
     // First, we create a CA and get a cert/key for linker
     val tmpdir = new File("mktemp -d -t linkerd-tls.XXXXXX".!!.stripLineEnd)
     try {
-      val configFile = mkCaDirs (tmpdir)
+      val configFile = mkCaDirs(tmpdir)
 
       val caCert = new File(tmpdir, "ca+cert.pem")
       val caKey = new File(tmpdir, "private/ca_key.pem")
@@ -46,8 +46,8 @@ object TlsUtils {
         name -> ServiceCert(routerCert, routerPk8)
       }.toMap
 
-      f(Certs (caCert, svcCerts) )
-    } finally{
+      f(Certs(caCert, svcCerts))
+    } finally {
       val _ = Seq("rm", "-rf", tmpdir.getPath).!
     }
   }
@@ -131,29 +131,25 @@ object TlsUtils {
   def newKeyAndCert(subj: String, cfg: File, key: File, cert: File): ProcessBuilder =
     Seq("openssl", "req", "-x509", "-nodes", "-newkey", "rsa:2048",
       "-config", cfg.getPath,
-      "-subj",   subj,
+      "-subj", subj,
       "-keyout", key.getPath,
-      "-out",    cert.getPath
-    )
+      "-out", cert.getPath)
 
-  def newReq(subj: String, cfg: File, req: File, key: File): ProcessBuilder  =
+  def newReq(subj: String, cfg: File, req: File, key: File): ProcessBuilder =
     Seq("openssl", "req", "-new", "-nodes",
       "-config", cfg.getPath,
-      "-subj",   subj,
+      "-subj", subj,
       "-keyout", key.getPath,
-      "-out",    req.getPath
-    )
+      "-out", req.getPath)
 
-  def signReq(cfg: File, key: File, cert: File, req: File, newCert: File): ProcessBuilder  =
+  def signReq(cfg: File, key: File, cert: File, req: File, newCert: File): ProcessBuilder =
     Seq("openssl", "ca", "-batch",
-      "-config",  cfg.getPath,
+      "-config", cfg.getPath,
       "-keyfile", key.getPath,
-      "-cert",    cert.getPath,
-      "-out",     newCert.getPath,
-      "-infiles", req.getPath
-    )
+      "-cert", cert.getPath,
+      "-out", newCert.getPath,
+      "-infiles", req.getPath)
 
-
-  def toPk8(in: File, out: File): ProcessBuilder  =
+  def toPk8(in: File, out: File): ProcessBuilder =
     Seq("openssl", "pkcs8", "-topk8", "-nocrypt", "-in", in.getPath, "-out", out.getPath)
 }

--- a/namer/consul/src/test/scala/io/buoyant/namer/consul/ConsulNamerTest.scala
+++ b/namer/consul/src/test/scala/io/buoyant/namer/consul/ConsulNamerTest.scala
@@ -384,7 +384,7 @@ class ConsulNamerTest extends FunSuite with Awaits {
               Future.value(Indexed[Seq[ServiceNode]](Seq(testServiceNode), Some("1")))
             case _ => Future.value(Indexed(Nil, Some("1")))
           }
-        case _ => new Promise// don't respond to blocking index calls
+        case _ => new Promise // don't respond to blocking index calls
       }
     }
 
@@ -642,7 +642,7 @@ class ConsulNamerTest extends FunSuite with Awaits {
       namer.lookup(Path.read("/dc1/servicename/residual")).states respond { state = _ }
     assert(reqs == 2)
     await(closer.close())
-    withClue ("after close") { assert(reqs == 2, "Consul observed by closed activity!") }
+    withClue("after close") { assert(reqs == 2, "Consul observed by closed activity!") }
     assert(stats.counters.get(Seq("service", "opens")).contains(1))
     assert(stats.counters.get(Seq("service", "closes")).contains(1))
     assert(stats.counters.get(Seq("service", "errors")) == None)

--- a/namerd/iface/interpreter-thrift/src/main/scala/io/buoyant/namerd/iface/ThriftNamerInterface.scala
+++ b/namerd/iface/interpreter-thrift/src/main/scala/io/buoyant/namerd/iface/ThriftNamerInterface.scala
@@ -110,39 +110,39 @@ object ThriftNamerInterface {
       synchronized((current, pending)) match {
         case (Some(current), _) => current.future
         case (None, pending) =>
-          val p = Promise.attached(pending.flatMap(_.future))
+          val p = Promise.attached(pending)
           p.setInterruptHandler {
             case e: Throwable =>
               p.detach()
               p.setException(e)
           }
-          p
+          p.flatMap(_.future)
       }
 
     final def apply(stamp: Stamp): Future[(Stamp, T)] =
       synchronized((current, pending)) match {
         case (Some(current), _) if current.stamp != stamp => current.future
         case (_, pending) =>
-          val p = Promise.attached(pending.flatMap(_.future))
+          val p = Promise.attached(pending)
           p.setInterruptHandler {
             case e: Throwable =>
               p.detach()
               p.setException(e)
           }
-          p
+          p.flatMap(_.future)
       }
 
     final def apply(tstamp: TStamp): Future[(Stamp, T)] =
       apply(Stamp(tstamp))
 
     final def nextValue: Future[(Stamp, T)] = {
-      val p = Promise.attached(pending.flatMap(_.future))
+      val p = Promise.attached(pending)
       p.setInterruptHandler {
         case e: Throwable =>
           p.detach()
           p.setException(e)
       }
-      p
+      p.flatMap(_.future)
     }
 
     final def close(t: Time): Future[Unit] =

--- a/namerd/iface/interpreter-thrift/src/main/scala/io/buoyant/namerd/iface/ThriftNamerInterface.scala
+++ b/namerd/iface/interpreter-thrift/src/main/scala/io/buoyant/namerd/iface/ThriftNamerInterface.scala
@@ -110,11 +110,12 @@ object ThriftNamerInterface {
       synchronized((current, pending)) match {
         case (Some(current), _) => current.future
         case (None, pending) =>
-          val p = new Promise[(Stamp, T)]()
+          val p = Promise.attached(pending.flatMap(_.future))
           p.setInterruptHandler {
-            case e: Throwable => p.setException(e)
+            case e: Throwable =>
+              p.detach()
+              p.setException(e)
           }
-          pending.flatMap(_.future).proxyTo(p)
           p
       }
 
@@ -122,11 +123,12 @@ object ThriftNamerInterface {
       synchronized((current, pending)) match {
         case (Some(current), _) if current.stamp != stamp => current.future
         case (_, pending) =>
-          val p = new Promise[(Stamp, T)]()
+          val p = Promise.attached(pending.flatMap(_.future))
           p.setInterruptHandler {
-            case e: Throwable => p.setException(e)
+            case e: Throwable =>
+              p.detach()
+              p.setException(e)
           }
-          pending.flatMap(_.future).proxyTo(p)
           p
       }
 
@@ -134,11 +136,12 @@ object ThriftNamerInterface {
       apply(Stamp(tstamp))
 
     final def nextValue: Future[(Stamp, T)] = {
-      val p = new Promise[(Stamp, T)]()
+      val p = Promise.attached(pending.flatMap(_.future))
       p.setInterruptHandler {
-        case e: Throwable => p.setException(e)
+        case e: Throwable =>
+          p.detach()
+          p.setException(e)
       }
-      pending.flatMap(_.future).proxyTo(p)
       p
     }
 

--- a/router/base-http/src/main/scala/io/buoyant/router/http/HeadersLike.scala
+++ b/router/base-http/src/main/scala/io/buoyant/router/http/HeadersLike.scala
@@ -1,9 +1,9 @@
 package io.buoyant.router.http
 
 /**
-  * Type class for HTTP headers object
-  * @tparam H Headers object type
-  */
+ * Type class for HTTP headers object
+ * @tparam H Headers object type
+ */
 trait HeadersLike[H] {
   def toSeq(headers: H): Seq[(String, String)]
   def contains(headers: H, k: String): Boolean

--- a/router/base-http/src/main/scala/io/buoyant/router/http/RequestLike.scala
+++ b/router/base-http/src/main/scala/io/buoyant/router/http/RequestLike.scala
@@ -1,10 +1,10 @@
 package io.buoyant.router.http
 
 /**
-  * Type class for HTTP 1.1/2 requests
-  * @tparam R Request type
-  * @tparam H Headers object type
-  */
+ * Type class for HTTP 1.1/2 requests
+ * @tparam R Request type
+ * @tparam H Headers object type
+ */
 abstract class RequestLike[R, H: HeadersLike] {
   def headers(request: R): H
 }


### PR DESCRIPTION
# Problem

When a client establishes a pending request on Namerd's ThirftNamerInterface and then disconnects, the request stays pending rather than being properly cancelled.  If this occurs repeatedly, it can lead to a memory leak in Namerd as the number of pending requests grows without bound.

# Solution

Add an interrupt handler to the Promise returned by Observer so that the Future fails when it is cancelled.

# Testing done

Manually tested that the pending requests stat properly resets when the client disconnects.