### PR TITLE
Change default BufferedStream size to 16kb

### DIFF
--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/BufferedStream.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/BufferedStream.scala
@@ -2,7 +2,6 @@ package com.twitter.finagle.buoyant.h2
 
 import java.util.concurrent.atomic.AtomicBoolean
 import com.twitter.concurrent.AsyncQueue
-import com.twitter.conversions.storage._
 import com.twitter.finagle.buoyant.h2.BufferedStream.{RefCountedDataFrame, RefCountedFrame, RefCountedTrailersFrame, State}
 import com.twitter.finagle.buoyant.h2.Stream.AsyncQueueReader
 import com.twitter.finagle.util.AsyncLatch
@@ -26,7 +25,7 @@ import scala.util.control.NoStackTrace
  * buffer itself releases the Frame.  Threrefore you should always call discardBuffer on a
  * BufferedStream before it leaves scope.
  */
-class BufferedStream(underlying: Stream, bufferCapacity: Long = 8.kilobytes.bytes) { bufferedStream =>
+class BufferedStream(underlying: Stream, bufferCapacity: Long = 16383) { bufferedStream =>
 
   // Mutable state.  All mutations of state must be explicitly synchronized
   private[this] val buffer = mutable.MutableList[RefCountedFrame]()

--- a/linkerd/docs/protocol-h2.md
+++ b/linkerd/docs/protocol-h2.md
@@ -72,9 +72,6 @@ requests.  Plaintext clients are currently only capable of issuing
 prior-knowledge requests.
 
 
-<aside class="warning">
-Note that HTTP/2 clients should be careful not to send any DATA frame whose body is longer than the current window size minus the size of the response classification buffer (8 kb), as doing so may cause the stream to hang.
-</aside>
 
 ## HTTP/2 Server Parameters
 
@@ -96,10 +93,14 @@ retryBufferSize         | see below     | A RetryBufferSize object describing th
 
 #### RetryBufferSize
 
+<aside class="warning">
+Note that HTTP/2 clients should be careful not to send any request DATA frame whose body is longer than the current window size minus the size of the request buffer, as doing so may cause the stream to hang.
+</aside>
+
 Key           | Default Value   | Description
 ------------- | --------------- | -----------
-requestBytes  | `65535`         | If the request stream exceeds this value, the request cannot be retried.  This should be set to the server's window size.
-responseBytes | `65535`         | If the response stream exceeds this value, the request cannot be retried.  This should be set to the client's window size.
+requestBytes  | `8000`         | If the request stream exceeds this value, the request cannot be retried.  This should be set to the server's window size.
+responseBytes | `8000`         | If the response stream exceeds this value, the request cannot be retried.  This should be set to the client's window size.
 
 ## HTTP/2 Client Parameters
 

--- a/linkerd/docs/protocol-h2.md
+++ b/linkerd/docs/protocol-h2.md
@@ -99,8 +99,8 @@ Note that HTTP/2 clients should be careful not to send any request DATA frame wh
 
 Key           | Default Value   | Description
 ------------- | --------------- | -----------
-requestBytes  | `8000`         | If the request stream exceeds this value, the request cannot be retried.  This should be set to the server's window size.
-responseBytes | `8000`         | If the response stream exceeds this value, the request cannot be retried.  This should be set to the client's window size.
+requestBytes  | `16383`         | If the request stream exceeds this value, the request cannot be retried.
+responseBytes | `16383`         | If the response stream exceeds this value, the request cannot be retried.
 
 ## HTTP/2 Client Parameters
 

--- a/linkerd/docs/protocol-h2.md
+++ b/linkerd/docs/protocol-h2.md
@@ -71,6 +71,11 @@ When TLS is not configured, h2 servers accept both
 requests.  Plaintext clients are currently only capable of issuing
 prior-knowledge requests.
 
+
+<aside class="warning">
+Note that HTTP/2 clients should be careful not to send any DATA frame whose body exceeds 1/4th of the stream window size, as doing so may cause the connection to hang.
+</aside>
+
 ## HTTP/2 Server Parameters
 
 Key | Default Value | Description

--- a/linkerd/docs/protocol-h2.md
+++ b/linkerd/docs/protocol-h2.md
@@ -71,8 +71,6 @@ When TLS is not configured, h2 servers accept both
 requests.  Plaintext clients are currently only capable of issuing
 prior-knowledge requests.
 
-
-
 ## HTTP/2 Server Parameters
 
 Key | Default Value | Description

--- a/linkerd/docs/protocol-h2.md
+++ b/linkerd/docs/protocol-h2.md
@@ -73,7 +73,7 @@ prior-knowledge requests.
 
 
 <aside class="warning">
-Note that HTTP/2 clients should be careful not to send any DATA frame whose body exceeds 1/4th of the stream window size, as doing so may cause the connection to hang.
+Note that HTTP/2 clients should be careful not to send any DATA frame whose body is longer than the current window size minus the size of the response classification buffer (8 kb), as doing so may cause the stream to hang.
 </aside>
 
 ## HTTP/2 Server Parameters

--- a/router/h2/src/main/scala/io/buoyant/router/h2/ClassifiedRetryFilter.scala
+++ b/router/h2/src/main/scala/io/buoyant/router/h2/ClassifiedRetryFilter.scala
@@ -8,6 +8,7 @@ import com.twitter.finagle.stats.StatsReceiver
 import com.twitter.finagle.{Service, SimpleFilter}
 import com.twitter.util._
 import scala.util.control.NoStackTrace
+import com.twitter.util.StorageUnitConversions._
 import scala.{Stream => SStream}
 
 /**
@@ -249,5 +250,5 @@ class ClassifiedRetryFilter(
 }
 
 object ClassifiedRetryFilter {
-  val DefaultBufferSize = 65535
+  val DefaultBufferSize = 8.kilobytes.bytes
 }

--- a/router/h2/src/main/scala/io/buoyant/router/h2/ClassifiedRetryFilter.scala
+++ b/router/h2/src/main/scala/io/buoyant/router/h2/ClassifiedRetryFilter.scala
@@ -8,7 +8,6 @@ import com.twitter.finagle.stats.StatsReceiver
 import com.twitter.finagle.{Service, SimpleFilter}
 import com.twitter.util._
 import scala.util.control.NoStackTrace
-import com.twitter.util.StorageUnitConversions._
 import scala.{Stream => SStream}
 
 /**

--- a/router/h2/src/main/scala/io/buoyant/router/h2/ClassifiedRetryFilter.scala
+++ b/router/h2/src/main/scala/io/buoyant/router/h2/ClassifiedRetryFilter.scala
@@ -250,5 +250,5 @@ class ClassifiedRetryFilter(
 }
 
 object ClassifiedRetryFilter {
-  val DefaultBufferSize = 8.kilobytes.bytes
+  val DefaultBufferSize = 16383
 }


### PR DESCRIPTION
This PR changes the default buffer size for `ClassifiedRetryFilter` to 16kb. This should prevent the flow control issues described in #1697 in a majority of cases.

I've tested this change against the repro script provided in https://github.com/linkerd/linkerd/issues/1605#issuecomment-343233149 and Linkerd now proxies all requests successfully. I've also added documentation warning not to send pathologically large request bodies 

Fixes #1697. Fixes #1605.