### PR TITLE
Move Namerd retries to the application layer

### DIFF
--- a/namerd/iface/interpreter-thrift/src/test/scala/io/buoyant/namerd/iface/ThriftNamerClientTest.scala
+++ b/namerd/iface/interpreter-thrift/src/test/scala/io/buoyant/namerd/iface/ThriftNamerClientTest.scala
@@ -78,7 +78,7 @@ class ThriftNamerClientTest extends FunSuite with Awaits {
     val namespace = "yeezy"
     val clientId = Path.read("/rando/x8u4i5j")
     val service = new TestNamerService(clientId)
-    val client = new ThriftNamerClient(service, namespace, clientId = clientId)
+    val client = new ThriftNamerClient(service, namespace, Stream.continually(Duration.Zero), clientId = clientId)
 
     val act = client.delegate(Dtab.empty, Path.read("/yeezy/tlop/wolves"))
     val delegation = act.toFuture
@@ -108,7 +108,7 @@ class ThriftNamerClientTest extends FunSuite with Awaits {
     """)
 
     val service = new TestNamerService(clientId)
-    val client = new ThriftNamerClient(service, namespace, clientId = clientId)
+    val client = new ThriftNamerClient(service, namespace, Stream.continually(Duration.Zero), clientId = clientId)
     @volatile var state: Activity.State[NameTree[Name.Bound]] = Activity.Pending
     val closer = client.bind(dtab, wolvesPath).states.respond(state = _)
     try {

--- a/namerd/iface/interpreter-thrift/src/test/scala/io/buoyant/namerd/iface/ThriftNamerEndToEndTest.scala
+++ b/namerd/iface/interpreter-thrift/src/test/scala/io/buoyant/namerd/iface/ThriftNamerEndToEndTest.scala
@@ -49,7 +49,7 @@ class ThriftNamerEndToEndTest extends FunSuite with Eventually with IntegrationP
     }
     val namers = Map(Path.read("/io.l5d.w00t") -> namer)
     val service = new ThriftNamerInterface(interpreter, namers, newStamper, retryIn, Capacity.default, NullStatsReceiver)
-    val client = new ThriftNamerClient(service, ns, clientId = clientId)
+    val client = new ThriftNamerClient(service, ns, Stream.continually(Duration.Zero), clientId = clientId)
 
     val act = client.bind(reqDtab, reqPath)
     val obs = act.states.respond { s =>
@@ -129,7 +129,7 @@ class ThriftNamerEndToEndTest extends FunSuite with Eventually with IntegrationP
       namers
     )
     val service = new ThriftNamerInterface(interpreter, namers.toMap, newStamper, retryIn, Capacity.default, NullStatsReceiver)
-    val client = new ThriftNamerClient(service, ns, clientId = clientId)
+    val client = new ThriftNamerClient(service, ns, Stream.continually(Duration.Zero), clientId = clientId)
 
     val tree = await(client.delegate(
       Dtab.read("/host/poop => /srv/woop"),
@@ -178,7 +178,7 @@ class ThriftNamerEndToEndTest extends FunSuite with Eventually with IntegrationP
       namers
     )
     val service = new ThriftNamerInterface(interpreter, namers.toMap, newStamper, retryIn, Capacity.default, NullStatsReceiver)
-    val client = new ThriftNamerClient(service, ns, clientId = clientId)
+    val client = new ThriftNamerClient(service, ns, Stream.continually(Duration.Zero), clientId = clientId)
     witness.notify(Return(NameTree.Leaf(Name.Bound(
       Var(Addr.Bound(Address("localhost", 9000))),
       Path.read("/io.l5d.w00t/foo"),


### PR DESCRIPTION
Namerd retries are difficult to reason about because they happen inside the stack of the namerd thriftmux client.

Since we have a long-polling loop anyway, move all retry logic to that long-polling loop.  We do this by turning off retries in the thriftmux client and modifying the long-polling loop to continue looping in the event of an error.