### PR TITLE
add forwardClientCert param doc

### DIFF
--- a/linkerd/docs/protocol-h2.md
+++ b/linkerd/docs/protocol-h2.md
@@ -111,6 +111,10 @@ maxFrameBytes | 16KB | Configures `SETTINGS_MAX_FRAME_SIZE` on new streams.
 maxHeaderListByts | none | Configures `SETTINGS_MAX_HEADER_LIST_SIZE` on new streams.
 forwardClientCert | false | Determines if client certificates are forwarded through the `x-forwarded-client-cert` header of a request.
 
+<aside class="notice">
+`forwardClientCert` makes Linkerd forward client certificates using the `x-forwarded-client-cert` header to let destination services make authorization decisions on the requests
+they receive.   
+</aside>
 
 ## HTTP/2 Identifiers
 

--- a/linkerd/docs/protocol-h2.md
+++ b/linkerd/docs/protocol-h2.md
@@ -109,6 +109,7 @@ headerTableBytes | none | Configures `SETTINGS_HEADER_TABLE_SIZE` on new streams
 initialStreamWindowBytes | 64KB | Configures `SETTINGS_INITIAL_WINDOW_SIZE` on streams.
 maxFrameBytes | 16KB | Configures `SETTINGS_MAX_FRAME_SIZE` on new streams.
 maxHeaderListByts | none | Configures `SETTINGS_MAX_HEADER_LIST_SIZE` on new streams.
+forwardClientCert | false | Determines if client certificates are forwarded through the `x-forwarded-client-cert` header of a request.
 
 
 ## HTTP/2 Identifiers

--- a/linkerd/docs/protocol-http.md
+++ b/linkerd/docs/protocol-http.md
@@ -113,12 +113,18 @@ requestRandom | An obfuscated random label like `_6Oq8jJ` _generated for each re
 router | Uses the router's `label` as an obfuscated static label.
 static | Accepts a `label` parameter. Produces obfuscated static labels like `_linkerd`.
 
-<a name="http-1-1-identifiers"></a>
+<a name="http-client-parameters"></a>
 ## HTTP Client Parameters
 Key | Default Value | Description
 --- | ------------- | -----------
 forwardClientCert | false | Determines if client certificates are forwarded through the `x-forwarded-client-cert` header of a request.
-<a name="http-client-parameters"></a>
+
+<aside class="notice">
+`forwardClientCert` makes Linkerd forward client certificates using the `x-forwarded-client-cert` header to let destination services make authorization decisions on the requests
+they receive. 
+</aside>
+
+<a name="http-1-1-identifiers"></a>
 ## HTTP/1.1 Identifiers
 
 Identifiers are responsible for creating logical *names* from an incoming

--- a/linkerd/docs/protocol-http.md
+++ b/linkerd/docs/protocol-http.md
@@ -114,6 +114,11 @@ router | Uses the router's `label` as an obfuscated static label.
 static | Accepts a `label` parameter. Produces obfuscated static labels like `_linkerd`.
 
 <a name="http-1-1-identifiers"></a>
+## HTTP Client Parameters
+Key | Default Value | Description
+--- | ------------- | -----------
+forwardClientCert | false | Determines if client certificates are forwarded through the `x-forwarded-client-cert` header of a request.
+<a name="http-client-parameters"></a>
 ## HTTP/1.1 Identifiers
 
 Identifiers are responsible for creating logical *names* from an incoming

--- a/linkerd/docs/routers.md
+++ b/linkerd/docs/routers.md
@@ -253,7 +253,6 @@ failFast | `false` | If `true`, connection failures are punished more aggressive
 requeueBudget | see [retry budget](#retry-budget-parameters) | A [requeue budget](#retry-budget-parameters) for connection-level retries.
 failureAccrual | 5 consecutive failures | a [failure accrual policy](#failure-accrual) for all clients created by this router.
 requestAttemptTimeoutMs | no timeout | The timeout, in milliseconds, for each attempt (original or retry) of the request made by this client.
-forwardClientCert | false | Determines if client certificates are forwarded through the `x-forwarded-client-cert` header of a request.
 
 <aside class="notice">
 `forwardClientCert` makes Linkerd forward client certificates using the `x-forwarded-client-cert` header to let destination services make authorization decisions on the requests.

--- a/linkerd/docs/routers.md
+++ b/linkerd/docs/routers.md
@@ -253,6 +253,12 @@ failFast | `false` | If `true`, connection failures are punished more aggressive
 requeueBudget | see [retry budget](#retry-budget-parameters) | A [requeue budget](#retry-budget-parameters) for connection-level retries.
 failureAccrual | 5 consecutive failures | a [failure accrual policy](#failure-accrual) for all clients created by this router.
 requestAttemptTimeoutMs | no timeout | The timeout, in milliseconds, for each attempt (original or retry) of the request made by this client.
+forwardClientCert | false | Determines if client certificates are forwarded through the `x-forwarded-client-cert` header of a request.
+
+<aside class="notice">
+`forwardClientCert` makes Linkerd forward client certificates using the `x-forwarded-client-cert` header to let destination services make authorization decisions on the requests.
+they receive. 
+</aside>
 
 #### Host Connection Pool
 

--- a/linkerd/docs/routers.md
+++ b/linkerd/docs/routers.md
@@ -254,11 +254,6 @@ requeueBudget | see [retry budget](#retry-budget-parameters) | A [requeue budget
 failureAccrual | 5 consecutive failures | a [failure accrual policy](#failure-accrual) for all clients created by this router.
 requestAttemptTimeoutMs | no timeout | The timeout, in milliseconds, for each attempt (original or retry) of the request made by this client.
 
-<aside class="notice">
-`forwardClientCert` makes Linkerd forward client certificates using the `x-forwarded-client-cert` header to let destination services make authorization decisions on the requests.
-they receive. 
-</aside>
-
 #### Host Connection Pool
 
 ```yaml

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/H2Config.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/H2Config.scala
@@ -234,7 +234,6 @@ case class RetryBufferSize(
 class H2ServerConfig extends ServerConfig with H2EndpointConfig {
 
   var maxConcurrentStreamsPerConnection: Option[Int] = None
-  val forwardClientCert: Option[Boolean] = None
 
   @JsonIgnore
   override val alpnProtocols: Option[Seq[String]] =
@@ -245,7 +244,6 @@ class H2ServerConfig extends ServerConfig with H2EndpointConfig {
 
   override def withEndpointParams(params: Stack.Params): Stack.Params = super.withEndpointParams(params)
     .maybeWith(maxConcurrentStreamsPerConnection.map(c => Settings.MaxConcurrentStreams(Some(c.toLong))))
-    .maybeWith(forwardClientCert.map(ForwardClientCertFilter.Enabled))
 
   @JsonIgnore
   override def serverParams = withEndpointParams(super.serverParams)


### PR DESCRIPTION
This PR updates the docs to describe a new parameter that was added (#1656) to the Linkerd configuration under the Router Client Configuration.  

fixes #1707 