### PR TITLE
Reset client streams on errors when the server stream has already closed

### DIFF
--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/Message.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/Message.scala
@@ -97,7 +97,6 @@ trait Request extends Message {
   def headers: Headers
   override def dup(): Request
   def onFail: Future[Unit]
-  onFail.onFailure { e => log.debug("Request trait (not Impl) observed onFail: %s; onFail=%s; ", e, onFail.hashCode()) }
 
   def copy(
     headers: Headers = this.headers.dup(),
@@ -129,8 +128,10 @@ object Request {
     Impl(headers, stream, fail)
 
   private case class Impl(headers: Headers, stream: Stream, onFail: Future[Unit]) extends Request {
-    log.debug("Created %s; onFail=%s;", this, onFail.hashCode())
-    onFail.onFailure { e => log.debug("Request.Impl observed onFail: %s; onFail=%s;", e, onFail.hashCode()) }
+    log.trace("Created %s; onFail=%s;", this, onFail.hashCode())
+    onFail.onFailure { e =>
+      log.trace("Request.Impl observed onFail: %s; onFail=%s;", e, onFail.hashCode())
+    }
     //    override def onFail: Future[Unit] = failF
     override def toString = s"Request($scheme, $method, $authority, $path, $stream)"
     override def dup() = copy(headers = headers.dup())

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/Message.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/Message.scala
@@ -18,14 +18,12 @@ import com.twitter.util.{Future, Promise}
  * to satisfy a broader set of use cases.
  */
 sealed trait Message {
+  protected val log = Logger.get("h2")
   def headers: Headers
   def stream: Stream
 
   /** Create a deep copy of the Message with a new copy of headers (but the same stream). */
   def dup(): Message
-}
-protected[Message] object Message {
-  val log = Logger.get("h2")
 }
 
 trait Headers {
@@ -109,7 +107,7 @@ trait Request extends Message {
 }
 
 object Request {
-  import Message._
+  protected val log = Logger.get("h2")
   def apply(
     scheme: String,
     method: Method,
@@ -142,7 +140,6 @@ object Request {
     )
     req
   }
-
 
   def apply(headers: Headers, stream: Stream, fail: Future[Unit]): Request =
     Impl(headers, stream, fail)

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4DispatcherBase.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4DispatcherBase.scala
@@ -33,15 +33,14 @@ trait Netty4DispatcherBase[SendMsg <: Message, RecvMsg <: Message] {
     def reset(err: Reset): Unit = {}
   }
   private[this] case class StreamOpen(stream: Netty4StreamTransport[SendMsg, RecvMsg]) extends StreamTransport {
-    def toClosed: StreamClosed = StreamClosed(stream.streamId, this.stream.resetClient)
+    def toClosed: Option[StreamClosed] =
+      this.stream.resetClient.map { resetP => StreamClosed(stream.streamId, resetP ) }
     override def reset(err: Reset): Unit = stream.remoteReset(err)
   }
-  private[this] case class StreamClosed(id: Int, onReset: Option[Promise[Unit]]) extends StreamTransport {
+  private[this] case class StreamClosed(id: Int, onReset: Promise[Unit]) extends StreamTransport {
     override def reset(err: Reset): Unit = synchronized {
-      onReset.foreach { resetP =>
-        log.debug("[%s S:%d] propagating %s to client half of closed stream", prefix, id, err)
-        resetP.setException(err)
-      }
+      log.debug("[%s S:%d] propagating %s to client half of closed stream", prefix, id, err)
+      onReset.setException(err)
       streams.remove(id); ()
     }
   }
@@ -79,10 +78,19 @@ trait Netty4DispatcherBase[SendMsg <: Message, RecvMsg <: Message] {
       case Return(_) =>
         // Free and clear.
         addClosedId(id)
-        if (streams.replace(id, open, open.toClosed)) {
-          log.debug("[%s S:%d] open stream closed", prefix, id)
-        } else {
-          streams.remove(id)
+        open.toClosed match {
+          case Some(closed) if streams.replace(id, open, closed) =>
+            // the open stream is a server dispatcher stream whose corresponding
+            // client stream may not be closed yet. we need to continue tracking
+            // it in the event of a reset.
+            log.debug("[%s S:%d] open stream replaced by StreamClosed", prefix, id)
+          case _ =>
+            // either the stream is a client dispatcher stream, or the stream
+            // transitioned to closed from a state other than open. just
+            // remove it.
+            log.debug("[%s S:%d] open stream removed", prefix, id)
+            streams.remove(id)
+
         }
         log.debug("[%s S:%d] stream closed", prefix, id)
 

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4Message.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4Message.scala
@@ -83,8 +83,10 @@ private[h2] object Netty4Message {
   }
 
   object Request {
-    def apply(netty4Headers: Http2Headers, data: Stream): h2.Request =
-      h2.Request(Headers(netty4Headers), data)
+    def apply(netty4Headers: Http2Headers, data: Stream): h2.Request = {
+      log.warning("constructing new request without onFail future, you probably shouldn't do this")
+      h2.Request(Headers(netty4Headers), data, Future.never)
+    }
   }
 
   object Response {

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4StreamTransport.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4StreamTransport.scala
@@ -674,7 +674,7 @@ object Netty4StreamTransport {
           case _ => Reset.Cancel
         }
         log.debug("[%s] server failed with remote reset: %s", prefix, rst)
-        remoteReset(rst)
+        localReset(rst)
 
       case StreamError.Local(e) =>
         val rst = e match {
@@ -682,7 +682,7 @@ object Netty4StreamTransport {
           case _ => Reset.Cancel
         }
         log.debug("[%s] server failed with local reset: %s", prefix, rst)
-        localReset(rst)
+        remoteReset(rst)
 
       case e =>
         log.error(e, "[%s] unexpected server error", prefix)

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4StreamTransport.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4StreamTransport.scala
@@ -727,7 +727,7 @@ object Netty4StreamTransport {
     id: Int,
     writer: H2Transport.Writer,
     stats: StatsReceiver = NullStatsReceiver,
-    onServerReset: Future[Unit]
+    onServerReset: Future[Unit] = Future.never
   ): Netty4StreamTransport[Request, Response] = {
     new Client(id, writer, stats, onServerReset)
   }

--- a/router/h2/src/main/scala/io/buoyant/router/h2/ClassifiedRetryFilter.scala
+++ b/router/h2/src/main/scala/io/buoyant/router/h2/ClassifiedRetryFilter.scala
@@ -59,7 +59,7 @@ class ClassifiedRetryFilter(
     val fork = Future.const(requestBuffer.fork())
 
     def dispatch(reqStream: Stream, backoffs: SStream[Duration], count: Int): Future[Response] = {
-      val req = Request(request.headers.dup(), reqStream)
+      val req = request.copy(stream = reqStream)
 
       // Attempt to retry.
       // If a retry is not possible because the request buffer has been discarded or we have run

--- a/router/h2/src/main/scala/io/buoyant/router/h2/StreamStatsFilter.scala
+++ b/router/h2/src/main/scala/io/buoyant/router/h2/StreamStatsFilter.scala
@@ -152,7 +152,7 @@ class StreamStatsFilter(
   override def apply(req0: Request, service: Service[Request, Response]): Future[Response] = {
     reqCount.incr()
     val reqT = Stopwatch.start()
-    val req1 = Request(req0.headers, reqStreamStats(reqT)(req0.stream))
+    val req1 = req0.copy(stream = reqStreamStats(reqT)(req0.stream))
 
     @inline def classify(rsp: Response)(frame: Option[Try[Frame]]): Unit =
       // Only classify if early classification wasn't applicable.


### PR DESCRIPTION
Currently, an error (#1696) exists where stream transports on the H2 `ClientDispatcher` can be leaked when a global reset occurs when the request stream has not been fully sent, but the response stream has finished. The sequence of events is as follows:

1. Request headers are sent from the client to Linkerd
2. Request headers are sent from Linkerd to the server.
3. Response headers with the EOS flag set are sent from the server to Linkerd.
4. Response headers are sent from Linkerd to the client, and the stream is closed by the EOS. 
5. A request data Aframe with an EOS is sent from the client to Linkerd. At this point, the `StreamTransport` in Linkerd's `ServerDispatcher` streams hash map is removed.
Meanwhile, the request body is still being sent from Linkerd to the server.
6. The client disconnects abruptly, causing Linkerd to reset all streams.
7. When the connection terminates, the stream in Linkerd's `ClientDispatcher` is left in the `StreamOpen(RemoteClosed)` state, rather than the `StreamRemoteReset` state, and is never removed.

Typically, we propagate this error by failing the client transport's send queue, but when the client has no more frames to send, it never offers frames into the excepting queue, and thus never sees the error. 

This can happen when the response body is much shorter than the request body (or the response consists only of a headers frame), and the response is started before the request finishes. Although this is a fairly uncommon case, it does seem to actually happen, such as when proxying bidirectional gRPC streaming requests which result in gRPC errors (represented as a HEADERS-only response).

I've added a `Future` to H2 `Request`s that is failed when the server dispatcher resets, and modified the way streams transition to the closed state in `Netty4StreamTransport`. Rather than just immediately removing closed streams from the `streams` hash map, we replace these streams with a `StreamClosed` object that holds a reference to a future that can be used to propagate errors to the client dispatcher. This allows streams on the server dispatcher which have been closed but still have streams open on the client dispatcher to close their corresponding client streams when there's a global reset.

Closes #1696.