### PR TITLE
Replace total setInterruptHandlers with Promise.InterruptHandler

### DIFF
--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/Stream.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/Stream.scala
@@ -105,11 +105,11 @@ object Stream {
   }
 
   private[this] def failOnInterrupt[T, Q](f: Future[T], q: AsyncQueue[Q]): Future[T] = {
-    val p = new Promise[T]
-    p.setInterruptHandler {
-      case e =>
+    val p = new Promise[T] with Promise.InterruptHandler {
+      override protected def onInterrupt(e: Throwable): Unit = {
         q.fail(e, discard = true)
         f.raise(e)
+      }
     }
     f.proxyTo(p)
     p


### PR DESCRIPTION
I've replaced calls to `Promise.setInterruptHandler` where the partial function passed as the interrupt handler is total with `new Promise with Promise.InterruptHandler`. According to the [twitter.util docs](https://twitter.github.io/util/docs/com/twitter/util/Promise$$InterruptHandler.html), this is equivalent to `Promise.setInterruptHandler` but reduces the number of allocations, since it doesn't allocate an additional partial function.

This might have a meaningful impact on performance if any of these calls to `setInterruptHandler` happen in a hot path.