### PR TITLE
Fix netty ByteBuf reference counting

### DIFF
--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4Message.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4Message.scala
@@ -102,7 +102,7 @@ private[h2] object Netty4Message {
 
     def apply(f: Http2DataFrame, updateWindow: Int => Future[Unit]): Frame.Data = {
       val sz = f.content.readableBytes + f.padding
-      val buf = ByteBufAsBuf(f.content.retain())
+      val buf = ByteBufAsBuf(f.content)
       val releaser: () => Future[Unit] =
         if (sz > 0) () => updateWindow(sz)
         else () => Future.Unit


### PR DESCRIPTION
Netty was reporting "LEAK: ByteBuf.release() was not called", direct
memory was growing unbounded.

Remove unnecessary call to retain in h2 code.

Verified netty leak messages go away with this fix.

Fixes #1678