### PR TITLE
Fixes #1716. Allow Namers to extend the admin UI

### DIFF
--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/LinkerdAdmin.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/LinkerdAdmin.scala
@@ -73,7 +73,7 @@ object LinkerdAdmin {
       NavItem("dtab", "delegator"),
       NavItem("logging", "logging")
     ) ++ Admin.extractNavItems(
-        linker.namers ++
+        linker.namers.map(_._2) ++
           linker.routers.map(_.interpreter) ++
           linker.routers ++
           linker.telemeters
@@ -89,7 +89,7 @@ object LinkerdAdmin {
     val adminHandler = new AdminHandler(uniqBy(navItems)(_.name))
 
     val extHandlers = Admin.extractHandlers(
-      linker.namers ++
+      linker.namers.map(_._2) ++
         linker.routers ++
         linker.routers.map(_.interpreter) ++
         linker.telemeters


### PR DESCRIPTION
As explained in #1716, Namers are not handled correctly when collecting the handlers for the admin UI.
`LinkerAdmin` passes the Seq `linker.namers` to check if the elements implement the respective traits `Admin.WithHandlers` and `Admin.WithNavItems`.
As `linker.names` has the type `Seq[(Path,Namer)]` this will never succeed.
Instead the right part of the tuples should be checked.