### PR TITLE
Ensure dnssrv namer update DNS updated records

### DIFF
--- a/namer/dnssrv/src/main/scala/io/buoyant/namer/dnssrv/DnsSrvNamer.scala
+++ b/namer/dnssrv/src/main/scala/io/buoyant/namer/dnssrv/DnsSrvNamer.scala
@@ -1,15 +1,14 @@
 package io.buoyant.namer.dnssrv
 
-import java.io.IOException
 import java.net.{InetAddress, InetSocketAddress, UnknownHostException}
-import java.util.concurrent.atomic.AtomicBoolean
 
 import com.twitter.finagle._
 import com.twitter.finagle.stats.{Stat, StatsReceiver}
 import com.twitter.logging.Logger
-import com.twitter.util.Activity.State
 import com.twitter.util._
 import org.xbill.DNS
+
+import scala.util.control.NoStackTrace
 
 class DnsSrvNamer(
   prefix: Path,
@@ -32,80 +31,90 @@ class DnsSrvNamer(
   private val memoizedLookup: (Path) => Activity[NameTree[Name]] = Memoize { path =>
     path.take(1) match {
       case id@Path.Utf8(address) =>
-        Activity(Var.async[State[NameTree[Name]]](Activity.Pending) { state =>
+        val vaddr = watchDns(address, timer).run.map {
+          case Activity.Ok(rsp) =>
+            Addr.Bound(rsp: _*)
+          case Activity.Pending =>
+            Addr.Pending
+          case Activity.Failed(e) =>
+            log.debug("SRV lookup failure: %s", e.getMessage)
+            Addr.Failed(e)
+        }
 
-          val done = new AtomicBoolean(false)
-          val initialized = new AtomicBoolean(false)
+        val state: Var[Activity.State[NameTree[Name]]] = vaddr.map {
+          case Addr.Bound(addrs, _) if addrs.isEmpty =>
+            Activity.Ok(NameTree.Neg)
+          case Addr.Bound(addrs, _) =>
+            Activity.Ok(NameTree.Leaf(Name.Bound(vaddr, prefix ++ id, path.drop(1))))
+          case Addr.Pending =>
+            Activity.Pending
+          case Addr.Failed(_) =>
+            Activity.Ok(NameTree.Neg)
+        }
 
-          Future.whileDo(!done.get) {
-            lookupSrv(address, prefix ++ id, path.drop(1)).transform { result =>
-              result match {
-                case Return(nameTree) =>
-                  initialized.set(true)
-                  state.update(Activity.Ok(nameTree))
-                case Throw(e) =>
-                  failure.incr()
-                  log.error(e, "resolution error: %s", address)
-                  if (!initialized.get) {
-                    state.update(Activity.Failed(e))
-                  }
-              }
-              Future.sleep(refreshInterval)
-            }
-          }
-
-          Closable.make { _ =>
-            done.set(true)
-            Future.Unit
-          }
-
-        })
-      case _ => Activity.value(NameTree.Neg)
+        Activity(state)
+      case _ =>
+        Activity.value(NameTree.Neg)
     }
   }
 
-  private def lookupSrv(address: String, id: Path, residual: Path): Future[NameTree[Name]] = {
-    log.debug("looking up %s", address)
-    pool {
-      val lookup = new DNS.Lookup(address, DNS.Type.SRV, DNS.DClass.IN)
-      lookup.setResolver(resolver)
-      Stat.time(latency)(lookup.run())
-      lookup.getResult match {
-        case DNS.Lookup.HOST_NOT_FOUND | DNS.Lookup.TYPE_NOT_FOUND =>
-          log.trace("no results for %s", address)
-          failure.incr()
-          NameTree.Neg
-        case DNS.Lookup.SUCCESSFUL =>
-          val answers = Option(lookup.getAnswers).getOrElse(Array.empty)
-          val srvRecords = answers.flatMap {
-            case srv: DNS.SRVRecord => try {
-              val inetAddress = InetAddress.getByName(srv.getTarget.toString())
-              Some(Address(new InetSocketAddress(inetAddress, srv.getPort)))
-            } catch {
-              case _: UnknownHostException =>
-                log.warning(s"srv lookup of $address returned unknown host ${srv.getTarget}")
-                badHosts.incr()
-                None
+  private def watchDns(dsnsrvRecord: String, timer: Timer): Activity[List[Address]] = {
+    val state = Var.async[Activity.State[List[Address]]](Activity.Pending) { update =>
+
+      def doUnit(): Unit = {
+        val lookup = new DNS.Lookup(dsnsrvRecord, DNS.Type.SRV, DNS.DClass.IN)
+        lookup.setResolver(resolver)
+        Stat.time(latency)(lookup.run())
+        lookup.getResult match {
+          case DNS.Lookup.HOST_NOT_FOUND | DNS.Lookup.TYPE_NOT_FOUND =>
+            val msg = s"no results for $dsnsrvRecord"
+            log.trace(msg)
+            failure.incr()
+            update.update(Activity.Failed(new DNSLookupException(msg)))
+          case DNS.Lookup.SUCCESSFUL =>
+            val answers = Option(lookup.getAnswers).getOrElse(Array.empty)
+            val srvRecords = answers.flatMap {
+              case srv: DNS.SRVRecord => try {
+                val inetAddress = InetAddress.getByName(srv.getTarget.toString())
+                Some(Address(new InetSocketAddress(inetAddress, srv.getPort)))
+              } catch {
+                case _: UnknownHostException =>
+                  log.warning(s"srv lookup of $dsnsrvRecord returned unknown host ${srv.getTarget}")
+                  badHosts.incr()
+                  None
+              }
+              case _ => None
             }
-            case _ => None
-          }
-          if (srvRecords.isEmpty) {
-            // valid DNS entry, but no instances.
-            // return NameTree.Neg because NameTree.Empty causes requests to fail,
-            // even in the presence of load-balancing (NameTree.Union) and fail-over (NameTree.Alt)
-            log.trace("empty response for %s", address)
-            zeroResults.incr()
-            NameTree.Neg
-          } else {
-            log.trace("got %d results for %s", srvRecords.length, address)
-            success.incr()
-            NameTree.Leaf(Name.Bound(Var.value(Addr.Bound(srvRecords: _*)), id, residual))
-          }
-        case code =>
-          val msg = s"unexpected result: $code for $address: ${lookup.getErrorString}"
-          log.error(msg)
-          throw new IOException(msg)
+            if (srvRecords.isEmpty) {
+              // valid DNS entry, but no instances.
+              // return NameTree.Neg because NameTree.Empty causes requests to fail,
+              // even in the presence of load-balancing (NameTree.Union) and fail-over (NameTree.Alt)
+              val msg = s"empty response for $dsnsrvRecord"
+              log.trace(msg)
+              zeroResults.incr()
+              update.update(Activity.Failed(new DNSLookupException(msg)))
+            } else {
+              log.trace("got %d results for %s", srvRecords.length, dsnsrvRecord)
+              success.incr()
+              update.update(Activity.Ok(srvRecords.toList))
+            }
+          case code =>
+            val msg = s"unexpected result: $code for $dsnsrvRecord: ${lookup.getErrorString}"
+            log.error(msg)
+            update.update(Activity.Failed(new DNSLookupException(msg)))
+        }
+      }
+
+      doUnit()
+
+      timer.schedule(refreshInterval) {
+        doUnit()
       }
     }
+    Activity(state)
   }
 }
+
+case class DNSLookupException(msg: String)
+  extends Exception(msg)
+  with NoStackTrace


### PR DESCRIPTION
 * Refactor the DNS lookup function using a Finagle Timer for DNS refresh interval and wrap it with an Activity.
 * Refactor the lookup function to map all in terms of Activity.
Fixes: #1718