### PR TITLE
Replace CLA with DCO

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,20 @@ If you have a question about linkerd or have encountered problems using it,
 start by [asking a question in the forums][discourse] or join us on
 [Slack][slack].
 
+## Certificate of Origin ##
+
+By contributing to this project you agree to the Developer Certificate of
+Origin (DCO). This document was created by the Linux Kernel community and is a
+simple statement that you, as a contributor, have the legal right to make the
+contribution. See the [DCO](DCO) file for details.
+
+In practice, just add a line to every git commit message:
+
+Signed-off-by: Jane Smith <jane.smith@example.com>
+Use your real name (sorry, no pseudonyms or anonymous contributions).
+
+If you set your user.name and user.email git configs, you can sign your commit automatically with git commit -s.
+
 ## Submitting a Pull Request ##
 
 Do you have an improvement?
@@ -16,8 +30,7 @@ Do you have an improvement?
 2. We will try to respond to your issue promptly.
 3. Fork this repo, develop and test your code changes. See the project's [README](README.md) for further information about working in this repository.
 4. Submit a pull request against this repo's `master` branch.
-5. You'll need to have signed our [Contributor License Agreement][cla] before we can accept any non-trivial changes.
-6. Your branch may be merged once all configured checks pass, including:
+5. Your branch may be merged once all configured checks pass, including:
     - 2 code review approvals, at least 1 of which is from a [linkerd organization member][members].
     - The branch has passed tests in CI.
 
@@ -85,7 +98,6 @@ Describe the modifications you've made.
 Describe the testing you've done to validate your change.  Performance-related
 changes should include before- and after- benchmark results.
 
-[cla]: https://buoyant.io/cla/
 [discourse]: https://discourse.linkerd.io/
 [es]: https://twitter.github.io/effectivescala/
 [issue]: https://github.com/linkerd/linkerd/issues/new

--- a/DCO
+++ b/DCO
@@ -1,0 +1,37 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+1 Letterman Drive
+Suite D4700
+San Francisco, CA, 94129
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.


### PR DESCRIPTION
CLA's are optional for CNCF projects, DCO is preferred.

Replace reference of CLA with DCO in CONTRIBUTING.md, add DCO file.

Fixes #1686