### PR TITLE
Strip transformer prefix in addr mesh requests to namerd

### DIFF
--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4StreamTransport.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4StreamTransport.scala
@@ -184,9 +184,9 @@ private[h2] trait Netty4StreamTransport[SendMsg <: Message, RecvMsg <: Message] 
   private[this] val stateRef: AtomicReference[StreamState] = {
     val remoteMsgP = new Promise[RecvMsg] with Promise.InterruptHandler {
       override protected def onInterrupt(t: Throwable): Unit =
-      // When the remote message--especially a client's response--is
-      // canceled, close the transport, sending a RST_STREAM as
-      // appropriate.
+        // When the remote message--especially a client's response--is
+        // canceled, close the transport, sending a RST_STREAM as
+        // appropriate.
         t match {
           case err: Reset =>
             log.debug("[%s] remote message interrupted: %s", prefix, err)

--- a/k8s/src/main/scala/io/buoyant/k8s/resources.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/resources.scala
@@ -91,18 +91,18 @@ private[k8s] class NsVersion[O <: KubeObject](
 }
 
 /**
-  * A custom resource version contains CustomResource-typed objects. The API was called ThirdPartyResources in Kubernetes
-  * < 1.7 and has been deprecated since version 1.8. The APIs for both resource versions are identical in implementation. However,
-  * various naming standards have been changed to make the apis more meaningful. For more details
-  * see https://kubernetes.io/docs/tasks/access-kubernetes-api/extend-api-third-party-resource/.
-  * To understand how to create your own custom resources see
-  * https://kubernetes.io/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions/ for a description of the
-  * design model.
-  *
-  * Implementors are likely to want to extend this to provide convenience methods on top of the `list` method.
-  *
-  * @tparam O The parent type for all [[KubeObject]]s served by this Version.
-  */
+ * A custom resource version contains CustomResource-typed objects. The API was called ThirdPartyResources in Kubernetes
+ * < 1.7 and has been deprecated since version 1.8. The APIs for both resource versions are identical in implementation. However,
+ * various naming standards have been changed to make the apis more meaningful. For more details
+ * see https://kubernetes.io/docs/tasks/access-kubernetes-api/extend-api-third-party-resource/.
+ * To understand how to create your own custom resources see
+ * https://kubernetes.io/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions/ for a description of the
+ * design model.
+ *
+ * Implementors are likely to want to extend this to provide convenience methods on top of the `list` method.
+ *
+ * @tparam O The parent type for all [[KubeObject]]s served by this Version.
+ */
 trait CustomResourceVersion[O <: KubeObject] extends Version[O] {
   /** domain name, i.e. "buoyant.io" */
   def owner: String

--- a/namerd/iface/mesh/src/main/scala/io/buoyant/namerd/iface/mesh/ResolverService.scala
+++ b/namerd/iface/mesh/src/main/scala/io/buoyant/namerd/iface/mesh/ResolverService.scala
@@ -1,14 +1,14 @@
 package io.buoyant.namerd
 package iface.mesh
 
-import com.twitter.finagle.{Addr, Address, Dtab, Name, Namer, NameTree, Path}
+import com.twitter.finagle.{Addr, Address, Dtab, Name, NameTree, Namer, Path}
 import com.twitter.finagle.stats.StatsReceiver
 import com.twitter.io.Buf
 import com.twitter.util.{Activity, Future, Return, Throw, Try, Var}
 import io.buoyant.grpc.runtime.{Stream, VarEventStream}
 import io.linkerd.mesh
 import io.linkerd.mesh.Converters._
-import io.buoyant.namer.Metadata
+import io.buoyant.namer.{Metadata, Paths}
 import java.net.Inet6Address
 
 object ResolverService {
@@ -29,7 +29,7 @@ object ResolverService {
     }
 
     private[this] def bind(pid: mesh.Path): Var[Addr] = {
-      val id = fromPath(pid)
+      val id = Paths.stripTransformerPrefix(fromPath(pid))
       val (pfx, namer) = namers
         .find { case (pfx, _) => id.startsWith(pfx) }
         .getOrElse(DefaultNamer)

--- a/namerd/iface/mesh/src/test/scala/io/buoyant/namerd/iface/mesh/ResolverServiceTest.scala
+++ b/namerd/iface/mesh/src/test/scala/io/buoyant/namerd/iface/mesh/ResolverServiceTest.scala
@@ -1,0 +1,129 @@
+package io.buoyant.namerd.iface.mesh
+
+import com.twitter.finagle.stats.NullStatsReceiver
+import com.twitter.finagle._
+import com.twitter.io.Buf
+import com.twitter.util.{Activity, Var}
+import io.buoyant.test.FunSuite
+import io.linkerd.mesh.Endpoint.AddressFamily
+import io.linkerd.mesh.{Endpoint, Replicas, ReplicasReq, Path => MPath}
+
+class ResolverServiceTest extends FunSuite {
+
+  test("getReplicas") {
+    val pfx = Path.read("/#/atl")
+    val states = Var[Activity.State[NameTree[Name.Bound]]](Activity.Pending)
+    val namers = Map(pfx -> new Namer { def lookup(path: Path) = Activity(states) })
+    val resolver = new ResolverService.ServerImpl(namers, NullStatsReceiver)
+
+    val vaddr = Var[Addr](Addr.Bound(Address("1.2.3.4", 7777)))
+    states() = Activity.Ok(NameTree.Leaf(Name.Bound(vaddr, Path.read("/#/atl/slime/season"))))
+
+    val path = Path.read("/#/atl/slime/season")
+    val req = ReplicasReq(Some(MPath(path.elems)))
+
+    val endpoint = Endpoint(
+      inetAf = Some(AddressFamily.INET4),
+      address = Some(Buf.ByteArray.Owned(Array[Byte](1, 2, 3, 4))),
+      port = Some(7777),
+      meta = Some(Endpoint.Meta(nodeName = None))
+    )
+    val rsp = await(resolver.getReplicas(req))
+    assert(rsp.result.get == Replicas.OneofResult.Bound(Replicas.Bound(Seq(endpoint))))
+  }
+
+  test("streamReplicas") {
+    val pfx = Path.read("/#/atl")
+    val states = Var[Activity.State[NameTree[Name.Bound]]](Activity.Pending)
+    val namers = Map(pfx -> new Namer { def lookup(path: Path) = Activity(states) })
+    val resolver = new ResolverService.ServerImpl(namers, NullStatsReceiver)
+
+    val path = Path.read("/#/atl/slime/season")
+    val req = ReplicasReq(Some(MPath(path.elems)))
+
+    val vaddr = Var[Addr](Addr.Bound(Address("1.2.3.4", 7777)))
+    states() = Activity.Ok(NameTree.Leaf(Name.Bound(vaddr, Path.read("/#/atl/slime/season"))))
+    val endpoint0 = Endpoint(
+      inetAf = Some(AddressFamily.INET4),
+      address = Some(Buf.ByteArray.Owned(Array[Byte](1, 2, 3, 4))),
+      port = Some(7777),
+      meta = Some(Endpoint.Meta(nodeName = None))
+    )
+
+    val stream = resolver.streamReplicas(req)
+
+    val item0 = await(resolver.streamReplicas(req).recv())
+    assert(item0.value.result.get == Replicas.OneofResult.Bound(Replicas.Bound(Seq(endpoint0))))
+    item0.release()
+
+    vaddr() = Addr.Bound(Address("5.6.7.8", 7777))
+    val endpoint1 = Endpoint(
+      inetAf = Some(AddressFamily.INET4),
+      address = Some(Buf.ByteArray.Owned(Array[Byte](5, 6, 7, 8))),
+      port = Some(7777),
+      meta = Some(Endpoint.Meta(nodeName = None))
+    )
+    val item1 = await(resolver.streamReplicas(req).recv())
+    assert(item1.value.result.get == Replicas.OneofResult.Bound(Replicas.Bound(Seq(endpoint1))))
+    item1.release()
+  }
+
+  test("getReplicas strips transformer prefixes") {
+    val pfx = Path.read("/#/atl")
+    val states = Var[Activity.State[NameTree[Name.Bound]]](Activity.Pending)
+    val namers = Map(pfx -> new Namer { def lookup(path: Path) = Activity(states) })
+    val resolver = new ResolverService.ServerImpl(namers, NullStatsReceiver)
+
+    val vaddr = Var[Addr](Addr.Bound(Address("1.2.3.4", 7777)))
+    states() = Activity.Ok(NameTree.Leaf(Name.Bound(vaddr, Path.read("/%/optimus/#/atl/slime/season"))))
+
+    val path = Path.read("/%/optimus/#/atl/slime/season")
+    val req = ReplicasReq(Some(MPath(path.elems)))
+
+    val endpoint = Endpoint(
+      inetAf = Some(AddressFamily.INET4),
+      address = Some(Buf.ByteArray.Owned(Array[Byte](1, 2, 3, 4))),
+      port = Some(7777),
+      meta = Some(Endpoint.Meta(nodeName = None))
+    )
+    val rsp = await(resolver.getReplicas(req))
+    assert(rsp.result.get == Replicas.OneofResult.Bound(Replicas.Bound(Seq(endpoint))))
+  }
+
+  test("streamReplicas strips transformer prefixes") {
+    val pfx = Path.read("/#/atl")
+    val states = Var[Activity.State[NameTree[Name.Bound]]](Activity.Pending)
+    val namers = Map(pfx -> new Namer { def lookup(path: Path) = Activity(states) })
+    val resolver = new ResolverService.ServerImpl(namers, NullStatsReceiver)
+
+    val vaddr = Var[Addr](Addr.Bound(Address("1.2.3.4", 7777)))
+    states() = Activity.Ok(NameTree.Leaf(Name.Bound(vaddr, Path.read("/%/optimus/#/atl/slime/season"))))
+
+    val path = Path.read("/%/optimus/#/atl/slime/season")
+    val req = ReplicasReq(Some(MPath(path.elems)))
+
+    val endpoint0 = Endpoint(
+      inetAf = Some(AddressFamily.INET4),
+      address = Some(Buf.ByteArray.Owned(Array[Byte](1, 2, 3, 4))),
+      port = Some(7777),
+      meta = Some(Endpoint.Meta(nodeName = None))
+    )
+
+    val stream = resolver.streamReplicas(req)
+
+    val item0 = await(resolver.streamReplicas(req).recv())
+    assert(item0.value.result.get == Replicas.OneofResult.Bound(Replicas.Bound(Seq(endpoint0))))
+    item0.release()
+
+    vaddr() = Addr.Bound(Address("5.6.7.8", 7777))
+    val endpoint1 = Endpoint(
+      inetAf = Some(AddressFamily.INET4),
+      address = Some(Buf.ByteArray.Owned(Array[Byte](5, 6, 7, 8))),
+      port = Some(7777),
+      meta = Some(Endpoint.Meta(nodeName = None))
+    )
+    val item1 = await(resolver.streamReplicas(req).recv())
+    assert(item1.value.result.get == Replicas.OneofResult.Bound(Replicas.Bound(Seq(endpoint1))))
+    item1.release()
+  }
+}

--- a/namerd/storage/k8s/src/main/scala/io/buoyant/namerd/storage/K8sDtabStore.scala
+++ b/namerd/storage/k8s/src/main/scala/io/buoyant/namerd/storage/K8sDtabStore.scala
@@ -114,7 +114,7 @@ class K8sDtabStore(client: Http.Client, dst: String, namespace: String)
   /**
    * Update an existing dtab based on the current version or create a new
    * dtab if one doesn't already exist. Put returns a DtabVersionMismatchException if the dtab resource version being updated
-    * does not match the current version. If this is the case, a retry for a dtab update should be done.
+   * does not match the current version. If this is the case, a retry for a dtab update should be done.
    */
   def put(ns: String, dtab: FDtab): Future[Unit] = {
     val nsDTab = api.dtabs.named(ns)


### PR DESCRIPTION
Fixes #1660 

When Linkerd uses the namerd mesh interpreter and namerd has namers that use transformers, the bound names that namerd returns will include transformer prefixes e.g. `/%/io.l5d.k8s.daemonset/linkerd/http/l5d/#/ds/default/http/hello`.  When this bound id is passed to the resolve endpoint, the transformer prefix is still present and therefore the id will not match any namers and the call will return Addr.Neg.  This results in a NoHostsAvailable exception.

We have the resolve endpoint strip off any transformer prefix from the bound id before attempting to match it against the namers.  This is what the thrift namer interface already does.