### PR TITLE
Upgrade guava to 23.0

### DIFF
--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -59,7 +59,7 @@ object Deps {
   val junit = "junit" % "junit" % "4.10"
 
   // guava
-  val guava = "com.google.guava" % "guava" % "19.0"
+  val guava = "com.google.guava" % "guava" % "23.0"
 
   // jwt for Marathon API
   val jwt = "com.pauldijou" %% "jwt-core" % "0.12.1"


### PR DESCRIPTION
Finagle depends on guava 23.0.  Upgrading our dependency to 23.0 silences many version conflict warnings when compiling Linkerd.