### PR TITLE
Fix incorrect name for Consul namer in example

### DIFF
--- a/linkerd/examples/consul.yaml
+++ b/linkerd/examples/consul.yaml
@@ -7,7 +7,7 @@ namers:
 routers:
 - protocol: http
   dtab: |
-    /svc     => /#/consul/dc1/prod;
+    /svc     => /#/io.l5d.consul/dc1/prod;
   servers:
   - port: 4140
     ip: 0.0.0.0


### PR DESCRIPTION
The namer is `io.l5d.consul`, not `consul`. The config will not work as it exists currently.