### PR TITLE
Fix incorrect handling of Consul ServiceRelease exception

### DIFF
--- a/namer/consul/src/main/scala/io/buoyant/namer/consul/SvcAddr.scala
+++ b/namer/consul/src/main/scala/io/buoyant/namer/consul/SvcAddr.scala
@@ -18,7 +18,8 @@ private[consul] case class SvcKey(name: String, tag: Option[String]) {
 
 private[consul] object SvcAddr {
 
-  private[this] object ServiceRelease extends Exception with NoStackTrace
+  private[this] val ServiceRelease =
+    new Exception("service observation released") with NoStackTrace
 
   case class Stats(stats: StatsReceiver) {
     val opens = stats.counter("opens")
@@ -64,7 +65,7 @@ private[consul] object SvcAddr {
 
         if (stopped) Future.Unit
         else getAddresses(index0).transform {
-          case Throw(Failure(Some(ServiceRelease))) =>
+          case Throw(Failure(Some(cause))) if cause == ServiceRelease =>
             // this exception is raised when we close a watch - thus, it needs
             // to be special-cased so that we don't continue observing that
             // service.


### PR DESCRIPTION
In the Consul namer `SvcAddr` class, a singleton exception called `ServiceRelease` is raised when an `Activity` watching Consul is closed. Previously, this exception was a `val`. However, due to how equality is implemented for `Failure`s, the by the time exception raised reached the `match` in `loop()`, the `Failure` did not always equal the value of `ServiceRelease`, seemingly because of the `ProcessFailure` filter masking some of the flags on the `Failure`. This led to service releases being handled as errors, rather than gracefully cancelling the observation, leading to a _lot_ of unnecessary exceptions in the logs.

I've fixed this issue by setting the cause of the raised exception to a singleton object rather than a `val`, so that the match arm can test type rather than equality. The exception raised to cancel an observation should now always match the correct pattern.

I tried to write a unit test for this that makes assertions about the contents of the logs, but I couldn't make it fail against the current master. It appeared that the failure was being munged only when the namer was fully integrated with Linkerd. Instead, I tested this manually using Consul running locally and setting the number of bound names in the binding cache to 1. I would request one service in Consul, and then a second one – thus forcing the namer to evict the first bound name from the bindcache, stopping the observation.

Fixes #1670, for real this time.