### PR TITLE
Add a check to disallow invalid namespaces

### DIFF
--- a/namerd/core/src/main/scala/io/buoyant/namerd/DtabStore.scala
+++ b/namerd/core/src/main/scala/io/buoyant/namerd/DtabStore.scala
@@ -52,6 +52,9 @@ object DtabStore {
   class DtabNamespaceDoesNotExistException(ns: Ns)
     extends Exception(s"The dtab namespace $ns does not exist")
 
+  class DtabNamespaceInvalidException(ns: Ns)
+    extends Exception(s"The dtab namespace $ns contains invalid characters")
+
   object Forbidden extends Exception("You do not have sufficient permissions")
 
   class Proxy(underlying: DtabStore) extends DtabStore {

--- a/namerd/core/src/main/scala/io/buoyant/namerd/DtabStore.scala
+++ b/namerd/core/src/main/scala/io/buoyant/namerd/DtabStore.scala
@@ -53,7 +53,7 @@ object DtabStore {
     extends Exception(s"The dtab namespace $ns does not exist")
 
   class DtabNamespaceInvalidException(ns: Ns)
-    extends Exception(s"The dtab namespace $ns contains invalid characters")
+    extends Exception(s"invalid dtab namespace $ns: namespace must contain only letter, number or '-' characters")
 
   object Forbidden extends Exception("You do not have sufficient permissions")
 

--- a/namerd/storage/consul/src/main/scala/io/buoyant/namerd/storage/consul/ConsulDtabStore.scala
+++ b/namerd/storage/consul/src/main/scala/io/buoyant/namerd/storage/consul/ConsulDtabStore.scala
@@ -1,8 +1,6 @@
 package io.buoyant.namerd
 package storage.consul
 
-import java.util.regex.Pattern
-
 import com.google.common.cache.{CacheBuilder, CacheLoader}
 import com.twitter.finagle.{Dtab, Failure, Path}
 import com.twitter.io.Buf
@@ -21,7 +19,12 @@ class ConsulDtabStore(
 
   private[this] val log = Logger.get("consul")
 
-  def namespaceIsValid(ns: Ns): Boolean = Pattern.matches("[\\w+\\-?/?]+", ns)
+  val validNs = raw"^[A-Za-z0-9_-]+".r
+
+  def namespaceIsValid(ns: Ns): Boolean = ns match {
+    case validNs(_*) => true
+    case _ => false
+  }
 
   override val list: Activity[Set[Ns]] = {
     def namespace(key: String): Ns = key.stripPrefix("/").stripSuffix("/").substring(root.show.length)

--- a/namerd/storage/consul/src/test/scala/io/buoyant/namerd/storage/consul/ConsulDtabStoreTest.scala
+++ b/namerd/storage/consul/src/test/scala/io/buoyant/namerd/storage/consul/ConsulDtabStoreTest.scala
@@ -1,11 +1,12 @@
 package io.buoyant.namerd.storage.consul
 
 import com.twitter.finagle.http.{Request, Response, Status}
-import com.twitter.finagle.{Path, Service}
+import com.twitter.finagle.{Dtab, Path, Service}
 import com.twitter.io.Buf
 import com.twitter.util.{Activity, Future}
 import io.buoyant.consul.v1.KvApi
-import io.buoyant.namerd.Ns
+import io.buoyant.namerd.DtabStore.{DtabNamespaceAlreadyExistsException, DtabNamespaceInvalidException}
+import io.buoyant.namerd.{Ns, VersionedDtab}
 import io.buoyant.test.{Awaits, Exceptions, FunSuite}
 
 class ConsulDtabStoreTest extends FunSuite with Awaits with Exceptions {
@@ -42,7 +43,7 @@ class ConsulDtabStoreTest extends FunSuite with Awaits with Exceptions {
     assert(state == Activity.Ok(Set("foo/bar", "foo/baz")))
   }
 
-  test("Block when namespaces are not found") {
+  test("return an empty set when namespaces are absent") {
     val service = Service.mk[Request, Response] { req =>
       val rsp = Response(status = Status(404))
       req.getParam("index", "") match {
@@ -62,9 +63,172 @@ class ConsulDtabStoreTest extends FunSuite with Awaits with Exceptions {
     )
 
     @volatile var state: Activity.State[Set[Ns]] = Activity.Pending
-    store.list.states respond {
-      state = _
-    }
+    store.list.states respond { state = _ }
     assert(state == Activity.Ok(Set()))
   }
+
+  test("Throw DtabNamespaceInvalidException when creating dtab with bad namespace") {
+    val service = Service.mk[Request, Response] { req =>
+      val rsp = Response()
+      rsp.setContentTypeJson()
+      Future.never
+    }
+    val store = new ConsulDtabStore(
+      KvApi(service),
+      Path.read(namerdPrefix),
+      None,
+      readConsistency = None,
+      writeConsistency = None
+    )
+    assertThrows[DtabNamespaceInvalidException] {
+      await(store.create("%2e%2e", Dtab.empty))
+    }
+  }
+
+  test("Throw DtabNamespaceAlreadyExistsException when creating an already existing dtab") {
+    val service = Service.mk[Request, Response] { req =>
+      val rsp = Response()
+      rsp.setContentTypeJson()
+      rsp.content = Buf.Utf8("""false""")
+      rsp.headerMap.set("X-Consul-Index", "4")
+      if (req.path.contains("default")) {
+        Future.value(rsp)
+      } else {
+        Future.never
+      }
+    }
+    val store = new ConsulDtabStore(
+      KvApi(service),
+      Path.read(namerdPrefix),
+      None,
+      readConsistency = None,
+      writeConsistency = None
+    )
+    assertThrows[DtabNamespaceAlreadyExistsException] {
+      await(store.create("default", Dtab.empty))
+    }
+  }
+
+  test("Throw DtabNamespaceInvalidException when deleting dtab with bad namespace") {
+    val badNamespace = "b@dn@m35p@c3"
+    val service = Service.mk[Request, Response] { req =>
+      val rsp = Response()
+      rsp.setContentTypeJson()
+      rsp.content = Buf.Utf8("""true""")
+      rsp.headerMap.set("X-Consul-Index", "4")
+      if (req.path.contains(badNamespace)) {
+        Future.value(rsp)
+      } else {
+        Future.never
+      }
+    }
+    val store = new ConsulDtabStore(
+      KvApi(service),
+      Path.read(namerdPrefix),
+      None,
+      readConsistency = None,
+      writeConsistency = None
+    )
+    assertThrows[DtabNamespaceInvalidException] {
+      await(store.delete(badNamespace))
+    }
+  }
+
+  test("Throw DtabNamespaceInvalidException when updating dtab with bad namespace") {
+    val badNamespace = "b@dn@m35p@c3"
+    val service = Service.mk[Request, Response] { req =>
+      val rsp = Response()
+      rsp.setContentTypeJson()
+      rsp.content = Buf.Utf8("""true""")
+      rsp.headerMap.set("X-Consul-Index", "4")
+      if (req.path.contains(badNamespace)) {
+        Future.value(rsp)
+      } else {
+        Future.never
+      }
+    }
+    val store = new ConsulDtabStore(
+      KvApi(service),
+      Path.read(namerdPrefix),
+      None,
+      readConsistency = None,
+      writeConsistency = None
+    )
+    assertThrows[DtabNamespaceInvalidException] {
+      await(store.update(badNamespace, Dtab.empty, Buf.Empty))
+    }
+  }
+
+  test("Throw DtabNamespaceInvalidException when updating a dtab using put with bad namespace") {
+    val badNamespace = "b@dn@m35p@c3"
+    val service = Service.mk[Request, Response] { req =>
+      val rsp = Response()
+      rsp.setContentTypeJson()
+      rsp.content = Buf.Utf8("""true""")
+      rsp.headerMap.set("X-Consul-Index", "4")
+      if (req.path.contains(badNamespace)) {
+        Future.value(rsp)
+      } else {
+        Future.never
+      }
+    }
+    val store = new ConsulDtabStore(
+      KvApi(service),
+      Path.read(namerdPrefix),
+      None,
+      readConsistency = None,
+      writeConsistency = None
+    )
+    assertThrows[DtabNamespaceInvalidException] {
+      await(store.put(badNamespace, Dtab.empty))
+    }
+  }
+
+  test("return Activity Failed with DtabNamespaceInvalidException") {
+    val badNamespace = "%2e%2e"
+    val service = Service.mk[Request, Response] { req =>
+      val rsp = Response()
+      rsp.setContentTypeJson()
+      Future.never
+    }
+    val store = new ConsulDtabStore(
+      KvApi(service),
+      Path.read(namerdPrefix),
+      None,
+      readConsistency = None,
+      writeConsistency = None
+    )
+    @volatile var state: Activity.State[Option[VersionedDtab]] = Activity.Pending
+    store.observe(badNamespace).states respond { state = _ }
+    assert(state.isInstanceOf[Activity.Failed])
+  }
+
+  test("return Activity of Option[VersionedDtab] on observe") {
+    val namespace = "default"
+    val dtab = """/svc => /#/inet/host/port;"""
+    val version = "4"
+    val service = Service.mk[Request, Response] { req =>
+      val rsp = Response()
+      rsp.setContentTypeJson()
+      rsp.headerMap.set("X-Consul-Index", version)
+      rsp.content = Buf.Utf8(dtab)
+      if (req.path.contains(namespace) && req.getParam("index", "").isEmpty) {
+        Future.value(rsp)
+      } else {
+        Future.never
+      }
+
+    }
+    val store = new ConsulDtabStore(
+      KvApi(service),
+      Path.read(namerdPrefix),
+      None,
+      readConsistency = None,
+      writeConsistency = None
+    )
+    @volatile var state: Activity.State[Option[VersionedDtab]] = Activity.Pending
+    store.observe(namespace).states respond { state = _ }
+    assert(state == Activity.Ok(Some(VersionedDtab(Dtab.read(dtab), Buf.Utf8(version)))))
+  }
+
 }

--- a/namerd/storage/consul/src/test/scala/io/buoyant/namerd/storage/consul/ConsulDtabStoreTest.scala
+++ b/namerd/storage/consul/src/test/scala/io/buoyant/namerd/storage/consul/ConsulDtabStoreTest.scala
@@ -1,0 +1,70 @@
+package io.buoyant.namerd.storage.consul
+
+import com.twitter.finagle.http.{Request, Response, Status}
+import com.twitter.finagle.{Path, Service}
+import com.twitter.io.Buf
+import com.twitter.util.{Activity, Future}
+import io.buoyant.consul.v1.KvApi
+import io.buoyant.namerd.Ns
+import io.buoyant.test.{Awaits, Exceptions, FunSuite}
+
+class ConsulDtabStoreTest extends FunSuite with Awaits with Exceptions {
+
+  val namespacesJson = """["namerd/dtabs/foo/bar/", "namerd/dtabs/foo/baz/"]"""
+  val namerdPrefix = "/namerd/dtabs"
+
+  test("List available namespaces") {
+    val service = Service.mk[Request, Response] { req =>
+      val rsp = Response()
+      rsp.setContentTypeJson()
+      req.getParam("index", "") match {
+        case "" =>
+          rsp.headerMap.set("X-Consul-Index", "4")
+          rsp.content = Buf.Utf8(namespacesJson)
+          Future.value(rsp)
+        case _ => Future.never
+
+      }
+    }
+
+    val store = new ConsulDtabStore(
+      KvApi(service),
+      Path.read(namerdPrefix),
+      None,
+      readConsistency = None,
+      writeConsistency = None
+    )
+
+    @volatile var state: Activity.State[Set[Ns]] = Activity.Pending
+    store.list.states respond {
+      state = _
+    }
+    assert(state == Activity.Ok(Set("foo/bar", "foo/baz")))
+  }
+
+  test("Block when namespaces are not found") {
+    val service = Service.mk[Request, Response] { req =>
+      val rsp = Response(status = Status(404))
+      req.getParam("index", "") match {
+        case "" =>
+          rsp.headerMap.set("X-Consul-Index", "4")
+          Future.value(rsp)
+        case _ => Future.never
+      }
+    }
+
+    val store = new ConsulDtabStore(
+      KvApi(service),
+      Path.read(namerdPrefix),
+      None,
+      readConsistency = None,
+      writeConsistency = None
+    )
+
+    @volatile var state: Activity.State[Set[Ns]] = Activity.Pending
+    store.list.states respond {
+      state = _
+    }
+    assert(state == Activity.Ok(Set()))
+  }
+}


### PR DESCRIPTION
Problem
When namerd uses consul for dtab storage, invalid characters in a namespace e.g. `%2e%2e/foo` causes namerd to infinitely log a `dtab observation error`

Solution
Add a check to ensure that only alphanumeric characters can be used as keys in consul to store dtabs. 

Validation
Created a varying number of valid and invalid strings with a regex pattern and curled namerd with both types of strings. The tests worked successfully. However, curling a large number of requests to namerd caused consul to remove namerd as a service and subsequently caused `ChannelClosedExceptions`. I believe that is probably caused by DoSing consul with a bash script and not because of the proposed change.

Fixes #1733