### PR TITLE
Added a namer for Rancher

### DIFF
--- a/linkerd/docs/namer.md
+++ b/linkerd/docs/namer.md
@@ -15,7 +15,7 @@ These parameters are available to the namer regardless of kind. Namers may also 
 
 Key | Default Value | Description
 --- | ------------- | -----------
-kind | _required_ | Either [`io.l5d.fs`](#file-based-service-discovery), [`io.l5d.serversets`](#zookeeper-serversets-service-discovery), [`io.l5d.consul`](#consul-service-discovery), [`io.l5d.k8s`](#kubernetes-service-discovery), [`io.l5d.marathon`](#marathon-service-discovery), [`io.l5d.zkLeader`](#zookeeper-leader), [`io.l5d.curator`](#curator), or [`io.l5d.rewrite`](#rewrite).
+kind | _required_ | Either [`io.l5d.fs`](#file-based-service-discovery), [`io.l5d.serversets`](#zookeeper-serversets-service-discovery), [`io.l5d.consul`](#consul-service-discovery), [`io.l5d.k8s`](#kubernetes-service-discovery), [`io.l5d.marathon`](#marathon-service-discovery), [`io.l5d.zkLeader`](#zookeeper-leader), [`io.l5d.curator`](#curator), [`io.l5d.rancher`](#rancher), or [`io.l5d.rewrite`](#rewrite).
 prefix | namer dependent | Resolves names with `/#/<prefix>`.
 experimental | `false` | Set this to `true` to enable the namer if it is experimental.
 transformers | No transformers | A list of [transformers](#transformer) to apply to the resolved addresses.
@@ -692,6 +692,54 @@ Key | Required | Description
 --- | -------- | -----------
 prefix | yes | Tells linkerd to resolve the request path using the curator namer.
 serviceName | yes | The name of the Curator service to lookup in ZooKeeper.
+
+<a name="rancher"></a>
+## Rancher
+
+kind: `io.l5d.rancher`
+
+### Rancher configuration
+
+> Configure a Rancher namer:
+
+```yaml
+namers:
+- kind: io.l5d.rancher
+  experimental: true
+  portMappings:
+    proxy: 8080
+```
+
+> Then reference the namer in the dtab to use it:
+
+```yaml
+dtab: |
+  /rancher => /#/io.l5d.rancher
+  /svc => /$/io.buoyant.http.domainToPathPfx/rancher/http;
+```
+
+linkerd provides support for service discovery via Rancher's [Metadata-API](https://rancher.com/docs/rancher/v1.6/en/rancher-services/metadata-service/).
+
+Key | Default Value | Description
+--- | ------------- | -----------
+prefix | `io.l5d.rancher` | Resolves names with `/#/<prefix>`.
+experimental | `false` | Since the Rancher namer is still considered experimental, this must be set to `true`.
+portMappings | `<empty map>` | If specified, you can use the names of these port-mappings for the `<port>` path parameter. By default, the namer knows `http` and `https`.
+
+### Rancher Path Parameters
+
+> Dtab Path Format
+
+```yaml
+/#/<prefix>/<port>/<stack>/<service>
+```
+
+Key | Required | Description
+--- | -------- | -----------
+prefix | yes | Tells linkerd to resolve the request path using the Rancher namer.
+port | yes | The port name or number to route the request to
+stack | yes | Name of the stack of the service
+service | yes | The name of the service
 
 <a name="rewrite"></a>
 ## Rewrite

--- a/linkerd/docs/namer.md
+++ b/linkerd/docs/namer.md
@@ -714,8 +714,9 @@ namers:
 
 ```yaml
 dtab: |
-  /rancher => /#/io.l5d.rancher
-  /svc => /$/io.buoyant.http.domainToPathPfx/rancher/http;
+  /rancher => /#/io.l5d.rancher;
+  /s => /rancher/http;
+  /svc => /$/io.buoyant.http.domainToPathPfx/s;
 ```
 
 linkerd provides support for service discovery via Rancher's [Metadata-API](https://rancher.com/docs/rancher/v1.6/en/rancher-services/metadata-service/).
@@ -725,6 +726,7 @@ Key | Default Value | Description
 prefix | `io.l5d.rancher` | Resolves names with `/#/<prefix>`.
 experimental | `false` | Since the Rancher namer is still considered experimental, this must be set to `true`.
 portMappings | `<empty map>` | If specified, you can use the names of these port-mappings for the `<port>` path parameter. By default, the namer knows `http` and `https`.
+maxWait | 30 | The max number of seconds to wait for changes in the Rancher Metadata-API before starting a new request.
 
 ### Rancher Path Parameters
 

--- a/namer/rancher/src/main/resources/META-INF/services/io.buoyant.namer.NamerInitializer
+++ b/namer/rancher/src/main/resources/META-INF/services/io.buoyant.namer.NamerInitializer
@@ -1,0 +1,1 @@
+io.buoyant.namer.rancher.RancherInitializer

--- a/namer/rancher/src/main/scala/io/buoyant/namer/rancher/RancherClient.scala
+++ b/namer/rancher/src/main/scala/io/buoyant/namer/rancher/RancherClient.scala
@@ -1,45 +1,47 @@
 package io.buoyant.namer.rancher
 
-import com.fasterxml.jackson.databind.{ObjectMapper, PropertyNamingStrategy}
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.{DeserializationContext, ObjectMapper, PropertyNamingStrategy}
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer
+import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-
 import com.twitter.finagle.{Service, Http, Address, Stack}
 import com.twitter.finagle.http
 import com.twitter.finagle.service.Retries
-import com.twitter.finagle.tracing.NullTracer
 import com.twitter.finagle.stats.{Stat, StatsReceiver}
-
+import com.twitter.finagle.tracing.NullTracer
 import com.twitter.logging.Logger
 import com.twitter.util.Activity.State
 import com.twitter.util.{Timer, Var, Activity, Duration, Future, Closable, Return, Throw}
-
 import java.util.concurrent.atomic.AtomicBoolean
+import scala.reflect.{ClassTag, classTag}
 
 case class PortMapping(
-  val ip: String,
-  val publicPort: Int,
-  val privatePort: Int,
-  val protocol: String
+  ip: String,
+  publicPort: Int,
+  privatePort: Int,
+  protocol: String
 ) {
-  // This is a bit of a hack - and should have more error-checking. But it
-  // makes the JSON parsing work.
-  // If anyone knows how to do a better constructor - or JSON Deserializer,
-  // that would be nice
-  def this(mapping: String) = this(
-    mapping.split(":")(0),
-    mapping.split(":")(1).toInt,
-    mapping.split(":")(2).split("/")(0).toInt,
-    mapping.split(":")(2).split("/")(1)
-  )
   override def toString(): String = s"$ip:$privatePort:$publicPort/$protocol"
+}
+class PortMappingDeserializer extends StdDeserializer[PortMapping](RancherParser.jClass[PortMapping]) {
+  private[this] val Mapping = raw"([\.0-9]+):([0-9]+):([0-9]+)/(tcp|udp)".r
+  override def deserialize(jp: JsonParser, ctx: DeserializationContext): PortMapping = {
+    val mapping = _parseString(jp, ctx)
+    mapping match {
+      case Mapping(ip, privatePort, publicPort, protocol) =>
+        PortMapping(ip, privatePort.toInt, publicPort.toInt, protocol)
+      case _ =>
+        throw ctx.mappingException(s"Failed to understand ip-binding: $mapping")
+    }
+  }
 }
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 case class RancherContainer(
   createIndex: Int,
-  dns: List[String],
   ips: List[String],
   primaryIp: String,
   labels: Map[String, String],
@@ -55,18 +57,29 @@ case class RancherContainer(
   }
 }
 
+object RancherParser {
+  private[rancher] def jClass[T: ClassTag] = classTag[T].runtimeClass.asInstanceOf[Class[T]]
+
+  private[this] val customTypes = new SimpleModule("RancherClient custom types")
+  customTypes.addDeserializer(
+    RancherParser.jClass[PortMapping],
+    new PortMappingDeserializer()
+  )
+  private[this] val objectMapper = new ObjectMapper() with ScalaObjectMapper
+  objectMapper.registerModule(DefaultScalaModule)
+  objectMapper.registerModule(customTypes)
+  objectMapper.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE)
+
+  def apply() = objectMapper
+}
+
 class RancherClient(
+  maxWait: Int,
   log: Logger,
   params: Stack.Params,
   stats: StatsReceiver
 )(implicit val timer: Timer) {
-  private[this] val objectMapper = new ObjectMapper() with ScalaObjectMapper
-  objectMapper.registerModule(DefaultScalaModule)
-  objectMapper.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE)
-
   private[this] val numVersions = stats.counter("metadata_versions")
-
-  private[this] val maxWait = 30
 
   private[this] val service = Http.client
     .withStack(Http.client.stack.remove(Retries.Role))
@@ -78,8 +91,7 @@ class RancherClient(
   private[this] val version: Activity[String] =
     Activity(Var.async[State[String]](Activity.Pending) { state =>
       val done = new AtomicBoolean(false)
-      val initialized = new AtomicBoolean(false)
-      var v = "initial"
+      @volatile var v: Option[String] = None
 
       Future.whileDo(!done.get) {
         log.trace("starting version request")
@@ -89,29 +101,26 @@ class RancherClient(
 
         service(request)
           .map { _.getContentString().trim }
-          .liftToTry
-          .flatMap {
-            case Return(newVersion) => {
-              if (newVersion != v) {
-                log.info("fetched new metadata-version: %s", newVersion)
-                v = newVersion
-                initialized.set(true)
-                numVersions.incr()
-                state.update(Activity.Ok(newVersion))
-              } else {
-                log.trace("metadata-version didn't change. Old: %s, received: %s", v, newVersion)
-              }
+          .transform {
+            case Return(newVersion) if !v.contains(newVersion) =>
+              log.info("fetched new metadata-version: %s", newVersion)
+              v = Some(newVersion)
+              numVersions.incr()
+              state.update(Activity.Ok(newVersion))
               Future.Unit
-            }
-            case Throw(e) => {
+            case Return(newVersion) if v.contains(newVersion) =>
+              log.trace("metadata-version didn't change. Old: %s, received: %s", v, newVersion)
+              Future.Unit
+            case Throw(e) =>
               // TODO: This should probably be handled by a exponentail back-off
               // in the Finagle client - but I'm not sure how to achieve that
               log.error("failed to fetch metadata-version. %s", e)
-              if (!initialized.get) {
+              if (!v.isEmpty) {
+                // We have previously managed to get a version, but now we can't
+                // so we set mark the activity as failed
                 state.update(Activity.Failed(e))
               }
               Future.sleep(Duration.fromFractionalSeconds(5.0))
-            }
           }
       }
 
@@ -129,7 +138,7 @@ class RancherClient(
 
       service(request)
         .map { _.getContentString() }
-        .map { objectMapper.readValue[List[RancherContainer]] }
+        .map { RancherParser().readValue[List[RancherContainer]] }
         .onSuccess { containers =>
           log.debug("received %s new containers", containers.size)
         }: Future[List[RancherContainer]]

--- a/namer/rancher/src/main/scala/io/buoyant/namer/rancher/RancherClient.scala
+++ b/namer/rancher/src/main/scala/io/buoyant/namer/rancher/RancherClient.scala
@@ -13,8 +13,8 @@ import com.twitter.finagle.service.Retries
 import com.twitter.finagle.stats.{Stat, StatsReceiver}
 import com.twitter.finagle.tracing.NullTracer
 import com.twitter.logging.Logger
+import com.twitter.util._
 import com.twitter.util.Activity.State
-import com.twitter.util.{Timer, Var, Activity, Duration, Future, Closable, Return, Throw}
 import java.util.concurrent.atomic.AtomicBoolean
 import scala.reflect.{ClassTag, classTag}
 

--- a/namer/rancher/src/main/scala/io/buoyant/namer/rancher/RancherClient.scala
+++ b/namer/rancher/src/main/scala/io/buoyant/namer/rancher/RancherClient.scala
@@ -1,0 +1,140 @@
+package io.buoyant.namer.rancher
+
+import com.fasterxml.jackson.databind.{ObjectMapper, PropertyNamingStrategy}
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
+import com.twitter.finagle.{Service, Http, Address, Stack}
+import com.twitter.finagle.http
+import com.twitter.finagle.service.Retries
+import com.twitter.finagle.tracing.NullTracer
+import com.twitter.finagle.stats.{Stat, StatsReceiver}
+
+import com.twitter.logging.Logger
+import com.twitter.util.Activity.State
+import com.twitter.util.{Timer, Var, Activity, Duration, Future, Closable, Return, Throw}
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+case class PortMapping(
+  val ip: String,
+  val publicPort: Int,
+  val privatePort: Int,
+  val protocol: String
+) {
+  // This is a bit of a hack - and should have more error-checking. But it
+  // makes the JSON parsing work.
+  // If anyone knows how to do a better constructor - or JSON Deserializer,
+  // that would be nice
+  def this(mapping: String) = this(
+    mapping.split(":")(0),
+    mapping.split(":")(1).toInt,
+    mapping.split(":")(2).split("/")(0).toInt,
+    mapping.split(":")(2).split("/")(1)
+  )
+  override def toString(): String = s"$ip:$privatePort:$publicPort/$protocol"
+}
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+case class RancherContainer(
+  createIndex: Int,
+  dns: List[String],
+  ips: List[String],
+  primaryIp: String,
+  labels: Map[String, String],
+  name: String,
+  ports: List[PortMapping],
+  serviceName: String,
+  stackName: String,
+  state: String
+) {
+  def toAddr(port: Int): Option[Address] = state match {
+    case "running" => Some(Address(primaryIp, port))
+    case _ => None
+  }
+}
+
+class RancherClient(
+  log: Logger,
+  params: Stack.Params,
+  stats: StatsReceiver
+)(implicit val timer: Timer) {
+  private[this] val objectMapper = new ObjectMapper() with ScalaObjectMapper
+  objectMapper.registerModule(DefaultScalaModule)
+  objectMapper.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE)
+
+  private[this] val numVersions = stats.counter("metadata_versions")
+
+  private[this] val maxWait = 30
+
+  private[this] val service = Http.client
+    .withStack(Http.client.stack.remove(Retries.Role))
+    .withParams(Http.client.params ++ params)
+    .withLabel("io.buoyant.namer.rancher.client")
+    .withTracer(NullTracer)
+    .newService(s"/$$/inet/rancher-metadata/80")
+
+  private[this] val version: Activity[String] =
+    Activity(Var.async[State[String]](Activity.Pending) { state =>
+      val done = new AtomicBoolean(false)
+      val initialized = new AtomicBoolean(false)
+      var v = "initial"
+
+      Future.whileDo(!done.get) {
+        log.trace("starting version request")
+
+        val request = http.Request(http.Method.Get, s"/2015-12-19/version?wait=true&maxWait=${maxWait}&value=${v}")
+        request.host = "rancher-metadata"
+
+        service(request)
+          .map { _.getContentString().trim }
+          .liftToTry
+          .flatMap {
+            case Return(newVersion) => {
+              if (newVersion != v) {
+                log.info("fetched new metadata-version: %s", newVersion)
+                v = newVersion
+                initialized.set(true)
+                numVersions.incr()
+                state.update(Activity.Ok(newVersion))
+              } else {
+                log.trace("metadata-version didn't change. Old: %s, received: %s", v, newVersion)
+              }
+              Future.Unit
+            }
+            case Throw(e) => {
+              // TODO: This should probably be handled by a exponentail back-off
+              // in the Finagle client - but I'm not sure how to achieve that
+              log.error("failed to fetch metadata-version. %s", e)
+              if (!initialized.get) {
+                state.update(Activity.Failed(e))
+              }
+              Future.sleep(Duration.fromFractionalSeconds(5.0))
+            }
+          }
+      }
+
+      Closable.make { _ =>
+        done.set(true)
+        Future.Unit
+      }
+    })
+
+  private[this] val containers: Activity[List[RancherContainer]] = version.flatMap { version =>
+    Activity.future {
+      val request = http.Request(http.Method.Get, "/2015-12-19/containers")
+      request.host = "rancher-metadata"
+      request.accept = "application/json"
+
+      service(request)
+        .map { _.getContentString() }
+        .map { objectMapper.readValue[List[RancherContainer]] }
+        .onSuccess { containers =>
+          log.debug("received %s new containers", containers.size)
+        }: Future[List[RancherContainer]]
+    }
+  }
+
+  def activity: Activity[List[RancherContainer]] = containers.stabilize
+}

--- a/namer/rancher/src/main/scala/io/buoyant/namer/rancher/RancherClient.scala
+++ b/namer/rancher/src/main/scala/io/buoyant/namer/rancher/RancherClient.scala
@@ -141,7 +141,7 @@ class RancherClient(
         .map { RancherParser().readValue[List[RancherContainer]] }
         .onSuccess { containers =>
           log.debug("received %s new containers", containers.size)
-        }: Future[List[RancherContainer]]
+        }
     }
   }
 

--- a/namer/rancher/src/main/scala/io/buoyant/namer/rancher/RancherClient.scala
+++ b/namer/rancher/src/main/scala/io/buoyant/namer/rancher/RancherClient.scala
@@ -96,7 +96,7 @@ class RancherClient(
       Future.whileDo(!done.get) {
         log.trace("starting version request")
 
-        val request = http.Request(http.Method.Get, s"/2015-12-19/version?wait=true&maxWait=${maxWait}&value=${v}")
+        val request = http.Request(http.Method.Get, s"/2015-12-19/version?wait=true&maxWait=${maxWait}&value=${v.getOrElse("initial")}")
         request.host = "rancher-metadata"
 
         service(request)
@@ -109,7 +109,7 @@ class RancherClient(
               state.update(Activity.Ok(newVersion))
               Future.Unit
             case Return(newVersion) if v.contains(newVersion) =>
-              log.trace("metadata-version didn't change. Old: %s, received: %s", v, newVersion)
+              log.trace("metadata-version didn't change. Old: %s, received: %s", v.get, newVersion)
               Future.Unit
             case Throw(e) =>
               // TODO: This should probably be handled by a exponentail back-off

--- a/namer/rancher/src/main/scala/io/buoyant/namer/rancher/RancherInitializer.scala
+++ b/namer/rancher/src/main/scala/io/buoyant/namer/rancher/RancherInitializer.scala
@@ -1,10 +1,10 @@
 package io.buoyant.namer.rancher
 
 import com.fasterxml.jackson.annotation.JsonIgnore
-import com.twitter.finagle.{Path, Stack, param}
-import io.buoyant.namer.{NamerConfig, NamerInitializer}
-import com.twitter.util.Timer
 import com.twitter.conversions.time._
+import com.twitter.finagle.{Path, Stack, param}
+import com.twitter.util.Timer
+import io.buoyant.namer.{NamerConfig, NamerInitializer}
 
 class RancherInitializer extends NamerInitializer {
   val configClass = classOf[RancherConfig]

--- a/namer/rancher/src/main/scala/io/buoyant/namer/rancher/RancherInitializer.scala
+++ b/namer/rancher/src/main/scala/io/buoyant/namer/rancher/RancherInitializer.scala
@@ -14,7 +14,8 @@ class RancherInitializer extends NamerInitializer {
 object RancherInitializer extends RancherInitializer
 
 case class RancherConfig(
-  portMappings: Option[Map[String, Int]]
+  portMappings: Option[Map[String, Int]],
+  maxWait: Option[Int]
 ) extends NamerConfig {
   @JsonIgnore
   override def defaultPrefix: Path = Path.read("/io.l5d.rancher")
@@ -29,6 +30,6 @@ case class RancherConfig(
   override def newNamer(params: Stack.Params): RancherNamer = {
     val timer: Timer = params[param.Timer].timer
     val stats = params[param.Stats].statsReceiver.scope(prefix.show.stripPrefix("/"))
-    new RancherNamer(prefix, portMappings, params, stats)(timer)
+    new RancherNamer(prefix, portMappings, maxWait.getOrElse(30), params, stats)(timer)
   }
 }

--- a/namer/rancher/src/main/scala/io/buoyant/namer/rancher/RancherInitializer.scala
+++ b/namer/rancher/src/main/scala/io/buoyant/namer/rancher/RancherInitializer.scala
@@ -1,0 +1,34 @@
+package io.buoyant.namer.rancher
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.twitter.finagle.{Path, Stack, param}
+import io.buoyant.namer.{NamerConfig, NamerInitializer}
+import com.twitter.util.Timer
+import com.twitter.conversions.time._
+
+class RancherInitializer extends NamerInitializer {
+  val configClass = classOf[RancherConfig]
+  override def configId = "io.l5d.rancher"
+}
+
+object RancherInitializer extends RancherInitializer
+
+case class RancherConfig(
+  portMappings: Option[Map[String, Int]]
+) extends NamerConfig {
+  @JsonIgnore
+  override def defaultPrefix: Path = Path.read("/io.l5d.rancher")
+
+  @JsonIgnore
+  override def experimentalRequired = true
+
+  /**
+   * Construct a namer.
+   */
+  @JsonIgnore
+  override def newNamer(params: Stack.Params): RancherNamer = {
+    val timer: Timer = params[param.Timer].timer
+    val stats = params[param.Stats].statsReceiver.scope(prefix.show.stripPrefix("/"))
+    new RancherNamer(prefix, portMappings, params, stats)(timer)
+  }
+}

--- a/namer/rancher/src/main/scala/io/buoyant/namer/rancher/RancherNamer.scala
+++ b/namer/rancher/src/main/scala/io/buoyant/namer/rancher/RancherNamer.scala
@@ -1,11 +1,11 @@
 package io.buoyant.namer.rancher
 
-import com.twitter.finagle.buoyant.ExistentialStability._
 import com.twitter.finagle._
+import com.twitter.finagle.buoyant.ExistentialStability._
 import com.twitter.finagle.stats.StatsReceiver
 import com.twitter.logging.Logger
-import com.twitter.util.Activity.State
 import com.twitter.util._
+import com.twitter.util.Activity.State
 
 class RancherNamer(
   prefix: Path,

--- a/namer/rancher/src/main/scala/io/buoyant/namer/rancher/RancherNamer.scala
+++ b/namer/rancher/src/main/scala/io/buoyant/namer/rancher/RancherNamer.scala
@@ -1,0 +1,56 @@
+package io.buoyant.namer.rancher
+
+import com.twitter.finagle.buoyant.ExistentialStability._
+import com.twitter.finagle._
+import com.twitter.finagle.stats.StatsReceiver
+import com.twitter.logging.Logger
+import com.twitter.util.Activity.State
+import com.twitter.util._
+
+class RancherNamer(
+  prefix: Path,
+  portMappings: Option[Map[String, Int]],
+  params: Stack.Params,
+  stats: StatsReceiver
+)(implicit val timer: Timer) extends Namer {
+  private[this] val log = Logger.get("io.buoyant.namer.rancher")
+
+  private[this] val ports = Map(
+    "http" -> 80,
+    "https" -> 443
+  ) ++ portMappings.getOrElse(Map())
+
+  private[this] val client = new RancherClient(log, params, stats)
+
+  private[this] def lookupPort(port: String): Option[Int] =
+    (Try(port.toInt).toOption, ports.get(port)) match {
+      case (Some(portNum), _) => Some(portNum)
+      case (_, Some(portNum)) => Some(portNum)
+      case _ => None
+    }
+
+  def lookup(path: Path): Activity[NameTree[Name]] = path.take(3) match {
+    case phd@Path.Utf8(port, stack, service) => lookupPort(port) match {
+      case Some(portNum) =>
+        val containers: Activity[Option[Addr]] = client.activity.map { allContainers =>
+          val eligable: Set[Address] = allContainers
+            .filter(c => stack.equalsIgnoreCase(c.stackName) && service.equalsIgnoreCase(c.serviceName))
+            .collect(scala.Function.unlift(_.toAddr(portNum)))
+            .toSet
+
+          Option(eligable).filter(_.nonEmpty).map(Addr.Bound(_))
+        }
+        val stabilized: Activity[Option[Var[Addr]]] = containers.stabilizeExistence
+        stabilized.map {
+          case Some(addr) =>
+            NameTree.Leaf(Name.Bound(addr, prefix ++ phd, path.drop(3)))
+          case None =>
+            NameTree.Neg
+        }
+      case _ =>
+        log.warning("unable to understand port: %s", port)
+        Activity.value(NameTree.Neg)
+    }
+    case _ => Activity.value(NameTree.Neg)
+  }
+}

--- a/namer/rancher/src/test/scala/io/buoyant/namer/rancher/RancherTest.scala
+++ b/namer/rancher/src/test/scala/io/buoyant/namer/rancher/RancherTest.scala
@@ -1,0 +1,36 @@
+package io.buoyant.namer.rancher
+
+import com.twitter.finagle._
+import com.twitter.finagle.util.LoadService
+import io.buoyant.config.Parser
+import io.buoyant.namer.{NamerConfig, NamerInitializer}
+import io.buoyant.test.FunSuite
+import org.scalatest.Matchers
+
+class RancherTest extends FunSuite with Matchers {
+
+  test("sanity") {
+    // ensure it doesn't totally blowup
+    val _ = RancherConfig(
+      portMappings = None
+    ).newNamer(Stack.Params.empty)
+  }
+
+  test("service registration") {
+    assert(LoadService[NamerInitializer]().exists(_.isInstanceOf[RancherInitializer]))
+  }
+
+  test("parse config") {
+    val yaml = s"""
+                  |kind: io.l5d.rancher
+                  |experimental: true
+                  |portMappings:
+                  |  proxy: 8080
+      """.stripMargin
+
+    val mapper = Parser.objectMapper(yaml, Iterable(Seq(RancherInitializer)))
+    val config = mapper.readValue[NamerConfig](yaml).asInstanceOf[RancherConfig]
+    assert(config.portMappings === Some(Map("proxy" -> 8080)))
+    assert(config.disabled === false)
+  }
+}

--- a/namer/rancher/src/test/scala/io/buoyant/namer/rancher/RancherTest.scala
+++ b/namer/rancher/src/test/scala/io/buoyant/namer/rancher/RancherTest.scala
@@ -12,7 +12,8 @@ class RancherTest extends FunSuite with Matchers {
   test("sanity") {
     // ensure it doesn't totally blowup
     val _ = RancherConfig(
-      portMappings = None
+      portMappings = None,
+      Some(30)
     ).newNamer(Stack.Params.empty)
   }
 
@@ -32,5 +33,77 @@ class RancherTest extends FunSuite with Matchers {
     val config = mapper.readValue[NamerConfig](yaml).asInstanceOf[RancherConfig]
     assert(config.portMappings === Some(Map("proxy" -> 8080)))
     assert(config.disabled === false)
+  }
+
+  test("parse api response") {
+    val json = s"""
+      {
+          "create_index": 1,
+          "dns": [
+              "169.254.169.250"
+          ],
+          "dns_search": [
+              "sample-stack.rancher.internal",
+              "sample-service1.sample-stack.rancher.internal",
+              "rancher.internal"
+          ],
+          "environment_uuid": "6953974d-9b75-4534-ae87-58167ee1ffb3",
+          "external_id": "4be2afd08ff32b77c060b5588ea91d37782d0d14e4cb45775a0abc2ca1a9486a",
+          "health_check_hosts": [],
+          "health_state": null,
+          "host_uuid": "a19e45b8-afa3-44e6-8d16-896cb71f9b5d",
+          "hostname": null,
+          "ips": [
+              "10.1.1.42"
+          ],
+          "labels": {
+              "io.rancher.project.name": "sample-stack",
+              "io.rancher.project_service.name": "sample-stack/sample-service1",
+              "io.rancher.stack.name": "sample-stack",
+              "io.rancher.stack_service.name": "sample-stack/sample-service1"
+          },
+          "links": {},
+          "memory_reservation": null,
+          "metadata_kind": "container",
+          "milli_cpu_reservation": null,
+          "name": "sample-stack-sample-service1-1",
+          "network_from_container_uuid": null,
+          "network_uuid": "03e258d3-d481-47ed-9b90-ef97f41d04d8",
+          "ports": [
+              "0.0.0.0:80:80/tcp"
+          ],
+          "primary_ip": "10.1.1.42",
+          "primary_mac_address": "02:ee:64:23:90:90",
+          "service_index": "1",
+          "service_name": "sample-service1",
+          "service_uuid": "18c60d0d-e60a-4ed1-a9fb-84f50a9c3b6f",
+          "stack_name": "sample-stack",
+          "stack_uuid": "5e45da87-3149-448c-8f64-44368e06101e",
+          "start_count": 1,
+          "state": "running",
+          "system": false,
+          "uuid": "0717ff00-af61-4786-8262-74daf1344f89"
+      }
+    """.stripMargin
+
+    val response = RancherParser().readValue[RancherContainer](json)
+    assert(response.createIndex === 1)
+    assert(response.ips === List(
+      "10.1.1.42"
+    ))
+    assert(response.primaryIp === "10.1.1.42")
+    assert(response.labels === Map(
+      "io.rancher.project.name" -> "sample-stack",
+      "io.rancher.project_service.name" -> "sample-stack/sample-service1",
+      "io.rancher.stack.name" -> "sample-stack",
+      "io.rancher.stack_service.name" -> "sample-stack/sample-service1"
+    ))
+    assert(response.name === "sample-stack-sample-service1-1")
+    assert(response.ports === List(
+      PortMapping("0.0.0.0", 80, 80, "tcp")
+    ))
+    assert(response.stackName === "sample-stack")
+    assert(response.serviceName === "sample-service1")
+    assert(response.state === "running")
   }
 }

--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -163,7 +163,12 @@ object LinkerdBuild extends Base {
       .withLib(Deps.zkCandidate)
       .withTests()
 
-    val all = aggregateDir("namer", core, consul, curator, dnssrv, fs, k8s, istio, marathon, serversets, zkLeader)
+    val rancher = projectDir("namer/rancher")
+      .dependsOn(core)
+      .withTwitterLib(Deps.finagle("http"))
+      .withTests()
+
+    val all = aggregateDir("namer", core, consul, curator, dnssrv, fs, k8s, istio, marathon, serversets, zkLeader, rancher)
 
   }
 
@@ -346,7 +351,7 @@ object LinkerdBuild extends Base {
     val BundleProjects = Seq[ProjectReference](
       core, main, Namer.fs, Storage.inMemory, Router.http,
       Iface.controlHttp, Iface.interpreterThrift, Iface.mesh,
-      Namer.consul, Namer.k8s, Namer.marathon, Namer.serversets, Namer.zkLeader, Namer.dnssrv,
+      Namer.consul, Namer.k8s, Namer.marathon, Namer.serversets, Namer.zkLeader, Namer.dnssrv, Namer.rancher,
       Iface.mesh,
       Interpreter.perHost, Interpreter.k8s,
       Storage.etcd, Storage.inMemory, Storage.k8s, Storage.zk, Storage.consul,
@@ -594,7 +599,7 @@ object LinkerdBuild extends Base {
 
     val BundleProjects = Seq[ProjectReference](
       admin, core, main, configCore,
-      Namer.consul, Namer.fs, Namer.k8s, Namer.istio, Namer.marathon, Namer.serversets, Namer.zkLeader, Namer.curator, Namer.dnssrv,
+      Namer.consul, Namer.fs, Namer.k8s, Namer.istio, Namer.marathon, Namer.serversets, Namer.zkLeader, Namer.curator, Namer.dnssrv, Namer.rancher,
       Interpreter.fs, Interpreter.k8s, Interpreter.istio, Interpreter.mesh, Interpreter.namerd, Interpreter.perHost, Interpreter.subnet,
       Protocol.h2, Protocol.http, Protocol.mux, Protocol.thrift, Protocol.thriftMux,
       Announcer.serversets,
@@ -693,6 +698,7 @@ object LinkerdBuild extends Base {
   val namerMarathon = Namer.marathon
   val namerServersets = Namer.serversets
   val namerZkLeader = Namer.zkLeader
+  val namerRancher = Namer.rancher
 
   val namerd = Namerd.all
   val namerdExamples = Namerd.examples


### PR DESCRIPTION
Linkerd currently does not support service-discovery in environments that uses Rancher for orchestration. This makes Linkerd less attractive to people using Rancher for the Docker environments, as they would have to implement additional infrastructure to get service-discovery that way. Rancher has a JSON-based metadata-API that contains information about all of the containers that are running in Rancher, so it would be possible to perform service-discovery that way.

This commit introduces a new namer that utilizes the long-polling functionality of the Rancher metadata-API to achieve near-instant updates to the discovered services.

I have run some small-scale validation tests on a Rancher platform to ensure that the client accuratly detects the running services and can route requests to them.

Fixes #1146