### PR TITLE
Capitalize Linkerd and Namerd in documentation

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,16 +1,16 @@
 ## Development guide ##
 
-This document will help you build linkerd from source.
+This document will help you build Linkerd from source.
 
 This repo contains two main application build targets:
-- linkerd, a service mesh router
-- namerd, a service for centrally managing routing policy and fronting service discovery.
+- `linkerd`, a service mesh router
+- `namerd`, a service for centrally managing routing policy and fronting service discovery.
 
-More details at [namerd's quickstart](namerd/README.md#quickstart)
+More details at [Namerd's quickstart](namerd/README.md#quickstart)
 
 ## Working in this repository ##
 
-[sbt][sbt] is used to build and test linkerd. Developers should not
+[sbt][sbt] is used to build and test Linkerd. Developers should not
 use a system-installed version of sbt, and should instead use the
 `./sbt` script, which ensures that a compatible version of sbt is
 available.
@@ -138,9 +138,9 @@ See the [javascript readme](/admin/src/main/resources/io/buoyant/admin/README.md
 
 #### Building an executable ####
 
-linkerd provides a plugin system so that features may be chosen at
+Linkerd provides a plugin system so that features may be chosen at
 packaging time.  To this end, there are multiple configurations for
-running and packaging linkerd executables.
+running and packaging Linkerd executables.
 
 The _assembly_ plugin can be used to produce an executable containing
 all library dependencies.  The `linkerd` subproject has several build
@@ -154,7 +154,7 @@ configurations to support packaging:
 [success] Total time: 14 s, completed Jan 29, 2016 4:29:40 PM
 ```
 
-Similarly, a namerd executable can be produced with the command:
+Similarly, a Namerd executable can be produced with the command:
 ```
 > namerd/assembly
 ```
@@ -165,10 +165,10 @@ Before releasing ensure that [CHANGES.md](CHANGES.md) is updated to include the
 version that you're trying to release.
 
 By default, the _-SNAPSHOT_ suffix is appended to the version number when
-building linkerd.  In order to build a non-snapshot (i.e. releasable) version of
-linkerd, the build must occur from a release tag in git.
+building Linkerd.  In order to build a non-snapshot (i.e. releasable) version of
+Linkerd, the build must occur from a release tag in git.
 
-For example, in order to build the 0.0.10 release of linkerd:
+For example, in order to build the 0.0.10 release of Linkerd:
 
 1. Ensure that the head version is 0.0.10
 2. `git tag 0.0.10 && git push origin 0.0.10`
@@ -187,8 +187,8 @@ Each of these configurations may be used to build a docker image.
 
 The produced image does not contain any configuration.  It's expected
 that configuration is provided by another docker layer or volume.  For
-example, if you have linkerd configuration in
-_path/to/myapp/linkerd.yml_, you could start linkerd in docker with
+example, if you have a Linkerd configuration in
+_path/to/myapp/linkerd.yml_, you could start Linkerd in docker with
 the following command:
 
 ```
@@ -214,13 +214,13 @@ The list of image names may be changed with a command like:
 #### DCOS ####
 
 Namerd supports a DCOS-specific configuration. When used in conjunction with
-namerd's `io.l5d.zk` dtab storage, this
+Namerd's `io.l5d.zk` dtab storage, this
 configuration provides bootstrapping of the ZooKeeper `pathPrefix`, along with
 a default dtab.
 
 ##### Run locally #####
 
-This executes only the namerd-dcos-bootstrap command, it does not boot namerd.
+This executes only the `namerd-dcos-bootstrap` command, it does not boot Namerd.
 
 ```bash
 $ ./sbt "namerd/dcos:run-main io.buoyant.namerd.DcosBootstrap namerd/examples/zk.yaml"
@@ -229,8 +229,8 @@ $ ./sbt "namerd/dcos:run-main io.buoyant.namerd.DcosBootstrap namerd/examples/zk
 ##### Run assembly script locally #####
 
 The assembly script executes two commands serially:
-1. runs namerd-dcos-bootstrap
-2. boots namerd
+1. runs `namerd-dcos-bootstrap`
+2. boots Namerd
 
 ```bash
 $ ./sbt namerd/dcos:assembly

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,10 +13,10 @@ to release 1.3.3.
 
 ## 1.3.2 2017-11-16
 * Kubernetes
-  * Deprecate ThirdPartyResources in favor of CustomResourceDefinitions for namerd dtab storage (#1688)
+  * Deprecate ThirdPartyResources in favor of CustomResourceDefinitions for Namerd dtab storage (#1688)
 * Thrift
     * Fix a bug with the Thrift Identifier not properly identifying TTwitterThrift requests
-* Consul 
+* Consul
     * Add the ability to weight addresses based on Consul tags
 * Namerd
     * Fix a memory leak involving the `io.l5d.thriftNameInterpreter` interface
@@ -71,8 +71,8 @@ Also includes:
 
 ## 1.2.0 2017-09-07
 
-* **Breaking Change**: `io.l5d.mesh`, `io.l5d.thriftNameInterpreter`, linkerd
-  admin, and namerd admin now serve on 127.0.0.1 by default (instead of
+* **Breaking Change**: `io.l5d.mesh`, `io.l5d.thriftNameInterpreter`, Linkerd
+  admin, and Namerd admin now serve on 127.0.0.1 by default (instead of
   0.0.0.0).
 * **Breaking Change**: Removed support for PKCS#1-formatted keys. PKCS#1 formatted keys must be converted to PKCS#8 format.
 * Added experimental `io.l5d.dnssrv` namer for DNS SRV records (#1611)
@@ -96,8 +96,8 @@ Also includes:
 * TLS
   * Removed support for PKCS#1 keys (#1590)
   * Added validation to prevent incompatible `disableValidation: true` and `clientAuth` settings in TLS client configurations (#1621)
-* Changed `io.l5d.mesh`, `io.l5d.thriftNameInterpreter`, linkerd
-  admin, and namerd admin to serve on 127.0.0.1 by default (instead of
+* Changed `io.l5d.mesh`, `io.l5d.thriftNameInterpreter`, Linkerd
+  admin, and Namerd admin to serve on 127.0.0.1 by default (instead of
   0.0.0.0) (#1366)
 * Deprecated `io.l5d.statsd` telemeter.
 
@@ -152,7 +152,7 @@ We’ve made some internal changes to keep up with the latest and greatest:
 
 * TLS
   * Add support for client auth TLS.
-  * Add TLS support for `io.l5d.httpController` and `io.l5d.mesh` namerd
+  * Add TLS support for `io.l5d.httpController` and `io.l5d.mesh` Namerd
     interfaces.
 * HTTP/2
   * Reset h2 remote streams that continue to send frames after the local stream
@@ -176,7 +176,7 @@ We’ve made some internal changes to keep up with the latest and greatest:
 ## 1.0.2 2017-05-12
 
 * Fix issue where TLS could not be used with H2.
-* Fix linkerd admin dashboard edge case.
+* Fix Linkerd admin dashboard edge case.
 
 ## 1.0.1 2017-05-12
 
@@ -184,7 +184,7 @@ We’ve made some internal changes to keep up with the latest and greatest:
 * Upgrade to finagle 6.44.
 * HTTP/1.1:
   * Fix connection leak when retrying on responses with chunked bodies.
-  * Remove linkerd headers and body when clearContext is set.
+  * Remove Linkerd headers and body when clearContext is set.
   * Add io.l5d.http.allSuccessful and io.l5d.h2.allSuccessful response classifiers.
 * HTTP/2:
   * Fix race condition causing every request on a connection to deadline.
@@ -245,19 +245,19 @@ We’ve made some internal changes to keep up with the latest and greatest:
 ## 0.9.1 2017-03-15
 
 * Admin dashboard:
-  * Fix display issues for long dtabs in the namerd tab.
+  * Fix display issues for long dtabs in the Namerd tab.
   * Indicate the primary path in the dtab tab.
   * Add `tree` and `q` params to /admin/metrics.json.
 * Kubernetes:
   * Allow k8s namer to accept port numbers.
   * Make k8s namer case insensitive.
-  * Add k8s ingress identifiers to allow linkerd to act as an ingress controller.
+  * Add k8s ingress identifiers to allow Linkerd to act as an ingress controller.
 * Fix TTwitter thrift protocol upgrade bug.
 * Rewrite Location & Refresh HTTP response headers when Linkerd
   rewrites request Host header.
 * Increase default binding cache size to reduce connection churn.
 * Fetch correct protoc version on demand.
-* Introduce the `io.l5d.mesh` linkerd interpreter and namerd iface. The mesh
+* Introduce the `io.l5d.mesh` Linkerd interpreter and Namerd iface. The mesh
   iface exposes a gRPC API that can be used for multiplexed, streaming updates.
   (*Experimental*)
 
@@ -310,15 +310,15 @@ We’ve made some internal changes to keep up with the latest and greatest:
 
 * Introduce the grpc-gen and grpc-runtime projects, enabling code
   generation of gRPC clients and servers for Finagle.
-* Various bug fixes to the linkerd admin dashboard.
+* Various bug fixes to the Linkerd admin dashboard.
 * The default docker images now use a 64 bit JVM.  A `-32b` docker image is
   also availble but does not support the boringssl TLS extensions required for
   ALPN, etc.
 * Marathon:
   * Support "ip per task" feature
 * Client failure accrual is now configurable via the `failureAccrual` parameter
-* Add `io.l5d.namerd.http` interpreter which uses namerd's streaming HTTP api
-* linkerd now writes the local dtab to the `l5d-ctx-dtab` header instead of
+* Add `io.l5d.namerd.http` interpreter which uses Namerd's streaming HTTP api
+* Linkerd now writes the local dtab to the `l5d-ctx-dtab` header instead of
   `dtab-local`
 * Transformers:
   * Transformers will now prepend a prefix to the id of the bound names they
@@ -339,7 +339,7 @@ We’ve made some internal changes to keep up with the latest and greatest:
 
 ## 0.8.3 2016-11-07
 
-* Make several namers available to namerd that were missing
+* Make several namers available to Namerd that were missing
 * Fix crash when viewing the dtab playground
 * Announce to all routable addresses when announcing 0.0.0.0
 * Add experimental Apache Curator namer
@@ -363,8 +363,8 @@ We’ve made some internal changes to keep up with the latest and greatest:
   * Remove unused TLS options from the k8s storage plugin config.
   * Add k8s external namer for routing to k8s ingress services.
   * Improve error-handling behavior in k8s API clients.
-* Support serving the namerd namer interface over TLS.
-* Document namerd's HTTP API.
+* Support serving the Namerd namer interface over TLS.
+* Document Namerd's HTTP API.
 * Improve retry metrics to include a total counter of all retry requests.
 * Fix a path-parsing bug in the io.l5d.path namer.
 * Provide a default log4j configuration so that netty logging is managed properly.
@@ -377,7 +377,7 @@ We’ve made some internal changes to keep up with the latest and greatest:
 
 ## 0.8.1 2016-09-21
 
-* Fix missing data on the linkerd admin dashboard
+* Fix missing data on the Linkerd admin dashboard
 * Allow a non-default port to be specified for the etcd storage plugin
 
 ## 0.8.0 2016-09-20
@@ -404,21 +404,21 @@ We’ve made some internal changes to keep up with the latest and greatest:
 * Lowercase `Host` header value in `io.l5d.methodAndHost` identifier
 * Introduce transformers for post-processing the set of addresses returned by
   an interpreter.
-  * Add k8s transformers to support linkerd-to-linkerd deployments when linkerd
+  * Add k8s transformers to support linker-to-linker deployments when Linkerd
     is deployed as a k8s daemonset.
 * Remove hop-by-hop headers for better HTTP proxy compliance
 
 
 ## 0.7.5
 
-* Beautiful new linkerd docs!!! :heart_eyes: https://linkerd.io/config/0.7.5/linkerd
+* Beautiful new Linkerd docs!!! :heart_eyes: https://linkerd.io/config/0.7.5/linkerd
 * HTTP response classifiers must not consider a request to be
   retryable when it has a chunked request body.
 * Fix query paramater encoding when rewriting proxied requests
 * Improve error handling and retry behavior of consul plugins.
 * Add `useHealthCheck` parameter to Consul Namer #589
 * The k8s namer will now resume watches if the connection is closed.
-* Improved the performance of the namerd HTTP API.
+* Improved the performance of the Namerd HTTP API.
 * Configured namers are now available to other plugins
 * `enableProbation` is now disabled by default on clients. It leads to
   unexpected behavior in environments that reuse IP:PORT pairs across
@@ -427,7 +427,7 @@ We’ve made some internal changes to keep up with the latest and greatest:
 ## 0.7.4
 
 * Dashboard: add toggling to the router clients to better handle large numbers of clients
-* namerd HTTP API:
+* Namerd HTTP API:
   * Add `resolve` endpoint
   * All endpoints return json
 * Add `authority` metadata field to re-write HTTP host/:authority on demand
@@ -439,21 +439,21 @@ We’ve made some internal changes to keep up with the latest and greatest:
 * Path identifier should only parse as many segments as requested
 * Introduce the _telemetry_ plugin subsystem to support arbitrary stats
   exporters and to eventually supplant the `tracers` subsystem.
-* Add announcer support! linkerd can now announce to service discovery backends!
+* Add announcer support! Linkerd can now announce to service discovery backends!
   * Add zk announcer.
 
 ## 0.7.3
 
 * Allow protocol-specific parameters to be inherited on servers #561.
 * Don't clear addr on k8s service deletion #567.
-* Modify namerd's `/delegate` http endpoint to return bound names #569.
+* Modify Namerd's `/delegate` http endpoint to return bound names #569.
 * Memoize status stats components #547.
 
 ## 0.7.2
 
 * Add support for tags in the `io.l5d.consul` namer.
-* Add an experimental `io.l5d.consul` storage backend for namerd.
-* linkerd should use last known good data if it get errors from namerd.
+* Add an experimental `io.l5d.consul` storage backend for Namerd.
+* Linkerd should use last known good data if it get errors from Namerd.
 * Fix exceptions when k8s namer encounters unexpected end of stream #551.
 * Expose HTTP codec parameters as configuration options.
 * Handle "too old" error when re-establishing Kubernetes watches.
@@ -461,7 +461,7 @@ We’ve made some internal changes to keep up with the latest and greatest:
 
 ## 0.7.1
 
-* Turn off HTTP decompression so that linkerd doesn't decompress and then
+* Turn off HTTP decompression so that Linkerd doesn't decompress and then
   recompress bodies.
 * Various bug fixes in the dtab UI
 * Optional dtab query parameter for selected Namerd HTTP Control API endpoints
@@ -484,13 +484,13 @@ We’ve made some internal changes to keep up with the latest and greatest:
     specified by users.
   * `l5d-dst-*` no longer set on responses
 * Fix graceful connection teardown on streaming HTTP responses #482.
-* linkerd routers' `timeoutMs` configuration now applies on the
+* Linkerd routers' `timeoutMs` configuration now applies on the
   server-side, so that the timeout acts as a global timeout rather
   than an individual request timeout.
-* Binding cache size is now configurable in linkerd and namerd
+* Binding cache size is now configurable in Linkerd and Namerd
 * Use :: as the zk host delimiter in the zk leader namer
 * Admin site/dashboard UI improvements:
-  * The linkerd dtab UI now works correctly with the namerd interpreter
+  * The Linkerd dtab UI now works correctly with the Namerd interpreter
   * Added server success rate graphs to the dashboard, improved responsiveness
   * Added the ability to navigate to a specific router's dashboard
   * Standardized the look and feel of the admin pages
@@ -530,27 +530,27 @@ We’ve made some internal changes to keep up with the latest and greatest:
   time to spend binding a path.
 * Add experimental support for storing dtabs in Kubernetes via the
   ThirdPartyResource API (which must be enabled in your cluster).
-* **Breaking api change** in namerd: dtabs are now string-encoded
+* **Breaking api change** in Namerd: dtabs are now string-encoded
   rather than thrift-encoded.
-* Add `/api/1/bind`, `/api/1/addr`, and `/api/1/delegate` HTTP APIs to namerd
+* Add `/api/1/bind`, `/api/1/addr`, and `/api/1/delegate` HTTP APIs to Namerd
   * Most HTTP APIs now support `?watch=true` for returning updates via a
     streaming response.
 * Add ACL and authentication support to the ZooKeeper DtabStore.
 * Support wildcards in dtabs!
-* New linkerd dashboard is now enabled by default!! :chart_with_upwards_trend:
+* New Linkerd dashboard is now enabled by default!! :chart_with_upwards_trend:
 
 ## 0.3.1
 
-* Add beta version of linkerd dashboard version 2.0.  Try it out at
-  `/dashboard` on the linkerd admin site. :chart_with_upwards_trend:
+* Add beta version of Linkerd dashboard version 2.0.  Try it out at
+  `/dashboard` on the Linkerd admin site. :chart_with_upwards_trend:
 * Support Zipkin tracer configuration via config file, to enable automatic
-  export of tracing data from linkerd to a Zipkin collector.
-* namerd's HTTP dtab API now supports the HEAD and DELETE methods
-* Tear-down address observations in namerd if a service is deleted
+  export of tracing data from Linkerd to a Zipkin collector.
+* Namerd's HTTP dtab API now supports the HEAD and DELETE methods
+* Tear-down address observations in Namerd if a service is deleted
 
 ## 0.3.0
 
-* Added :sparkles: namerd :sparkles: : a service for managing linkerd (and finagle)
+* Added :sparkles: Namerd :sparkles: : a service for managing Linkerd (and finagle)
   name delegation.
 * **Breaking change** to configs: `httpUriInDst` is now specified under the
   `identifier` header (see linkerd/docs/config.md for add'l info)
@@ -568,7 +568,7 @@ We’ve made some internal changes to keep up with the latest and greatest:
 * Add a loadBalancer section to the client config where a load balancer can be
   specified and configured.  The load balancers that are currently supported are
   p2c, ewma, aperture, and heap.
-* Add a config.json admin endpoint which re-serializes the parsed linkerd config.
+* Add a config.json admin endpoint which re-serializes the parsed Linkerd config.
 * Add a `maxConcurrentRequests` config option to limit number of concurrent
   requests accepted by a server.
 * Add a `hostConnectionPool` client config section to control the number of
@@ -579,7 +579,7 @@ We’ve made some internal changes to keep up with the latest and greatest:
 ## 0.2.0
 
 * This release contains **breaking changes** to the configuration file format.
-  linkerd config files are now a bit more explicit and less "magical",
+  Linkerd config files are now a bit more explicit and less "magical",
   in the following ways:
   * Router configuration options can no longer be specified globally at the
     root level of the config file, but must be specified per-router.
@@ -642,7 +642,7 @@ We’ve made some internal changes to keep up with the latest and greatest:
 
 This is a big release! Get ready.
 
-* Brand new name: :sunrise: linkerd :balloon:
+* Brand new name: :sunrise: Linkerd :balloon:
 * We're open source! This release is under Apache License v2.
 * Tons of documentation on https://linkerd.io!
 * This release adds config file support! You can express all your routing,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,10 @@
-# Contributing to linkerd #
+# Contributing to Linkerd #
 
 :balloon: Thanks for your help improving the project!
 
 ## Getting Help ##
 
-If you have a question about linkerd or have encountered problems using it,
+If you have a question about Linkerd or have encountered problems using it,
 start by [asking a question in the forums][discourse] or join us on
 [Slack][slack].
 

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -3,13 +3,13 @@
 ## Getting Help ##
 
 Github issues are for bug reports and feature requests. For questions about
-linkerd, how to use it, or debugging assistance, start by
+Linkerd, how to use it, or debugging assistance, start by
 [asking a question in the forums](https://discourse.linkerd.io/) or join us on
 [Slack](https://slack.linkerd.io/).
 
 Full details at [CONTRIBUTING.md](https://github.com/linkerd/linkerd/blob/master/CONTRIBUTING.md).
 
-## Filing a linkerd issue ##
+## Filing a Linkerd issue ##
 
 Issue Type:
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,6 +1,6 @@
 Maintainers of this repository with their focus areas:
 
 * Oliver Gould <ver@buoyant.io> @olix0r: linkerd-core, H2, gRPC, namers.
-* Alex Leong <alex@buoyant.io> @adleong: All things linkerd & namerd.
+* Alex Leong <alex@buoyant.io> @adleong: All things Linkerd & Namerd.
 * Risha Mars <mars@buoyant.io> @rmars: Admin UI.
 * William Morgan <william@buoyant.io> @wmorgan: general.

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -1,7 +1,7 @@
 # External Linkerd Plugins
 
-A list of linkerd plugins that exist outside of the linkerd repo.  If you have
-developed a linkerd plugin, we'd love a pull request that adds it to this list.
+A list of Linkerd plugins that exist outside of the Linkerd repo.  If you have
+developed a Linkerd plugin, we'd love a pull request that adds it to this list.
 
 * [linkerd-zipkin telemeter](https://github.com/linkerd/linkerd-zipkin)
 * [Open Policy Agent identifier](https://github.com/open-policy-agent/contrib/tree/master/linkerd_authz)

--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ contributing changes.
 ## Related Repos ##
 
 * [linkerd-examples][l5d-eg]: A variety of configuration examples and explanations
-* [linkerd-tcp][l5d-tcp]: A lightweight TCP/TLS load balancer that uses namerd
-* [linkerd-viz][l5d-viz]: Zero-configuration service dashboard for linkerd
+* [linkerd-tcp][l5d-tcp]: A lightweight TCP/TLS load balancer that uses Namerd
+* [linkerd-viz][l5d-viz]: Zero-configuration service dashboard for Linkerd
 * [linkerd-zipkin][l5d-zipkin]: [Zipkin][zipkin] tracing plugins
-* [namerctl][namerctl]: A commandline utility for controlling namerd
+* [namerctl][namerctl]: A commandline utility for controlling Namerd
 
 ## Code of Conduct ##
 

--- a/finagle/README.md
+++ b/finagle/README.md
@@ -1,4 +1,4 @@
-# linkerd: finagle extensions #
+# Linkerd: Finagle extensions #
 
 This directory contains protocol extensions to Finagle published under
 the `io.buoyant` organization.

--- a/linkerd/README.md
+++ b/linkerd/README.md
@@ -1,4 +1,4 @@
-# linkerd #
+# Linkerd #
 
 [linkerd.io](https://linkerd.io)
 
@@ -22,7 +22,7 @@ initiate a graceful shutdown of a running router.
 ### Running ###
 
 The `linkerd` project's packaging configurations may also be used to
-run linkerd locally, e.g.:
+run Linkerd locally, e.g.:
 
 ```
 > linkerd/bundle:run path/to/config.yml

--- a/linkerd/docs/client_tls.md
+++ b/linkerd/docs/client_tls.md
@@ -7,7 +7,7 @@ routers:
 - protocol: http
   servers:
   - port: 4140
-    # accept incoming TLS traffic from remote linkerd
+    # accept incoming TLS traffic from remote Linkerd
     tls:
       certPath: /certificates/certificate.pem
       keyPath: /certificates/key.pem
@@ -25,7 +25,7 @@ keyPath | _required_ | File path to the TLS key file.
 requireClientAuth | false | If true, only accept requests with valid client certificates.
 caCertPath | none | File path to the CA cert to validate the client certificates.
 
-See [Transparent TLS with linkerd](https://blog.buoyant.io/2016/03/24/transparent-tls-with-linkerd/) for more on how to generate certificate
+See [Transparent TLS with Linkerd](https://blog.buoyant.io/2016/03/24/transparent-tls-with-linkerd/) for more on how to generate certificate
 and key files.
 
 ## Client TLS
@@ -48,7 +48,7 @@ routers:
 In order to send outgoing tls traffic, the tls parameter must be defined as a
 [client parameter](#client-parameters).
 
-A client TLS object describes how linkerd should use TLS when sending requests
+A client TLS object describes how Linkerd should use TLS when sending requests
 to destination services.
 
 Key               | Default Value                              | Description

--- a/linkerd/docs/config.md
+++ b/linkerd/docs/config.md
@@ -1,6 +1,6 @@
 # Introduction
 
-> A linkerd config example
+> A Linkerd config example
 
 ```yaml
 admin:
@@ -43,9 +43,9 @@ telemetry:
   level: TRACE
 ```
 
-Welcome to the Configuration Reference for linkerd!
+Welcome to the Configuration Reference for Linkerd!
 
-linkerd's configuration is controlled via a configuration file, which must be provided
+Linkerd's configuration is controlled via a configuration file, which must be provided
 as a command-line argument. It may be a local file path or `-` to
 indicate that the configuration should be read from the standard input.
 For convenience, the release package includes a default `linkerd.yaml` file in
@@ -57,11 +57,11 @@ The configuration may be specified as a JSON or YAML object. There are no requir
 
 Key | Required | Description
 --- | -------- | -----------
-[admin](#administrative-interface) | no | Configures linkerd's administrative interface.
-[routers](#routers-intro) | yes | Configures linkerd's RPC support for various protocols.
-[namers](#namers-and-service-discovery) | no | Configures linkerd's integration with various service discovery backends.
-[telemetry](#telemetry-intro) | no | Configures linkerd's metrics instrumentation.
-[usage](#usage) | no | Configures linkerd usage reporting.
+[admin](#administrative-interface) | no | Configures Linkerd's administrative interface.
+[routers](#routers-intro) | yes | Configures Linkerd's RPC support for various protocols.
+[namers](#namers-and-service-discovery) | no | Configures Linkerd's integration with various service discovery backends.
+[telemetry](#telemetry-intro) | no | Configures Linkerd's metrics instrumentation.
+[usage](#usage) | no | Configures Linkerd usage reporting.
 
 
 ### Administrative interface
@@ -75,7 +75,7 @@ admin:
     keyPath: /foo/key.pem
 ```
 
-linkerd supports an administrative interface, both as a web ui and a collection
+Linkerd supports an administrative interface, both as a web ui and a collection
 of json endpoints. The exposed admin port and ip to listen on are configurable
 via a top-level `admin` section.
 
@@ -99,7 +99,7 @@ curl ":9990/admin/pprof/profile?seconds=10&hz=100"
 curl ":9990/delegator.json?path=/http/1.1/GET/foo&dtab=/http/*=>/$/inet/127.1/9990"
 ```
 
-Default admin endpoints available in both linkerd and namerd:
+Default admin endpoints available in both Linkerd and Namerd:
 
 Endpoint | Description
 -------- | -----------
@@ -112,15 +112,15 @@ Endpoint | Description
 `/admin/pprof/contention` | CPU contention profile which identifies blocked threads (Thread.State.BLOCKED), in pprof format. The process will be profiled for 10 seconds at a frequency of 100 hz. These values can be controlled via HTTP request parameters `seconds` and `hz` respectively.
 `/admin/pprof/heap` | heap profile computed by the heapster agent, output is in pprof format
 `/admin/pprof/profile` | CPU usage profile in pprof format. The process will be profiled for 10 seconds at a frequency of 100 hz. These values can be controlled via HTTP request parameters `seconds` and `hz` respectively.
-`/admin/registry.json` | displays how linkerd is currently configured across a variety of dimensions including the client stack, server stack, flags, service loader values, system properties, environment variables, build properties and more
-`/admin/server_info` | build information about this linkerd
+`/admin/registry.json` | displays how Linkerd is currently configured across a variety of dimensions including the client stack, server stack, flags, service loader values, system properties, environment variables, build properties and more
+`/admin/server_info` | build information about this Linkerd
 `/admin/shutdown` | initiate a graceful shutdown
 `/admin/threads` | capture the current stacktraces, set `Accept: application/json` to force json
 `/admin/threads.json` | identical to `admin/threads`
 `/admin/tracing` | enable (`/admin/tracing?enable=true`) or disable tracing (`/admin/tracing?disable=true`)
-`/config.json` | current linkerd configuration, this should match your config file
+`/config.json` | current Linkerd configuration, this should match your config file
 
-Endpoints only available in linkerd:
+Endpoints only available in Linkerd:
 
 Endpoint | Description
 -------- | -----------
@@ -128,7 +128,7 @@ Endpoint | Description
 `/delegator.json` | given `path`, `dtab`, and an optional `namespace` param, return the delegation tree
 `/logging.json` | currently configured loggers and log levels
 
-Note that in addition to a default set of admin endpoints, linkerd plugins may
+Note that in addition to a default set of admin endpoints, Linkerd plugins may
 dynamically add their own endpoints.
 
 HTTP Identifier Endpoints (running on `httpIdentifierPort`):
@@ -144,7 +144,7 @@ be found at
 
 ### Routers Intro
 
-> A minimal linkerd configuration example, which forwards all requests on `localhost:8080` to `localhost:8888`
+> A minimal Linkerd configuration example, which forwards all requests on `localhost:8080` to `localhost:8888`
 
 ```yaml
 routers:
@@ -155,7 +155,7 @@ routers:
 ```
 
 All configurations must define a **routers** key, the value of which
-must be an array of router configurations. Each router implements RPC for a supported protocol. linkerd doesn't need to understand the payload in an RPC call, but it does need to know enough about the protocol to determine the logical name of the destination.
+must be an array of router configurations. Each router implements RPC for a supported protocol. Linkerd doesn't need to understand the payload in an RPC call, but it does need to know enough about the protocol to determine the logical name of the destination.
 
 See [routers](#routers).
 
@@ -167,8 +167,8 @@ namers:
   rootDir: disco
 ```
 
-linkerd supports a variety of common service discovery backends, including
-ZooKeeper and Consul. linkerd provides abstractions on top of service discovery
+Linkerd supports a variety of common service discovery backends, including
+ZooKeeper and Consul. Linkerd provides abstractions on top of service discovery
 lookups that allow the use of arbitrary numbers of service discovery backends,
 and for precedence and failover rules to be expressed between them. This logic
 is governed by the [routing](#router-parameters) configuration.
@@ -194,7 +194,7 @@ telemetry:
 ```
 
 A telemeter may receive stats and trace annotations, i.e. to send to a collector
-or export. Telemetry data can be collected and exported from a linkerd process by
+or export. Telemetry data can be collected and exported from a Linkerd process by
 configuring telemeters via a top-level `telemetry` section. See
 [telemetry](#telemetry).
 
@@ -208,15 +208,15 @@ usage:
 ```
 
 In order to make improvements and prioritize features, we'd like to gain a
-broader picture of how users run linkerd. Linkerd gathers anonymized usage data,
+broader picture of how users run Linkerd. Linkerd gathers anonymized usage data,
 and sends it to Buoyant once an hour.  This behavior can be configured or
 disabled in the usage config.
 
 The kind of data captured is as follows:
 
-1. How linkerds are configured (The kinds of namers, initializers, identifiers, transformers, protocols, & interpreters used)
-2. What environments are linkerds running in (Operating System, Container orchestration solution),
-3. How do linkerds perform in those contexts (JVM performance, Number of requests served)
+1. How Linkerd is configured (The kinds of namers, initializers, identifiers, transformers, protocols, & interpreters used)
+2. What environments Linkerd is running in (Operating System, Container orchestration solution),
+3. How Linkerd performs in those contexts (JVM performance, Number of requests served)
 
 We do not collect the labels of namers/routers, designated service addresses or
 directories, dtabs, request/response data, or any other possibly identifying information.

--- a/linkerd/docs/failure_accrual.md
+++ b/linkerd/docs/failure_accrual.md
@@ -14,10 +14,10 @@ routers:
         maxMs: 300000
 ```
 
-linkerd uses failure accrual to track the number of requests that have failed to
+Linkerd uses failure accrual to track the number of requests that have failed to
 a given node, and it will back off sending requests to any nodes whose failures
 have exceeded a given threshold. Both the failure threshold and the backoff
-behavior are configurable. By default, if linkerd observes 5 consecutive
+behavior are configurable. By default, if Linkerd observes 5 consecutive
 failures from a node, it will mark the node as dead and only attempt to resend
 it traffic in increasing intervals between 5 seconds and 5 minutes.
 

--- a/linkerd/docs/interpreter.md
+++ b/linkerd/docs/interpreter.md
@@ -29,72 +29,72 @@ The default interpreter resolves names via the configured
 [`namers`](#namers), with a fallback to the default Finagle
 `Namer.Global` that handles paths of the form `/$/`.
 
-## namerd thrift
+## Namerd thrift
 
 kind: `io.l5d.namerd`
 
-The namerd thrift interpreter offloads the responsibilities of name resolution
-to the namerd service.  Any namers configured in this linkerd are not used.  The
-interpreter uses namerd's long-poll thrift interface
+The Namerd thrift interpreter offloads the responsibilities of name resolution
+to the Namerd service.  Any namers configured in this Linkerd are not used.  The
+interpreter uses Namerd's long-poll thrift interface
 (`io.l5d.thriftNameInterpreter`). Note that the protocol that the interpreter
-uses to talk to namerd is unrelated to the protocols of linkerd's routers.
+uses to talk to Namerd is unrelated to the protocols of Linkerd's routers.
 
 Key | Default Value | Description
 --- | ------------- | -----------
-dst | _required_ | A Finagle path locating the namerd service.
-namespace | `default` | The name of the namerd dtab to use.
-retry | see [namerd retry](#namerd-retry) | An object configuring retry backoffs for requests to namerd.
-tls | no tls | Requests to namerd will be made using TLS if this parameter is provided.  It must be a [namerd client TLS](#namerd-client-tls) object.
+dst | _required_ | A Finagle path locating the Namerd service.
+namespace | `default` | The name of the Namerd dtab to use.
+retry | see [Namerd retry](#namerd-retry) | An object configuring retry backoffs for requests to Namerd.
+tls | no tls | Requests to Namerd will be made using TLS if this parameter is provided.  It must be a [Namerd client TLS](#namerd-client-tls) object.
 
-### namerd retry
+### Namerd retry
 
 Key | Default Value | Description
 --- | ------------- | -----------
 baseSeconds | 5 seconds | The base number of seconds to wait before retrying.
 maxSeconds | 10 minutes | The maximum number of seconds to wait before retrying.
 
-### namerd client tls
+### Namerd client tls
 
 Key | Default Value | Description
 --- | ------------- | -----------
-commonName | _required_ | The common name to use for namerd requests.
+commonName | _required_ | The common name to use for Namerd requests.
 caCert | N/A | The path to the CA cert used for common name validation.
 
-## namerd http
+## Namerd http
 
 kind: `io.l5d.namerd.http`
 
-The namerd http interpreter offloads the responsibilities of name resolution to
-the namerd service.  Any namers configured in this linkerd are not used.  The
-interpreter uses namerd's HTTP streaming interface (`io.l5d.httpController`).
-Note that the protocol that the interpreter uses to talk to namerd is unrelated
-to the protocols of linkerd's routers.
+The Namerd http interpreter offloads the responsibilities of name resolution to
+the Namerd service.  Any namers configured in this Linkerd are not used.  The
+interpreter uses Namerd's HTTP streaming interface (`io.l5d.httpController`).
+Note that the protocol that the interpreter uses to talk to Namerd is unrelated
+to the protocols of Linkerd's routers.
 
 Key | Default Value | Description
 --- | ------------- | -----------
 experimental | _required_ | Because the http interpreter is still considered experimental, you must set this to `true` to use it.
-dst | _required_ | A Finagle path locating the namerd service.
-namespace | `default` | The name of the namerd dtab to use.
-retry | see [namerd retry](#namerd-retry) | An object configuring retry backoffs for requests to namerd.
-tls | no tls | Requests to namerd will be made using TLS if this parameter is provided.  It must be a [client TLS](#client-tls) object.
+dst | _required_ | A Finagle path locating the Namerd service.
+namespace | `default` | The name of the Namerd dtab to use.
+retry | see [Namerd retry](#namerd-retry) | An object configuring retry backoffs for requests to Namerd.
+tls | no tls | Requests to Namerd will be made using TLS if this parameter is provided.  It must be a [client TLS](#client-tls) object.
 
-## namerd mesh
+## Namerd mesh
 
 kind: `io.l5d.mesh`
 
-The namerd mesh interpreter offloads the responsibilities of name resolution to
-the namerd service.  Any namers configured in this linkerd are not used.  The
-interpreter uses namerd's gRPC mesh interface (`io.l5d.mesh`). Note that the
-protocol that the interpreter uses to talk to namerd is unrelated to the
-protocols of linkerd's routers.
+The Namerd mesh interpreter offloads the responsibilities of name resolution to
+the Namerd service.  Any namers configured in this Linkerd are not used.  The
+interpreter uses Namerd's gRPC mesh interface (`io.l5d.mesh`). Note that the
+protocol that the interpreter uses to talk to Namerd is unrelated to the
+protocols of Linkerd's routers.
 
 Key | Default Value | Description
 --- | ------------- | -----------
 experimental | _required_ | Because the mesh interpreter is still considered experimental, you must set this to `true` to use it.
-dst | _required_ | A Finagle path locating the namerd service.
-root | `/default` | A single-element Finagle path representing the namerd namespace.
-retry | see [namerd retry](#namerd-retry) | An object configuring retry backoffs for requests to namerd.
-tls | no tls | Requests to namerd will be made using TLS if this parameter is provided.  It must be a [client TLS](#client-tls) object.
+dst | _required_ | A Finagle path locating the Namerd service.
+root | `/default` | A single-element Finagle path representing the Namerd namespace.
+retry | see [Namerd retry](#namerd-retry) | An object configuring retry backoffs for requests to Namerd.
+tls | no tls | Requests to Namerd will be made using TLS if this parameter is provided.  It must be a [client TLS](#client-tls) object.
 
 ## File-System
 

--- a/linkerd/docs/namer.md
+++ b/linkerd/docs/namer.md
@@ -63,7 +63,7 @@ Due to the implmentation of file watches in Java, this namer consumes a high
 amount of CPU and is not suitable for production use.
 </aside>
 
-linkerd ships with a simple file-based service discovery mechanism called the
+Linkerd ships with a simple file-based service discovery mechanism called the
 *file-based namer*. This system is intended to act as a structured form of
 basic host lists.
 
@@ -77,13 +77,13 @@ experimentation.
 
 This service discovery mechanism is tied to the directory set by the
 `namers/rootDir` key in `config.yaml`. This directory must be on the local
-filesystem and relative to linkerd's start path. Every file in this directory
+filesystem and relative to Linkerd's start path. Every file in this directory
 corresponds to a service, where the name of the file is the service's _concrete
 name_, and the contents of the file must be a newline-delimited set of
 addresses.
 
-linkerd watches all files in this directory, so files can be added, removed, or
-updated, and linkerd will pick up the changes automatically.
+Linkerd watches all files in this directory, so files can be added, removed, or
+updated, and Linkerd will pick up the changes automatically.
 
 Key | Default Value | Description
 --- | ------------- | -----------
@@ -100,7 +100,7 @@ rootDir | _required_ | the directory containing name files as described above.
 
 Key | Required | Description
 --- | -------- | -----------
-prefix | yes | Tells linkerd to resolve the request path using the fs namer.
+prefix | yes | Tells Linkerd to resolve the request path using the fs namer.
 fileName | yes | The file in `rootDir` to use when resolving this request.
 
 <a name="serversets"></a>
@@ -128,7 +128,7 @@ dtab: |
   /svc => /#/io.l5d.serversets/discovery/prod;
 ```
 
-linkerd provides support for [ZooKeeper
+Linkerd provides support for [ZooKeeper
 ServerSets](https://twitter.github.io/commons/apidocs/com/twitter/common/zookeeper/ServerSet.html).
 
 Key | Default Value | Description
@@ -146,7 +146,7 @@ zkAddrs | _required_ | A list of ZooKeeper addresses, each of which have `host` 
 
 Key | Required | Description
 --- | -------- | -----------
-prefix | yes | Tells linkerd to resolve the request path using the serversets namer.
+prefix | yes | Tells Linkerd to resolve the request path using the serversets namer.
 zkHosts | yes | The ZooKeeper host to use for this request.
 zkPath | yes | The ZooKeeper path to use for this request.
 endpoint | no | The ZooKeeper endpoint to use for this request.
@@ -193,7 +193,7 @@ namers:
      weight: 5.0
 ```
 
-linkerd provides support for service discovery via [Consul](https://www.consul.io/).
+Linkerd provides support for service discovery via [Consul](https://www.consul.io/).
 
 Key | Default Value | Description
 --- | ------------- | -----------
@@ -201,14 +201,14 @@ prefix | `io.l5d.consul` | Resolves names with `/#/<prefix>`.
 host | `localhost` | The Consul host.
 port | `8500` | The Consul port.
 includeTag | `false` | If `true`, read a Consul tag from the path.
-useHealthCheck | `false` | If `true`, exclude app instances that do not match one of the provided `healthStatuses`. Even if `false`, linkerd's built-in resiliency algorithms will still apply.
-healthStatuses | `passing` | List of statuses to used to filter Consul app instances by. Possible values are `passing`, `warning`, `critical`, `maintenance`. Note that if a service defines more than one health check per app instance then the most representative statuses is used (`maintenance` > `critical` > `warning` > `passing`). If `useHealthCheck` is `false` then this parameter has no effect. Regardless of the statuses used to filter, linkerd's built-in resiliency algorithms will still apply.
+useHealthCheck | `false` | If `true`, exclude app instances that do not match one of the provided `healthStatuses`. Even if `false`, Linkerd's built-in resiliency algorithms will still apply.
+healthStatuses | `passing` | List of statuses to used to filter Consul app instances by. Possible values are `passing`, `warning`, `critical`, `maintenance`. Note that if a service defines more than one health check per app instance then the most representative statuses is used (`maintenance` > `critical` > `warning` > `passing`). If `useHealthCheck` is `false` then this parameter has no effect. Regardless of the statuses used to filter, Linkerd's built-in resiliency algorithms will still apply.
 token | no authentication | The auth token to use when making API calls.
 setHost | `false` | If `true`, HTTP requests resolved by Consul will have their Host header overwritten to `${serviceName}.service.${datacenter}.${domain}`. `$domain` is fetched from Consul.
 consistencyMode | `default` | Select between [Consul API consistency modes](https://www.consul.io/docs/agent/http.html) such as `default`, `stale` and `consistent`.
 failFast | `false` | If `false`, disable fail fast and failure accrual for Consul client. Keep it `false` when using a local agent but change it to `true` when talking directly to an HA Consul API.
 preferServiceAddress | `true` | If `true` use the service address if defined and default to the node address. If `false` always use the node address.
-weights | none | List of tag-weight configurations, for adjusting the weights of node addresses. When a node matches more than one tag, it gets the highest matching weight. In the absence of match or configuration, nodes get a default weight of `1.0`. 
+weights | none | List of tag-weight configurations, for adjusting the weights of node addresses. When a node matches more than one tag, it gets the highest matching weight. In the absence of match or configuration, nodes get a default weight of `1.0`.
 
 ### Consul Path Parameters
 
@@ -226,7 +226,7 @@ weights | none | List of tag-weight configurations, for adjusting the weights of
 
 Key | Required | Description
 --- | -------- | -----------
-prefix | yes | Tells linkerd to resolve the request path using the consul namer.
+prefix | yes | Tells Linkerd to resolve the request path using the consul namer.
 datacenter | yes | The Consul datacenter to use for this request. It can have a value `.local` (otherwise invalid datacenter name from Consul's perspective) in order to reference a datacenter of the agent namer is connected to.
 tag | yes if includeTag is `true` | The Consul tag to use for this request.
 serviceName | yes | The Consul service name to use for this request.
@@ -256,7 +256,7 @@ dtab: |
   /svc => /#/io.l5d.k8s/prod/http;
 ```
 
-linkerd provides support for service discovery via
+Linkerd provides support for service discovery via
 [Kubernetes](https://k8s.io/).
 
 Key | Default Value | Description
@@ -281,7 +281,7 @@ which will create a local proxy for securely talking to the Kubernetes cluster A
 
 Key | Required | Description
 --- | -------- | -----------
-prefix | yes | Tells linkerd to resolve the request path using the k8s namer.
+prefix | yes | Tells Linkerd to resolve the request path using the k8s namer.
 namespace | yes | The Kubernetes namespace.
 port-name | yes | The port name or port number.
 svc-name | yes | The name of the service.
@@ -309,7 +309,7 @@ dtab: |
 
 The [Kubernetes](https://k8s.io/) External namer looks up the IP of the external
 load balancer for the given service on the given port.  This can be used by
-linkerd instances running outside of k8s to route to services running in k8s.
+Linkerd instances running outside of k8s to route to services running in k8s.
 
 Key | Default Value | Description
 --- | ------------- | -----------
@@ -334,7 +334,7 @@ which will create a local proxy for securely talking to the Kubernetes cluster A
 
 Key | Required | Description
 --- | -------- | -----------
-prefix | yes | Tells linkerd to resolve the request path using the k8s external namer.
+prefix | yes | Tells Linkerd to resolve the request path using the k8s external namer.
 namespace | yes | The Kubernetes namespace.
 port-name | yes | The port name.
 svc-name | yes | The name of the service.
@@ -451,7 +451,7 @@ which will create a local proxy for securely talking to the Kubernetes cluster A
 
 Key | Required | Description
 --- | -------- | -----------
-prefix | yes | Tells linkerd to resolve the request path using the k8s external namer.
+prefix | yes | Tells Linkerd to resolve the request path using the k8s external namer.
 port-name | yes | The port name.
 svc-name | yes | The name of the service.
 label-value | yes if `labelSelector` is defined | The label value used to filter services.
@@ -495,7 +495,7 @@ port | `8080` | The port of the Istio-Manager.
 
 Key | Required | Description
 --- | -------- | -----------
-prefix | yes | Tells linkerd to resolve the request path using the Istio namer.
+prefix | yes | Tells Linkerd to resolve the request path using the Istio namer.
 port-name | yes | The port name.
 cluster | yes | The fully qualified name of the service.
 labels | yes | A `::` delimited list of `label:value` pairs.  Only endpoints that match all of these label selectors will be returned.
@@ -528,7 +528,7 @@ dtab: |
   /svc => /host;
 ```
 
-linkerd provides support for service discovery via
+Linkerd provides support for service discovery via
 [Marathon](https://mesosphere.github.io/marathon/).
 
 Key | Default Value | Description
@@ -538,7 +538,7 @@ host | `marathon.mesos` | The Marathon master host.
 port | `80` | The Marathon master port.
 uriPrefix | none | The Marathon API prefix. This prefix depends on your Marathon configuration. For example, running Marathon locally, the API is available at `localhost:8080/v2/`, while the default setup on AWS/DCOS is `$(dcos config show core.dcos_url)/marathon/v2/apps`.
 ttlMs | `5000` | The polling interval in milliseconds against the Marathon API.
-useHealthCheck | `false` | If `true`, exclude app instances that are failing Marathon health checks. Even if `false`, linkerd's built-in resiliency algorithms will still apply.
+useHealthCheck | `false` | If `true`, exclude app instances that are failing Marathon health checks. Even if `false`, Linkerd's built-in resiliency algorithms will still apply.
 tls | no tls | The Marathon namer will make requests to Marathon/DCOS using TLS if this parameter is provided. This is useful when DC/OS is run in [strict](https://docs.mesosphere.com/latest/security/#security-modes) security mode. It must be a [client TLS](#client-tls) object. Note that the `clientAuth` config value will be unused, as DC/OS does not use mutual TLS.
 
 ### Marathon Path Parameters
@@ -551,7 +551,7 @@ tls | no tls | The Marathon namer will make requests to Marathon/DCOS using TLS 
 
 Key | Required | Description
 --- | -------- | -----------
-prefix | yes | Tells linkerd to resolve the request path using the marathon namer.
+prefix | yes | Tells Linkerd to resolve the request path using the marathon namer.
 appId | yes | The app id of a marathon application. This id can be multiple path segments long. For example, the app with id "/users" can be reached with `/#/io.l5d.marathon/users`. Likewise, the app with id "/appgroup/usergroup/users" can be reached with `/#/io.l5d.marathon/appgroup/usergroup/users`.
 
 ### Marathon Authentication
@@ -614,14 +614,14 @@ dtab: |
     /dnssrv/myservice.srv.dc-2.example.org.;
 ```
 
-linkerd provides support for service discovery via DNS SRV records.
+Linkerd provides support for service discovery via DNS SRV records.
 
 Key | Default Value | Description
 --- | ------------- | -----------
 prefix | `io.l5d.dnssrv` | Resolves names with `/#/<prefix>`.
 experimental | `false` | Since the DNS-SRV namer is still considered experimental, this must be set to `true`.
-refreshIntervalSeconds | `5` | linkerd will perform a SRV lookup for each host every `refreshIntervalSeconds`.
-dnsHosts | `<empty list>` | If specified, linkerd will use these DNS servers to perform SRV lookups. If not specified, linkerd will use the default system resolver.
+refreshIntervalSeconds | `5` | Linkerd will perform a SRV lookup for each host every `refreshIntervalSeconds`.
+dnsHosts | `<empty list>` | If specified, Linkerd will use these DNS servers to perform SRV lookups. If not specified, Linkerd will use the default system resolver.
 
 ### DNS-SRV Path Parameters
 
@@ -633,7 +633,7 @@ dnsHosts | `<empty list>` | If specified, linkerd will use these DNS servers to 
 
 Key | Required | Description
 --- | -------- | -----------
-prefix | yes | Tells linkerd to resolve the request path using the marathon namer.
+prefix | yes | Tells Linkerd to resolve the request path using the marathon namer.
 address | yes | The DNS address of a SRV record. Linkerd resolves the record to one or more `address:port` tuples using a SRV lookup.
 
 ## ZooKeeper Leader
@@ -659,7 +659,7 @@ zkAddrs | _required_ | A list of ZooKeeper addresses, each of which have `host` 
 
 Key | Required | Description
 --- | -------- | -----------
-prefix | yes | Tells linkerd to resolve the request path using the marathon namer.
+prefix | yes | Tells Linkerd to resolve the request path using the marathon namer.
 zkPath | yes | The ZooKeeper path of a leader group. This path can be multiple path segments long. The namer resolves to the address stored in the data of the leader.
 
 <a name="curator"></a>
@@ -690,7 +690,7 @@ basePath | `/` | The ZooKeeper path for Curator discovery.
 
 Key | Required | Description
 --- | -------- | -----------
-prefix | yes | Tells linkerd to resolve the request path using the curator namer.
+prefix | yes | Tells Linkerd to resolve the request path using the curator namer.
 serviceName | yes | The name of the Curator service to lookup in ZooKeeper.
 
 <a name="rewrite"></a>
@@ -744,13 +744,13 @@ name    | _required_       | The replacement name.  Variables captured in the pa
 
 Key    | Required | Description
 ------ | -------- | -----------
-prefix | yes      | Tells linkerd to resolve the request path using the rewrite namer.
+prefix | yes      | Tells Linkerd to resolve the request path using the rewrite namer.
 name   | yes      | Attempt to match this name against the pattern and replace it with the configured name.
 
 <a name="rewritingNamers"></a>
 ## Rewriting Namers
 
-In addition to service discovery namers, linkerd supplies a number of utility
+In addition to service discovery namers, Linkerd supplies a number of utility
 namers. These namers assist in path rewriting when the transformation is more
 complicated than just prefix substitution. They are prefixed with `/$/` instead
 of `/#/`, and can be used without explicitly adding them to the

--- a/linkerd/docs/protocol-h2.md
+++ b/linkerd/docs/protocol-h2.md
@@ -50,7 +50,7 @@ accordingly. Note that gRPC may be configured over TLS as well.
 
 protocol: `h2`
 
-linkerd now has _experimental_ support for HTTP/2. There are a number of
+Linkerd now has _experimental_ support for HTTP/2. There are a number of
 [open issues](https://github.com/linkerd/linkerd/issues?q=is%3Aopen+is%3Aissue+label%3Ah2)
 that are being addressed. Please
 [report](https://github.com/linkerd/linkerd/issues/new) any
@@ -113,13 +113,13 @@ forwardClientCert | false | Determines if client certificates are forwarded thro
 
 <aside class="notice">
 `forwardClientCert` makes Linkerd forward client certificates using the `x-forwarded-client-cert` header to let destination services make authorization decisions on the requests
-they receive.   
+they receive.
 </aside>
 
 ## HTTP/2 Identifiers
 
 Identifiers are responsible for creating logical *names* from an incoming
-request; these names are then matched against the dtab. (See the [linkerd
+request; these names are then matched against the dtab. (See the [Linkerd
 routing overview](https://linkerd.io/in-depth/routing/) for more details on
 this.) All h2 identifiers have a `kind`.  If a list of identifiers is
 provided, each identifier is tried in turn until one successfully assigns a
@@ -218,7 +218,7 @@ urlPath | N/A | The first `segments` elements of the path from the URL
 
 kind: `io.l5d.ingress`
 
-Using this identifier enables linkerd to function as a Kubernetes ingress
+Using this identifier enables Linkerd to function as a Kubernetes ingress
 controller. The ingress identifier compares HTTP/2 requests to [ingress
 resource](https://kubernetes.io/docs/user-guide/ingress/) rules, and assigns a
 name based on those rules.
@@ -247,7 +247,7 @@ namers:
 - kind: io.l5d.k8s
 ```
 
-> An example ingress resource watched by the linkerd ingress controller:
+> An example ingress resource watched by the Linkerd ingress controller:
 
 ```yaml
 apiVersion: extensions/v1beta1
@@ -271,7 +271,7 @@ spec:
 
 Key  | Default Value | Description
 ---- | ------------- | -----------
-namespace | (all) | The Kubernetes namespace where the ingress resources are deployed. If not specified, linkerd will watch all namespaces.
+namespace | (all) | The Kubernetes namespace where the ingress resources are deployed. If not specified, Linkerd will watch all namespaces.
 ingressClassAnnotation | `linkerd` | When using [multiple ingress controllers](https://github.com/kubernetes/ingress/blob/master/docs/faq/README.md#how-do-i-run-multiple-ingress-controllers-in-the-same-cluster), Linkerd will only use the ingress resource annotated with this class.
 host | `localhost` | The Kubernetes master host.
 port | `8001` | The Kubernetes master port.
@@ -380,20 +380,20 @@ mixerPort | `9091` | Port of the Mixer server.
 
 ## HTTP/2 Headers
 
-linkerd reads and sets several headers prefixed by `l5d-`, as is done
+Linkerd reads and sets several headers prefixed by `l5d-`, as is done
 by the `http` protocol.
 
 ### HTTP/2 Context Headers
 
-_Context headers_ (`l5d-ctx-*`) are generated and read by linkerd
+_Context headers_ (`l5d-ctx-*`) are generated and read by Linkerd
 instances. Applications should forward all context headers in order
-for all linkerd features to work.
+for all Linkerd features to work.
 
 Header | Description
 ------ | -----------
 `dtab-local` | Deprecated. Use `l5d-ctx-dtab` and `l5d-dtab`.
 `l5d-ctx-deadline` | Describes time bounds within which a request is expected to be satisfied. Currently deadlines are only advisory and do not factor into request cancellation.
-`l5d-ctx-trace` | Encodes Zipkin-style trace IDs and flags so that trace annotations emitted by linkerd may be correlated.
+`l5d-ctx-trace` | Encodes Zipkin-style trace IDs and flags so that trace annotations emitted by Linkerd may be correlated.
 
 <aside class="warning">
 Edge services should take care to ensure these headers are not set
@@ -416,9 +416,9 @@ Header | Description
 `l5d-sample` | A client-specified trace sample rate override.
 
 <aside class="notice">
-If linkerd processes incoming requests for applications
+If Linkerd processes incoming requests for applications
 (i.e. in linker-to-linker configurations), applications do not need to
-provide special treatment for these headers since linkerd does <b>not</b>
+provide special treatment for these headers since Linkerd does <b>not</b>
 forward these headers (and instead translates them into context
 headers). If applications receive traffic directly, they <b>should</b>
 forward these headers.
@@ -431,14 +431,14 @@ from untrusted sources.
 
 ### HTTP/2 Informational Request Headers
 
-The informational headers linkerd emits on outgoing requests.
+The informational headers Linkerd emits on outgoing requests.
 
 Header | Description
 ------ | -----------
-`l5d-dst-service` | The logical service name of the request as identified by linkerd.
+`l5d-dst-service` | The logical service name of the request as identified by Linkerd.
 `l5d-dst-client` | The concrete client name after delegation.
 `l5d-dst-residual` | An optional residual path remaining after delegation.
-`l5d-reqid` | A token that may be used to correlate requests in a callgraph across services and linkerd instances.
+`l5d-reqid` | A token that may be used to correlate requests in a callgraph across services and Linkerd instances.
 
 Applications are not required to forward these headers on downstream
 requests.
@@ -451,11 +451,11 @@ headers from requests sent to the outside world.
 
 ### HTTP/2 Informational Response Headers
 
-The informational headers linkerd emits on outgoing responses.
+The informational headers Linkerd emits on outgoing responses.
 
 Header | Description
 ------ | -----------
-`l5d-err` | Indicates a linkerd-generated error. Error responses that do not have this header are application errors.
+`l5d-err` | Indicates a Linkerd-generated error. Error responses that do not have this header are application errors.
 
 Applications are not required to forward these headers on upstream
 responses.

--- a/linkerd/docs/protocol-http.md
+++ b/linkerd/docs/protocol-http.md
@@ -38,12 +38,12 @@ maxInitialLineKB | 4 | The maximum size of an initial HTTP message line.
 maxRequestKB | 5120 | The maximum size of a non-chunked HTTP request payload.
 maxResponseKB | 5120 | The maximum size of a non-chunked HTTP response payload.
 compressionLevel | `-1`, automatically compresses textual content types with compression level 6 | The compression level to use (on 0-9).
-streamingEnabled | `true` | Streaming allows linkerd to work with HTTP messages that have large (or infinite) content bodies using chunked encoding.  Disabling this is highly discouraged.
+streamingEnabled | `true` | Streaming allows Linkerd to work with HTTP messages that have large (or infinite) content bodies using chunked encoding.  Disabling this is highly discouraged.
 
 <aside class="warning">
 These memory constraints are selected to allow reliable
-concurrent usage of linkerd. Changing these parameters may
-significantly alter linkerd's performance characteristics.
+concurrent usage of Linkerd. Changing these parameters may
+significantly alter Linkerd's performance characteristics.
 </aside>
 
 
@@ -121,14 +121,14 @@ forwardClientCert | false | Determines if client certificates are forwarded thro
 
 <aside class="notice">
 `forwardClientCert` makes Linkerd forward client certificates using the `x-forwarded-client-cert` header to let destination services make authorization decisions on the requests
-they receive. 
+they receive.
 </aside>
 
 <a name="http-1-1-identifiers"></a>
 ## HTTP/1.1 Identifiers
 
 Identifiers are responsible for creating logical *names* from an incoming
-request; these names are then matched against the dtab. (See the [linkerd
+request; these names are then matched against the dtab. (See the [Linkerd
 routing overview](https://linkerd.io/doc/latest/routing/) for more details on
 this.) All HTTP/1.1 identifiers have a `kind`.  If a list of identifiers is
 provided, each identifier is tried in turn until one successfully assigns a
@@ -318,7 +318,7 @@ headerValue | N/A | The value of the HTTP header as a path segment.
 
 kind: `io.l5d.ingress`
 
-Using this identifier enables linkerd to function as a Kubernetes ingress
+Using this identifier enables Linkerd to function as a Kubernetes ingress
 controller. The ingress identifier compares HTTP requests to [ingress
 resource](https://kubernetes.io/docs/user-guide/ingress/) rules, and assigns a
 name based on those rules.
@@ -341,7 +341,7 @@ namers:
 - kind: io.l5d.k8s
 ```
 
-> An example ingress resource watched by the linkerd ingress controller:
+> An example ingress resource watched by the Linkerd ingress controller:
 
 ```yaml
 apiVersion: extensions/v1beta1
@@ -365,7 +365,7 @@ spec:
 
 Key  | Default Value | Description
 ---- | ------------- | -----------
-namespace | (all) | The Kubernetes namespace where the ingress resources are deployed. If not specified, linkerd will watch all namespaces.
+namespace | (all) | The Kubernetes namespace where the ingress resources are deployed. If not specified, Linkerd will watch all namespaces.
 ingressClassAnnotation | `linkerd` | When using [multiple ingress controllers](https://github.com/kubernetes/ingress/blob/master/docs/faq/README.md#how-do-i-run-multiple-ingress-controllers-in-the-same-cluster), Linkerd will only use the ingress resource annotated with this class.
 host | `localhost` | The Kubernetes master host.
 port | `8001` | The Kubernetes master port.
@@ -512,20 +512,20 @@ mixerPort | `9091` | Port of the Mixer server.
 <a name="http-headers"></a>
 ## HTTP Headers
 
-linkerd reads and sets several headers prefixed by `l5d-`.
+Linkerd reads and sets several headers prefixed by `l5d-`.
 
 <a name="context-headers"></a>
 ### Context Headers
 
-_Context headers_ (`l5d-ctx-*`) are generated and read by linkerd
+_Context headers_ (`l5d-ctx-*`) are generated and read by Linkerd
 instances. Applications should forward all context headers in order
-for all linkerd features to work.
+for all Linkerd features to work.
 
 Header | Description
 ------ | -----------
 `dtab-local` | Deprecated. Use `l5d-ctx-dtab` and `l5d-dtab`.
 `l5d-ctx-deadline` | Describes time bounds within which a request is expected to be satisfied. Currently deadlines are only advisory and do not factor into request cancellation.
-`l5d-ctx-trace` | Encodes Zipkin-style trace IDs and flags so that trace annotations emitted by linkerd may be correlated.
+`l5d-ctx-trace` | Encodes Zipkin-style trace IDs and flags so that trace annotations emitted by Linkerd may be correlated.
 
 <aside class="warning">
 Edge services should take care to ensure these headers are not set
@@ -548,9 +548,9 @@ Header | Description
 `l5d-sample` | A client-specified trace sample rate override.
 
 <aside class="notice">
-If linkerd processes incoming requests for applications
+If Linkerd processes incoming requests for applications
 (i.e. in linker-to-linker configurations), applications do not need to
-provide special treatment for these headers since linkerd does <b>not</b>
+provide special treatment for these headers since Linkerd does <b>not</b>
 forward these headers (and instead translates them into context
 headers). If applications receive traffic directly, they <b>should</b>
 forward these headers.
@@ -563,14 +563,14 @@ from untrusted sources.
 
 ### Informational Request Headers
 
-The informational headers linkerd emits on outgoing requests.
+The informational headers Linkerd emits on outgoing requests.
 
 Header | Description
 ------ | -----------
-`l5d-dst-service` | The logical service name of the request as identified by linkerd.
+`l5d-dst-service` | The logical service name of the request as identified by Linkerd.
 `l5d-dst-client` | The concrete client name after delegation.
 `l5d-dst-residual` | An optional residual path remaining after delegation.
-`l5d-reqid` | A token that may be used to correlate requests in a callgraph across services and linkerd instances.
+`l5d-reqid` | A token that may be used to correlate requests in a callgraph across services and Linkerd instances.
 
 Applications are not required to forward these headers on downstream
 requests.
@@ -583,11 +583,11 @@ headers from requests sent to the outside world.
 
 ### Informational Response Headers
 
-The informational headers linkerd emits on outgoing responses.
+The informational headers Linkerd emits on outgoing responses.
 
 Header          | Description
 --------------- | -----------
-`l5d-err`       | Indicates a linkerd-generated error. Error responses that do not have this header are application errors.
+`l5d-err`       | Indicates a Linkerd-generated error. Error responses that do not have this header are application errors.
 `l5d-retryable` | Indicates that the request for this response is known to be safe to retry (for example, because it was not delivered to its destination).
 
 Applications should not forward these headers on upstream

--- a/linkerd/docs/protocol-mux.md
+++ b/linkerd/docs/protocol-mux.md
@@ -14,7 +14,7 @@ routers:
 
 protocol: `mux`
 
-linkerd experimentally supports the [mux
+Linkerd experimentally supports the [mux
 protocol](http://twitter.github.io/finagle/guide/Protocols.html#mux).
 
 ## Mux Router Parameters

--- a/linkerd/docs/protocol-thriftmux.md
+++ b/linkerd/docs/protocol-thriftmux.md
@@ -16,7 +16,7 @@ routers:
 
 protocol: `thriftmux`
 
-linkerd _experimentally_ supports the thriftmux
+Linkerd _experimentally_ supports the thriftmux protocol.
 
 Thriftmux protocol is capable of routing traffic to pure thrift service and
 will use [Thrift](http://twitter.github.io/finagle/guide/Protocols.html#thrift) protocol on the client.

--- a/linkerd/docs/retries.md
+++ b/linkerd/docs/retries.md
@@ -15,7 +15,7 @@ routers:
         maxMs: 10000
 ```
 
-linkerd can automatically retry requests on certain failures and can be
+Linkerd can automatically retry requests on certain failures and can be
 configured via the retries block.  Retries fall into two categories: retries
 and requeues.
 

--- a/linkerd/docs/routers.md
+++ b/linkerd/docs/routers.md
@@ -89,11 +89,11 @@ ip | loopback address | The local IP address. A value like 0.0.0.0 configures th
 tls | no tls | The server will serve over TLS if this parameter is provided. see [TLS](#server-tls).
 maxConcurrentRequests | unlimited | The maximum number of concurrent requests the server will accept.
 announce | an empty list | A list of concrete names to announce using the router's [announcers](#announcers).
-clearContext | `false` | If `true`, all headers that set linkerd contexts are removed from inbound requests. Useful for servers exposed on untrusted networks.
+clearContext | `false` | If `true`, all headers that set Linkerd contexts are removed from inbound requests. Useful for servers exposed on untrusted networks.
 
 ## Service Configuration
 
-This section defines the policy that linkerd will use when talking to services.
+This section defines the policy that Linkerd will use when talking to services.
 The structure of this section depends on its `kind`.
 
 Key  | Default Value    | Description
@@ -168,7 +168,7 @@ responseClassifier  | `io.l5d.http.nonRetryable5XX` | A (sometimes protocol-spec
 
 ## Client Configuration
 
-This section defines how the clients that linkerd creates will be configured.  The structure of this section depends on
+This section defines how the clients that Linkerd creates will be configured.  The structure of this section depends on
 its `kind`.
 
 Key  | Default Value    | Description

--- a/linkerd/docs/telemetry.md
+++ b/linkerd/docs/telemetry.md
@@ -1,7 +1,7 @@
 # Telemetry
 
 A telemeter may receive stats and trace annotations, e.g., to send to a collector
-or export. Telemetry data can be collected and exported from a linkerd process by
+or export. Telemetry data can be collected and exported from a Linkerd process by
 configuring telemeters via a top-level `telemetry` section.
 
 <aside class="notice">
@@ -33,7 +33,7 @@ Exposes admin endpoints:
 
 Key | Default Value | Description
 --- | ------------- | -----------
-path | `/admin/metrics/prometheus` | HTTP path where linkerd exposes Prometheus metrics
+path | `/admin/metrics/prometheus` | HTTP path where Linkerd exposes Prometheus metrics
 prefix | No prefix | Prefix for exposed Prometheus metrics
 
 ## InfluxDB
@@ -92,7 +92,7 @@ prefix | `linkerd` | String to prefix all exported metric names with.
 hostname | `127.0.0.1` | Hostname of the StatsD server.
 port | `8125` | Port of the StatsD server.
 gaugeIntervalMs | `10000` | Interval to export Gauges, in milliseconds.
-sampleRate | `0.01` | A value between 0.0 and 1.0 indicating what proportion of counter and timing/histogram events to export. Higher values will result in higher linkerd latency.
+sampleRate | `0.01` | A value between 0.0 and 1.0 indicating what proportion of counter and timing/histogram events to export. Higher values will result in higher Linkerd latency.
 
 ## TraceLog
 
@@ -113,7 +113,7 @@ Key | Default Value | Description
 --- | ------------- | -----------
 host | `localhost` | Host to send trace data to.
 sampleRate | `1.0` | A value between 0.0 and 1.0 indicating what proportion of traces to log.
-level | `INFO` | Log-level used to log traces. It should be equal (or greater) to the linkerd log level, set by the `-log.level` flag or at runtime in the logging tab of the admin dashboard (defaults to `INFO`). Field can have one of the following values: `ALL`, `CRITICAL`, `DEBUG`, `ERROR`, `FATAL`, `INFO`, `OFF`, `TRACE`, `WARNING`. For full details, see [TwitterServer's Logging documentation](https://twitter.github.io/twitter-server/Features.html#logging).
+level | `INFO` | Log-level used to log traces. It should be equal (or greater) to the Linkerd log level, set by the `-log.level` flag or at runtime in the logging tab of the admin dashboard (defaults to `INFO`). Field can have one of the following values: `ALL`, `CRITICAL`, `DEBUG`, `ERROR`, `FATAL`, `INFO`, `OFF`, `TRACE`, `WARNING`. For full details, see [TwitterServer's Logging documentation](https://twitter.github.io/twitter-server/Features.html#logging).
 
 ## Recent Requests
 
@@ -130,7 +130,7 @@ kind: `io.l5d.recentRequests`
 
 The recent requests telemeter keeps an in-memory record of recent requests and uses it to populate
 the recent requests table on the admin dashboard.  This table can be viewed at `/requests` on the
-admin port.  Recording requests can have an impact on linkerd performance, so make sure to set a
+admin port.  Recording requests can have an impact on Linkerd performance, so make sure to set a
 sample rate that is appropriate for your level of traffic.
 
 Key        | Default Value | Description

--- a/linkerd/docs/transformer.md
+++ b/linkerd/docs/transformer.md
@@ -35,7 +35,7 @@ kind: `io.l5d.specificHost`
 The specific host transformer filters the list of addresses down to only
 addresses that have the same IP address as the specified host. This transformer
 can be used by an incoming router to only route traffic to specific
-destinations. This is useful when linkerd is running inside a Docker container
+destinations. This is useful when Linkerd is running inside a Docker container
 and the traffic is to be sent to another Docker container on the same host.
 
 Key  | Default Value | Description
@@ -47,7 +47,7 @@ host | _required_    | The host to use.
 kind: `io.l5d.port`
 
 The port transformer replaces the port number in every address with a
-configured value.  This can be used if there is an incoming linkerd router (or
+configured value.  This can be used if there is an incoming Linkerd router (or
 other reverse-proxy) running on a fixed port on each host and you wish to send
 traffic to that port instead of directly to the destination address.
 

--- a/mesh/README.md
+++ b/mesh/README.md
@@ -1,10 +1,10 @@
 # io.linkerd.mesh #
 
-A set of gRPC APIs that can be used to control linkerd.
+A set of gRPC APIs that can be used to control Linkerd.
 
 The mesh consists of client-side plugin interfaces (initially, just
 NameInterpreter) as well as server-side service implementations
-(initially, in namerd's 'io.l5d.mesh' iface).
+(initially, in Namerd's 'io.l5d.mesh' iface).
 
 **Status**: Experimental; the API will break in an upcoming release.
 

--- a/namerd/README.md
+++ b/namerd/README.md
@@ -1,6 +1,6 @@
-# namerd #
+# Namerd #
 
-namerd is a service for managing linkerd (and finagle) name delegation
+Namerd is a service for managing Linkerd (and finagle) name delegation
 (i.e. routing).
 
 ```
@@ -9,7 +9,7 @@ Application
 Request
   |
   V
-linkerd ----logical name-----> namerd <--> Service Discovery
+Linkerd ----logical name-----> Namerd <--> Service Discovery
         <---concrete address--        <--> Dtab Storage
   |
 Request
@@ -18,19 +18,19 @@ Request
 Destination
 ```
 
-namerd is a service that resolves logical names to concrete addresses.  By
-having linkerd use namerd for name delegation, we reduce the load on service
-discovery backends and can use namerd as a central place to control routing
+Namerd is a service that resolves logical names to concrete addresses.  By
+having Linkerd use Namerd for name delegation, we reduce the load on service
+discovery backends and can use Namerd as a central place to control routing
 across a fleet of linkers.
 
-namerd supports pluggable modules for dtab storage, naming and service
-discovery, and servable interfaces.  For example, namerd can be configured to
+Namerd supports pluggable modules for dtab storage, naming and service
+discovery, and servable interfaces.  For example, Namerd can be configured to
 use ZooKeeper for storage, ZooKeeper Serversets for service discovery, and
 a long-poll thrift interface.
 
 ## Quickstart ##
 
-namerd can be run locally with the commands
+Namerd can be run locally with the commands
 
 ```
 ./sbt namerd-examples/basic:run
@@ -42,7 +42,7 @@ or
 
 ## Http Control Interface ##
 
-namerd provides an http interface to create, update and retrieve Dtabs, as
+Namerd provides an http interface to create, update and retrieve Dtabs, as
 defined in `HttpControlService`.
 
 For a command-line tool which wraps this interface, try

--- a/namerd/docs/config.md
+++ b/namerd/docs/config.md
@@ -1,6 +1,6 @@
 # Introduction
 
-> A namerd config example
+> A Namerd config example
 
 ```yaml
 storage:
@@ -22,9 +22,9 @@ interfaces:
   port: 4321
 ```
 
-Welcome to the Configuration Reference for namerd!
+Welcome to the Configuration Reference for Namerd!
 
-namerd's configuration is controlled via a config file, which must be provided
+Namerd's configuration is controlled via a config file, which must be provided
 as a command-line argument. It may be a local file path or `-` to
 indicate that the configuration should be read from the standard input.
 
@@ -34,11 +34,11 @@ The configuration may be specified as a JSON or YAML object.
 
 Key | Required | Description
 --- | -------- | -----------
-[admin](#administrative-interface) | no | Configures namerd's administrative interface. namerd admin has the same options as linkerd admin.
-[interfaces](#interfaces) | yes | Configures namerd's published network interfaces.
-[storage](#storage) | yes | Configures namerd's storage backend.
-[namers](https://linkerd.io/config/head/linkerd#namers) | no | Configures namerd's integration with various service discovery backends. namerd uses the same namers as linkerd.
-[telemetry](https://linkerd.io/config/head/linkerd#telemetry) | no | Configures namerd's metrics instrumentation. Namerd does not support tracing, so tracers provided by telemeters are ignored.
+[admin](#administrative-interface) | no | Configures Namerd's administrative interface. Namerd admin has the same options as Linkerd admin.
+[interfaces](#interfaces) | yes | Configures Namerd's published network interfaces.
+[storage](#storage) | yes | Configures Namerd's storage backend.
+[namers](https://linkerd.io/config/head/linkerd#namers) | no | Configures Namerd's integration with various service discovery backends. Namerd uses the same namers as Linkerd.
+[telemetry](https://linkerd.io/config/head/linkerd#telemetry) | no | Configures Namerd's metrics instrumentation. Namerd does not support tracing, so tracers provided by telemeters are ignored.
 
 ### Administrative interface
 
@@ -48,7 +48,7 @@ admin:
   port: 9991
 ```
 
-namerd supports an administrative interface. The exposed admin port and
+Namerd supports an administrative interface. The exposed admin port and
 IP are configurable via a top-level `admin` section.
 
 Key | Default Value | Description
@@ -58,13 +58,13 @@ port | `9991` | Port for the admin interface.
 
 #### Administrative endpoints
 
-Namerd's admin interface mirrors linkerd's, with one exception: the
-`/delegator.json` endpoint in linkerd is served as `/dtab/delegator.json` in
-namerd.
+Namerd's admin interface mirrors Linkerd's, with one exception: the
+`/delegator.json` endpoint in Linkerd is served as `/dtab/delegator.json` in
+Namerd.
 
 To learn about default admin endpoints, have a look at
-[linkerd's administrative interface](https://linkerd.io/config/head/linkerd/index.html#administrative-interface).
+[Linkerd's administrative interface](https://linkerd.io/config/head/linkerd/index.html#administrative-interface).
 
-For metrics information, namerd also exposes
-[linkerd's CommonMetrics endpoints](https://linkerd.io/config/head/linkerd/index.html#commonmetrics)
+For metrics information, Namerd also exposes
+[Linkerd's CommonMetrics endpoints](https://linkerd.io/config/head/linkerd/index.html#commonmetrics)
 by default.

--- a/namerd/docs/interface.md
+++ b/namerd/docs/interface.md
@@ -1,10 +1,10 @@
 # Interfaces
 
-An interface is a published network interface to namerd. All of the interfaces
+An interface is a published network interface to Namerd. All of the interfaces
 listed below provide Finagle's [`NameInterpreter`](
 https://twitter.github.io/finagle/docs/com/twitter/finagle/naming/NameInterpreter.html)
 functionality for remote resolution of destinations using dtabs stored in
-namerd. Additionally, the [`io.l5d.httpController`](#http-controller) interface
+Namerd. Additionally, the [`io.l5d.httpController`](#http-controller) interface
 provides a dtab read/write API that's used by
 [namerctl](https://github.com/linkerd/namerctl).
 
@@ -25,12 +25,12 @@ tls | no tls | The namer interface will serve over TLS if this parameter is prov
 kind: `io.l5d.thriftNameInterpreter`
 
 A read-only interface providing `NameInterpreter` functionality over the
-ThriftMux protocol. Use linkerd's `io.l5d.namerd` interpreter to resolve
+ThriftMux protocol. Use Linkerd's `io.l5d.namerd` interpreter to resolve
 destinations via this interface.
 
 Key | Default Value | Description
 --- | ------------- | -----------
-ip | loopback address | The local IP address on which to serve the namer interface. A value like 0.0.0.0 configures namerd to listen on all local IPv4 interfaces.
+ip | loopback address | The local IP address on which to serve the namer interface. A value like 0.0.0.0 configures Namerd to listen on all local IPv4 interfaces.
 port | `4100` | The port number on which to serve the namer interface.
 retryBaseSecs | `600` | Base number of seconds to tell clients to wait before retrying after an error.
 retryJitterSecs | `60` | Maximum number of seconds to jitter retry time by.
@@ -51,12 +51,12 @@ addrCacheInactive | `100` | The size of the address inactive cache.
 kind: `io.l5d.mesh`
 
 A read-only interface providing `NameInterpreter` functionality over the gRCP
-protocol. Use linkerd's `io.l5d.mesh` interpreter to resolve destinations via
+protocol. Use Linkerd's `io.l5d.mesh` interpreter to resolve destinations via
 this interface.
 
 Key | Default Value | Description
 --- | ------------- | -----------
-ip | loopback address | The local IP address on which to serve the namer interface. A value like 0.0.0.0 configures namerd to listen on all local IPv4 interfaces.
+ip | loopback address | The local IP address on which to serve the namer interface. A value like 0.0.0.0 configures Namerd to listen on all local IPv4 interfaces.
 port | `4321` | The port number on which to serve the namer interface.
 tls | no tls | The namer interface will serve over TLS if this parameter is provided. See [Server TLS](https://linkerd.io/config/head/linkerd#server-tls). The server TLS key file must be in PKCS#8 format.
 
@@ -68,12 +68,12 @@ The HTTP controller provides APIs for reading and writing dtabs, as well as for
 viewing how names are resolved.  This API can also be accessed using the
 [namerctl](https://github.com/linkerd/namerctl) command line tool.
 Additionally, this API provides an HTTP implementation of the `NameInterpreter`
-interface. Use linkerd's `io.l5d.namerd.http` interpreter to resolve
+interface. Use Linkerd's `io.l5d.namerd.http` interpreter to resolve
 destinations via this interface.
 
 Key | Default Value | Description
 --- | ------------- | -----------
-ip | loopback address | The local IP address on which to serve the namer interface. A value like 0.0.0.0 configures namerd to listen on all local IPv4 interfaces.
+ip | loopback address | The local IP address on which to serve the namer interface. A value like 0.0.0.0 configures Namerd to listen on all local IPv4 interfaces.
 port | `4180` | The port number on which to serve the namer interface.
 tls | no tls | The namer interface will serve over TLS if this parameter is provided. See [Server TLS](https://linkerd.io/config/head/linkerd#server-tls).
 
@@ -403,7 +403,7 @@ curl :4180/api/1/bound-names
 ]
 ```
 
-Returns a list of concrete names that namerd knows about.
+Returns a list of concrete names that Namerd knows about.
 
 Parameter | Type | Description
 --------- | ---- | -----------

--- a/namerd/docs/storage.md
+++ b/namerd/docs/storage.md
@@ -1,6 +1,6 @@
 # Storage
 
-A storage object configures the namerd dtabStore which stores and retrieves
+A storage object configures the Namerd dtabStore which stores and retrieves
 dtabs. This object supports the following parameters:
 
 <aside class="notice">
@@ -33,7 +33,7 @@ Key | Default Value | Description
 --- | ------------- | -----------
 host | `localhost` | The Kubernetes master host.
 port | `8001` | The Kubernetes master port.
-namespace | `default` | The Kubernetes namespace in which dtabs will be stored. This should usually be the same namespace in which namerd is running.
+namespace | `default` | The Kubernetes namespace in which dtabs will be stored. This should usually be the same namespace in which Namerd is running.
 
 <aside class="notice">
 The Kubernetes storage plugin does not support TLS.  Instead, you should run `kubectl proxy` on each host
@@ -44,7 +44,7 @@ which will create a local proxy for securely talking to the Kubernetes cluster A
 The "ThirdPartyResource" resource has been deprecated in favor of a "CustomResourceDefinition" resource in Kubernetes 1.7 and has officially been removed in Kubernetes 1.8+.
 To learn more about how to migrate existing third party resources to Custom Resource Definitions (CRD) <a href="https://kubernetes.io/docs/tasks/access-kubernetes-api/migrate-third-party-resource">See this guide.</a>
 </aside>
- 
+
 ### How to check if ThirdPartyResource is enabled (for Kubernetes v1.7 and below)
 
 1. Open `extensions/v1beta1` api - `https://<k8s-cluster-host>/apis/extensions/v1beta1`.


### PR DESCRIPTION
This will help to standardize the capitalization throughout all of the docs hosted on https://linkerd.io.