### PR TITLE
Add shell script for running h2spec against Linkerd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ npm-debug.log
 .DS_Store
 
 **/*.iml
+h2spec-*
+h2spec
+l5d-h2spec.log

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,3 @@ npm-debug.log
 .DS_Store
 
 **/*.iml
-h2spec-*
-h2spec
-l5d-h2spec.log

--- a/BUILD.md
+++ b/BUILD.md
@@ -111,6 +111,18 @@ assembled artifacts. It may be run with:
 > validator/validateAssembled
 ```
 
+The `ci/` directory contains a Bash script to run the HTTP/2 conformance
+testing tool [`h2spec`](https://github.com/summerwind/h2spec) against a
+Linkerd HTTP/2 router:
+```
+$ ./ci/h2spec.sh
+```
+
+Note that the script requires both `h2spec` and `nghttpd`. It will
+download and install `h2spec` to `~/bin`, if it is not already installed
+on your system. `nghttpd` can be installed from your package manager of
+choice.
+
 #### Writing tests ####
 
 Test files for each of the above test configurations are stored in a

--- a/ci/h2spec.sh
+++ b/ci/h2spec.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+set -eu
+set -o pipefail
+shopt -s extglob
+
+SEP="$(tput bold)⣷$(tput sgr0)"
+LOGFILE="l5d-h2spec.log"
+SPIN='⣾⣽⣻⢿⡿⣟⣯⣷'
+
+spin() {
+    local pid=$!
+    local i=0
+    while [ "$(ps a | awk '{print $1}' | grep $pid)" ]; do
+        i=$(( (i+1) %8 ))
+        printf "\r$(tput bold)${SPIN:$i:1}$(tput sgr0)"
+        sleep .1
+    done
+}
+
+echo "${SEP} running h2spec against linkerd..."
+# if we can't find h2spec, download it
+if ! [ -e "h2spec" ] ; then
+    # if we don't already have a h2spec executable, wget it from github
+    echo "${SEP} h2spec not found..."
+    # detect OS for downloading h2spec
+    case $OSTYPE in
+        darwin*)
+          echo "${SEP} detected OS as macOS"
+          H2SPEC_FILE="h2spec_darwin_amd64.tar.gz"
+          ;;
+        linux*)
+          echo "${SEP} detected OS as linux"
+          H2SPEC_FILE="h2spec_linux_amd64.tar.ghz"
+          ;;
+
+    esac
+    H2SPEC_URL="https://github.com/summerwind/h2spec/releases/download/v2.1.0/${H2SPEC_FILE}"
+    printf "${SEP} downloading h2spec..."
+    wget "${H2SPEC_URL}" > /dev/null 2>&1 &
+    spin
+    tar xf "${H2SPEC_FILE}" > /dev/null 2>&1 &
+    spin
+    printf "\n"
+fi
+
+L5D_PATH=$(find . -name 'linkerd-*-exec')
+
+until [ -e "${L5D_PATH}" ]; do
+    echo "${SEP} linkerd executable not found!"
+    ./sbt linkerd:compile | sed "s/^/${SEP} sbt ${SEP} /"
+    L5D_PATH=$(find . -name 'linkerd-*-exec')
+done
+
+echo "${SEP} found linkerd executable: $L5D_PATH"
+
+nghttpd 8080 --no-tls 2>&1 &
+NGHTTPD_PID=$!
+echo "${SEP} started nghttpd"
+
+ # run linkerd and send output to logfile.
+"${L5D_PATH}" -log.level=DEBUG linkerd/examples/h2spec.yaml &> "$LOGFILE" &
+L5D_PID=$!
+printf "${SEP} starting linkerd..."
+
+# make sure to kill the linkerd and nghttpd processes when terminating the
+# script, regardless of how
+trap '
+    echo ${SEP} killing nghttpd; kill ${NGHTTPD_PID};
+    echo ${SEP} killing linkerd; kill ${L5D_PID}
+    ' EXIT
+
+# wait until linkerd starts...
+i=0
+set +e
+until $(curl -sfo /dev/null http://localhost:9990/admin/ping); do
+    i=$(( (i+1) %8 ))
+    printf "\r$(tput bold)${SPIN:$i:1}$(tput sgr0)"
+    sleep .1
+done
+printf "\n"
+set -e
+
+# run h2spec against linkerd, printing linkerd's logs if h2spec failed.
+set +e
+./h2spec -p 4140
+H2SPEC_STATUS=$?
+set -e
+if [ "${H2SPEC_STATUS}" -eq 0 ]; then
+    echo "${SEP} h2spec passed!"
+else
+    echo "${SEP} h2spec failed! linkerd logs:"
+    cat "${LOGFILE}"
+fi
+
+exit "${H2SPEC_STATUS}"

--- a/linkerd/examples/h2spec.yaml
+++ b/linkerd/examples/h2spec.yaml
@@ -5,9 +5,6 @@ admin:
 usage:
   enabled: false
 
-telemetry:
-- kind: io.l5d.prometheus
-
 routers:
 - protocol: h2
   experimental: true

--- a/linkerd/examples/h2spec.yaml
+++ b/linkerd/examples/h2spec.yaml
@@ -1,0 +1,18 @@
+admin:
+  port: 9990
+  ip: 0.0.0.0
+
+usage:
+  enabled: false
+
+telemetry:
+- kind: io.l5d.prometheus
+
+routers:
+- protocol: h2
+  experimental: true
+  label: h2
+  servers:
+  - port: 4140
+    ip: 0.0.0.0
+  dtab: /svc => /$/inet/127.1/8080


### PR DESCRIPTION
This PR adds a shell script for running [`h2spec`](https://github.com/summerwind/h2spec), a conformance testing tool for HTTP/2, against a Linkerd HTTP/2 proxy. The script starts an `nghttpd` server for testing, starts Linkerd configured to forward traffic to `nghttpd`, and then starts `h2spec` pointed at Linkerd's port. The script will automatically build Linkerd first if there is no executable in `linkerd/target`, and will download the correct h2spec binary for the host OS if it is not present.

Right now, I put the script in the `ci` directory, even though it does not actually run on CI yet.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>