### PR TITLE
Set Host header to concrete resolved name

### DIFF
--- a/linkerd/protocol/http/src/main/scala/com/twitter/finagle/buoyant/linkerd/LinkerdHeaders.scala
+++ b/linkerd/protocol/http/src/main/scala/com/twitter/finagle/buoyant/linkerd/LinkerdHeaders.scala
@@ -6,7 +6,7 @@ import com.twitter.finagle.context.{Contexts, Deadline => FDeadline}
 import com.twitter.finagle.http._
 import com.twitter.finagle.tracing._
 import com.twitter.util.{Future, Return, Throw, Time, Try}
-import java.net.URLEncoder
+import java.net.{InetSocketAddress, URLEncoder}
 import java.nio.charset.StandardCharsets.ISO_8859_1
 import java.util.Base64
 import scala.collection.breakOut
@@ -421,6 +421,12 @@ object Headers {
       private[this] def annotate(msg: Message): Unit = {
         val headers = msg.headerMap
         val _b = headers.set(Bound, boundShow)
+
+        val addr = bound.addr.sample().asInstanceOf[com.twitter.finagle.Addr.Bound]
+        val inet = addr.addrs.head.asInstanceOf[com.twitter.finagle.Address.Inet]
+        val host = inet.addr.getHostString
+        headers.set("Host", host)
+
         pathShow match {
           case None =>
           case Some(p) =>


### PR DESCRIPTION
This addresses the issue seen in #509. Right now when a request is proxied through linkerd, the `Host` header remains unchanged from what the client used. This can cause requests to fail when the request is forwarded to a backend that uses Host header-based virtual hosting.

The example in #509 is IIS, but this functionality is coming back into vogue with Amazon's Application Load Balancer service [now supporting host based routing](https://aws.amazon.com/blogs/aws/new-host-based-routing-support-for-aws-application-load-balancers/). 

As an aside, this is probably the worst code ever submitted to the linkerd project - it's my first Scala ever. I'm very happy to change it in response to any advice, also happy to have it completely rewritten by someone who actually knows what they're doing.

Thanks!