### PR TITLE
stabilizeExistence match should be exhaustive

### DIFF
--- a/finagle/buoyant/src/main/scala/com/twitter/finagle/buoyant/ExistentialStability.scala
+++ b/finagle/buoyant/src/main/scala/com/twitter/finagle/buoyant/ExistentialStability.scala
@@ -75,6 +75,8 @@ object ExistentialStability {
             update() = Activity.Ok(None)
           case Activity.Pending =>
             update() = Activity.Pending
+          case Activity.Failed(e) =>
+            update() = Activity.exception(e)
         }
       }
       Activity(inner)


### PR DESCRIPTION
To avoid MatchErrors, this function must be exhaustive.

Signed-off-by: Alex Leong <alex@buoyant.io>