### PR TITLE
Call f.content.release() after updateWindow. Fixes #1728

### DIFF
--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4Message.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4Message.scala
@@ -104,9 +104,12 @@ private[h2] object Netty4Message {
       val sz = f.content.readableBytes + f.padding
       val buf = ByteBufAsBuf(f.content.retain())
       val releaser: () => Future[Unit] = {
-        f.content.release()
-        if (sz > 0) () => updateWindow(sz)
-        else () => Future.Unit
+        () =>
+          {
+            val res = if (sz > 0) updateWindow(sz) else Future.Unit
+            f.content.release()
+            res
+          }
       }
       Frame.Data(buf, f.isEndStream, releaser)
     }


### PR DESCRIPTION
This fixes gRPC deserialization errors described in #1728 that I'm having with linkerd `1.3.3` in DC/OS AWS environment.