### PR TITLE
Remove reference to netty3 in example config

### DIFF
--- a/linkerd/examples/http.yaml
+++ b/linkerd/examples/http.yaml
@@ -6,7 +6,6 @@ namers:
 routers:
 - protocol: http
   httpAccessLog: logs/access.log
-  label: netty3
   maxChunkKB: 16
   maxHeadersKB: 16
   maxInitialLineKB: 16


### PR DESCRIPTION
Our example http.yaml still references netty3, even though support was
removed.

Remove reference to netty3, the router's label name will default to http.