### PR TITLE
Data frames release the underlying ByteBuf, not the wrapped Buf

### DIFF
--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4Message.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4Message.scala
@@ -104,9 +104,12 @@ private[h2] object Netty4Message {
       val sz = f.content.readableBytes + f.padding
       val buf = ByteBufAsBuf(f.content.retain())
       val releaser: () => Future[Unit] = {
-        f.content.release()
-        if (sz > 0) () => updateWindow(sz)
-        else () => Future.Unit
+        () =>
+          {
+            val res = if (sz > 0) updateWindow(sz) else Future.Unit
+            f.content.release()
+            res
+          }
       }
       Frame.Data(buf, f.isEndStream, releaser)
     }


### PR DESCRIPTION
The Finagle `ByteBufAsBuf` converter wraps a Netty 4 `ByteBuf`, but does not support reference counting (see [this comment](https://github.com/twitter/finagle/blob/82d00660373582d6bfe56df8155b52528df36691/finagle-netty4/src/main/scala/com/twitter/finagle/netty4/ByteBufAsBuf.scala#L58-L61)). Therefore, when releasing a data frame whose content `ByteBuf` we `retain()` before wrapping it as a `Buf`, we must `release()` the underlying `ByteBuf`. 

This fixes the memory leak observed in #1678 without removing the call to `retain()` which was removed in #1711, which introduced a data corruption issue (#1728). If we `release()` the underlying `ByteBuf` after releasing the data frame, we can once again `retain()` it before converting to `Buf` without leaking, thus avoiding the data corruption caused by removing the `retain()`.

Thanks to @vadimi for helping with this fix!

Fixes #1728.