### PR TITLE
Handle unexpected status codes on the initial get of a k8s watch

### DIFF
--- a/finagle/buoyant/src/main/scala/com/twitter/finagle/buoyant/ExistentialStability.scala
+++ b/finagle/buoyant/src/main/scala/com/twitter/finagle/buoyant/ExistentialStability.scala
@@ -75,6 +75,8 @@ object ExistentialStability {
             update() = Activity.Ok(None)
           case Activity.Pending =>
             update() = Activity.Pending
+          case Activity.Failed(e) =>
+            update() = Activity.Failed(e)
         }
       }
       Activity(inner)


### PR DESCRIPTION
Ensure that unexpected status codes are retried when they are encountered on the initial get of a k8s watch.

Signed-off-by: Alex Leong <alex@buoyant.io>