### PR TITLE
Seed ThriftNameInterpreter’s stamper with a random long 🎲

### DIFF
--- a/namerd/iface/interpreter-thrift/src/main/scala/io/buoyant/namerd/iface/ThriftNamerInterface.scala
+++ b/namerd/iface/interpreter-thrift/src/main/scala/io/buoyant/namerd/iface/ThriftNamerInterface.scala
@@ -13,6 +13,7 @@ import io.buoyant.namerd.iface.ThriftNamerInterface.Capacity
 import io.buoyant.namerd.iface.thriftscala.{Delegation, DtabRef, DtabReq}
 import io.buoyant.namerd.iface.{thriftscala => thrift}
 import java.nio.ByteBuffer
+import java.util.Random
 import java.util.concurrent.atomic.AtomicLong
 import scala.util.control.NonFatal
 
@@ -73,7 +74,11 @@ object ThriftNamerInterface {
    * A utility for generating stamps unique to an instance.
    */
   private[namerd] class LocalStamper extends Stamper {
-    private[this] val counter = new AtomicLong(Long.MinValue)
+    private[this] val counter = {
+      // Start with a random long so stamps between multiple instances are unlikely to collide
+      val rand = new Random()
+      new AtomicLong(rand.nextLong())
+    }
 
     def apply(): Stamp = Stamp.mk(counter.getAndIncrement())
   }


### PR DESCRIPTION
`ThriftNameInterpreter` "stamps" observable resources when it sends them to clients. This stamp works much like a hash; the client sends the stamp of its cached resource to the server, and the server responds only when this is out of date.

These stamps are generated by incrementing a `Long` whenever there is an update, but because it is currently seeded from a static value (`Long.MinValue`), these stamps may collide if there are multiple replicas of Namerd. When this happens, Linkerd may miss an update, which can cause traffic to be improperly routed to endpoints which no longer exist. This can be particularly problematic if the collision happens on the `bind` request as we have observed that this can block the `addr` request from ever being made unless the dtab itself changes. linkerd/namerd processes may need to be restarted for endpoint updates to be propagated.

To fix this, I have seeded `LocalStamper` with a random value on launch so that multiple namerd's generating colliding stamps becomes very improbable. I feel like in an ideal world this would be an actual hash of the observed resources, but that is a much more invasive change.