### PR TITLE
Bump base Docker image to 8u151, add jdk configs

### DIFF
--- a/project/Base.scala
+++ b/project/Base.scala
@@ -153,7 +153,7 @@ class Base extends Build {
     assemblyJarName in assembly := s"${name.value}-${version.value}-${configuration.value}-exec",
     docker := (docker dependsOn (assembly in configuration)).value,
     dockerEnvPrefix := "",
-    dockerJavaImage := (dockerJavaImage in Global).?(_.getOrElse("openjdk:8u131-jre")).value,
+    dockerJavaImage := (dockerJavaImage in Global).?(_.getOrElse("openjdk:8u151-jre")).value,
     dockerfile in docker := new Dockerfile {
       val envPrefix = dockerEnvPrefix.value.toUpperCase
       val home = s"/${organization.value}/${name.value}/${version.value}"

--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -12,6 +12,7 @@ object LinkerdBuild extends Base {
 
   val Bundle = config("bundle")
   val Dcos = config("dcos") extend Bundle
+  val Jdk = config("jdk") extend Bundle
   val LowMem = config("lowmem") extend Bundle
 
   val configCore = projectDir("config")
@@ -353,6 +354,12 @@ object LinkerdBuild extends Base {
       Telemetry.adminMetricsExport, Telemetry.core, Telemetry.influxdb, Telemetry.prometheus, Telemetry.recentRequests, Telemetry.statsd, Telemetry.tracelog, Telemetry.zipkin
     )
 
+    val JdkSettings = BundleSettings ++ Seq(
+      dockerJavaImage := "openjdk:8u151-jdk",
+      dockerTag := s"${version.value}-jdk",
+      assemblyJarName in assembly := s"${name.value}-${version.value}-jdk-exec"
+    )
+
     val LowMemSettings = BundleSettings ++ Seq(
       dockerJavaImage := "buoyantio/debian-32-bit",
       dockerTag := s"${version.value}-32b",
@@ -405,10 +412,12 @@ object LinkerdBuild extends Base {
 
     val all = aggregateDir("namerd",
         core, dcosBootstrap, main, Storage.all, Interpreter.all, Iface.all)
-      .configs(Bundle, Dcos, LowMem)
+      .configs(Bundle, Dcos, Jdk, LowMem)
       // Bundle includes all of the supported features:
       .configDependsOn(Bundle)(BundleProjects: _*)
       .settings(inConfig(Bundle)(BundleSettings))
+      .configDependsOn(Jdk)(BundleProjects: _*)
+      .settings(inConfig(Jdk)(JdkSettings))
       .configDependsOn(LowMem)(BundleProjects: _*)
       .settings(inConfig(LowMem)(LowMemSettings))
       .configDependsOn(Dcos)(dcosBootstrap)
@@ -609,13 +618,21 @@ object LinkerdBuild extends Base {
       assemblyJarName in assembly := s"${name.value}-${version.value}-32b-exec"
     )
 
+    val JdkSettings = BundleSettings ++ Seq(
+      dockerJavaImage := "openjdk:8u151-jdk",
+      dockerTag := s"${version.value}-jdk",
+      assemblyJarName in assembly := s"${name.value}-${version.value}-jdk-exec"
+    )
+
     val all = aggregateDir("linkerd",
         admin, configCore, core, failureAccrual, main, tls,
         Announcer.all, Namer.all, Protocol.all)
-      .configs(Bundle, LowMem)
+      .configs(Bundle, Jdk, LowMem)
       // Bundle is includes all of the supported features:
       .configDependsOn(Bundle)(BundleProjects: _*)
       .settings(inConfig(Bundle)(BundleSettings))
+      .configDependsOn(Jdk)(BundleProjects: _*)
+      .settings(inConfig(Jdk)(JdkSettings))
       .configDependsOn(LowMem)(BundleProjects: _*)
       .settings(inConfig(LowMem)(LowMemSettings))
       .settings(


### PR DESCRIPTION
Linkerd is currently built on openjdk:8u131-jre, which is deprecated,
and does not support jmap for heap dumps.

Update Linkerd to use openjdk:8u151-jre as a base image, and add a jdk
config for heap dumps. These new images will appear as
buoyantio/linkerd:1.3.4-jdk and buoyantio/namerd:1.3.4-jdk.

Signed-off-by: Andrew Seigner <andrew@sig.gy>