### PR TITLE
Improve handling of dtab parse errors in ConsulDtabStore

### DIFF
--- a/namerd/storage/consul/src/main/scala/io/buoyant/namerd/storage/consul/ConsulDtabStore.scala
+++ b/namerd/storage/consul/src/main/scala/io/buoyant/namerd/storage/consul/ConsulDtabStore.scala
@@ -188,8 +188,7 @@ class ConsulDtabStore(
             case Throw(e: NotFound) =>
               updates() = Activity.Ok(None)
               cycle(e.rsp.headerMap.get(Headers.Index), backoffs0)
-            case Throw(e: Failure) if e.isFlagged(Failure.Interrupted) =>
-              Future.Done
+            case Throw(e: Failure) if e.isFlagged(Failure.Interrupted) => Future.Done
             case Throw(e) =>
               updates() = Activity.Failed(e)
               log.error("consul ns %s dtab observation error %s", ns, e)

--- a/namerd/storage/consul/src/main/scala/io/buoyant/namerd/storage/consul/ConsulDtabStore.scala
+++ b/namerd/storage/consul/src/main/scala/io/buoyant/namerd/storage/consul/ConsulDtabStore.scala
@@ -168,13 +168,28 @@ class ConsulDtabStore(
           ).transform {
             case Return(result) =>
               val version = Buf.Utf8(result.index.get)
-              val dtab = Dtab.read(result.value)
-              updates() = Activity.Ok(Some(VersionedDtab(dtab, version)))
+              // the raw string, not yet parsed as a dtab.
+              val rawDtab = result.value
+              // attempt to parse the string as a dtab, and update the the
+              // Activity with  the new state - either Ok if the string was
+              // parsed successfully, or Failed if an error occurred.
+              val nextState = Try {
+                Dtab.read(rawDtab)
+              } match {
+                case Return(dtab) => // dtab parsing succeeded.
+                  Activity.Ok(Some(VersionedDtab(dtab, version)))
+                case Throw(e) => // dtab parsing failed!
+                  log.error("consul ns %s dtab parsing failed: %s; dtab: '%s'", ns, e, rawDtab)
+                  Activity.Failed(e)
+              }
+              updates() = nextState
               cycle(result.index, backoffs0)
+
             case Throw(e: NotFound) =>
               updates() = Activity.Ok(None)
               cycle(e.rsp.headerMap.get(Headers.Index), backoffs0)
-            case Throw(e: Failure) if e.isFlagged(Failure.Interrupted) => Future.Done
+            case Throw(e: Failure) if e.isFlagged(Failure.Interrupted) =>
+              Future.Done
             case Throw(e) =>
               updates() = Activity.Failed(e)
               log.error("consul ns %s dtab observation error %s", ns, e)

--- a/namerd/storage/consul/src/test/scala/io/buoyant/namerd/storage/consul/ConsulDtabStoreTest.scala
+++ b/namerd/storage/consul/src/test/scala/io/buoyant/namerd/storage/consul/ConsulDtabStoreTest.scala
@@ -8,9 +8,9 @@ import com.twitter.util._
 import io.buoyant.consul.v1.KvApi
 import io.buoyant.namerd.DtabStore.{DtabNamespaceAlreadyExistsException, DtabNamespaceInvalidException}
 import io.buoyant.namerd.{Ns, VersionedDtab}
-import io.buoyant.test.{Awaits, Exceptions, FunSuite}
+import io.buoyant.test.{ActivityValues, Awaits, Exceptions, FunSuite}
 
-class ConsulDtabStoreTest extends FunSuite with Awaits with Exceptions {
+class ConsulDtabStoreTest extends FunSuite with Awaits with Exceptions with ActivityValues  {
 
   val namespacesJson = """["namerd/dtabs/foo/bar/", "namerd/dtabs/foo/baz/"]"""
   val namerdPrefix = "/namerd/dtabs"
@@ -262,7 +262,7 @@ class ConsulDtabStoreTest extends FunSuite with Awaits with Exceptions {
     )
     @volatile var state: Activity.State[Option[VersionedDtab]] = Activity.Pending
     store.observe(namespace).states respond { state = _ }
-    assert(state == Activity.Failed(expectedException))
+    assert(state.failed.getMessage == expectedException.getMessage)
   }
 
 }

--- a/namerd/storage/consul/src/test/scala/io/buoyant/namerd/storage/consul/ConsulDtabStoreTest.scala
+++ b/namerd/storage/consul/src/test/scala/io/buoyant/namerd/storage/consul/ConsulDtabStoreTest.scala
@@ -4,7 +4,7 @@ import com.twitter.finagle.http.{Request, Response, Status}
 import com.twitter.finagle.service.Backoff
 import com.twitter.finagle.{Dtab, Path, Service}
 import com.twitter.io.Buf
-import com.twitter.util.{Activity, Duration, Future}
+import com.twitter.util._
 import io.buoyant.consul.v1.KvApi
 import io.buoyant.namerd.DtabStore.{DtabNamespaceAlreadyExistsException, DtabNamespaceInvalidException}
 import io.buoyant.namerd.{Ns, VersionedDtab}
@@ -231,6 +231,38 @@ class ConsulDtabStoreTest extends FunSuite with Awaits with Exceptions {
     @volatile var state: Activity.State[Option[VersionedDtab]] = Activity.Pending
     store.observe(namespace).states respond { state = _ }
     assert(state == Activity.Ok(Some(VersionedDtab(Dtab.read(dtab), Buf.Utf8(version)))))
+  }
+
+  test("return Activity.Failed when the dtab is malformed") {
+    val namespace = "default"
+    val dtab = """lol im an invalid dtab"""
+    val expectedException = Try(Dtab.read(dtab)) match {
+      case Return(_) => fail("parsing invalid dtab should have succeeded")
+      case Throw(e) => e
+    }
+    val version = "4"
+    val service = Service.mk[Request, Response] { req =>
+      val rsp = Response()
+      rsp.setContentTypeJson()
+      rsp.headerMap.set("X-Consul-Index", version)
+      rsp.content = Buf.Utf8(dtab)
+      if (req.path.contains(namespace) && req.getParam("index", "").isEmpty) {
+        Future.value(rsp)
+      } else {
+        Future.never
+      }
+
+    }
+    val store = new ConsulDtabStore(
+      KvApi(service, constBackoff),
+      Path.read(namerdPrefix),
+      None,
+      readConsistency = None,
+      writeConsistency = None
+    )
+    @volatile var state: Activity.State[Option[VersionedDtab]] = Activity.Pending
+    store.observe(namespace).states respond { state = _ }
+    assert(state == Activity.Failed(expectedException))
   }
 
 }

--- a/test-util/src/main/scala/io/buoyant/test/ActivityValues.scala
+++ b/test-util/src/main/scala/io/buoyant/test/ActivityValues.scala
@@ -4,7 +4,47 @@ import com.twitter.util.Activity
 import org.scalatest.exceptions.TestFailedException
 
 /**
- * Like TryValues but for Activity.
+ * Like ScalaTest's <code>TryValues</code> trait, but for <code>Activity.State</code>s.
+ *
+ * Trait that provides an implicit conversion that adds <code>ok</code>, <code>failed</code>, and <code>pending</code>
+ * methods to <code>com.twitter.util.Activity.State</code>, enabling you to make assertions about the value of an
+ * <code>Activity.Ok</code> state or the exception of an <code>Activity.Failed</code> state.
+ *
+ * <p>
+ * The <code>ok</code> method will return the value of the <code>Activity.State</code> on which it is invoked if the
+ * state is <code>Ok</code>, or throw <code>TestFailedException</code> if not.
+ * The <code>failed</code> method will return the exception value of an <code>Activity.State</code> on which it is
+ * invoked if the state is a <code>Activity.Failed</code>, or throw <code>TestFailedException</code> if not.
+ * Finally, the <code>pending</code> method, which is largely included for completeness, will return <code>()</code> if
+ * <code>Activity.State</code> on which it is invoked if the state is <code>Activity.Pending</code>, or throw
+ * <code>TestFailedException</code> if not.
+ * </p>
+ *
+ * <p>
+ * This construct allows you to express in one statement that an <code>Activity.State</code> should be an
+ * <code>Activity.Ok</code>, <code>Activity.Pending</code>, or an <code>Activity.Failed</code>, and that its value or
+ * exception (if it is Ok or Failed), respectively,should meet some expectation. Here's an example:
+ * </p>
+ *
+ * <pre class="stHighlight">
+ * state1.ok should be &gt; 9
+ * state2.failed should have message "/ by zero"
+ * </pre>
+ *
+ * <p>
+ * Or, using assertions instead of a matchers:
+ * </p>
+ *
+ * <pre class="stHighlight">
+ * assert(try1.ok &gt; 9)
+ * assert(try2.failed.getMessage == "/ by zero")
+ * </pre>
+ *
+ * <p>
+ * This makes it much easier to expect that a given `Activity` is in a certain state than having to manually match
+ * against the state.
+ * </p>
+ *
  */
 trait ActivityValues {
 
@@ -25,12 +65,12 @@ trait ActivityValues {
         throw new TestFailedException(s"expected Activity.Failed, found Activity.Pending", 1)
     }
 
-    def pending = state match {
+    def pending: Unit = state match {
       case Activity.Ok(t) =>
         throw new TestFailedException(s"expected Activity.Pending, found Activity.Ok($t)", 1)
       case Activity.Failed(e) =>
         throw new TestFailedException(s"expected Activity.Ok, found Activity.Failed($e)", e, 1)
-      case p @ Activity.Pending => p
+      case Activity.Pending => ()
     }
   }
 

--- a/test-util/src/main/scala/io/buoyant/test/ActivityValues.scala
+++ b/test-util/src/main/scala/io/buoyant/test/ActivityValues.scala
@@ -1,0 +1,37 @@
+package io.buoyant.test
+
+import com.twitter.util.Activity
+import org.scalatest.exceptions.TestFailedException
+
+/**
+ * Like TryValues but for Activity.
+ */
+trait ActivityValues {
+
+  implicit class Valuable[T](state: Activity.State[T]) extends AnyRef {
+    def ok: T = state match {
+      case Activity.Ok(t) => t
+      case Activity.Failed(e) =>
+        throw new TestFailedException(s"expected Activity.Ok, found Activity.Failed($e)", e, 1)
+      case Activity.Pending =>
+        throw new TestFailedException(s"expected Activity.Ok, found Activity.Pending", 1)
+    }
+
+    def failed: Throwable = state match {
+      case Activity.Ok(t) =>
+        throw new TestFailedException(s"expected Activity.Failed, found Activity.Ok($t)", 1)
+      case Activity.Failed(e) => e
+      case Activity.Pending =>
+        throw new TestFailedException(s"expected Activity.Failed, found Activity.Pending", 1)
+    }
+
+    def pending = state match {
+      case Activity.Ok(t) =>
+        throw new TestFailedException(s"expected Activity.Pending, found Activity.Ok($t)", 1)
+      case Activity.Failed(e) =>
+        throw new TestFailedException(s"expected Activity.Ok, found Activity.Failed($e)", e, 1)
+      case p @ Activity.Pending => p
+    }
+  }
+
+}


### PR DESCRIPTION
Fixes #1759.

Currently, when Namerd's `ConsulDtabStore` makes a request to Consul's KV API that returns a value, it passes that value to `Dtab.read()` to parse it as a dtab. Dtab parsing can fail if the string returned by the KV API is not properly formatted as a dtab; if this is the case, `Dtab.read()` will throw an `InvalidArgumentException`. However, this is not handled in `ConsulDtabStore`; instead, the exception will be thrown upwards. When the dtab observation was opened by the Admin UI's `DtabHandler`, no additional error handling is performed, causing the exception to cancel the request, printing a message like
```
E 1220 00:26:45.879 UTC THREAD27: adminhttp
com.twitter.finagle.CancelledRequestException: request cancelled. Remote Info: Not Available
```
and causing the admin UI to hang, as though it's still waiting to receive a response from Namerd.

I've updated the code handling Consul GET responses in `ConsulDtabStore` to `Try` the call to `Dtab.read()`, and update the activity's state to `Activity.Failed` when the dtab could not be parsed successfully. Namerd will now log messages which state that the dtab was malformed, and surface the parse error, including showing which character was invalid. The log message now looks like this:

```
E 1220 20:46:06.770 UTC THREAD31 TraceId:30cbad82deebb433: consul ns consul dtab parsing failed: java.lang.IllegalArgumentException: '/' expected but 'a' found at '[a]sjgfdskjhsdfg;'; dtab: 'asjgfdskjhsdfg;'
```

The admin UI web interface doesn't currently handle the error in this case, and will load a blank page rather than displaying a useful error message. However, it no longer appears to be awaiting a response, and the error messages in the logs are much more meaningful; and I think changes to the web UI should be in a separate PR.

I've written a new unit test to assert that an unparsable dtab fails the `Activity` returned by `ConsulDtabStore.observe()`. This unit test fails against the current master. I've also added some test utility code to make assertions about `Activity.State` values more ergonomic. I've also manually verified the changes by creating an invalid dtab value in Consul running locally and opening the admin UI for that namespace.
