### PR TITLE
Add a client_state.json admin endpoint to expose the client address set

### DIFF
--- a/linkerd/admin/src/main/scala/com/twitter/finagle/client/buoyant/ClientStateHandler.scala
+++ b/linkerd/admin/src/main/scala/com/twitter/finagle/client/buoyant/ClientStateHandler.scala
@@ -1,0 +1,41 @@
+package com.twitter.finagle.client.buoyant
+
+import com.twitter.finagle.{Addr, Address, Service}
+import com.twitter.finagle.client.ClientRegistry
+import com.twitter.finagle.http.{MediaType, Request, Response}
+import com.twitter.finagle.loadbalancer.LoadBalancerFactory
+import com.twitter.util.Future
+import io.buoyant.config.Parser
+
+class ClientStateHandler extends Service[Request, Response] {
+
+  private[this] val mapper = Parser.jsonObjectMapper(Nil)
+
+  override def apply(request: Request): Future[Response] = {
+    val entries = ClientRegistry.registrants.map { entry =>
+      val LoadBalancerFactory.Dest(va) = entry.params[LoadBalancerFactory.Dest]
+      va.changes.toFuture().map(entry.addr -> _)
+    }
+    Future.collect(entries.toSeq).map { entries =>
+      val clientState = entries.map {
+        case (client, addr) =>
+          val state = addr match {
+            case Addr.Bound(addresses, meta) =>
+              addresses.map {
+                case Address.Inet(isa, _) => isa.getHostString
+                case a => a.toString
+              }.toSeq
+            case Addr.Failed(why) => s"Failed: ${why.getMessage}"
+            case a@Addr.Pending => a.toString
+            case a@Addr.Neg => a.toString
+          }
+          client -> state
+      }.toMap
+
+      val response = Response()
+      response.contentType = MediaType.Json + ";charset=UTF-8"
+      response.contentString = mapper.writeValueAsString(clientState)
+      response
+    }
+  }
+}

--- a/linkerd/admin/src/main/scala/com/twitter/finagle/client/buoyant/ClientStateHandler.scala
+++ b/linkerd/admin/src/main/scala/com/twitter/finagle/client/buoyant/ClientStateHandler.scala
@@ -1,41 +1,41 @@
 package com.twitter.finagle.client.buoyant
 
-import com.twitter.finagle.{Addr, Address, Service}
+import com.twitter.finagle.{Addr, Address, Path, Service}
 import com.twitter.finagle.client.ClientRegistry
 import com.twitter.finagle.http.{MediaType, Request, Response}
 import com.twitter.finagle.loadbalancer.LoadBalancerFactory
-import com.twitter.util.Future
+import com.twitter.util.{Future, Try}
 import io.buoyant.config.Parser
 
 class ClientStateHandler extends Service[Request, Response] {
 
+  private case class ClientState(state: String, addresses: Seq[String] = Nil)
+
   private[this] val mapper = Parser.jsonObjectMapper(Nil)
 
   override def apply(request: Request): Future[Response] = {
-    val entries = ClientRegistry.registrants.map { entry =>
-      val LoadBalancerFactory.Dest(va) = entry.params[LoadBalancerFactory.Dest]
-      va.changes.toFuture().map(entry.addr -> _)
-    }
-    Future.collect(entries.toSeq).map { entries =>
-      val clientState = entries.map {
-        case (client, addr) =>
-          val state = addr match {
-            case Addr.Bound(addresses, meta) =>
-              addresses.map {
-                case Address.Inet(isa, _) => isa.getHostString
-                case a => a.toString
-              }.toSeq
-            case Addr.Failed(why) => s"Failed: ${why.getMessage}"
-            case a@Addr.Pending => a.toString
-            case a@Addr.Neg => a.toString
-          }
-          client -> state
+    val entries = ClientRegistry.registrants
+      .filter { entry =>
+        // only display clients with a Path name
+        Try(Path.read(entry.addr)).isReturn
+      }.map { entry =>
+        val LoadBalancerFactory.Dest(va) = entry.params[LoadBalancerFactory.Dest]
+        val clientState = va.sample() match {
+          case Addr.Bound(addresses, _) =>
+            ClientState("bound", addresses.map {
+              case Address.Inet(isa, _) => s"${isa.getHostString}:${isa.getPort}"
+              case a => a.toString
+            }.toSeq)
+          case Addr.Failed(why) => ClientState(s"Failed: ${why.getMessage}")
+          case a@Addr.Pending => ClientState(a.toString)
+          case a@Addr.Neg => ClientState(a.toString)
+        }
+        entry.addr -> clientState
       }.toMap
 
-      val response = Response()
-      response.contentType = MediaType.Json + ";charset=UTF-8"
-      response.contentString = mapper.writeValueAsString(clientState)
-      response
-    }
+    val response = Response()
+    response.contentType = MediaType.Json + ";charset=UTF-8"
+    response.contentString = mapper.writeValueAsString(entries)
+    Future.value(response)
   }
 }

--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/LinkerdAdmin.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/LinkerdAdmin.scala
@@ -2,6 +2,7 @@ package io.buoyant.linkerd
 package admin
 
 import com.twitter.finagle._
+import com.twitter.finagle.client.buoyant.ClientStateHandler
 import com.twitter.finagle.http.Request
 import com.twitter.finagle.naming.buoyant.DstBindingFactory
 import com.twitter.finagle.naming.NameInterpreter
@@ -41,6 +42,8 @@ object LinkerdAdmin {
       Handler("/delegator.json", new DelegateApiHandler(getInterpreter))
     )
   }
+
+  val clientState: Handler = Handler("/client_state.json", new ClientStateHandler)
 
   def static(adminHandler: AdminHandler): Seq[Handler] = Seq(
     Handler("/", new DashboardHandler(adminHandler)),
@@ -102,6 +105,6 @@ object LinkerdAdmin {
     static(adminHandler) ++ config(lc) ++
       boundNames(linker.namers.map { case (_, n) => n }) ++
       delegator(adminHandler, linker.routers) ++
-      extHandlers
+      extHandlers :+ clientState
   }
 }


### PR DESCRIPTION
Add client_state.json admin endpoint which outputs the current address set for each client in the client registry.  

Sample output:
```
{
  "/$/inet/localhost/4100": {
    "state": "bound",
    "addresses": [
      "localhost:4100"
    ]
  },
  "/#/io.l5d.k8s/emojivoto/grpc/voting-svc": {
    "state": "bound",
    "addresses": [
      "172.17.0.8:8080",
      "172.17.0.7:8080",
      "172.17.0.5:8080"
    ]
  }
}
```

Signed-off-by: Alex Leong <alex@buoyant.io>
  