### PR TITLE
Add configurable failureThreshold for namerd interpreter

### DIFF
--- a/interpreter/namerd/src/main/scala/io/buoyant/namerd/iface/NamerdInterpreterInitializer.scala
+++ b/interpreter/namerd/src/main/scala/io/buoyant/namerd/iface/NamerdInterpreterInitializer.scala
@@ -136,10 +136,10 @@ object NamerdInterpreterConfig {
 
 object FailureThresholdConfig {
 
-  val DefaultMinPeriod = 5000.milliseconds
+  val DefaultMinPeriod = 5.seconds
   val DefaultThreshold = 2.0
   val DefaultWindowSize = 100
-  val DefaultCloseTimeout = 4000.milliseconds
+  val DefaultCloseTimeout = 4.seconds
 
   def defaultStackParam = StackParams.empty + FailureDetector.Param(ThresholdConfig(
     DefaultMinPeriod,

--- a/interpreter/namerd/src/test/scala/io/buoyant/namerd/iface/NamerdTest.scala
+++ b/interpreter/namerd/src/test/scala/io/buoyant/namerd/iface/NamerdTest.scala
@@ -9,7 +9,7 @@ import org.scalatest.FunSuite
 class NamerdTest extends FunSuite {
   test("sanity") {
     // ensure it doesn't totally blowup
-    val _ = NamerdInterpreterConfig(Some(Path.read("/whats/in/a")), Some("name"), None, None)
+    val _ = NamerdInterpreterConfig(Some(Path.read("/whats/in/a")), Some("name"), None, None, None)
       .newInterpreter(Stack.Params.empty)
   }
 

--- a/linkerd/docs/interpreter.md
+++ b/linkerd/docs/interpreter.md
@@ -45,6 +45,19 @@ dst | _required_ | A Finagle path locating the Namerd service.
 namespace | `default` | The name of the Namerd dtab to use.
 retry | see [Namerd retry](#namerd-retry) | An object configuring retry backoffs for requests to Namerd.
 tls | no tls | Requests to Namerd will be made using TLS if this parameter is provided.  It must be a [Namerd client TLS](#namerd-client-tls) object.
+failureThreshold | no failureThreshold | Sets the [failure threshold](#failure-threshold) used by Linkerd's threshold failure detector to gauge a Namerd instance's health
+
+### Failure Threshold
+
+Linkerd uses a [Threshold Failure Detector](https://github.com/twitter/finagle/blob/master/finagle-core/src/main/scala/com/twitter/finagle/liveness/ThresholdFailureDetector.scala) 
+to determine the health of a Namerd instance. Linkerd sends pings to Namerd periodically and evaluates the health of Namerd based on a set number of ping latencies
+
+Key | Default Value | Description
+--- | ------------- | -----------
+minPeriodMs | 5000 | period between session pings to Namerd
+threshold | 2.0 | Used to calculate the maximum allowed ping latency 
+windowSize | 100 | number of observations to make to gauge session liveness of Namerd
+closeTimeoutMs | 4000 | timeout for a session ping's response before Linkerd terminates a session
 
 ### Namerd retry
 

--- a/linkerd/docs/interpreter.md
+++ b/linkerd/docs/interpreter.md
@@ -50,14 +50,14 @@ failureThreshold | no failureThreshold | Sets the [failure threshold](#failure-t
 ### Failure Threshold
 
 Linkerd uses a [Threshold Failure Detector](https://github.com/twitter/finagle/blob/master/finagle-core/src/main/scala/com/twitter/finagle/liveness/ThresholdFailureDetector.scala) 
-to determine the health of a Namerd instance. Linkerd sends pings to Namerd periodically and evaluates the health of Namerd based on a set number of ping latencies
+to determine the health of the connection to a Namerd instance. Linkerd sends pings to Namerd periodically and evaluates the health of Namerd based on a set number of ping latencies
 
 Key | Default Value | Description
 --- | ------------- | -----------
-minPeriodMs | 5000 | period between session pings to Namerd
+minPeriodMs | 5000 | The period between session pings to Namerd
 threshold | 2.0 | Used to calculate the maximum allowed ping latency 
-windowSize | 100 | number of observations to make to gauge session liveness of Namerd
-closeTimeoutMs | 4000 | timeout for a session ping's response before Linkerd terminates a session
+windowSize | 100 | The number of observations to make to gauge session liveness of Namerd
+closeTimeoutMs | 4000 | Timeout for a session ping's response before Linkerd terminates a session
 
 ### Namerd retry
 


### PR DESCRIPTION
Linkerd interpreter for Namerd uses a default failure detector and does not allow for configuration changes for users. This PR adds in four new fields in the intepreter section of the config to modify Linkerd's failure detection module when resolving names through Namerd 

Tests are being run currently to see if changing the values affects the failure detection but I am putting the PR up for visibility.

fixes #1767
Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>