### PR TITLE
Use a single client for the entire k8s namer

### DIFF
--- a/namer/k8s/src/main/scala/io/buoyant/namer/k8s/K8sInitializer.scala
+++ b/namer/k8s/src/main/scala/io/buoyant/namer/k8s/K8sInitializer.scala
@@ -41,9 +41,9 @@ case class K8sConfig(
    */
   @JsonIgnore
   override def newNamer(params: Stack.Params): Namer = {
-    val client = mkClient(params).withLabel("client")
+    val client = Api(mkClient(params).withLabel("client").newService(dst))
     def mkNs(ns: String) = {
-      Api(client.newService(dst)).withNamespace(ns)
+      client.withNamespace(ns)
     }
     new MultiNsNamer(prefix, labelSelector, mkNs)
   }


### PR DESCRIPTION
Each watch on the Kubernetes API made by the io.l5d.k8s namer uses a separate finagle client.  This causes stat name conflicts which results in incorrect reporting of client stats.  It may also have an adverse affect on memory usage.

We switch the io.l5d.k8s namer to use a single finagle client for all watches on the Kubernetes API.

This isolation of watches to separate finagle clients was originally done to work around https://github.com/linkerd/linkerd/issues/83.  However, since then, the [underlying issue](https://github.com/twitter/finagle/issues/471) has been [fixed in finagle](https://github.com/twitter/finagle/pull/481) making this no longer necessary.

Signed-off-by: Alex Leong <alex@buoyant.io>