### PR TITLE
Add sendConcreteDest thrift config option

### DIFF
--- a/linkerd/docs/protocol-thrift.md
+++ b/linkerd/docs/protocol-thrift.md
@@ -38,6 +38,7 @@ Key | Default Value | Description
 dstPrefix | `/svc` | A path prefix used in `dtab`.
 thriftMethodInDst | `false` | If `true`, thrift method names are appended to destinations for outgoing requests.
 thriftProtocol | `binary` | Either `binary` (TBinaryProtocol) or `compact` (TCompactProtocol). Applies to both clients and servers.
+sendConcreteDest | `false` | If `true`, Linkerd will send the concrete bound name in the TTwitter Dest header.  This option only applies if the TTwitter thrift protocol is used.
 
 
 ## Thrift Server Parameters

--- a/linkerd/protocol/thrift/src/e2e/scala/io/buoyant/linkerd/protocol/ThriftEndToEndTest.scala
+++ b/linkerd/protocol/thrift/src/e2e/scala/io/buoyant/linkerd/protocol/ThriftEndToEndTest.scala
@@ -1,14 +1,17 @@
 package io.buoyant.linkerd.protocol
 
 import com.twitter.finagle.buoyant.linkerd.{ThriftClientPrep, ThriftServerPrep, ThriftTraceInitializer}
+import com.twitter.finagle.naming.buoyant.DstBindingFactory
 import com.twitter.finagle.stats.NullStatsReceiver
 import com.twitter.finagle.tracing.NullTracer
 import com.twitter.finagle.{Thrift => FinagleThrift, _}
 import com.twitter.util.{Future, Var}
 import io.buoyant.config.types.Port
+import io.buoyant.namer.DefaultInterpreterConfig
 import io.buoyant.router.thrift.Dest
 import io.buoyant.router.thriftscala._
 import io.buoyant.test.FunSuite
+import io.buoyant.transformer.perHost.{LocalhostTransformerConfig, PortTransformerConfig}
 import java.net.InetSocketAddress
 
 class ThriftEndToEndTest extends FunSuite {
@@ -53,7 +56,7 @@ class ThriftEndToEndTest extends FunSuite {
   test("end-to-end echo routing") {
     val cat = Downstream.const("cat", "meow")
     val router = {
-      val config = new ThriftConfig(Some(true), None) {
+      val config = new ThriftConfig(Some(true), None, None) {
         dtab = Some(Dtab.read(s"""/svc/cat => /$$/inet/127.1/${cat.port} ;"""))
         servers = Seq(
           new ThriftServerConfig(None) {
@@ -88,7 +91,7 @@ class ThriftEndToEndTest extends FunSuite {
   test("multiple clients") {
     val cat = Downstream.const("cat", "meow")
     val router = {
-      val config = new ThriftConfig(Some(true), None) {
+      val config = new ThriftConfig(Some(true), None, None) {
         dtab = Some(Dtab.read(s"""/svc/cat => /$$/inet/127.1/${cat.port} ;"""))
         servers = Seq(
           new ThriftServerConfig(None) {
@@ -128,7 +131,7 @@ class ThriftEndToEndTest extends FunSuite {
   test("linker-to-linker echo routing") {
     val cat = Downstream.const("cat", "meow")
     val incoming = {
-      val config = new ThriftConfig(Some(true), None) {
+      val config = new ThriftConfig(Some(true), None, None) {
         _label = Some("incoming")
         dtab = Some(Dtab.read(s"""/svc/cat => /$$/inet/127.1/${cat.port} ;"""))
         servers = Seq(
@@ -144,7 +147,7 @@ class ThriftEndToEndTest extends FunSuite {
     }
 
     val outgoing = {
-      val config = new ThriftConfig(Some(true), None) {
+      val config = new ThriftConfig(Some(true), None, None) {
         _label = Some("outgoing")
         dtab = Some(Dtab.read(s"""/svc/cat => /$$/inet/127.1/${incoming.boundAddress.asInstanceOf[InetSocketAddress].getPort} ;"""))
         servers = Seq(
@@ -177,4 +180,155 @@ class ThriftEndToEndTest extends FunSuite {
       await(outgoing.close())
     }
   }
+
+  test("linker-to-linker echo routing with transformers") {
+    val cat = Downstream.const("cat", "meow")
+
+    val incoming = {
+      val config = new ThriftConfig(Some(true), None, None) {
+        _label = Some("incoming")
+        dtab = Some(Dtab.read(s"""/svc/cat => /$$/inet/127.1/${cat.port} ;"""))
+        _interpreter = Some({
+          val interpreterConfig = new DefaultInterpreterConfig()
+          interpreterConfig.transformers = Some(Seq(
+            new LocalhostTransformerConfig()
+          ))
+          interpreterConfig
+        })
+        servers = Seq(
+          new ThriftServerConfig(None) {
+            port = Some(Port(0))
+          }
+        )
+        val c = new ThriftDefaultClient
+        c.attemptTTwitterUpgrade = Some(true)
+        _client = Some(c)
+      }
+      val interpreter = config.interpreter.interpreter(Stack.Params.empty)
+      config.router(Stack.Params.empty + DstBindingFactory.Namer(interpreter)).initialize().servers.head.serve()
+    }
+
+    val outgoing = {
+      val config = new ThriftConfig(Some(true), None, None) {
+        _label = Some("outgoing")
+        dtab = Some(Dtab.read(s"""/svc/cat => /$$/inet/127.1/${cat.port} ;"""))
+        _interpreter = Some({
+          val interpreterConfig = new DefaultInterpreterConfig()
+          interpreterConfig.transformers = Some(Seq(
+            new PortTransformerConfig(Port(incoming.boundAddress.asInstanceOf[InetSocketAddress].getPort))
+          ))
+          interpreterConfig
+        })
+        servers = Seq(
+          new ThriftServerConfig(None) {
+            port = Some(Port(0))
+          }
+        )
+        val c = new ThriftDefaultClient
+        c.attemptTTwitterUpgrade = Some(true)
+        _client = Some(c)
+      }
+      val interpreter = config.interpreter.interpreter(Stack.Params.empty)
+      config.router(Stack.Params.empty + DstBindingFactory.Namer(interpreter)).initialize().servers.head.serve()
+    }
+
+    val client = upstream(outgoing)
+    def ping(dst: Path, msg: String = "")(f: String => Unit): Unit = {
+      Dest.local = dst
+      val rsp = await(client.ping(msg))
+      f(rsp)
+    }
+
+    try {
+      ping(Path.read("/cat")) { rsp =>
+        assert(rsp == "meow")
+        ()
+      }
+    } finally {
+      await(cat.server.close())
+      await(incoming.close())
+      await(outgoing.close())
+    }
+  }
+
+  test("linker-to-linker echo routing with transformers and concrete dest") {
+    val cat = Downstream.const("cat", "meow")
+
+    val incoming = {
+      val config = new ThriftConfig(
+        thriftMethodInDst = Some(true),
+        thriftProtocol = None,
+        sendConcreteDest = Some(true)
+      ) {
+        _label = Some("incoming")
+        // This dtab takes the concrete dest from the outgoing Linkerd, strips the transformer
+        // prefix, and uses the result as the concrete dest for the incoming Linkerd.
+        dtab = Some(Dtab.read(s"""/svc/*/*/* => / ;"""))
+        _interpreter = Some({
+          val interpreterConfig = new DefaultInterpreterConfig()
+          interpreterConfig.transformers = Some(Seq(
+            new LocalhostTransformerConfig()
+          ))
+          interpreterConfig
+        })
+        servers = Seq(
+          new ThriftServerConfig(None) {
+            port = Some(Port(0))
+          }
+        )
+        val c = new ThriftDefaultClient
+        c.attemptTTwitterUpgrade = Some(true)
+        _client = Some(c)
+      }
+      val interpreter = config.interpreter.interpreter(Stack.Params.empty)
+      config.router(Stack.Params.empty + DstBindingFactory.Namer(interpreter)).initialize().servers.head.serve()
+    }
+
+    val outgoing = {
+      val config = new ThriftConfig(
+        thriftMethodInDst = Some(true),
+        thriftProtocol = None,
+        sendConcreteDest = Some(true)
+      ) {
+        _label = Some("outgoing")
+        dtab = Some(Dtab.read(s"""/svc/cat => /$$/inet/127.1/${cat.port} ;"""))
+        _interpreter = Some({
+          val interpreterConfig = new DefaultInterpreterConfig()
+          interpreterConfig.transformers = Some(Seq(
+            new PortTransformerConfig(Port(incoming.boundAddress.asInstanceOf[InetSocketAddress].getPort))
+          ))
+          interpreterConfig
+        })
+        servers = Seq(
+          new ThriftServerConfig(None) {
+            port = Some(Port(0))
+          }
+        )
+        val c = new ThriftDefaultClient
+        c.attemptTTwitterUpgrade = Some(true)
+        _client = Some(c)
+      }
+      val interpreter = config.interpreter.interpreter(Stack.Params.empty)
+      config.router(Stack.Params.empty + DstBindingFactory.Namer(interpreter)).initialize().servers.head.serve()
+    }
+
+    val client = upstream(outgoing)
+    def ping(dst: Path, msg: String = "")(f: String => Unit): Unit = {
+      Dest.local = dst
+      val rsp = await(client.ping(msg))
+      f(rsp)
+    }
+
+    try {
+      ping(Path.read("/cat")) { rsp =>
+        assert(rsp == "meow")
+        ()
+      }
+    } finally {
+      await(cat.server.close())
+      await(incoming.close())
+      await(outgoing.close())
+    }
+  }
 }
+

--- a/linkerd/protocol/thrift/src/main/scala/io/buoyant/linkerd/protocol/ThriftInitializer.scala
+++ b/linkerd/protocol/thrift/src/main/scala/io/buoyant/linkerd/protocol/ThriftInitializer.scala
@@ -44,7 +44,8 @@ object ThriftInitializer extends ThriftInitializer
 
 case class ThriftConfig(
   thriftMethodInDst: Option[Boolean],
-  thriftProtocol: Option[ThriftProtocol]
+  thriftProtocol: Option[ThriftProtocol],
+  sendConcreteDest: Option[Boolean]
 ) extends RouterConfig {
 
   var servers: Seq[ThriftServerConfig] = Nil
@@ -62,6 +63,7 @@ case class ThriftConfig(
   override def routerParams = super.routerParams
     .maybeWith(thriftMethodInDst.map(Thrift.param.MethodInDst(_)))
     .maybeWith(thriftProtocol.map(proto => param.ProtocolFactory(proto.factory)))
+    .maybeWith(sendConcreteDest.map(ThriftClientPrep.SendConcreteDest(_)))
 }
 
 case class ThriftServerConfig(

--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -530,7 +530,7 @@ object LinkerdBuild extends Base {
         .dependsOn(core, Router.mux)
 
       val thrift = projectDir("linkerd/protocol/thrift")
-        .dependsOn(core, Router.thrift % "compile->compile;test->test;e2e->e2e")
+        .dependsOn(core, Router.thrift % "compile->compile;test->test;e2e->e2e", Interpreter.perHost % "e2e")
         .withTests()
         .withE2e()
 


### PR DESCRIPTION
When using the TTwitter thrift protocol, Linkerd uses the value of the `dest` header during identification and also forwards the header along.  In Linkerd-to-Linkerd cases, this means that both the outgoing and incoming routers receive the same logical name (based on the `dest` header) and both perform delegation.  If the delegation contains a weighted union, this can result in outgoing and incoming picking different arms of the union which can lead to routing failures.

We add a `sendConcreteDest` config option to the thrift router that changes the behavior to send the concrete bound id in the `dest` header instead of forwarding the existing value.  This allows the incoming router to be configured to simply use this already bound id instead of doing delegation again.  This is analogous to using the `l5d-dst-client` header in HTTP.

Signed-off-by: Alex Leong <alex@buoyant.io>