### PR TITLE
Graduate H2 protocol and io.l5d.mesh interpreter out of experimental

### DIFF
--- a/interpreter/mesh/src/main/scala/io/buoyant/interpreter/MeshInterpreterInitializer.scala
+++ b/interpreter/mesh/src/main/scala/io/buoyant/interpreter/MeshInterpreterInitializer.scala
@@ -45,9 +45,6 @@ case class MeshInterpreterConfig(
 ) extends InterpreterConfig {
   import MeshInterpreterConfig._
 
-  @JsonIgnore
-  override val experimentalRequired = true
-
   /**
    * Construct a namer.
    */

--- a/interpreter/mesh/src/test/scala/io/buoyant/interpreter/MeshInterpreterInitializerTest.scala
+++ b/interpreter/mesh/src/test/scala/io/buoyant/interpreter/MeshInterpreterInitializerTest.scala
@@ -19,7 +19,6 @@ class MeshInterpreterInitializerTest extends FunSuite {
 
   test("parse config") {
     val yaml = s"""|kind: io.l5d.mesh
-                   |experimental: true
                    |dst: /$$/inet/127.1/4321
                    |root: /default
                    |tls:
@@ -45,25 +44,5 @@ class MeshInterpreterInitializerTest extends FunSuite {
     assert(tls.trustCerts == Some(List("/foo/caCert.pem")))
     assert(tls.clientAuth.get.certPath == "/namerd-cert.pem")
     assert(tls.clientAuth.get.keyPath == "/namerd-key.pk8")
-  }
-
-  test("without experimental") {
-    val yaml = s"""|kind: io.l5d.mesh
-                   |dst: /$$/inet/127.1/4321
-                   |root: /default
-                   |tls:
-                   |  disableValidation: false
-                   |  commonName: "{service}"
-                   |  trustCerts:
-                   |  - /foo/caCert.pem
-                   |  clientAuth:
-                   |    certPath: /namerd-cert.pem
-                   |    keyPath: /namerd-key.pk8
-                   |""".stripMargin
-
-    val mapper = Parser.objectMapper(yaml, Iterable(Seq(MeshInterpreterInitializer)))
-    val namerd = mapper.readValue[InterpreterConfig](yaml).asInstanceOf[MeshInterpreterConfig]
-    mapper.writeValueAsString(namerd) // ensure serialization doesn't blow up
-    assert(namerd.disabled)
   }
 }

--- a/linkerd/examples/h2.yaml
+++ b/linkerd/examples/h2.yaml
@@ -5,7 +5,6 @@ namers:
 
 routers:
 - protocol: h2
-  experimental: true
   dtab: |
     /srv => /#/io.l5d.fs;
     /svc/localhost:4142 => /$/inet/127.1/8888;

--- a/linkerd/examples/h2spec.yaml
+++ b/linkerd/examples/h2spec.yaml
@@ -7,7 +7,6 @@ usage:
 
 routers:
 - protocol: h2
-  experimental: true
   label: h2
   servers:
   - port: 4140

--- a/linkerd/examples/namerd-mesh.yaml
+++ b/linkerd/examples/namerd-mesh.yaml
@@ -1,9 +1,8 @@
-# Use the experimental namerd gRPC API for name resolution.
+# Use the namerd gRPC API for name resolution.
 routers:
 - protocol: http
   interpreter:
     kind: io.l5d.mesh
-    experimental: true
     dst: /$/inet/127.1/4321
     root: /default
   servers:

--- a/linkerd/examples/namerd-tls.yaml
+++ b/linkerd/examples/namerd-tls.yaml
@@ -55,7 +55,6 @@ routers:
   label: namerd-grpc-tls
   interpreter:
     kind: io.l5d.mesh
-    experimental: true
     dst: /$/inet/127.1/4321
     root: /default
     tls:

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/H2Config.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/H2Config.scala
@@ -30,7 +30,6 @@ import scala.util.control.NonFatal
 class H2Initializer extends ProtocolInitializer.Simple {
   val name = "h2"
   val configClass = classOf[H2Config]
-  override val experimentalRequired = true
 
   protected type Req = Request
   protected type Rsp = Response


### PR DESCRIPTION
Both the H2 protocol and the `io.l5d.mesh` interpreter have been in production use by a number of large deployments for some time now.  Remove the experimental flag from them. 🎓  

Signed-off-by: Alex Leong <alex@buoyant.io>