### PR TITLE
Add CODEOWNERS file, mark @wm and @olix0r as owners of CHANGES.md

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# William and Oliver should approve all changelog entries.
+CHANGES.md @wmorgan @olix0r


### PR DESCRIPTION
GitHub's new [code owners](https://github.com/blog/2392-introducing-code-owners) feature allows users to be designated as the owners of certain files. Users marked as the owner of a file will be automatically added as reviewers of all pull requests that modify that file.

This PR adds @olix0r and @wmorgan as the owners of CHANGES.md, ensuring that they will have the chance to sign off on all additions to the changelog. Since we modify the changelog as part of the PR for each release, this implicitly also ensures that they are aware of and sign off on each Linkerd release.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>