### PR TITLE
add access logging for http2 requests

### DIFF
--- a/linkerd/examples/h2.yaml
+++ b/linkerd/examples/h2.yaml
@@ -5,6 +5,7 @@ namers:
 
 routers:
 - protocol: h2
+  h2AccessLog: logs/access.log
   dtab: |
     /srv => /#/io.l5d.fs;
     /svc/localhost:4142 => /$/inet/127.1/8888;

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/H2Config.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/H2Config.scala
@@ -18,7 +18,7 @@ import com.twitter.finagle.stack.nilStack
 import com.twitter.finagle.{ServiceFactory, Stack, param}
 import com.twitter.util.Monitor
 import io.buoyant.config.PolymorphicConfig
-import io.buoyant.linkerd.protocol.h2.{H2ClassifierConfig, H2RequestAuthorizerConfig}
+import io.buoyant.linkerd.protocol.h2._
 import io.buoyant.router.h2.ClassifiedRetries.{BufferSize, ClassificationTimeout}
 import io.buoyant.router.h2.{ClassifiedRetryFilter, DupRequest}
 import io.buoyant.router.http.ForwardClientCertFilter
@@ -46,6 +46,7 @@ class H2Initializer extends ProtocolInitializer.Simple {
       .prepend(LinkerdHeaders.Dst.BoundFilter.module)
 
     val clientStack = H2.router.clientStack
+      .prepend(h2.H2AccessLogger.module)
       .replace(H2TraceInitializer.role, H2TraceInitializer.clientModule)
       .insertAfter(StackClient.Role.prepConn, LinkerdHeaders.Ctx.clientModule)
       .insertAfter(DtabStatsFilter.role, H2RequestAuthorizerConfig.module)
@@ -81,7 +82,10 @@ class H2Initializer extends ProtocolInitializer.Simple {
 
 object H2Initializer extends H2Initializer
 
-case class H2Config(loggers: Option[Seq[H2RequestAuthorizerConfig]] = None) extends RouterConfig {
+case class H2Config(
+  loggers: Option[Seq[H2RequestAuthorizerConfig]] = None,
+  h2AccessLog: Option[String]
+) extends RouterConfig {
 
   var client: Option[H2Client] = None
   var service: Option[H2Svc] = None
@@ -104,7 +108,9 @@ case class H2Config(loggers: Option[Seq[H2RequestAuthorizerConfig]] = None) exte
 
   @JsonIgnore
   override def routerParams: Stack.Params =
-    (super.routerParams + identifierParam).maybeWith(loggerParam)
+    (super.routerParams + identifierParam)
+      .maybeWith(h2AccessLog.map(H2AccessLogger.param.File(_)))
+      .maybeWith(loggerParam)
 
   private[this] def identifierParam: H2.Identifier = identifier match {
     case None => h2.HeaderTokenIdentifier.param

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/H2AccessLogger.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/H2AccessLogger.scala
@@ -5,12 +5,16 @@ import com.twitter.finagle.buoyant.h2.{Request, Response}
 import com.twitter.finagle.context.RemoteInfo
 import com.twitter.logging._
 import com.twitter.util.{Time, TimeFormat}
+import java.net.{InetSocketAddress}
 
 case class H2AccessLogger(log: Logger) extends SimpleFilter[Request, Response] {
 
   def apply(req: Request, svc: Service[Request, Response]) = {
     val reqHeaders = req.headers
-    val remoteHost = RemoteInfo.Upstream.addr.getOrElse("-")
+    val remoteHost = RemoteInfo.Upstream.addr match {
+      case Some(isa: InetSocketAddress) => isa.getHostString
+      case _ => "-"
+    }
     val identd = "-"
     val user = "-"
     val referer = reqHeaders.get("referer").getOrElse("-")

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/H2AccessLogger.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/H2AccessLogger.scala
@@ -12,10 +12,10 @@ case class H2AccessLogger(log: Logger) extends SimpleFilter[Request, Response] {
     val remoteHost = "-"
     val identd = "-"
     val user = "-"
-    val referer = "-"
+    val referer = reqHeaders.get("referer").getOrElse("-")
     val userAgent = reqHeaders.get("user-agent").getOrElse("-")
     var hostHeader = req.authority
-    val reqResource = s"${req.method.toString.toUpperCase} ${req.path} -"
+    val reqResource = s"${req.method.toString.toUpperCase} ${req.path} HTTP/2"
 
     svc(req).onSuccess { rsp =>
       val statusCode = rsp.status.code

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/H2AccessLogger.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/H2AccessLogger.scala
@@ -2,6 +2,7 @@ package io.buoyant.linkerd.protocol.h2
 
 import com.twitter.finagle.{Service, ServiceFactory, SimpleFilter, Stack, Stackable}
 import com.twitter.finagle.buoyant.h2.{Request, Response}
+import com.twitter.finagle.context.RemoteInfo
 import com.twitter.logging._
 import com.twitter.util.{Time, TimeFormat}
 
@@ -9,7 +10,7 @@ case class H2AccessLogger(log: Logger) extends SimpleFilter[Request, Response] {
 
   def apply(req: Request, svc: Service[Request, Response]) = {
     val reqHeaders = req.headers
-    val remoteHost = "-"
+    val remoteHost = RemoteInfo.Upstream.addr.getOrElse("-")
     val identd = "-"
     val user = "-"
     val referer = reqHeaders.get("referer").getOrElse("-")

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/H2AccessLogger.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/H2AccessLogger.scala
@@ -1,0 +1,83 @@
+package io.buoyant.linkerd.protocol.h2
+
+import com.twitter.finagle.{Service, ServiceFactory, SimpleFilter, Stack, Stackable}
+import com.twitter.finagle.buoyant.h2.{Request, Response}
+import com.twitter.logging._
+import com.twitter.util.{Time, TimeFormat}
+
+case class H2AccessLogger(log: Logger) extends SimpleFilter[Request, Response] {
+
+  def apply(req: Request, svc: Service[Request, Response]) = {
+    val reqHeaders = req.headers
+    val remoteHost = "-"
+    val identd = "-"
+    val user = "-"
+    val referer = "-"
+    val userAgent = reqHeaders.get("user-agent").getOrElse("-")
+    var hostHeader = req.authority
+    val reqResource = s"${req.method.toString.toUpperCase} ${req.path} -"
+
+    svc(req).onSuccess { rsp =>
+      val statusCode = rsp.status.code
+      val responseBytes = "-"
+      val requestEndTime = new TimeFormat("dd/MM/yyyy:HH:mm:ss Z").format(Time.now)
+      log.info("""%s %s %s %s [%s] "%s" %d %s "%s" "%s"""", hostHeader, remoteHost, identd, user, requestEndTime,
+        reqResource, statusCode, responseBytes, referer, userAgent)
+    }
+  }
+}
+
+object H2AccessLogger {
+
+  object param {
+    case class File(path: String)
+    implicit object File extends Stack.Param[File] {
+      val default = File("")
+    }
+
+    case class RollPolicy(policy: Policy)
+    implicit object RollPolicy extends Stack.Param[RollPolicy] {
+      val default = RollPolicy(Policy.Never)
+    }
+
+    case class Append(append: Boolean)
+    implicit object Append extends Stack.Param[Append] {
+      val default = Append(true)
+    }
+
+    case class RotateCount(count: Int)
+    implicit object RotateCount extends Stack.Param[RotateCount] {
+      val default = RotateCount(-1)
+    }
+  }
+
+  val module: Stackable[ServiceFactory[Request, Response]] =
+    new Stack.Module4[param.File, param.RollPolicy, param.Append, param.RotateCount, ServiceFactory[Request, Response]] {
+      val role = Stack.Role("H2AccessLogger")
+      val description = "Log h2 requests/response summaries to a file"
+      def make(
+        file: param.File,
+        roll: param.RollPolicy,
+        append: param.Append,
+        rotate: param.RotateCount,
+        factory: ServiceFactory[Request, Response]
+      ): ServiceFactory[Request, Response] =
+        file match {
+          case param.File("") => factory
+          case param.File(path) =>
+            val logger = LoggerFactory(
+              node = "access",
+              level = Some(Level.INFO),
+              handlers = List(FileHandler(
+                path, roll.policy, append.append, rotate.count,
+                // avoid the default prefix
+                formatter = new com.twitter.logging.Formatter(prefix = ""),
+                level = Some(Level.INFO)
+              )),
+              useParents = false
+            )
+            new H2AccessLogger(logger()).andThen(factory)
+        }
+    }
+
+}


### PR DESCRIPTION
Access logs are stored in `./logs/access.log ` and can be accessed with `cat ./logs/access.log `

Our h2 Request and Response objects do not have all the attributes listed for logging requests in the [Apache Log best practices](https://httpd.apache.org/docs/1.3/logs.html). The information we don't have is represented with a `-` in the log, as we do in regular http logging.

The current Request object does not store a protocol version, we could potentially hard code this, as this code is only executed when http/2 are being made.

Current log output for h2 requests:
![screen shot 2018-01-19 at 11 06 24 am](https://user-images.githubusercontent.com/12401925/35167300-ce005758-fd09-11e7-8f36-5639ca217993.png)

By comparison, the log for http/1 requests:
![screen shot 2018-01-19 at 11 14 18 am](https://user-images.githubusercontent.com/12401925/35167343-f91c5b6c-fd09-11e7-93ad-3919632447c6.png)


Signed-off-by: Franziska von der Goltz <franziska@vdgoltz.eu>