### PR TITLE
Clean up inotify instances in the case of errors

### DIFF
--- a/namer/fs/src/main/scala/io/buoyant/namer/fs/Watcher.scala
+++ b/namer/fs/src/main/scala/io/buoyant/namer/fs/Watcher.scala
@@ -4,6 +4,7 @@ import com.twitter.conversions.storage._
 import com.twitter.io.Buf
 import com.twitter.logging.Logger
 import com.twitter.util._
+import java.io.IOException
 import java.nio.file.{Path => NioPath, _}
 import java.nio.file.StandardWatchEventKinds._
 import scala.collection.JavaConverters._
@@ -59,14 +60,11 @@ object Watcher {
       log.debug("fs observing %s", root)
       @volatile var closed = false
 
-      val watcher = root.getFileSystem.newWatchService()
-      root.register(watcher, ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY)
-
       /*
        * Watch this root directory for updates. When new directories
        * are observed, watch them.
        */
-      def watch(dirs: Map[String, File.Dir], regs: Map[String, File.UpReg]): Unit = pool {
+      def watch(dirs: Map[String, File.Dir], regs: Map[String, File.UpReg], watcher: WatchService): Unit = pool {
         if (closed) return
         log.debug("fs waiting for events on %s", root)
         val key = watcher.take()
@@ -118,47 +116,57 @@ object Watcher {
         }
 
         if (key.reset())
-          watch(updirs, upregs)
+          watch(updirs, upregs, watcher)
       }
 
       /*
        * Asynchronously load up the initial state of the root and then--if that succeeds--watch it for updates
        */
-      pool {
-        Try(Files.newDirectoryStream(root)) match {
-          case Return(files) =>
-            var (dirs, regs) = (Map.empty[String, File.Dir], Map.empty[String, File.UpReg])
-            files.asScala.foreach {
-              case d if Files.isDirectory(d) =>
-                val name = d.getFileName.toString
-                log.debug("fs init dir %s", name)
-                dirs += name -> Watcher(d)
 
-              case f if Files.isRegularFile(f) =>
-                val name = f.getFileName.toString
-                val reg = File.UpReg()
-                //val child = root.resolve(f)
-                val child = f
-                log.debug("fs init file %s => %s", root, child)
-                pool {
-                  reg.buf() = read(child)
-                }
-                regs += name -> reg
+      val watcher = Try {
+        val w = root.getFileSystem.newWatchService()
+        root.register(w, ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY)
+        w
+      }
 
-              case _ =>
-            }
+      watcher match {
+        case Throw(e) => state() = Activity.Failed(e)
+        case Return(w) => pool {
+          Try(Files.newDirectoryStream(root)) match {
+            case Return(files) =>
+              var (dirs, regs) = (Map.empty[String, File.Dir], Map.empty[String, File.UpReg])
+              files.asScala.foreach {
+                case d if Files.isDirectory(d) =>
+                  val name = d.getFileName.toString
+                  log.debug("fs init dir %s", name)
+                  dirs += name -> Watcher(d)
 
-            state() = Activity.Ok(regs ++ dirs)
-            watch(dirs, regs)
+                case f if Files.isRegularFile(f) =>
+                  val name = f.getFileName.toString
+                  val reg = File.UpReg()
+                  //val child = root.resolve(f)
+                  val child = f
+                  log.debug("fs init file %s => %s", root, child)
+                  pool {
+                    reg.buf() = read(child)
+                  }
+                  regs += name -> reg
 
-          case Throw(e) =>
-            state() = Activity.Failed(e)
+                case _ =>
+              }
+
+              state() = Activity.Ok(regs ++ dirs)
+              watch(dirs, regs, w)
+
+            case Throw(e) =>
+              state() = Activity.Failed(e)
+          }
         }
       }
 
       Closable.make { _ =>
         closed = true
-        watcher.close()
+        watcher.foreach(_.close())
         Future.Unit
       }
     }


### PR DESCRIPTION
Fixes #1781 

When using the filesystem namer, if Linkerd fails to establish a watch (because the maximum number of inotify watches has been reached, for example) then an IOException is thrown and the WatchService is never cleaned up.  On Linux, this can cause an inotify instance leak.

We catch exceptions thrown when watches are established to ensure that the WatchService is closed.

Signed-off-by: Alex Leong <alex@buoyant.io>