### PR TITLE
 Introduce a 'strict' Kubernetes ingress identifier that ignores default backends

### DIFF
--- a/k8s/src/main/scala/io/buoyant/k8s/IngressCache.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/IngressCache.scala
@@ -71,14 +71,14 @@ object IngressCache {
  * and checks incoming requests against cached ingress rules.
  *
  * @param namespace: The k8s namespace to filter on. If None, it watches all namespaces.
- * @param strict: Don't create a 'fallback' IngressPath that matches any request for each IngressSpec.
+ * @param ignoreDefaultBackends: Don't create a 'fallback' IngressPath that matches any request for each IngressSpec.
  */
 
 class IngressCache(
   namespace: Option[String],
   apiClient: Service[Request, Response],
   annotationClass: String,
-  strict: Boolean = false
+  ignoreDefaultBackends: Boolean = false
 ) {
   import IngressCache._
 
@@ -134,8 +134,8 @@ class IngressCache(
 
       val name = ingress.metadata.flatMap(_.name)
       val fallback = spec.backend.map(b => IngressPath(None, None, namespace.getOrElse("default"), b.serviceName, b.servicePort)).filter { p =>
-        if (strict) log.warning("ingress %s.%s: strict mode enabled, ignoring default backend: %s", name.getOrElse("unknown"), namespace.getOrElse("default"), p)
-        !strict
+        if (ignoreDefaultBackends) log.warning("ingress %s.%s: ignoreDefaultBackends mode enabled, ignoring default backend: %s", name.getOrElse("unknown"), namespace.getOrElse("default"), p)
+        !ignoreDefaultBackends
       }
       IngressSpec(name, namespace, fallback, paths)
     }

--- a/k8s/src/main/scala/io/buoyant/k8s/IngressCache.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/IngressCache.scala
@@ -15,8 +15,8 @@ case class IngressSpec(
   def getMatchingPath(hostHeader: Option[String], requestPath: String): Option[IngressPath] = {
     val matchingPath = rules.find(_.matches(hostHeader, requestPath))
     matchingPath match {
-      case Some(path) => log.info("k8s found rule matching %s %s: %s", hostHeader.getOrElse(""), requestPath, path)
-      case None => log.info("no ingress rule found for request %s %s", hostHeader.getOrElse(""), requestPath)
+      case Some(path) => log.info("ingress %s.%s: found rule matching %s %s: %s", name.getOrElse("unknown"), namespace.getOrElse("default"), hostHeader.getOrElse(""), requestPath, path)
+      case None => log.debug("ingress %s.%s: no rules found matching %s %s", name.getOrElse("unknown"), namespace.getOrElse("default"), hostHeader.getOrElse(""), requestPath)
     }
     matchingPath
   }

--- a/k8s/src/main/scala/io/buoyant/k8s/IngressCache.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/IngressCache.scala
@@ -133,10 +133,10 @@ class IngressCache(
       }
 
       val name = ingress.metadata.flatMap(_.name)
-      val fallback = spec.backend.map(b => IngressPath(None, None, namespace.getOrElse("default"), b.serviceName, b.servicePort)).filter { p =>
-        if (ignoreDefaultBackends) log.warning("ingress %s.%s: ignoreDefaultBackends mode enabled, ignoring default backend: %s", name.getOrElse("unknown"), namespace.getOrElse("default"), p)
-        !ignoreDefaultBackends
-      }
+      val fallback = if (ignoreDefaultBackends) {
+        log.warning("ingress %s.%s: ignoreDefaultBackends enabled, ignoring default backend", name.getOrElse("unknown"), namespace.getOrElse("default"))
+        None
+      } else spec.backend.map(b => IngressPath(None, None, namespace.getOrElse("default"), b.serviceName, b.servicePort))
       IngressSpec(name, namespace, fallback, paths)
     }
   }

--- a/k8s/src/test/scala/io/buoyant/k8s/IngressCacheTest.scala
+++ b/k8s/src/test/scala/io/buoyant/k8s/IngressCacheTest.scala
@@ -392,11 +392,18 @@ class IngressCacheTest extends FunSuite with Awaits {
     assert(await(cache.matchPath(Some("myhost:80"), "/some-path")).get.svc == "echo")
   }
 
-  test("ingress caches create fallback paths") {
+  test("ingress caches honor default backends") {
     val service = mkIngressApiServiceReturning(ingressResourceListWithOneIngressWithFallback)
     val cache = new IngressCache(None, service, annotationClass)
     assert(await(cache.matchPath(host, "/some-path")).get.svc == "echo")
     assert(await(cache.matchPath(host, "/unknown-path")).get.svc == "fallback")
+  }
+
+  test("strict ingress caches ignore default backends") {
+    val service = mkIngressApiServiceReturning(ingressResourceListWithOneIngressWithFallback)
+    val cache = new IngressCache(None, service, annotationClass, true)
+    assert(await(cache.matchPath(host, "/some-path")).get.svc == "echo")
+    assert(await(cache.matchPath(host, "/unknown-path")) == None)
   }
 
   test("on multiple path matches, return first match") {

--- a/k8s/src/test/scala/io/buoyant/k8s/IngressCacheTest.scala
+++ b/k8s/src/test/scala/io/buoyant/k8s/IngressCacheTest.scala
@@ -399,7 +399,7 @@ class IngressCacheTest extends FunSuite with Awaits {
     assert(await(cache.matchPath(host, "/unknown-path")).get.svc == "fallback")
   }
 
-  test("strict ingress caches ignore default backends") {
+  test("ignoreDefaultBackends ingress caches ignore default backends") {
     val service = mkIngressApiServiceReturning(ingressResourceListWithOneIngressWithFallback)
     val cache = new IngressCache(None, service, annotationClass, true)
     assert(await(cache.matchPath(host, "/some-path")).get.svc == "echo")

--- a/k8s/src/test/scala/io/buoyant/k8s/IngressCacheTest.scala
+++ b/k8s/src/test/scala/io/buoyant/k8s/IngressCacheTest.scala
@@ -294,6 +294,61 @@ class IngressCacheTest extends FunSuite with Awaits {
   ]
 }"""
 
+  val ingressResourceListWithOneIngressWithFallback =
+    """
+{
+  "kind": "IngressList",
+  "apiVersion": "extensions/v1beta1",
+  "metadata": {
+    "selfLink": "/apis/extensions/v1beta1/ingresses",
+    "resourceVersion": "58845"
+  },
+  "items": [
+    {
+      "metadata": {
+        "name": "the-ingress",
+        "namespace": "default",
+        "selfLink": "/apis/extensions/v1beta1/namespaces/default/ingresses/the-ingress",
+        "uid": "6c1466d7-813e-11e7-b89b-080027a996b8",
+        "resourceVersion": "58840",
+        "generation": 1,
+        "creationTimestamp": "2017-08-14T22:17:55Z"
+      },
+      "spec": {
+        "backend": {
+          "serviceName": "fallback",
+          "servicePort": 2022
+        },
+        "rules": [
+          {
+            "http": {
+              "paths": [
+                {
+                  "path": "/some-path",
+                  "backend": {
+                    "serviceName": "echo",
+                    "servicePort": 1010
+                  }
+                },
+                {
+                  "path": "/other-path",
+                  "backend": {
+                    "serviceName": "echo",
+                    "servicePort": 2021
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    }
+  ]
+}"""
+
   val annotationClass = "linkerd"
 
   def mkIngressApiServiceReturning(response: String) = Service.mk[Request, Response] {
@@ -335,6 +390,13 @@ class IngressCacheTest extends FunSuite with Awaits {
     val service = mkIngressApiServiceReturning(ingressResourceListWithOneIngress)
     val cache = new IngressCache(None, service, annotationClass)
     assert(await(cache.matchPath(Some("myhost:80"), "/some-path")).get.svc == "echo")
+  }
+
+  test("ingress caches create fallback paths") {
+    val service = mkIngressApiServiceReturning(ingressResourceListWithOneIngressWithFallback)
+    val cache = new IngressCache(None, service, annotationClass)
+    assert(await(cache.matchPath(host, "/some-path")).get.svc == "echo")
+    assert(await(cache.matchPath(host, "/unknown-path")).get.svc == "fallback")
   }
 
   test("on multiple path matches, return first match") {

--- a/linkerd/docs/protocol-h2.md
+++ b/linkerd/docs/protocol-h2.md
@@ -273,7 +273,7 @@ Key  | Default Value | Description
 ---- | ------------- | -----------
 namespace | (all) | The Kubernetes namespace where the ingress resources are deployed. If not specified, Linkerd will watch all namespaces.
 ingressClassAnnotation | `linkerd` | When using [multiple ingress controllers](https://github.com/kubernetes/ingress/blob/master/docs/faq/README.md#how-do-i-run-multiple-ingress-controllers-in-the-same-cluster), Linkerd will only use the ingress resource annotated with this class.
-ignoreDefaultBackends | `false` | Ignore default backends - identify requests only when ingress rules exist.
+ignoreDefaultBackends | `false` | Identify requests only when they match an explicit ingress rule specifying a host and/or path.
 host | `localhost` | The Kubernetes master host.
 port | `8001` | The Kubernetes master port.
 

--- a/linkerd/docs/protocol-h2.md
+++ b/linkerd/docs/protocol-h2.md
@@ -273,7 +273,7 @@ Key  | Default Value | Description
 ---- | ------------- | -----------
 namespace | (all) | The Kubernetes namespace where the ingress resources are deployed. If not specified, Linkerd will watch all namespaces.
 ingressClassAnnotation | `linkerd` | When using [multiple ingress controllers](https://github.com/kubernetes/ingress/blob/master/docs/faq/README.md#how-do-i-run-multiple-ingress-controllers-in-the-same-cluster), Linkerd will only use the ingress resource annotated with this class.
-strict | `false` | Ignore default backends - identify requests only when ingress rules exist.
+ignoreDefaultBackends | `false` | Ignore default backends - identify requests only when ingress rules exist.
 host | `localhost` | The Kubernetes master host.
 port | `8001` | The Kubernetes master port.
 

--- a/linkerd/docs/protocol-h2.md
+++ b/linkerd/docs/protocol-h2.md
@@ -273,6 +273,7 @@ Key  | Default Value | Description
 ---- | ------------- | -----------
 namespace | (all) | The Kubernetes namespace where the ingress resources are deployed. If not specified, Linkerd will watch all namespaces.
 ingressClassAnnotation | `linkerd` | When using [multiple ingress controllers](https://github.com/kubernetes/ingress/blob/master/docs/faq/README.md#how-do-i-run-multiple-ingress-controllers-in-the-same-cluster), Linkerd will only use the ingress resource annotated with this class.
+strict | `false` | Ignore default backends - identify requests only when ingress rules exist.
 host | `localhost` | The Kubernetes master host.
 port | `8001` | The Kubernetes master port.
 

--- a/linkerd/docs/protocol-http.md
+++ b/linkerd/docs/protocol-http.md
@@ -367,7 +367,7 @@ Key  | Default Value | Description
 ---- | ------------- | -----------
 namespace | (all) | The Kubernetes namespace where the ingress resources are deployed. If not specified, Linkerd will watch all namespaces.
 ingressClassAnnotation | `linkerd` | When using [multiple ingress controllers](https://github.com/kubernetes/ingress/blob/master/docs/faq/README.md#how-do-i-run-multiple-ingress-controllers-in-the-same-cluster), Linkerd will only use the ingress resource annotated with this class.
-ignoreDefaultBackends | `false` | Ignore default backends - identify requests only when ingress rules exist.
+ignoreDefaultBackends | `false` | Identify requests only when they match an explicit ingress rule specifying a host and/or path.
 host | `localhost` | The Kubernetes master host.
 port | `8001` | The Kubernetes master port.
 

--- a/linkerd/docs/protocol-http.md
+++ b/linkerd/docs/protocol-http.md
@@ -367,6 +367,7 @@ Key  | Default Value | Description
 ---- | ------------- | -----------
 namespace | (all) | The Kubernetes namespace where the ingress resources are deployed. If not specified, Linkerd will watch all namespaces.
 ingressClassAnnotation | `linkerd` | When using [multiple ingress controllers](https://github.com/kubernetes/ingress/blob/master/docs/faq/README.md#how-do-i-run-multiple-ingress-controllers-in-the-same-cluster), Linkerd will only use the ingress resource annotated with this class.
+strict | `false` | Ignore default backends - identify requests only when ingress rules exist.
 host | `localhost` | The Kubernetes master host.
 port | `8001` | The Kubernetes master port.
 

--- a/linkerd/docs/protocol-http.md
+++ b/linkerd/docs/protocol-http.md
@@ -367,7 +367,7 @@ Key  | Default Value | Description
 ---- | ------------- | -----------
 namespace | (all) | The Kubernetes namespace where the ingress resources are deployed. If not specified, Linkerd will watch all namespaces.
 ingressClassAnnotation | `linkerd` | When using [multiple ingress controllers](https://github.com/kubernetes/ingress/blob/master/docs/faq/README.md#how-do-i-run-multiple-ingress-controllers-in-the-same-cluster), Linkerd will only use the ingress resource annotated with this class.
-strict | `false` | Ignore default backends - identify requests only when ingress rules exist.
+ignoreDefaultBackends | `false` | Ignore default backends - identify requests only when ingress rules exist.
 host | `localhost` | The Kubernetes master host.
 port | `8001` | The Kubernetes master port.
 

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/IngressIdentifier.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/IngressIdentifier.scala
@@ -18,13 +18,13 @@ class IngressIdentifier(
   namespace: Option[String],
   apiClient: Service[http.Request, http.Response],
   annotationClass: String,
-  strict: Boolean
+  ignoreDefaultBackends: Boolean
 ) extends Identifier[Request] {
 
   private[this] val unidentified: RequestIdentification[Request] =
     new UnidentifiedRequest(s"no ingress rule matches")
 
-  private[this] val ingressCache = new IngressCache(namespace, apiClient, annotationClass, strict)
+  private[this] val ingressCache = new IngressCache(namespace, apiClient, annotationClass, ignoreDefaultBackends)
 
   override def apply(req: Request): Future[RequestIdentification[Request]] = {
     val headerToMatch = req.headers.get(Headers.Authority)
@@ -44,7 +44,7 @@ case class IngressIdentifierConfig(
   port: Option[Port],
   namespace: Option[String],
   ingressClassAnnotation: Option[String],
-  strict: Option[Boolean]
+  ignoreDefaultBackends: Option[Boolean]
 
 ) extends H2IdentifierConfig with ClientConfig {
   override def portNum: Option[Int] = port.map(_.port)
@@ -54,7 +54,7 @@ case class IngressIdentifierConfig(
     val DstPrefix(pfx) = params[DstPrefix]
     val BaseDtab(baseDtab) = params[BaseDtab]
     val client = mkClient(params).configured(Label("ingress-identifier"))
-    new IngressIdentifier(pfx, baseDtab, namespace, client.newService(dst), ingressClassAnnotation.getOrElse("linkerd"), strict.getOrElse(false))
+    new IngressIdentifier(pfx, baseDtab, namespace, client.newService(dst), ingressClassAnnotation.getOrElse("linkerd"), ignoreDefaultBackends.getOrElse(false))
   }
 }
 

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/IngressIdentifier.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/IngressIdentifier.scala
@@ -17,13 +17,14 @@ class IngressIdentifier(
   baseDtab: () => Dtab,
   namespace: Option[String],
   apiClient: Service[http.Request, http.Response],
-  annotationClass: String
+  annotationClass: String,
+  strict: Boolean
 ) extends Identifier[Request] {
 
   private[this] val unidentified: RequestIdentification[Request] =
     new UnidentifiedRequest(s"no ingress rule matches")
 
-  private[this] val ingressCache = new IngressCache(namespace, apiClient, annotationClass)
+  private[this] val ingressCache = new IngressCache(namespace, apiClient, annotationClass, strict)
 
   override def apply(req: Request): Future[RequestIdentification[Request]] = {
     val headerToMatch = req.headers.get(Headers.Authority)
@@ -42,7 +43,8 @@ case class IngressIdentifierConfig(
   host: Option[String],
   port: Option[Port],
   namespace: Option[String],
-  ingressClassAnnotation: Option[String]
+  ingressClassAnnotation: Option[String],
+  strict: Option[Boolean]
 
 ) extends H2IdentifierConfig with ClientConfig {
   override def portNum: Option[Int] = port.map(_.port)
@@ -52,7 +54,7 @@ case class IngressIdentifierConfig(
     val DstPrefix(pfx) = params[DstPrefix]
     val BaseDtab(baseDtab) = params[BaseDtab]
     val client = mkClient(params).configured(Label("ingress-identifier"))
-    new IngressIdentifier(pfx, baseDtab, namespace, client.newService(dst), ingressClassAnnotation.getOrElse("linkerd"))
+    new IngressIdentifier(pfx, baseDtab, namespace, client.newService(dst), ingressClassAnnotation.getOrElse("linkerd"), strict.getOrElse(false))
   }
 }
 

--- a/linkerd/protocol/h2/src/test/scala/io/buoyant/linkerd/protocol/h2/IngressIdentifierConfigTest.scala
+++ b/linkerd/protocol/h2/src/test/scala/io/buoyant/linkerd/protocol/h2/IngressIdentifierConfigTest.scala
@@ -7,7 +7,7 @@ import org.scalatest.FunSuite
 
 class IngressIdentifierConfigTest extends FunSuite {
   test("sanity") {
-    val ingressConfig = new IngressIdentifierConfig(Some("example.org"), Some(Port(9090)), None, Some("linkerd-ingress"))
+    val ingressConfig = new IngressIdentifierConfig(Some("example.org"), Some(Port(9090)), None, Some("linkerd-ingress"), Some(false))
     val _ = ingressConfig.newIdentifier(Params.empty)
   }
 
@@ -19,6 +19,7 @@ class IngressIdentifierConfigTest extends FunSuite {
     val ingress = mapper.readValue[IngressIdentifierConfig](yaml)
     assert(ingress.namespace == None)
     assert(ingress.ingressClassAnnotation == None)
+    assert(ingress.strict == None)
   }
 
   test("parse config with namespace") {
@@ -42,5 +43,17 @@ class IngressIdentifierConfigTest extends FunSuite {
     val ingress = mapper.readValue[IngressIdentifierConfig](yaml)
     assert(ingress.namespace == Some("istio-ns"))
     assert(ingress.ingressClassAnnotation == Some("istio"))
+  }
+
+  test("parse config for strict ingress") {
+    val yaml =
+      """|kind: io.l5d.ingress
+         |strict: true
+      """.stripMargin
+    val mapper = Parser.objectMapper(yaml, Iterable(Seq(IngressIdentifierInitializer)))
+    val ingress = mapper.readValue[IngressIdentifierConfig](yaml)
+    assert(ingress.namespace == None)
+    assert(ingress.ingressClassAnnotation == None)
+    assert(ingress.strict == Some(true))
   }
 }

--- a/linkerd/protocol/h2/src/test/scala/io/buoyant/linkerd/protocol/h2/IngressIdentifierConfigTest.scala
+++ b/linkerd/protocol/h2/src/test/scala/io/buoyant/linkerd/protocol/h2/IngressIdentifierConfigTest.scala
@@ -19,7 +19,7 @@ class IngressIdentifierConfigTest extends FunSuite {
     val ingress = mapper.readValue[IngressIdentifierConfig](yaml)
     assert(ingress.namespace == None)
     assert(ingress.ingressClassAnnotation == None)
-    assert(ingress.strict == None)
+    assert(ingress.ignoreDefaultBackends == None)
   }
 
   test("parse config with namespace") {
@@ -45,15 +45,15 @@ class IngressIdentifierConfigTest extends FunSuite {
     assert(ingress.ingressClassAnnotation == Some("istio"))
   }
 
-  test("parse config for strict ingress") {
+  test("parse config for ignoreDefaultBackends ingress") {
     val yaml =
       """|kind: io.l5d.ingress
-         |strict: true
+         |ignoreDefaultBackends: true
       """.stripMargin
     val mapper = Parser.objectMapper(yaml, Iterable(Seq(IngressIdentifierInitializer)))
     val ingress = mapper.readValue[IngressIdentifierConfig](yaml)
     assert(ingress.namespace == None)
     assert(ingress.ingressClassAnnotation == None)
-    assert(ingress.strict == Some(true))
+    assert(ingress.ignoreDefaultBackends == Some(true))
   }
 }

--- a/linkerd/protocol/h2/src/test/scala/io/buoyant/linkerd/protocol/h2/IngressIdentifierTest.scala
+++ b/linkerd/protocol/h2/src/test/scala/io/buoyant/linkerd/protocol/h2/IngressIdentifierTest.scala
@@ -89,7 +89,7 @@ class IngressIdentifierTest extends FunSuite with Awaits {
     }
   }
 
-  test("strict ingress identifies requests by host & path") {
+  test("ignoreDefaultBackends ingress identifies requests by host & path") {
     val identifier = new IngressIdentifier(Path.Utf8("svc"), () => Dtab.empty, None, service, "linkerd", true)
     val req0 = Request("http", Method.Get, "foo.bar.com", "/fooPath/penguins", Stream.empty())
     await(identifier(req0)) match {
@@ -99,7 +99,7 @@ class IngressIdentifierTest extends FunSuite with Awaits {
     }
   }
 
-  test("strict ingress does not fall back to the default backend") {
+  test("ignoreDefaultBackends ingress does not fall back to the default backend") {
     val identifier = new IngressIdentifier(Path.Utf8("svc"), () => Dtab.empty, None, service, "linkerd", true)
     val req0 = Request("http", Method.Get, "authority", "/fooPath/puffins", Stream.empty())
     await(identifier(req0)) match {

--- a/linkerd/protocol/h2/src/test/scala/io/buoyant/linkerd/protocol/h2/IngressIdentifierTest.scala
+++ b/linkerd/protocol/h2/src/test/scala/io/buoyant/linkerd/protocol/h2/IngressIdentifierTest.scala
@@ -60,7 +60,7 @@ class IngressIdentifierTest extends FunSuite with Awaits {
   }
 
   test("identifies requests by host, without path") {
-    val identifier = new IngressIdentifier(Path.Utf8("svc"), () => Dtab.empty, None, service, "linkerd")
+    val identifier = new IngressIdentifier(Path.Utf8("svc"), () => Dtab.empty, None, service, "linkerd", false)
     val req0 = Request("http", Method.Get, "foo.bar.com", "/penguins", Stream.empty())
     await(identifier(req0)) match {
       case IdentifiedRequest(Dst.Path(name, base, local), req1) =>
@@ -70,7 +70,7 @@ class IngressIdentifierTest extends FunSuite with Awaits {
   }
 
   test("identifies requests by host & path") {
-    val identifier = new IngressIdentifier(Path.Utf8("svc"), () => Dtab.empty, None, service, "linkerd")
+    val identifier = new IngressIdentifier(Path.Utf8("svc"), () => Dtab.empty, None, service, "linkerd", false)
     val req0 = Request("http", Method.Get, "foo.bar.com", "/fooPath/penguins", Stream.empty())
     await(identifier(req0)) match {
       case IdentifiedRequest(Dst.Path(name, base, local), req1) =>
@@ -80,12 +80,32 @@ class IngressIdentifierTest extends FunSuite with Awaits {
   }
 
   test("falls back to the default backend") {
-    val identifier = new IngressIdentifier(Path.Utf8("svc"), () => Dtab.empty, None, service, "linkerd")
+    val identifier = new IngressIdentifier(Path.Utf8("svc"), () => Dtab.empty, None, service, "linkerd", false)
     val req0 = Request("http", Method.Get, "authority", "/", Stream.empty())
     await(identifier(req0)) match {
       case IdentifiedRequest(Dst.Path(name, base, local), req1) =>
         assert(name == Path.read("/svc/fooNamespace/defaultPort/defaultService"))
       case id: UnidentifiedRequest[Request] => fail(s"unexpected identification: ${id.reason}")
+    }
+  }
+
+  test("strict ingress identifies requests by host & path") {
+    val identifier = new IngressIdentifier(Path.Utf8("svc"), () => Dtab.empty, None, service, "linkerd", true)
+    val req0 = Request("http", Method.Get, "foo.bar.com", "/fooPath/penguins", Stream.empty())
+    await(identifier(req0)) match {
+      case IdentifiedRequest(Dst.Path(name, base, local), req1) =>
+        assert(name == Path.read("/svc/fooNamespace/fooPathPort/fooPathService"))
+      case id: UnidentifiedRequest[Request] => fail(s"unexpected identification: ${id.reason}")
+    }
+  }
+
+  test("strict ingress does not fall back to the default backend") {
+    val identifier = new IngressIdentifier(Path.Utf8("svc"), () => Dtab.empty, None, service, "linkerd", true)
+    val req0 = Request("http", Method.Get, "authority", "/fooPath/puffins", Stream.empty())
+    await(identifier(req0)) match {
+      case IdentifiedRequest(Dst.Path(name, base, local), req1) =>
+        fail(s"unexpected identification: ${name}")
+      case id: UnidentifiedRequest[Request] => assert(id.reason == "no ingress rule matches")
     }
   }
 }

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/IngressIdentifier.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/IngressIdentifier.scala
@@ -19,13 +19,13 @@ class IngressIdentifier(
   namespace: Option[String],
   apiClient: Service[http.Request, http.Response],
   annotationClass: String,
-  strict: Boolean
+  ignoreDefaultBackends: Boolean
 ) extends Identifier[Request] {
 
   private[this] val unidentified: RequestIdentification[Request] =
     new UnidentifiedRequest(s"no ingress rule matches")
 
-  private[this] val ingressCache = new IngressCache(namespace, apiClient, annotationClass, strict)
+  private[this] val ingressCache = new IngressCache(namespace, apiClient, annotationClass, ignoreDefaultBackends)
 
   override def apply(req: Request): Future[RequestIdentification[Request]] = {
     val matchingPath = ingressCache.matchPath(req.host, req.path)
@@ -44,7 +44,7 @@ case class IngressIdentifierConfig(
   port: Option[Port],
   namespace: Option[String],
   ingressClassAnnotation: Option[String],
-  strict: Option[Boolean]
+  ignoreDefaultBackends: Option[Boolean]
 
 ) extends HttpIdentifierConfig with ClientConfig {
   @JsonIgnore
@@ -55,7 +55,7 @@ case class IngressIdentifierConfig(
     baseDtab: () => Dtab = () => Dtab.base
   ): Identifier[Request] = {
     val client = mkClient(Params.empty).configured(Label("ingress-identifier"))
-    new IngressIdentifier(prefix, baseDtab, namespace, client.newService(dst), ingressClassAnnotation.getOrElse("linkerd"), strict.getOrElse(false))
+    new IngressIdentifier(prefix, baseDtab, namespace, client.newService(dst), ingressClassAnnotation.getOrElse("linkerd"), ignoreDefaultBackends.getOrElse(false))
   }
 }
 

--- a/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/IngressIdentifierConfigTest.scala
+++ b/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/IngressIdentifierConfigTest.scala
@@ -19,7 +19,7 @@ class IngressIdentifierConfigTest extends FunSuite {
     val ingress = mapper.readValue[IngressIdentifierConfig](yaml)
     assert(ingress.namespace == None)
     assert(ingress.ingressClassAnnotation == None)
-    assert(ingress.strict == None)
+    assert(ingress.ignoreDefaultBackends == None)
   }
 
   test("parse config with namespace") {
@@ -45,15 +45,15 @@ class IngressIdentifierConfigTest extends FunSuite {
     assert(ingress.ingressClassAnnotation == Some("istio"))
   }
 
-  test("parse config for strict ingress") {
+  test("parse config for ignoreDefaultBackends ingress") {
     val yaml =
       """|kind: io.l5d.ingress
-         |strict: true
+         |ignoreDefaultBackends: true
       """.stripMargin
     val mapper = Parser.objectMapper(yaml, Iterable(Seq(IngressIdentifierInitializer)))
     val ingress = mapper.readValue[IngressIdentifierConfig](yaml)
     assert(ingress.namespace == None)
     assert(ingress.ingressClassAnnotation == None)
-    assert(ingress.strict == Some(true))
+    assert(ingress.ignoreDefaultBackends == Some(true))
   }
 }

--- a/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/IngressIdentifierConfigTest.scala
+++ b/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/IngressIdentifierConfigTest.scala
@@ -7,7 +7,7 @@ import org.scalatest.FunSuite
 
 class IngressIdentifierConfigTest extends FunSuite {
   test("sanity") {
-    val ingressConfig = new IngressIdentifierConfig(Some("example.org"), Some(Port(9090)), None, Some("linkerd-ingress"))
+    val ingressConfig = new IngressIdentifierConfig(Some("example.org"), Some(Port(9090)), None, Some("linkerd-ingress"), Some(false))
     val _ = ingressConfig.newIdentifier(Path.empty)
   }
 
@@ -19,6 +19,7 @@ class IngressIdentifierConfigTest extends FunSuite {
     val ingress = mapper.readValue[IngressIdentifierConfig](yaml)
     assert(ingress.namespace == None)
     assert(ingress.ingressClassAnnotation == None)
+    assert(ingress.strict == None)
   }
 
   test("parse config with namespace") {
@@ -42,5 +43,17 @@ class IngressIdentifierConfigTest extends FunSuite {
     val ingress = mapper.readValue[IngressIdentifierConfig](yaml)
     assert(ingress.namespace == Some("istio-ns"))
     assert(ingress.ingressClassAnnotation == Some("istio"))
+  }
+
+  test("parse config for strict ingress") {
+    val yaml =
+      """|kind: io.l5d.ingress
+         |strict: true
+      """.stripMargin
+    val mapper = Parser.objectMapper(yaml, Iterable(Seq(IngressIdentifierInitializer)))
+    val ingress = mapper.readValue[IngressIdentifierConfig](yaml)
+    assert(ingress.namespace == None)
+    assert(ingress.ingressClassAnnotation == None)
+    assert(ingress.strict == Some(true))
   }
 }

--- a/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/IngressIdentifierTest.scala
+++ b/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/IngressIdentifierTest.scala
@@ -99,7 +99,7 @@ class IngressIdentifierTest extends FunSuite with Awaits {
     }
   }
 
-  test("strict ingress identifies requests by host & path") {
+  test("ignoreDefaultBackends ingress identifies requests by host & path") {
     val identifier = new IngressIdentifier(Path.Utf8("svc"), () => Dtab.empty, None, service, "linkerd", true)
     val req0 = Request()
     req0.method = Method.Get
@@ -113,7 +113,7 @@ class IngressIdentifierTest extends FunSuite with Awaits {
     }
   }
 
-  test("strict ingress does not fall back to the default backend") {
+  test("ignoreDefaultBackends ingress does not fall back to the default backend") {
     val identifier = new IngressIdentifier(Path.Utf8("svc"), () => Dtab.empty, None, service, "linkerd", true)
     val req0 = Request()
     req0.method = Method.Get


### PR DESCRIPTION
I'd like to avoid the nondeterministic case in which there are multiple default backends defined and a request matches no explicit rules, instead having the ingress identifier fail through to a static identifier. Refer to https://github.com/linkerd/linkerd/issues/1793 for the full context and use case.