### PR TITLE
Add test case to ensure x-forwarded-client-cert header can't be spoofed.

### DIFF
--- a/linkerd/protocol/h2/src/integration/scala/io/buoyant/linkerd/protocol/h2/ForwardClientCertTest.scala
+++ b/linkerd/protocol/h2/src/integration/scala/io/buoyant/linkerd/protocol/h2/ForwardClientCertTest.scala
@@ -1,16 +1,15 @@
 package io.buoyant.linkerd.protocol.h2
 
-import java.io.FileInputStream
-import java.security.MessageDigest
-import java.security.cert.CertificateFactory
-import javax.xml.bind.DatatypeConverter.printHexBinary
-
 import com.twitter.finagle.buoyant.h2.{Method, Request, Response, Status, Stream}
 import com.twitter.util.Future
 import io.buoyant.linkerd.Linker
 import io.buoyant.linkerd.tls.TlsUtils.withCerts
 import io.buoyant.test.FunSuite
 import io.buoyant.test.h2.StreamTestUtils._
+import java.io.FileInputStream
+import java.security.MessageDigest
+import java.security.cert.CertificateFactory
+import javax.xml.bind.DatatypeConverter.printHexBinary
 
 class ForwardClientCertTest extends FunSuite {
 

--- a/linkerd/protocol/h2/src/integration/scala/io/buoyant/linkerd/protocol/h2/ForwardClientCertTest.scala
+++ b/linkerd/protocol/h2/src/integration/scala/io/buoyant/linkerd/protocol/h2/ForwardClientCertTest.scala
@@ -1,19 +1,28 @@
 package io.buoyant.linkerd.protocol.h2
 
+import java.io.FileInputStream
+import java.security.MessageDigest
+import java.security.cert.CertificateFactory
+import javax.xml.bind.DatatypeConverter.printHexBinary
+
 import com.twitter.finagle.buoyant.h2.{Method, Request, Response, Status, Stream}
 import com.twitter.util.Future
 import io.buoyant.linkerd.Linker
 import io.buoyant.linkerd.tls.TlsUtils.withCerts
 import io.buoyant.test.FunSuite
 import io.buoyant.test.h2.StreamTestUtils._
-import java.io.FileInputStream
-import java.security.MessageDigest
-import java.security.cert.CertificateFactory
-import javax.xml.bind.DatatypeConverter.printHexBinary
 
 class ForwardClientCertTest extends FunSuite {
 
   test("forward client certificate") {
+    testForwardedClient()
+  }
+
+  test("forward client certificate with existing x-forwarded-client-cert header") {
+    testForwardedClient(Some("""Hash=ABC;SAN=https://spoof.io;Subject="C=US,CN=root"""))
+  }
+
+  private def testForwardedClient(xForwardedClientCert: Option[String] = None) = {
     withCerts("upstream", "linkerd") { certs =>
       var downstreamRequest: Request = null
       val dog = Downstream.mk("dogs") { req =>
@@ -48,7 +57,9 @@ class ForwardClientCertTest extends FunSuite {
       val client = Upstream.mkTls(server, "linkerd", certs.caCert, Some(upstreamServiceCert))
 
       try {
-        val rsp = await(client(Request("http", Method.Get, "clifford", "/", Stream.empty())))
+        val request = Request("http", Method.Get, "clifford", "/", Stream.empty())
+        xForwardedClientCert.foreach(h => request.headers.add("x-forwarded-client-cert", h))
+        val rsp = await(client(request))
 
         assert(await(rsp.stream.readDataString) == "woof")
         assert(downstreamRequest.headers.get("x-forwarded-client-cert") == {


### PR DESCRIPTION
In the process of verifying some linkerd behavior we added this test case and thought it might be generally useful.