### PR TITLE
Update h2 docs to reflect current implementation

### DIFF
--- a/linkerd/docs/interpreter.md
+++ b/linkerd/docs/interpreter.md
@@ -49,13 +49,13 @@ failureThreshold | no failureThreshold | Sets the [failure threshold](#failure-t
 
 ### Failure Threshold
 
-Linkerd uses a [Threshold Failure Detector](https://github.com/twitter/finagle/blob/master/finagle-core/src/main/scala/com/twitter/finagle/liveness/ThresholdFailureDetector.scala) 
+Linkerd uses a [Threshold Failure Detector](https://github.com/twitter/finagle/blob/master/finagle-core/src/main/scala/com/twitter/finagle/liveness/ThresholdFailureDetector.scala)
 to determine the health of the connection to a Namerd instance. Linkerd sends pings to Namerd periodically and evaluates the health of Namerd based on a set number of ping latencies
 
 Key | Default Value | Description
 --- | ------------- | -----------
 minPeriodMs | 5000 | The period between session pings to Namerd
-threshold | 2.0 | Used to calculate the maximum allowed ping latency 
+threshold | 2.0 | Used to calculate the maximum allowed ping latency
 windowSize | 100 | The number of observations to make to gauge session liveness of Namerd
 closeTimeoutMs | 4000 | Timeout for a session ping's response before Linkerd terminates a session
 
@@ -103,7 +103,6 @@ protocols of Linkerd's routers.
 
 Key | Default Value | Description
 --- | ------------- | -----------
-experimental | _required_ | Because the mesh interpreter is still considered experimental, you must set this to `true` to use it.
 dst | _required_ | A Finagle path locating the Namerd service.
 root | `/default` | A single-element Finagle path representing the Namerd namespace.
 retry | see [Namerd retry](#namerd-retry) | An object configuring retry backoffs for requests to Namerd.

--- a/linkerd/docs/protocol-h2.md
+++ b/linkerd/docs/protocol-h2.md
@@ -7,7 +7,7 @@
 ```yaml
 routers:
 - protocol: h2
-  experimental: true
+  h2AccessLog: access.log
   servers:
   - port: 4143
     tls:
@@ -32,7 +32,6 @@ routers:
 ```yaml
 routers:
 - protocol: h2
-  experimental: true
   label: grpc
   servers:
   - port: 4142
@@ -50,17 +49,16 @@ accordingly. Note that gRPC may be configured over TLS as well.
 
 protocol: `h2`
 
-Linkerd now has _experimental_ support for HTTP/2. There are a number of
-[open issues](https://github.com/linkerd/linkerd/issues?q=is%3Aopen+is%3Aissue+label%3Ah2)
-that are being addressed. Please
-[report](https://github.com/linkerd/linkerd/issues/new) any
-additional issues with this protocol!
+The HTTP/2 protocol is used when the *protocol* option of the
+[routers configuration block](#router-parameters) is set to *h2*.
+This protocol has additional configuration options on the *routers* block.
 
 Key | Default Value | Description
 --- | ------------- | -----------
 dstPrefix | `/svc` | A path prefix used by [H2-specific identifiers](#http-2-identifiers).
-experimental | `false` | Set this to `true` to opt-in to experimental h2 support.
-identifier | The `io.l5d.header.token` identifier | An identifier or list of identifiers. See [HTTP/2 Identifiers](#http-2-identifiers).
+h2AccessLog | none | Sets the access log path.  If not specified, no access log is written.
+identifier | The `io.l5d.header.token` identifier | An identifier or list of identifiers. See [H2-specific identifiers](#http-2-identifiers).
+loggers | none | A list of loggers.  See [H2-specific loggers](#http-2-loggers).
 
 When TLS is configured, h2 routers negotiate to communicate over
 HTTP/2 via ALPN.
@@ -145,7 +143,6 @@ used as the logical name.
 ```yaml
 routers:
 - protocol: h2
-  experimental: true
   identifier:
     kind: io.l5d.header.token
     header: my-header
@@ -187,7 +184,6 @@ and will be routed based on this name by the corresponding Dtab.
 ```yaml
 routers:
 - protocol: h2
-  experimental: true
   identifier:
     kind: io.l5d.header.path
     segments: 2
@@ -235,7 +231,6 @@ The HTTP/2 Ingress Identifier compares an ingress rule's `host` field to the
 ```yaml
 routers:
 - protocol: h2
-  experimental: true
   identifier:
     kind: io.l5d.ingress
     namespace: default
@@ -305,7 +300,6 @@ on those rules.
 ```yaml
 routers:
 - protocol: h2
-  experimental: true
   identifier:
     kind: io.l5d.k8s.istio
 ```

--- a/linkerd/docs/protocol-http.md
+++ b/linkerd/docs/protocol-http.md
@@ -31,7 +31,7 @@ Key | Default Value | Description
 dstPrefix | `/svc` | A path prefix used by [Http-specific identifiers](#http-1-1-identifiers).
 httpAccessLog | none | Sets the access log path.  If not specified, no access log is written.
 identifier | The `io.l5d.header.token` identifier | An identifier or list of identifiers.  See [Http-specific identifiers](#http-1-1-identifiers).
-loggers | A list of loggers.  See [Http-specific loggers](#http-1-1-loggers).
+loggers | none | A list of loggers.  See [Http-specific loggers](#http-1-1-loggers).
 maxChunkKB | 8 | The maximum size of an HTTP chunk.
 maxHeadersKB | 8 | The maximum size of all headers in an HTTP message.
 maxInitialLineKB | 4 | The maximum size of an initial HTTP message line.


### PR DESCRIPTION
The h2 docs still say that the h2 protocol is experimental, even though it was graduated from experimental in #1782. Likewise the h2AccessLog configuration option that was added in #1786 was never documented.