### PR TITLE
Don't reset the ingress cache when ingresses are deleted

### DIFF
--- a/k8s/src/main/scala/io/buoyant/k8s/IngressCache.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/IngressCache.scala
@@ -96,8 +96,10 @@ class IngressCache(
             mkIngress(m)
               .map { item => ingresses.filterNot(isNameEqual(_, item)) :+ item }
               .getOrElse(ingresses)
-          case v1beta1.IngressDeleted(_) =>
-            Seq.empty
+          case v1beta1.IngressDeleted(d) =>
+            mkIngress(d)
+              .map { item => ingresses.filterNot(isNameEqual(_, item)) }
+              .getOrElse(ingresses)
           case v1beta1.IngressError(e) =>
             log.error("k8s watch error: %s", e)
             ingresses

--- a/k8s/src/test/scala/io/buoyant/k8s/IngressCacheTest.scala
+++ b/k8s/src/test/scala/io/buoyant/k8s/IngressCacheTest.scala
@@ -471,6 +471,10 @@ class IngressCacheTest extends FunSuite with Awaits {
       ingressDeletedFromMoreThanOneLinkerdIngresses
     )
     val cache = new IngressCache(None, service, annotationClass, true)
+    // The ingress that was deleted is gone.
+    assert(await(cache.matchPath(host, "/linkerd-1")) == None)
+
+    // Untouched ingresses remain.
     assert(await(cache.matchPath(host, "/linkerd-2")).get.svc == "echo2")
   }
 

--- a/k8s/src/test/scala/io/buoyant/k8s/IngressCacheTest.scala
+++ b/k8s/src/test/scala/io/buoyant/k8s/IngressCacheTest.scala
@@ -412,11 +412,9 @@ class IngressCacheTest extends FunSuite with Awaits with OptionValues {
       rsp.content = Buf.Utf8(response)
       Future.value(rsp)
     case req if req.uri.contains("/apis/extensions/v1beta1/watch/ingresses") =>
-      var doWatch = new Promise[Unit]
-      doWatch.setDone()
       val rsp = Response()
       rsp.setChunked(true)
-      doWatch before rsp.writer.write(Buf.Utf8(watchResponse))
+      rsp.writer.write(Buf.Utf8(watchResponse))
       Future.value(rsp)
     case req =>
       fail(s"unexpected request for [${req.uri}]: $req")

--- a/k8s/src/test/scala/io/buoyant/k8s/IngressCacheTest.scala
+++ b/k8s/src/test/scala/io/buoyant/k8s/IngressCacheTest.scala
@@ -6,9 +6,10 @@ import com.twitter.util.Future
 import com.twitter.util.Promise
 import io.buoyant.test.Awaits
 import org.scalatest.FunSuite
+import org.scalatest.OptionValues
 import com.twitter.finagle.http.{Request, Response}
 
-class IngressCacheTest extends FunSuite with Awaits {
+class IngressCacheTest extends FunSuite with Awaits with OptionValues {
   val host = Some("myhost")
   val ns = Some("ns")
 
@@ -427,41 +428,41 @@ class IngressCacheTest extends FunSuite with Awaits {
     assert(await(cache.matchPath(host, "/istio-only")).isEmpty)
     assert(await(cache.matchPath(host, "/nginx-only")).isEmpty)
     assert(await(cache.matchPath(host, "/non-existing-path")).isEmpty)
-    assert(await(cache.matchPath(host, "/linkerd-only")).get.svc == "echo")
+    assert(await(cache.matchPath(host, "/linkerd-only")).value.svc == "echo")
   }
 
   test("when multiple ingress resources with desired annotation class, matches based on path of either") {
     val service = mkIngressApiServiceReturning(ingressResourceListWithMoreThanOneLinkerdIngresses)
     val cache = new IngressCache(None, service, annotationClass)
-    assert(await(cache.matchPath(host, "/linkerd-1")).get.svc == "echo1")
-    assert(await(cache.matchPath(host, "/linkerd-2")).get.svc == "echo2")
-    assert(Set("shared1", "shared2").contains(await(cache.matchPath(host, "/shared")).get.svc))
+    assert(await(cache.matchPath(host, "/linkerd-1")).value.svc == "echo1")
+    assert(await(cache.matchPath(host, "/linkerd-2")).value.svc == "echo2")
+    assert(Set("shared1", "shared2").contains(await(cache.matchPath(host, "/shared")).value.svc))
   }
 
   test("when only one ingress configured, adds it irrespective of annotations") {
     val service = mkIngressApiServiceReturning(ingressResourceListWithOneIngress)
     val cache = new IngressCache(None, service, annotationClass)
-    assert(await(cache.matchPath(host, "/some-path")).get.svc == "echo")
+    assert(await(cache.matchPath(host, "/some-path")).value.svc == "echo")
     assert(await(cache.matchPath(host, "/non-existing-path")).isEmpty)
   }
 
   test("ignores port in a request's hostname") {
     val service = mkIngressApiServiceReturning(ingressResourceListWithOneIngress)
     val cache = new IngressCache(None, service, annotationClass)
-    assert(await(cache.matchPath(Some("myhost:80"), "/some-path")).get.svc == "echo")
+    assert(await(cache.matchPath(Some("myhost:80"), "/some-path")).value.svc == "echo")
   }
 
   test("ingress caches honor default backends") {
     val service = mkIngressApiServiceReturning(ingressResourceListWithOneIngressWithFallback)
     val cache = new IngressCache(None, service, annotationClass)
-    assert(await(cache.matchPath(host, "/some-path")).get.svc == "echo")
-    assert(await(cache.matchPath(host, "/unknown-path")).get.svc == "fallback")
+    assert(await(cache.matchPath(host, "/some-path")).value.svc == "echo")
+    assert(await(cache.matchPath(host, "/unknown-path")).value.svc == "fallback")
   }
 
   test("ignoreDefaultBackends ingress caches ignore default backends") {
     val service = mkIngressApiServiceReturning(ingressResourceListWithOneIngressWithFallback)
     val cache = new IngressCache(None, service, annotationClass, true)
-    assert(await(cache.matchPath(host, "/some-path")).get.svc == "echo")
+    assert(await(cache.matchPath(host, "/some-path")).value.svc == "echo")
     assert(await(cache.matchPath(host, "/unknown-path")) == None)
   }
 
@@ -475,7 +476,7 @@ class IngressCacheTest extends FunSuite with Awaits {
     assert(await(cache.matchPath(host, "/linkerd-1")) == None)
 
     // Untouched ingresses remain.
-    assert(await(cache.matchPath(host, "/linkerd-2")).get.svc == "echo2")
+    assert(await(cache.matchPath(host, "/linkerd-2")).value.svc == "echo2")
   }
 
   test("on multiple path matches, return first match") {
@@ -485,14 +486,14 @@ class IngressCacheTest extends FunSuite with Awaits {
     )
     val spec = IngressSpec(Some("my-ingress"), ns, None, paths)
     val matchingPath = IngressCache.getMatchingPath(host, "/path", Seq(spec))
-    assert(matchingPath.get.svc == "primary-svc")
+    assert(matchingPath.value.svc == "primary-svc")
   }
 
   test("on multiple host matches, return first match") {
     val resource1 = IngressSpec(Some("polar-bear1"), ns, None, Seq(IngressPath(host, None, ns.get, "svc1", "80")))
     val resource2 = IngressSpec(Some("polar-bear2"), ns, None, Seq(IngressPath(host, None, ns.get, "svc2", "80")))
     val matchingPath = IngressCache.getMatchingPath(host, "/path", Seq(resource1, resource2))
-    assert(matchingPath.get.svc == "svc1")
+    assert(matchingPath.value.svc == "svc1")
   }
 
   test("don't return default backend before checking all resources for matches") {
@@ -504,7 +505,7 @@ class IngressCacheTest extends FunSuite with Awaits {
     )
     val resource2 = IngressSpec(Some("polar-bear2"), ns, None, Seq(IngressPath(host, None, ns.get, "svc2", "80")))
     val matchingPath = IngressCache.getMatchingPath(host, "/path", Seq(resource1, resource2))
-    assert(matchingPath.get.svc == "svc2")
+    assert(matchingPath.value.svc == "svc2")
   }
 
   test("on no host/path matches, return first default backend") {
@@ -516,7 +517,7 @@ class IngressCacheTest extends FunSuite with Awaits {
       Seq(IngressPath(host, None, ns.get, "svc2", "80"))
     )
     val matchingPath = IngressCache.getMatchingPath(Some("unknown host"), "/path", Seq(resource1, resource2))
-    assert(matchingPath.get.svc == "fallback")
+    assert(matchingPath.value.svc == "fallback")
   }
 
   test("no matches") {


### PR DESCRIPTION
We've observed on our Kubernetes clusters that linkerd is unable to route ingress traffic after any one ingress resource is deleted, even when there are plenty of valid ingress resources remaining. I'm pretty sure this bug was introduced in https://github.com/linkerd/linkerd/pull/1622/files#diff-7e056dcc7844eb0f58a507bf1b29cff2L93

When we see an ingress being deleted we want to delete that ingress from our ingress cache, not set the ingress cache to an empty sequence. 9c3c619 adds a test intended to demonstrate the bug, which is fixed in bfed573.