### PR TITLE
Adding support for DNS SAN names in XFCC.

### DIFF
--- a/linkerd/protocol/h2/src/integration/scala/io/buoyant/linkerd/protocol/h2/ForwardClientCertTest.scala
+++ b/linkerd/protocol/h2/src/integration/scala/io/buoyant/linkerd/protocol/h2/ForwardClientCertTest.scala
@@ -22,7 +22,7 @@ class ForwardClientCertTest extends FunSuite {
   }
 
   private def testForwardedClient(xForwardedClientCert: Option[String] = None) = {
-    withCerts("upstream", "linkerd") { certs =>
+    withCerts(true, Seq("upstream", "linkerd")) { certs =>
       var downstreamRequest: Request = null
       val dog = Downstream.mk("dogs") { req =>
         downstreamRequest = req
@@ -65,7 +65,7 @@ class ForwardClientCertTest extends FunSuite {
           val cf = CertificateFactory.getInstance("X.509")
           val cert = cf.generateCertificate(new FileInputStream(upstreamServiceCert.cert))
           val digest = MessageDigest.getInstance("SHA-256")
-          Some(s"""Hash=${printHexBinary(digest.digest(cert.getEncoded))};SAN=https://buoyant.io;Subject="C=US,CN=upstream"""")
+          Some(s"""Hash=${printHexBinary(digest.digest(cert.getEncoded))};SAN=https://buoyant.io;DNS=upstream;DNS=linkerd;Subject="C=US,CN=upstream"""")
         })
         ()
       } finally {

--- a/linkerd/protocol/h2/src/integration/scala/io/buoyant/linkerd/protocol/h2/ForwardClientCertTest.scala
+++ b/linkerd/protocol/h2/src/integration/scala/io/buoyant/linkerd/protocol/h2/ForwardClientCertTest.scala
@@ -22,7 +22,7 @@ class ForwardClientCertTest extends FunSuite {
   }
 
   private def testForwardedClient(xForwardedClientCert: Option[String] = None) = {
-    withCerts(true, Seq("upstream", "linkerd")) { certs =>
+    withCerts("upstream", "linkerd") { certs =>
       var downstreamRequest: Request = null
       val dog = Downstream.mk("dogs") { req =>
         downstreamRequest = req

--- a/linkerd/protocol/http/src/integration/scala/io/buoyant/linkerd/protocol/ForwardClientCertTest.scala
+++ b/linkerd/protocol/http/src/integration/scala/io/buoyant/linkerd/protocol/ForwardClientCertTest.scala
@@ -12,7 +12,7 @@ import javax.xml.bind.DatatypeConverter.printHexBinary
 class ForwardClientCertTest extends FunSuite {
 
   test("forward client certificate") {
-    withCerts("upstream", "linkerd") { certs =>
+    withCerts(true, Seq("upstream", "linkerd")) { certs =>
       var downstreamRequest: Request = null
       val dog = Downstream.mk("dogs") { req =>
         downstreamRequest = req
@@ -58,7 +58,7 @@ class ForwardClientCertTest extends FunSuite {
           val cf = CertificateFactory.getInstance("X.509")
           val cert = cf.generateCertificate(new FileInputStream(upstreamServiceCert.cert))
           val digest = MessageDigest.getInstance("SHA-256")
-          s"""Hash=${printHexBinary(digest.digest(cert.getEncoded))};SAN=https://buoyant.io;Subject="C=US,CN=upstream""""
+          s"""Hash=${printHexBinary(digest.digest(cert.getEncoded))};SAN=https://buoyant.io;DNS=upstream;DNS=linkerd;Subject="C=US,CN=upstream""""
         })
         ()
       } finally {

--- a/linkerd/protocol/http/src/integration/scala/io/buoyant/linkerd/protocol/ForwardClientCertTest.scala
+++ b/linkerd/protocol/http/src/integration/scala/io/buoyant/linkerd/protocol/ForwardClientCertTest.scala
@@ -12,7 +12,7 @@ import javax.xml.bind.DatatypeConverter.printHexBinary
 class ForwardClientCertTest extends FunSuite {
 
   test("forward client certificate") {
-    withCerts(true, Seq("upstream", "linkerd")) { certs =>
+    withCerts("upstream", "linkerd") { certs =>
       var downstreamRequest: Request = null
       val dog = Downstream.mk("dogs") { req =>
         downstreamRequest = req

--- a/linkerd/protocol/http/src/integration/scala/io/buoyant/linkerd/protocol/TlsBoundPathTest.scala
+++ b/linkerd/protocol/http/src/integration/scala/io/buoyant/linkerd/protocol/TlsBoundPathTest.scala
@@ -212,8 +212,8 @@ class TlsBoundPathTest extends FunSuite with Awaits {
   }
 
   test("wrong common name") {
-
-    withCerts("bill.buoyant.io", "ted.buoyant.io") { certs =>
+    // Create certificates without SAN DNS entries that override CN.
+    withCertsWithCustomDnsAltNames(Seq("bill.buoyant.io", "ted.buoyant.io"), null) { certs =>
       val bill = Downstream
         .constTls(
           "bill",

--- a/linkerd/protocol/http/src/integration/scala/io/buoyant/linkerd/protocol/TlsCertReloadingTest.scala
+++ b/linkerd/protocol/http/src/integration/scala/io/buoyant/linkerd/protocol/TlsCertReloadingTest.scala
@@ -9,7 +9,8 @@ import java.net.InetSocketAddress
 class TlsCertReloadingTest extends FunSuite with Awaits {
 
   test("cert reloading") {
-    TlsUtils.withCerts("foo", "bar") { certs =>
+    // Create certificates without SAN DNS entries that override CN.
+    TlsUtils.withCertsWithCustomDnsAltNames(Seq("foo", "bar"), null) { certs =>
       val downstream = Downstream.const("foo", "foo")
 
       val fooCerts = certs.serviceCerts("foo")

--- a/linkerd/tls/src/main/scala/io/buoyant/linkerd/tls/TlsUtils.scala
+++ b/linkerd/tls/src/main/scala/io/buoyant/linkerd/tls/TlsUtils.scala
@@ -1,7 +1,6 @@
 package io.buoyant.linkerd.tls
 
 import java.io.{File, FileWriter}
-
 import scala.collection.mutable
 import scala.sys.process._
 
@@ -95,8 +94,7 @@ object TlsUtils {
   }
 
   def dnsAltNames(names: Seq[String]): String = {
-    val altNames = new Array[String](names.length)
-    names.indices.foreach(i => altNames(i) = "DNS." + (i + 1) + " = " + names(i))
+    val altNames = names.zipWithIndex.map { case(name, i) => s"DNS.${i+1} = $name" }
     altNames.mkString("\n")
   }
 

--- a/router/base-http/src/main/scala/io/buoyant/router/http/ForwardClientCertFilter.scala
+++ b/router/base-http/src/main/scala/io/buoyant/router/http/ForwardClientCertFilter.scala
@@ -31,7 +31,7 @@ class ForwardClientCertFilter[Req, H: HeadersLike, Rep](implicit requestLike: Re
               val nameType = altName.get(0)
               val nameValue = altName.get(1)
               nameType match {
-                case GeneralNameTypeUri => clientCertHeader ++= s";SAN=$nameValue"
+                case GeneralNameTypeUri => clientCertHeader ++= s";SAN=$nameValue" // Use "SAN:" instead of "URI:" for backward compatibility with previous releases.
                 case GeneralNameTypeDns => clientCertHeader ++= s";DNS=$nameValue"
               }
             }


### PR DESCRIPTION
Signed-off-by: Shakti Das shakti.das2002@gmail.com

Problem
The x-forwarded-client-cert header only forwards the SAN entry of type URI. SAN entries of type DNS are also used for TLS and mTLS verification. We need to support the same for XFCC header so that client implementations can use SAN DNS entries as well for certificate verification.

Solution
The solution as discussed in the issue conversation is to add DNS SAN entries directly to the XFCC header. So, after the change, the XFCC header would look like:
`Hash=468ed33be74eee6556d90c0149c1309e9ba61d6425303443c0748a02dd8de688;SAN=https://example.com;DNS=example.com;DNS=www.example.com`

Validation
The TLS related tests were run to verify it causes no regression. The tests were modified to verify propagation of DNS SAN entries in XFCC. 

Fixes #1802