### PR TITLE
Fix potential race condition in ExistentialStability

### DIFF
--- a/finagle/buoyant/src/main/scala/com/twitter/finagle/buoyant/ExistentialStability.scala
+++ b/finagle/buoyant/src/main/scala/com/twitter/finagle/buoyant/ExistentialStability.scala
@@ -83,9 +83,11 @@ object ExistentialStability {
           }
           case Activity.Pending => synchronized {
             update() = Activity.Pending
+            exists = false
           }
           case Activity.Failed(e) => synchronized {
             update() = Activity.Failed(e)
+            exists = false
           }
         }
       }

--- a/finagle/buoyant/src/main/scala/com/twitter/finagle/buoyant/ExistentialStability.scala
+++ b/finagle/buoyant/src/main/scala/com/twitter/finagle/buoyant/ExistentialStability.scala
@@ -25,24 +25,25 @@ object ExistentialStability {
         // the current inner Var, null if the outer Var is None
         @volatile var current: VarUp[T] = null
         @volatile var exists = false
+        val mu = new {}
         unstable.changes.respond {
-          case Some(t) if current == null => synchronized {
+          case Some(t) if current == null => mu.synchronized {
             // T created
             exists = true
             current = Var(t)
             update() = Some(current)
           }
-          case Some(t) if !exists => synchronized {
+          case Some(t) if !exists => mu.synchronized {
             // T re-created
             exists = true
             current() = t
             update() = Some(current)
           }
-          case Some(t) => synchronized {
+          case Some(t) => mu.synchronized {
             // T modified
             current() = t
           }
-          case None => synchronized {
+          case None => mu.synchronized {
             // T deleted
             exists = false
             update() = None
@@ -59,33 +60,34 @@ object ExistentialStability {
         // the current inner Var, null if the outer Var is None
         @volatile var current: VarUp[T] = null
         @volatile var exists = false
+        val mu = new {}
         unstable.states.respond {
-          case Activity.Ok(Some(t)) if current == null => synchronized {
+          case Activity.Ok(Some(t)) if current == null => mu.synchronized {
             // T created
             current = Var(t)
             exists = true
             update() = Activity.Ok(Some(current))
           }
-          case Activity.Ok(Some(t)) if !exists => synchronized {
+          case Activity.Ok(Some(t)) if !exists => mu.synchronized {
             // T recreated
             exists = true
             current() = t
             update() = Activity.Ok(Some(current))
           }
-          case Activity.Ok(Some(t)) => synchronized {
+          case Activity.Ok(Some(t)) => mu.synchronized {
             // T modified
             current() = t
           }
-          case Activity.Ok(None) => synchronized {
+          case Activity.Ok(None) => mu.synchronized {
             // T deleted
             exists = false
             update() = Activity.Ok(None)
           }
-          case Activity.Pending => synchronized {
+          case Activity.Pending => mu.synchronized {
             update() = Activity.Pending
             exists = false
           }
-          case Activity.Failed(e) => synchronized {
+          case Activity.Failed(e) => mu.synchronized {
             update() = Activity.Failed(e)
             exists = false
           }


### PR DESCRIPTION
There are two bugs in `ExistentialStability` that could lead to incorrect behaviour:
1. A potential race condition exists in the `respond` callback on the unstable `Var` or `Activity`. Since the `respond` callback is not synchronized, if an event were to trigger the callback while the callback for another event is being processed, the new callback could be handled by a different thread. If we are in the middle of the match case handling the creation of the unstable `Var`/`Activity`, `current` could be set to a different `Var` than the one that is sent to `update`. This would mean that the returned `Var`/`Activity` would fail to receive any subsequent events.
2. A potential bug exists in the `ExistentialStability` implementation for `Activity`, where the cases handling the `Activity` being set to `Pending` or `Failed` don't set the `exists` flag to `false`. If one of these cases were to happen after the `Activity` has already been in an `Ok` state, and then the underlying `Activity` transitioned back to `Ok`, `current` would be updated to the new value, but since `exists` was still `true`, `update` would not be set to `current` and would remain in the `Pending` or `Failed` state.

The first issue (the race condition) may potentially be linked to issue #1730, although we have not yet been able to verify whether this is true. The second bug seems unlikely to happen, since Linkerd should not intentionally cause an `Activity` to transition from `Ok` to `Pending` or `Failed`,  but could be triggered due to other bugs.

This PR fixes both of the above bugs, by synchronizing the match arms in the `respond` callback and by setting `exists = false` in the cases handling `Pending` and `Failed`, respectively.