### PR TITLE
Fix ZooKeeper session management

### DIFF
--- a/linkerd/tls/src/main/scala/io/buoyant/linkerd/tls/TlsUtils.scala
+++ b/linkerd/tls/src/main/scala/io/buoyant/linkerd/tls/TlsUtils.scala
@@ -94,7 +94,7 @@ object TlsUtils {
   }
 
   def dnsAltNames(names: Seq[String]): String = {
-    val altNames = names.zipWithIndex.map { case(name, i) => s"DNS.${i+1} = $name" }
+    val altNames = names.zipWithIndex.map { case (name, i) => s"DNS.${i + 1} = $name" }
     altNames.mkString("\n")
   }
 

--- a/namerd/docs/interface.md
+++ b/namerd/docs/interface.md
@@ -32,8 +32,6 @@ Key | Default Value | Description
 --- | ------------- | -----------
 ip | loopback address | The local IP address on which to serve the namer interface. A value like 0.0.0.0 configures Namerd to listen on all local IPv4 interfaces.
 port | `4100` | The port number on which to serve the namer interface.
-retryBaseSecs | `600` | Base number of seconds to tell clients to wait before retrying after an error.
-retryJitterSecs | `60` | Maximum number of seconds to jitter retry time by.
 cache | see [cache](#cache) | Binding and address cache size configuration.
 tls | no tls | The namer interface will serve over TLS if this parameter is provided. See [Server TLS](https://linkerd.io/config/head/linkerd#server-tls).
 

--- a/namerd/iface/interpreter-thrift-idl/src/main/thrift/namer.thrift
+++ b/namerd/iface/interpreter-thrift-idl/src/main/thrift/namer.thrift
@@ -64,7 +64,7 @@ struct Bound {
 
 exception BindFailure {
   1: string reason
-  2: i32 retryInSeconds
+  2: i32 retryInSeconds // DEPRECATED & IGNORED
   3: NameRef name
   4: Ns ns
 }
@@ -115,7 +115,7 @@ struct Addr {
 
 exception AddrFailure {
   1: string reason
-  2: i32 retryInSeconds
+  2: i32 retryInSeconds // DEPRECATED & IGNORED
   3: NameRef name
 }
 

--- a/namerd/iface/interpreter-thrift/src/main/scala/io/buoyant/namerd/iface/ThriftInterpreterInterfaceConfig.scala
+++ b/namerd/iface/interpreter-thrift/src/main/scala/io/buoyant/namerd/iface/ThriftInterpreterInterfaceConfig.scala
@@ -14,8 +14,6 @@ import java.net.{InetAddress, InetSocketAddress}
 import scala.util.Random
 
 case class ThriftInterpreterInterfaceConfig(
-  retryBaseSecs: Option[Int] = None,
-  retryJitterSecs: Option[Int] = None,
   cache: Option[CapacityConfig] = None
 ) extends InterpreterInterfaceConfig {
   @JsonIgnore
@@ -30,16 +28,10 @@ case class ThriftInterpreterInterfaceConfig(
   ): Servable = {
     val stats1 = stats.scope(ThriftInterpreterInterfaceConfig.kind)
 
-    val retryIn: () => Duration = {
-      val retry = retryBaseSecs.map(_.seconds).getOrElse(10.minutes)
-      val jitter = retryJitterSecs.map(_.seconds).getOrElse(1.minute)
-      () => retry + (Random.nextGaussian() * jitter.inSeconds).toInt.seconds
-    }
     val iface = new ThriftNamerInterface(
       interpreters,
       namers,
       new LocalStamper,
-      retryIn,
       cache.map(_.capacity).getOrElse(ThriftNamerInterface.Capacity.default),
       stats1
     )

--- a/namerd/iface/interpreter-thrift/src/main/scala/io/buoyant/namerd/iface/ThriftNamerClient.scala
+++ b/namerd/iface/interpreter-thrift/src/main/scala/io/buoyant/namerd/iface/ThriftNamerClient.scala
@@ -96,11 +96,12 @@ class ThriftNamerClient(
             }
             loop(stamp1, backoffs0)
 
-          case Throw(e@thrift.BindFailure(reason, retry, _, _)) =>
+          case Throw(e@thrift.BindFailure(reason, _, _, _)) =>
             bindFailureCounter.incr()
             Trace.recordBinary("namerd.client/bind.fail", reason)
             if (!stopped) {
-              pending = Future.sleep(retry.seconds).onSuccess(_ => loop(stamp0, backoffs0))
+              val sleep #:: backoffs1 = backoffs0
+              pending = Future.sleep(sleep).onSuccess(_ => loop(stamp0, backoffs1))
             }
 
           case Throw(e) =>
@@ -206,11 +207,12 @@ class ThriftNamerClient(
             addr() = Addr.Bound(addrs.toSet[Address], convertMeta(boundMeta))
             loop(stamp1, backoffs0)
 
-          case Throw(e@thrift.AddrFailure(msg, retry, _)) =>
+          case Throw(e@thrift.AddrFailure(msg, _, _)) =>
             addrFailureCounter.incr()
             Trace.recordBinary("namerd.client/addr.fail", msg)
             if (!stopped) {
-              pending = Future.sleep(retry.seconds).onSuccess(_ => loop(stamp0, backoffs0))
+              val sleep #:: backoffs1 = backoffs0
+              pending = Future.sleep(sleep).onSuccess(_ => loop(stamp0, backoffs1))
             }
 
           case Throw(e) =>

--- a/namerd/iface/interpreter-thrift/src/main/scala/io/buoyant/namerd/iface/ThriftNamerInterface.scala
+++ b/namerd/iface/interpreter-thrift/src/main/scala/io/buoyant/namerd/iface/ThriftNamerInterface.scala
@@ -379,7 +379,6 @@ class ThriftNamerInterface(
   interpreters: Ns => NameInterpreter,
   namers: Map[Path, Namer],
   stamper: ThriftNamerInterface.Stamper,
-  retryIn: () => Duration,
   capacity: Capacity,
   stats: StatsReceiver
 ) extends thrift.Namer.FutureIface {
@@ -400,7 +399,7 @@ class ThriftNamerInterface(
     mkPath(reqName) match {
       case Path.empty =>
         Trace.recordBinary("namerd.srv/bind.err", "empty path")
-        val failure = thrift.BindFailure("empty path", Int.MaxValue, ref, ns)
+        val failure = thrift.BindFailure("empty path", 0, ref, ns)
         Future.exception(failure)
 
       case path =>
@@ -418,7 +417,7 @@ class ThriftNamerInterface(
           case Throw(e) =>
             Trace.recordBinary("namerd.srv/bind.fail", e.toString)
             log.error(e, "binding name %s", path.show)
-            val failure = thrift.BindFailure(e.getMessage, retryIn().inSeconds, ref, ns)
+            val failure = thrift.BindFailure(e.getMessage, 0, ref, ns)
             Future.exception(failure)
         }
     }
@@ -468,7 +467,7 @@ class ThriftNamerInterface(
     mkPath(reqName) match {
       case Path.empty =>
         Trace.recordBinary("namerd.srv/addr.err", "empty path")
-        val failure = thrift.AddrFailure("empty path", Int.MaxValue, ref)
+        val failure = thrift.AddrFailure("empty path", 0, ref)
         Future.exception(failure)
 
       case fullPath =>
@@ -498,7 +497,7 @@ class ThriftNamerInterface(
           case Throw(NonFatal(e)) =>
             Trace.recordBinary("namerd.srv/addr.fail", e.toString)
             log.error(e, "resolving addr %s", path.show)
-            val failure = thrift.AddrFailure(e.getMessage, Int.MaxValue, ref)
+            val failure = thrift.AddrFailure(e.getMessage, 0, ref)
             Future.exception(failure)
 
           case Throw(e) =>

--- a/namerd/iface/interpreter-thrift/src/test/scala/io/buoyant/namerd/iface/ThriftNamerEndToEndTest.scala
+++ b/namerd/iface/interpreter-thrift/src/test/scala/io/buoyant/namerd/iface/ThriftNamerEndToEndTest.scala
@@ -20,7 +20,6 @@ class ThriftNamerEndToEndTest extends FunSuite with Eventually with IntegrationP
     interval = scaled(Span(100, Milliseconds))
   )
 
-  val retryIn = () => 1.second
   val clientId = Path.empty
   val ns = "testns"
 
@@ -48,7 +47,7 @@ class ThriftNamerEndToEndTest extends FunSuite with Eventually with IntegrationP
         else Activity.exception(new Exception)
     }
     val namers = Map(Path.read("/io.l5d.w00t") -> namer)
-    val service = new ThriftNamerInterface(interpreter, namers, newStamper, retryIn, Capacity.default, NullStatsReceiver)
+    val service = new ThriftNamerInterface(interpreter, namers, newStamper, Capacity.default, NullStatsReceiver)
     val client = new ThriftNamerClient(service, ns, Stream.continually(Duration.Zero), clientId = clientId)
 
     val act = client.bind(reqDtab, reqPath)
@@ -128,7 +127,7 @@ class ThriftNamerEndToEndTest extends FunSuite with Eventually with IntegrationP
       Activity.value(Dtab.read("/srv => /io.l5d.w00t; /host => /srv; /svc => /host")),
       namers
     )
-    val service = new ThriftNamerInterface(interpreter, namers.toMap, newStamper, retryIn, Capacity.default, NullStatsReceiver)
+    val service = new ThriftNamerInterface(interpreter, namers.toMap, newStamper, Capacity.default, NullStatsReceiver)
     val client = new ThriftNamerClient(service, ns, Stream.continually(Duration.Zero), clientId = clientId)
 
     val tree = await(client.delegate(
@@ -177,8 +176,8 @@ class ThriftNamerEndToEndTest extends FunSuite with Eventually with IntegrationP
       Activity.value(Dtab.read("/svc => /io.l5d.w00t")),
       namers
     )
-    val service = new ThriftNamerInterface(interpreter, namers.toMap, newStamper, retryIn, Capacity.default, NullStatsReceiver)
-    val client = new ThriftNamerClient(service, ns, Stream.continually(Duration.Zero), clientId = clientId)
+    val service = new ThriftNamerInterface(interpreter, namers.toMap, newStamper, Capacity.default, NullStatsReceiver)
+    val client = new ThriftNamerClient(service, ns, Stream.continually(Duration.Top), clientId = clientId)
     witness.notify(Return(NameTree.Leaf(Name.Bound(
       Var(Addr.Bound(Address("localhost", 9000))),
       Path.read("/io.l5d.w00t/foo"),

--- a/namerd/iface/interpreter-thrift/src/test/scala/io/buoyant/namerd/iface/ThriftNamerInterfaceTest.scala
+++ b/namerd/iface/interpreter-thrift/src/test/scala/io/buoyant/namerd/iface/ThriftNamerInterfaceTest.scala
@@ -16,7 +16,6 @@ import org.scalatest.FunSuite
 class ThriftNamerInterfaceTest extends FunSuite with Awaits {
   import ThriftNamerInterface._
 
-  val retryIn = () => 1.second
   val clientId = TPath(Path.empty)
   val ns = "testns"
 
@@ -27,7 +26,7 @@ class ThriftNamerInterfaceTest extends FunSuite with Awaits {
     }
     val stampCounter = new AtomicLong(1)
     val stamper = () => Stamp.mk(stampCounter.getAndIncrement)
-    val service = new ThriftNamerInterface(interpreter, Map.empty, stamper, retryIn, Capacity.default, NullStatsReceiver)
+    val service = new ThriftNamerInterface(interpreter, Map.empty, stamper, Capacity.default, NullStatsReceiver)
 
     // The first request before the tree has been refined -- no value initially
     val initName = thrift.NameRef(TStamp.empty, TPath("ysl", "thugger"), ns)
@@ -78,7 +77,7 @@ class ThriftNamerInterfaceTest extends FunSuite with Awaits {
 
     val stampCounter = new AtomicLong(1)
     val stamper = () => Stamp.mk(stampCounter.getAndIncrement)
-    val service = new ThriftNamerInterface(interpreter, Map.empty, stamper, retryIn, Capacity.default, NullStatsReceiver)
+    val service = new ThriftNamerInterface(interpreter, Map.empty, stamper, Capacity.default, NullStatsReceiver)
 
     // The first request before the tree has been refined -- no value initially
     val path = TPath("ysl", "thugger")
@@ -113,7 +112,7 @@ class ThriftNamerInterfaceTest extends FunSuite with Awaits {
 
     val stampCounter = new AtomicLong(1)
     val stamper = () => Stamp.mk(stampCounter.getAndIncrement)
-    val service = new ThriftNamerInterface(interpreter, Map.empty, stamper, retryIn, Capacity.default, NullStatsReceiver)
+    val service = new ThriftNamerInterface(interpreter, Map.empty, stamper, Capacity.default, NullStatsReceiver)
 
     val initF = service.dtab(thrift.DtabReq(TStamp.empty, "pandoracorn", clientId))
     assert(!initF.isDefined)
@@ -132,7 +131,7 @@ class ThriftNamerInterfaceTest extends FunSuite with Awaits {
     val namers = Map(pfx -> new Namer { def lookup(path: Path) = Activity(states) })
     val stampCounter = new AtomicLong(1)
     val stamper = () => Stamp.mk(stampCounter.getAndIncrement)
-    val service = new ThriftNamerInterface(interpreter, namers, stamper, retryIn, Capacity.default, NullStatsReceiver)
+    val service = new ThriftNamerInterface(interpreter, namers, stamper, Capacity.default, NullStatsReceiver)
   }
 
   test("addr") {

--- a/namerd/storage/zk/src/main/scala/com/twitter/finagle/serverset2/buoyant/ZkSession.scala
+++ b/namerd/storage/zk/src/main/scala/com/twitter/finagle/serverset2/buoyant/ZkSession.scala
@@ -25,7 +25,7 @@ class ZkSession(
 
   private[this] val client =
     Var(Watched[ZooKeeperRW](NullZooKeeperRW, Var(WatchState.Pending)))
-  def zk = client.sample.value
+  def zk: Var[ZooKeeperRW] = client.map(_.value)
   private[this] def state = client.sample.state
 
   reconnect()
@@ -34,14 +34,14 @@ class ZkSession(
 
   def close(): Future[Unit] = {
     closing = true
-    zk.close()
+    zk.sample.close()
   }
 
   private[this] def reconnect(): Unit = {
     if (closing) return
 
     logger.info("Closing zk session %s", sessionId)
-    zk.close()
+    zk.sample.close()
     val newClient = clientBuilder()
     logger.info("Starting new zk session %s", sessionId(newClient))
 


### PR DESCRIPTION
If a ZooKeeper watch is created on a session that expires, a new session will be created but the watch will remain on the expired session.  Furthermore, when Namerd encounters ZK errors, it signals that Linkerd should wait for a very long (10 minute) delay before retrying.  This leads to extremely slow recovery in the case of an error.

Fix the watch code to follow the new session in when a session expires.  Additionally, remove the ability for Namerd to signal retry delays to Linkerd and instead use the backoffs already configured in the client.

Fixes #1829