### PR TITLE
Use the system configured timezone when formatting logs

### DIFF
--- a/admin/src/test/scala/io/buoyant/admin/LogFormatterTest.scala
+++ b/admin/src/test/scala/io/buoyant/admin/LogFormatterTest.scala
@@ -1,0 +1,34 @@
+package io.buoyant.admin
+
+import java.util.TimeZone
+import java.util.logging.{Level, LogRecord}
+
+import com.twitter.util.TimeFormat
+import org.scalatest.WordSpec
+
+class LogFormatterTest extends WordSpec {
+
+  val record = new LogRecord(Level.INFO, "Logging useful info")
+  record.setMillis(1519468460239L)
+  record.setThreadID(10)
+
+  "LogFormatter" should {
+
+    "use UTC timezone" in {
+      val utcFormatter = new LogFormatter(
+        new TimeFormat(" MMdd HH:mm:ss.SSS z", TimeZone.getTimeZone("UTC"))
+      )
+      assert(utcFormatter
+        .format(record) == "I 0224 10:34:20.239 UTC THREAD10: Logging useful info\n")
+    }
+
+    "use non UTC timezone" in {
+      val utcFormatter = new LogFormatter(
+        new TimeFormat(" MMdd HH:mm:ss.SSS z", TimeZone.getTimeZone("GMT+8"))
+      )
+      assert(utcFormatter
+        .format(record) == "I 0224 18:34:20.239 GMT+08:00 THREAD10: Logging useful info\n")
+    }
+
+  }
+}


### PR DESCRIPTION
This PR addresses
- the issue of log formatter using hardcoded (utf) timezone formatter

Fixes #1799 

Sign the certificate of originSigned-off-by: Fantayeneh Asres Gizaw <fantayeneh@gmail.com>