### PR TITLE
Fix routers logging to the same access log

### DIFF
--- a/linkerd/examples/access-logs.yaml
+++ b/linkerd/examples/access-logs.yaml
@@ -1,0 +1,29 @@
+# Simple config for testing multiple access logs.
+# `curl localhost:4140`:
+#   linkerd1:4140 -> linkerd2:4141 -> admin:9990
+
+admin:
+  ip: 0.0.0.0
+  port: 9990
+
+telemetry:
+- kind: io.l5d.recentRequests
+  sampleRate: 1.0
+
+routers:
+- protocol: http
+  httpAccessLog: logs/access1.log
+  label: linkerd1
+  dtab: |
+    /svc => /$/inet/127.1/4141;
+  servers:
+  - port: 4140
+    ip: 0.0.0.0
+- protocol: http
+  httpAccessLog: logs/access2.log
+  label: linkerd2
+  dtab: |
+    /svc => /$/inet/127.1/9990;
+  servers:
+  - port: 4141
+    ip: 0.0.0.0

--- a/linkerd/tls/src/main/scala/io/buoyant/linkerd/tls/TlsUtils.scala
+++ b/linkerd/tls/src/main/scala/io/buoyant/linkerd/tls/TlsUtils.scala
@@ -94,7 +94,7 @@ object TlsUtils {
   }
 
   def dnsAltNames(names: Seq[String]): String = {
-    val altNames = names.zipWithIndex.map { case(name, i) => s"DNS.${i+1} = $name" }
+    val altNames = names.zipWithIndex.map { case (name, i) => s"DNS.${i + 1} = $name" }
     altNames.mkString("\n")
   }
 

--- a/router/core/src/main/scala/io/buoyant/router/Router.scala
+++ b/router/core/src/main/scala/io/buoyant/router/Router.scala
@@ -235,7 +235,7 @@ trait StdStackRouter[Req, Rsp, This <: StdStackRouter[Req, Rsp, This]]
           }
           val clientParams = params[StackRouter.Client.PerClientParams].paramsFor(name)
           // client stats are scoped by label within .newClient
-          client.withParams(params ++ clientParams + clientStats)
+          client.withParams(params ++ clientParams + RouterLabel.Param(label) + clientStats)
             .newClient(bound, mkClientLabel(bound))
         }
 


### PR DESCRIPTION
Multiple routers configured for access logging were incorrectly writing
to the same file.

Modify AccessLogger configuration to ensure each router has a logger
registered with a unique node name.

Fixes #1808

Signed-off-by: Andrew Seigner <siggy@buoyant.io>