### PR TITLE
Fixed ForwardClientCertFilter to handle SAN types other than DNS and URI

### DIFF
--- a/linkerd/tls/src/main/scala/io/buoyant/linkerd/tls/TlsUtils.scala
+++ b/linkerd/tls/src/main/scala/io/buoyant/linkerd/tls/TlsUtils.scala
@@ -152,6 +152,7 @@ object TlsUtils {
     |
     |[alt_names]
     |URI.1 = https://buoyant.io
+    |IP.1 = 127.0.0.1
     |""".stripMargin
 
   def newKeyAndCert(subj: String, cfg: File, key: File, cert: File): ProcessBuilder =

--- a/router/base-http/src/main/scala/io/buoyant/router/http/ForwardClientCertFilter.scala
+++ b/router/base-http/src/main/scala/io/buoyant/router/http/ForwardClientCertFilter.scala
@@ -33,6 +33,7 @@ class ForwardClientCertFilter[Req, H: HeadersLike, Rep](implicit requestLike: Re
               nameType match {
                 case GeneralNameTypeUri => clientCertHeader ++= s";SAN=$nameValue" // Use "SAN:" instead of "URI:" for backward compatibility with previous releases.
                 case GeneralNameTypeDns => clientCertHeader ++= s";DNS=$nameValue"
+                case _ =>
               }
             }
           }


### PR DESCRIPTION
Signed-off-by: Shakti Das shakti.das2002@gmail.com

Problem
The ForwardClientCertFilter will get a MatchError if it encounters SAN types other than DNS and URI. 

Solution
Added a default case in ForwardClientCertFilter.

Validation
The TLS related tests were run to verify it causes no regression. The tests were modified to verify ForwardClientCertFilter works with additional IP entries in SAN.

Fixes #1849