### PR TITLE
Add TLS client config option to disable it

### DIFF
--- a/interpreter/namerd/src/main/scala/io/buoyant/namerd/iface/NamerdInterpreterInitializer.scala
+++ b/interpreter/namerd/src/main/scala/io/buoyant/namerd/iface/NamerdInterpreterInitializer.scala
@@ -42,6 +42,7 @@ case class Retry(
 case class ClientTlsConfig(commonName: String, caCert: Option[String]) {
   def params: Stack.Params = {
     TlsClientConfig(
+      enabled = Some(true),
       disableValidation = Some(false),
       commonName = Some(commonName),
       trustCerts = caCert.map(Seq(_)),

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/ClientConfig.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/ClientConfig.scala
@@ -36,6 +36,7 @@ trait ClientConfig {
 }
 
 case class TlsClientConfig(
+  enabled: Option[Boolean],
   disableValidation: Option[Boolean],
   commonName: Option[String],
   trustCerts: Option[Seq[String]] = None,
@@ -47,6 +48,7 @@ case class TlsClientConfig(
   )
   def params(vars: Map[String, String]): Stack.Params =
     FTlsClientConfig(
+      enabled,
       disableValidation,
       commonName.map(PathMatcher.substitute(vars, _)),
       trustCerts,

--- a/linkerd/docs/client_tls.md
+++ b/linkerd/docs/client_tls.md
@@ -20,6 +20,7 @@ the server.
 
 Key | Default Value | Description
 --- | ------------- | -----------
+enabled | true | Enable TLS on outgoing connections.
 certPath | _required_ | File path to the TLS certificate file.
 keyPath | _required_ | File path to the TLS key file.
 requireClientAuth | false | If true, only accept requests with valid client certificates.

--- a/linkerd/examples/disable-tls.yaml
+++ b/linkerd/examples/disable-tls.yaml
@@ -1,0 +1,20 @@
+namers: []
+
+routers:
+- protocol: http
+  dtab: |
+    /svc/foo => /$/inet/www.google.com/443 ;
+    /svc/bar => /$/inet/localhost/7777
+
+  servers:
+  - port: 4140
+
+  client:
+    kind: io.l5d.static
+    configs:
+    - prefix: "/$/inet/{service}"
+      tls:
+        commonName: "{service}"
+    - prefix: /$/inet/localhost
+      tls:
+        enabled: false


### PR DESCRIPTION
TLS is enabled if the TLS param is set at all.  In the case of a per-client config, this means that if any matching config for a client enables TLS, it is impossible for a later client config to override this with a value that disables TLS.

We add an `enabled` property to the TLS client config which defaults to true, but can be set to false to disable client TLS.

Example config excerpt:

```
  client:
    kind: io.l5d.static
    configs:
    # enables TLS for all "inet" clients
    - prefix: "/$/inet/{service}"
      tls:
        commonName: "{service}"
    # override the above to disable TLS for localhost
    - prefix: /$/inet/localhost
      tls:
        enabled: false
```

Fixes #1845 

Signed-off-by: Alex Leong <alex@buoyant.io>