### PR TITLE
Update Delegator interface to return a single value only

### DIFF
--- a/admin/src/main/scala/io/buoyant/admin/names/DelegateApiHandler.scala
+++ b/admin/src/main/scala/io/buoyant/admin/names/DelegateApiHandler.scala
@@ -254,7 +254,6 @@ object DelegateApiHandler {
     (dtabTry, pathTry) match {
       case (Return(d), Return(p)) =>
         delegator.delegate(d, p)
-          .toFuture
           .flatMap(JsonDelegateTree.mk).map { tree =>
             val rsp = Response()
             rsp.content = Codec.writeBuf(tree)

--- a/config/src/main/scala/io/buoyant/config/JsonStreamParser.scala
+++ b/config/src/main/scala/io/buoyant/config/JsonStreamParser.scala
@@ -8,7 +8,6 @@ import com.twitter.concurrent.AsyncStream
 import com.twitter.io.{Buf, Reader}
 import com.twitter.logging.Logger
 import com.twitter.util.{Future, Try}
-
 import scala.util.control.NonFatal
 
 class JsonStreamParser(mapper: ObjectMapper with ScalaObjectMapper) {

--- a/grpc/runtime/src/main/scala/io/buoyant/grpc/runtime/Stream.scala
+++ b/grpc/runtime/src/main/scala/io/buoyant/grpc/runtime/Stream.scala
@@ -161,4 +161,6 @@ object Stream {
       }
     }
 
+  def fromFuture[T](fut: Future[T]): Stream[T] = deferred(fut.map(value))
+
 }

--- a/interpreter/per-host/src/main/scala/io/buoyant/transformer/perHost/PortTransformer.scala
+++ b/interpreter/per-host/src/main/scala/io/buoyant/transformer/perHost/PortTransformer.scala
@@ -2,7 +2,7 @@ package io.buoyant.transformer.perHost
 
 import com.twitter.finagle.Name.Bound
 import com.twitter.finagle._
-import com.twitter.util.Activity
+import com.twitter.util.{Activity, Future}
 import io.buoyant.namer.{DelegateTree, DelegatingNameTreeTransformer}
 import java.net.InetSocketAddress
 
@@ -35,6 +35,6 @@ class PortTransformer(prefix: Path, port: Int) extends DelegatingNameTreeTransfo
   override protected def transform(tree: NameTree[Bound]): Activity[NameTree[Bound]] =
     Activity.value(tree.map(mapBound))
 
-  override protected def transformDelegate(tree: DelegateTree[Bound]): Activity[DelegateTree[Bound]] =
-    Activity.value(DelegatingNameTreeTransformer.transformDelegate(tree, mapBound))
+  override protected def transformDelegate(tree: DelegateTree[Bound]): Future[DelegateTree[Bound]] =
+    Future.value(DelegatingNameTreeTransformer.transformDelegate(tree, mapBound))
 }

--- a/interpreter/subnet/src/main/scala/io/buoyant/transformer/SubnetGatewayTransformer.scala
+++ b/interpreter/subnet/src/main/scala/io/buoyant/transformer/SubnetGatewayTransformer.scala
@@ -2,8 +2,8 @@ package io.buoyant.transformer
 
 import com.twitter.finagle.Name.Bound
 import com.twitter.finagle._
-import com.twitter.util.{Activity, Var}
-import io.buoyant.namer.{DelegateTree, DelegatingNameTreeTransformer}
+import com.twitter.util.{Activity, Future, Var}
+import io.buoyant.namer.{DelegateTree, DelegatingNameTreeTransformer, RichActivity}
 
 /**
  * Transforms a bound name tree to only include addresses in
@@ -30,8 +30,8 @@ class GatewayTransformer(
   gatewayPredicate: (Address, Address) => Boolean
 ) extends DelegatingNameTreeTransformer {
 
-  override protected def transformDelegate(tree: DelegateTree[Bound]): Activity[DelegateTree[Bound]] =
-    gatewayTree.map { gateways =>
+  override protected def transformDelegate(tree: DelegateTree[Bound]): Future[DelegateTree[Bound]] =
+    gatewayTree.toFuture.map { gateways =>
       val routable = flatten(gateways.eval.toSet.flatten)
       DelegatingNameTreeTransformer.transformDelegate(tree, mapBound(_, routable))
     }

--- a/linkerd/admin/src/test/scala/io/buoyant/linkerd/admin/names/DelegatorTest.scala
+++ b/linkerd/admin/src/test/scala/io/buoyant/linkerd/admin/names/DelegatorTest.scala
@@ -1,8 +1,8 @@
 package io.buoyant.linkerd.admin.names
 
 import com.twitter.finagle._
-import com.twitter.util.{Var, Return}
-import io.buoyant.linkerd.{TestProtocol, Linker}
+import com.twitter.util.Var
+import io.buoyant.linkerd.{Linker, TestProtocol}
 import io.buoyant.namer._
 import io.buoyant.test.Awaits
 import org.scalatest.FunSuite
@@ -38,7 +38,7 @@ class DelegatorTest extends FunSuite with Awaits {
   test("uses NamerInterpreter to resolve names") {
     val path = Path.read("/nah/bro")
     val dtab = Dtab.read("""/nah=>/#/namer;""")
-    assert(await(interpreter.delegate(dtab, path).toFuture) ==
+    assert(await(interpreter.delegate(dtab, path)) ==
       DelegateTree.Delegate(path, Dentry.nop, DelegateTree.Leaf(
         Path.read("/#/namer/bro"),
         Dentry.read("/nah=>/#/namer"),
@@ -48,13 +48,13 @@ class DelegatorTest extends FunSuite with Awaits {
 
   test("explain neg delegation") {
     val path = Path.Utf8("nope")
-    assert(await(interpreter.delegate(dtab, path).toFuture) ==
+    assert(await(interpreter.delegate(dtab, path)) ==
       DelegateTree.Neg(path, Dentry.nop))
   }
 
   test("explain delegate delegation") {
     val path = Path.read("/meh/hey")
-    assert(await(interpreter.delegate(dtab, path).toFuture) ==
+    assert(await(interpreter.delegate(dtab, path)) ==
       DelegateTree.Delegate(
         path,
         Dentry.nop,
@@ -64,7 +64,7 @@ class DelegatorTest extends FunSuite with Awaits {
 
   test("explain alt delegation") {
     val path = Path.read("/boo/lol")
-    assert(await(interpreter.delegate(dtab, path).toFuture) ==
+    assert(await(interpreter.delegate(dtab, path)) ==
       DelegateTree.Delegate(path, Dentry.nop, DelegateTree.Alt(
         Path.read("/foo/lol"),
         Dentry.read("/boo=>/foo"),
@@ -76,7 +76,7 @@ class DelegatorTest extends FunSuite with Awaits {
 
   test("explain bound delegation") {
     val path = Path.read("/boo/humbug/ya")
-    assert(await(interpreter.delegate(dtab, path).toFuture) ==
+    assert(await(interpreter.delegate(dtab, path)) ==
       DelegateTree.Delegate(path, Dentry.nop, DelegateTree.Alt(
         Path.read("/foo/humbug/ya"),
         Dentry.read("/boo=>/foo"),
@@ -96,7 +96,7 @@ class DelegatorTest extends FunSuite with Awaits {
 
   test("explain error delegation") {
     val path = Path.read("/beh/humbug")
-    assert(await(interpreter.delegate(dtab, path).toFuture) ==
+    assert(await(interpreter.delegate(dtab, path)) ==
       DelegateTree.Delegate(
         path,
         Dentry.nop,

--- a/linkerd/examples/namerd.yaml
+++ b/linkerd/examples/namerd.yaml
@@ -1,10 +1,30 @@
 # Use namerd for name resolution.
 routers:
 - protocol: http
+  label: named-thrift
   interpreter:
     kind: io.l5d.namerd
     dst: /$/inet/localhost/4100
     namespace: default
   servers:
   - port: 4140
+    ip: 0.0.0.0
+- protocol: http
+  label: named-http
+  interpreter:
+    kind: io.l5d.namerd.http
+    experimental: true
+    dst: /$/inet/localhost/4180
+    namespace: default
+  servers:
+  - port: 4141
+    ip: 0.0.0.0
+- protocol: http
+  label: named-grpc
+  interpreter:
+    kind: io.l5d.mesh
+    dst: /$/inet/localhost/4321
+    root: /default
+  servers:
+  - port: 4142
     ip: 0.0.0.0

--- a/mesh/core/src/main/protobuf/delegator.proto
+++ b/mesh/core/src/main/protobuf/delegator.proto
@@ -18,6 +18,7 @@ service Delegator {
   rpc StreamDtab (DtabReq) returns (stream DtabRsp) {}
 
   rpc GetDelegateTree (DelegateTreeReq) returns (DelegateTreeRsp) {}
+  // DEPRECATED: This method will only return one value.  Use GetDelegateTree instead.
   rpc StreamDelegateTree (DelegateTreeReq) returns (stream DelegateTreeRsp) {}
 }
 

--- a/namer/core/src/main/scala/io/buoyant/namer/ConfiguredDtabNamer.scala
+++ b/namer/core/src/main/scala/io/buoyant/namer/ConfiguredDtabNamer.scala
@@ -3,7 +3,7 @@ package io.buoyant.namer
 import com.twitter.finagle.Name.Bound
 import com.twitter.finagle._
 import com.twitter.finagle.naming.NameInterpreter
-import com.twitter.util.{Activity, Var}
+import com.twitter.util.{Activity, Future, Var}
 
 case class ConfiguredDtabNamer(
   configuredDtab: Activity[Dtab],
@@ -45,8 +45,8 @@ case class ConfiguredDtabNamer(
   override def delegate(
     dtab: Dtab,
     tree: NameTree[Name.Path]
-  ): Activity[DelegateTree[Bound]] =
-    configuredDtab.flatMap { confDtab =>
+  ): Future[DelegateTree[Bound]] =
+    configuredDtab.toFuture.flatMap { confDtab =>
       namersInterpreter.delegate(confDtab ++ dtab, tree)
     }
 

--- a/namer/core/src/main/scala/io/buoyant/namer/Delegator.scala
+++ b/namer/core/src/main/scala/io/buoyant/namer/Delegator.scala
@@ -1,19 +1,19 @@
 package io.buoyant.namer
 
 import com.twitter.finagle.{Dentry, Dtab, Name, NameTree, Path}
-import com.twitter.util.Activity
+import com.twitter.util.{Activity, Future}
 
 trait Delegator {
 
   def delegate(
     dtab: Dtab,
     tree: NameTree[Name.Path]
-  ): Activity[DelegateTree[Name.Bound]]
+  ): Future[DelegateTree[Name.Bound]]
 
   final def delegate(
     dtab: Dtab,
     path: Path
-  ): Activity[DelegateTree[Name.Bound]] =
+  ): Future[DelegateTree[Name.Bound]] =
     delegate(dtab, NameTree.Leaf(Name.Path(path)))
 
   def dtab: Activity[Dtab]

--- a/namerd/examples/all.yaml
+++ b/namerd/examples/all.yaml
@@ -1,0 +1,16 @@
+admin:
+  port: 9991
+
+storage:
+  kind: io.l5d.inMemory
+  namespaces:
+    default: /svc => /#/io.l5d.fs;
+
+namers:
+  - kind: io.l5d.fs
+    rootDir: namerd/examples/disco
+
+interfaces:
+  - kind: io.l5d.httpController
+  - kind: io.l5d.mesh
+  - kind: io.l5d.thriftNameInterpreter

--- a/namerd/iface/control-http/src/test/scala/io/buoyant/namerd/iface/HttpNamerEndToEndTest.scala
+++ b/namerd/iface/control-http/src/test/scala/io/buoyant/namerd/iface/HttpNamerEndToEndTest.scala
@@ -128,7 +128,7 @@ class HttpNamerEndToEndTest extends FunSuite with Eventually with IntegrationPat
     val tree = await(client.delegate(
       Dtab.read("/host/poop => /srv/woop"),
       Path.read("/svc/poop")
-    ).toFuture)
+    ))
 
     assert(tree ==
       DelegateTree.Delegate(

--- a/namerd/iface/interpreter-thrift-idl/src/main/thrift/namer.thrift
+++ b/namerd/iface/interpreter-thrift-idl/src/main/thrift/namer.thrift
@@ -155,7 +155,8 @@ struct DelegateTree {
 }
 
 struct Delegation {
-  1: Stamp stamp
+  // Delegation does not support long-polling. Clients should always send an empty stamp.
+  1: Stamp stamp // DEPRECATED
   2: DelegateTree tree
   3: Ns ns
 }

--- a/namerd/iface/interpreter-thrift/src/test/scala/io/buoyant/namerd/iface/ThriftNamerClientTest.scala
+++ b/namerd/iface/interpreter-thrift/src/test/scala/io/buoyant/namerd/iface/ThriftNamerClientTest.scala
@@ -80,8 +80,7 @@ class ThriftNamerClientTest extends FunSuite with Awaits {
     val service = new TestNamerService(clientId)
     val client = new ThriftNamerClient(service, namespace, Stream.continually(Duration.Zero), clientId = clientId)
 
-    val act = client.delegate(Dtab.empty, Path.read("/yeezy/tlop/wolves"))
-    val delegation = act.toFuture
+    val delegation = client.delegate(Dtab.empty, Path.read("/yeezy/tlop/wolves"))
     assert(!delegation.isDefined)
 
     val tree = DelegateTree.Delegate(Path.read("/yeezus/tlop/wolves"), Dentry.read("/yeezy => /yeezus"), DelegateTree.Neg(Path.read("/yeezus/tlop/wolves"), Dentry.nop))

--- a/namerd/iface/interpreter-thrift/src/test/scala/io/buoyant/namerd/iface/ThriftNamerEndToEndTest.scala
+++ b/namerd/iface/interpreter-thrift/src/test/scala/io/buoyant/namerd/iface/ThriftNamerEndToEndTest.scala
@@ -133,7 +133,7 @@ class ThriftNamerEndToEndTest extends FunSuite with Eventually with IntegrationP
     val tree = await(client.delegate(
       Dtab.read("/host/poop => /srv/woop"),
       Path.read("/svc/poop")
-    ).toFuture)
+    ))
 
     assert(tree ==
       DelegateTree.Delegate(


### PR DESCRIPTION
The Delegator interface defines a `delegate` method that returns an Activity.  However, in all cases, only the first value of this Activity was ever used (for the delegator UI).  For complex delegations with fast changing values, a delegation lookup could be quite expensive because many values would be calculated before the Activity was canceled.

We modify the `delegate` method to return a Future instead of an Activity.  This implies changes to all of Namerd's interfaces.

* thriftNamerInterface: We change the client to do a one-shot call with an empty stamp and ignore the stamp in the response instead of long-polling.  For backwards compatibility with long-polling clients, we modify the server to keep requests that have a non-empty stamp pending until cancelled by the client.
* http streaming: No change necessary because the delegate method never took advantage of http streaming.
* mesh: We deprecate the StreamDelegateTree method and modify the implementation to only return a single value on the stream.

I have manually tested all combinations of:
* client version = {1.3.5, HEAD}
* server version = {1.3.5, HEAD}
* interface = {thriftNamerInterface, mesh, http streaming}

Fixes #1846 

Signed-off-by: Alex Leong <alex@buoyant.io>