### PR TITLE
Update address set to Neg when consul queries a non-existent datacenter

### DIFF
--- a/namer/consul/src/main/scala/io/buoyant/namer/consul/SvcAddr.scala
+++ b/namer/consul/src/main/scala/io/buoyant/namer/consul/SvcAddr.scala
@@ -87,9 +87,7 @@ private[consul] object SvcAddr {
                 " Last known state is %s",
               datacenter, key.name, e, currentValueToLog
             )
-            if (e.toString.contains(NonExistentDcMessage)) {
-              state.update(Addr.Neg)
-            }
+            state.update(Addr.Neg)
             val backoff #:: nextBackoffs = backoffs
             // subsequent errors are logged as DEBUG
             Future.sleep(backoff).before(loop(None, nextBackoffs, Level.DEBUG, currentValueToLog))

--- a/namer/consul/src/main/scala/io/buoyant/namer/consul/SvcAddr.scala
+++ b/namer/consul/src/main/scala/io/buoyant/namer/consul/SvcAddr.scala
@@ -77,7 +77,7 @@ private[consul] object SvcAddr {
             Future.Unit
 
           case Throw(e) =>
-            // do not update state, log error and continue polling with backoff
+            // update state with Addr.Neg, log error and continue polling with backoff
             stats.errors.incr()
             log.log(
               failureLogLevel,

--- a/namer/consul/src/main/scala/io/buoyant/namer/consul/SvcAddr.scala
+++ b/namer/consul/src/main/scala/io/buoyant/namer/consul/SvcAddr.scala
@@ -22,8 +22,6 @@ private[consul] object SvcAddr {
   private[this] val ServiceRelease =
     new Exception("service observation released") with NoStackTrace
 
-  private[this] val NonExistentDcMessage = "No path to datacenter"
-
   case class Stats(stats: StatsReceiver) {
     val opens = stats.counter("opens")
     val closes = stats.counter("closes")


### PR DESCRIPTION
When the ConsulNamer tries to discover a set of addresses using a consul endpoint that contains a non existent dc, it receives a 500 error from consul. The HTTP request is then retried indefinitely even though the request will never result in a valid HTTP response. This causes bind requests to Linkerd to always timeout. The issue is easily observed when using the dtab playground in Linkerd to evaluate paths to address sets and dtabs contain paths that point to non-existent datacenters in consul.

This PR fixes the issue by checking the HTTP 500 message to evaluate if it is a `No path to datacenter` message. This indicates that there is no `dc` in consul that contains the provided `dc` value. In this case, update the service discovery endpoints to `Addr.Neg` and then retry with a backoff interval.

Change was tested locally through the admin dtab UI and now all dtab requests no longer timeout and give an error back immediately when an invalid dc is used.

fixes #1836 

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>