### PR TITLE
Add buildtime base docker image overwrite guideline

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -242,6 +242,26 @@ The list of image names may be changed with a command like:
 [info] List(buoyantio/linkerd:0.0.10-SNAPSHOT, gcr.io/gce-project/linkerd:v0.0.10-SNAPSHOT)
 ```
 
+The base Docker image used to build the final images may be set and overwritten at buildtime like:
+
+```
+> set Base.dockerJavaImage in (linkerd, Bundle) := "myFromImage"
+[info] Defining linkerd/bundle:dockerJavaImage
+[info] The new value will be used by linkerd/bundle:docker::dockerfile
+[info] Reapplying settings...
+[info] Set current project to all (in build file:/Users/mohsenrezaei/dev/buoyant/linkerd/)
+>  show linkerd/bundle:dockerJavaImage
+[info] myFromImage
+```
+
+or, with build command like:
+
+```bash
+$ ./sbt 'set Base.dockerJavaImage in (linkerd, Bundle) := "myFromImage"' linkerd/docker
+```
+
+_NOTE:_ The same setting applies to all apps and configs, i.e. `set ... (linkerd|namerd, Bundle|LowMem|Jdk) ...`.
+
 #### DCOS ####
 
 Namerd supports a DCOS-specific configuration. When used in conjunction with

--- a/BUILD.md
+++ b/BUILD.md
@@ -249,8 +249,8 @@ The base Docker image used to build the final images may be set and overwritten 
 [info] Defining linkerd/bundle:dockerJavaImage
 [info] The new value will be used by linkerd/bundle:docker::dockerfile
 [info] Reapplying settings...
-[info] Set current project to all (in build file:/Users/mohsenrezaei/dev/buoyant/linkerd/)
->  show linkerd/bundle:dockerJavaImage
+[info] Set current project to all (in build file:~/buoyant/linkerd/)
+> show linkerd/bundle:dockerJavaImage
 [info] myFromImage
 ```
 


### PR DESCRIPTION
A guideline section to allow custom Docker image builds with a custom base Docker image.

Test run:
```
$ ./sbt 'set Base.dockerJavaImage in (linkerd, Bundle) := "java-1.8.0-oracle:8u121"' linkerd/docker
[info] Loading project definition from /Users/mohsenrezaei/dev/buoyant/linkerd/project
[info] Resolving key references (53076 settings) ...
[info] Set current project to all (in build file:/Users/mohsenrezaei/dev/buoyant/linkerd/)
[info] Defining linkerd/bundle:dockerJavaImage
[info] The new value will be used by linkerd/bundle:docker::dockerfile
[info] Reapplying settings...
[info] Set current project to all (in build file:/Users/mohsenrezaei/dev/buoyant/linkerd/)
[info] Including from cache: util-function_2.12-7.1.0.jar
[info] Including from cache: util-registry_2.12-7.1.0.jar
[info] Including from cache: util-app_2.12-7.1.0.jar
[info] Including from cache: scala-parser-combinators_2.12-1.0.4.jar
...
[info] Sending build context to Docker daemon   48.8MB
[info] 
[info] Step 1/7 : FROM java-1.8.0-oracle:8u121
[info]  ---> 3500a7f91184
[info] Step 2/7 : RUN ["mkdir", "-p", "\/io.buoyant\/linkerd\/1.3.6"]
[info]  ---> Running in 75b98b575984
[info] Removing intermediate container 75b98b575984
[info]  ---> 206250cce31b
[info] Step 3/7 : WORKDIR /io.buoyant/linkerd/1.3.6
[info] Removing intermediate container 89b678cbf8f0
[info]  ---> 1f8baebcda5a
[info] Step 4/7 : ENV L5D_HOME="/io.buoyant/linkerd/1.3.6"
[info]  ---> Running in 17263cbea3fd
[info] Removing intermediate container 17263cbea3fd
[info]  ---> 53792c9ee8f4
[info] Step 5/7 : ENV L5D_EXEC="/io.buoyant/linkerd/1.3.6/bundle-exec"
[info]  ---> Running in 7e06e3d4f27b
[info] Removing intermediate container 7e06e3d4f27b
[info]  ---> 12dc6765bb65
[info] Step 6/7 : COPY 0/linkerd-1.3.6-exec /io.buoyant/linkerd/1.3.6/bundle-exec
[info]  ---> 0d8591bd02e3
[info] Step 7/7 : ENTRYPOINT ["\/io.buoyant\/linkerd\/1.3.6\/bundle-exec"]
[info]  ---> Running in 71237e3afe1b
[info] Removing intermediate container 71237e3afe1b
[info]  ---> 7e53cc849b85
[info] Successfully built 7e53cc849b85
[info] Tagging image 7e53cc849b85 with name: buoyantio/linkerd:1.3.6
[success] Total time: 31 s, completed Mar 15, 2018 3:45:50 PM

```

Fixes #1855 

Signed-off-by: Mohsen Rezaei <morezaei00@gmail.com>