### PR TITLE
Add a retry budget to flaky tests

### DIFF
--- a/grpc/interop/src/test/scala/io/buoyant/grpc/interop/InteropTestBase.scala
+++ b/grpc/interop/src/test/scala/io/buoyant/grpc/interop/InteropTestBase.scala
@@ -1,8 +1,9 @@
 package io.buoyant.grpc.interop
 
-import com.twitter.util.{Future, Return, Throw, Try}
+import com.twitter.util.Future
 import grpc.{testing => pb}
 import io.buoyant.test.FunSuite
+import org.scalatest.tagobjects.Retryable
 
 trait InteropTestBase { _: FunSuite =>
 
@@ -32,13 +33,13 @@ trait InteropTestBase { _: FunSuite =>
     if (only.nonEmpty && !only(name)) ignore(name) {}
     else todo.get(name) match {
       case Some(msg) =>
-        test(name) {
+        test(name, Retryable) {
           assertThrows[Throwable](await(withClient(run)))
           cancel(s"TODO: $msg")
         }
 
       case None =>
-        test(name) { await(withClient(run)) }
+        test(name, Retryable) { await(withClient(run)) }
     }
 
 }

--- a/grpc/interop/src/test/scala/io/buoyant/grpc/interop/NetworkedEndToEndTest.scala
+++ b/grpc/interop/src/test/scala/io/buoyant/grpc/interop/NetworkedEndToEndTest.scala
@@ -1,15 +1,23 @@
 package io.buoyant.grpc.interop
 
+import java.net.InetSocketAddress
 import com.twitter.conversions.storage._
 import com.twitter.finagle.buoyant.{H2, h2}
 import com.twitter.util.Future
 import grpc.{testing => pb}
 import io.buoyant.test.FunSuite
-import java.net.InetSocketAddress
+import org.scalatest.Retries
 
-class NetworkedInteropTest extends FunSuite with InteropTestBase {
+class NetworkedInteropTest extends FunSuite with InteropTestBase with Retries {
 
   // override def only = Set("large_unary")
+
+  override def withFixture(test: NoArgTest) = {
+    if (isRetryable(test))
+      withRetry { super.withFixture(test) }
+    else
+      super.withFixture(test)
+  }
 
   val autoRefillConnectionWindow = h2.param.FlowControl.AutoRefillConnectionWindow(true)
   val initialWindowSize = h2.param.Settings.InitialStreamWindowSize(Some(1.megabyte))

--- a/grpc/interop/src/test/scala/io/buoyant/grpc/interop/NetworkedEndToEndTest.scala
+++ b/grpc/interop/src/test/scala/io/buoyant/grpc/interop/NetworkedEndToEndTest.scala
@@ -5,19 +5,11 @@ import com.twitter.conversions.storage._
 import com.twitter.finagle.buoyant.{H2, h2}
 import com.twitter.util.Future
 import grpc.{testing => pb}
-import io.buoyant.test.FunSuite
-import org.scalatest.Retries
+import io.buoyant.test.{BudgetedRetries, FunSuite}
 
-class NetworkedInteropTest extends FunSuite with InteropTestBase with Retries {
+class NetworkedInteropTest extends FunSuite with InteropTestBase with BudgetedRetries {
 
   // override def only = Set("large_unary")
-
-  override def withFixture(test: NoArgTest) = {
-    if (isRetryable(test))
-      withRetry { super.withFixture(test) }
-    else
-      super.withFixture(test)
-  }
 
   val autoRefillConnectionWindow = h2.param.FlowControl.AutoRefillConnectionWindow(true)
   val initialWindowSize = h2.param.Settings.InitialStreamWindowSize(Some(1.megabyte))

--- a/linkerd/core/src/e2e/scala/io/buoyant/linkerd/telemeter/UsageDataTelemeterEndToEndTest.scala
+++ b/linkerd/core/src/e2e/scala/io/buoyant/linkerd/telemeter/UsageDataTelemeterEndToEndTest.scala
@@ -1,8 +1,5 @@
 package io.buoyant.linkerd.telemeter
 
-import java.net.InetSocketAddress
-import java.text.SimpleDateFormat
-import java.util.Date
 import com.google.protobuf.CodedInputStream
 import com.twitter.conversions.time._
 import com.twitter.finagle.Address.Inet
@@ -19,6 +16,9 @@ import io.buoyant.linkerd.usage.UsageMessage
 import io.buoyant.namer.{NamerInitializer, TestNamerInitializer}
 import io.buoyant.telemetry.MetricsTree
 import io.buoyant.test.{Awaits, BudgetedRetries, FunSuite}
+import java.net.InetSocketAddress
+import java.text.SimpleDateFormat
+import java.util.Date
 import org.scalatest.tagobjects.Retryable
 import scala.util.Try
 

--- a/linkerd/core/src/e2e/scala/io/buoyant/linkerd/telemeter/UsageDataTelemeterEndToEndTest.scala
+++ b/linkerd/core/src/e2e/scala/io/buoyant/linkerd/telemeter/UsageDataTelemeterEndToEndTest.scala
@@ -18,19 +18,11 @@ import io.buoyant.linkerd._
 import io.buoyant.linkerd.usage.UsageMessage
 import io.buoyant.namer.{NamerInitializer, TestNamerInitializer}
 import io.buoyant.telemetry.MetricsTree
-import io.buoyant.test.{Awaits, FunSuite}
-import org.scalatest.Retries
+import io.buoyant.test.{Awaits, BudgetedRetries, FunSuite}
 import org.scalatest.tagobjects.Retryable
 import scala.util.Try
 
-class UsageDataTelemeterEndToEndTest extends FunSuite with Awaits with Retries {
-
-  override def withFixture(test: NoArgTest) = {
-    if (isRetryable(test))
-      withRetry { super.withFixture(test) }
-    else
-      super.withFixture(test)
-  }
+class UsageDataTelemeterEndToEndTest extends FunSuite with Awaits with BudgetedRetries {
 
   case class Downstream(name: String, server: ListeningServer, service: Service[Request, Response]) {
     val address = server.boundAddress.asInstanceOf[InetSocketAddress]

--- a/linkerd/protocol/http/src/e2e/scala/io/buoyant/linkerd/protocol/HttpEndToEndTest.scala
+++ b/linkerd/protocol/http/src/e2e/scala/io/buoyant/linkerd/protocol/HttpEndToEndTest.scala
@@ -10,9 +10,9 @@ import com.twitter.finagle.stats.{InMemoryStatsReceiver, NullStatsReceiver}
 import com.twitter.finagle.tracing.{Annotation, BufferingTracer, NullTracer}
 import com.twitter.finagle.{Http => FinagleHttp, Status => _, http => _, _}
 import com.twitter.util._
-import io.buoyant.test.Awaits
+import io.buoyant.test.{Awaits, BudgetedRetries}
 import org.scalatest.tagobjects.Retryable
-import org.scalatest.{FunSuite, MustMatchers, OptionValues, Retries}
+import org.scalatest.{FunSuite, MustMatchers, OptionValues}
 import scala.io.Source
 import scala.util.Random
 
@@ -21,14 +21,8 @@ class HttpEndToEndTest
     with Awaits
     with MustMatchers
     with OptionValues
-    with Retries {
+    with BudgetedRetries {
 
-  override def withFixture(test: NoArgTest) = {
-    if (isRetryable(test))
-      withRetry { super.withFixture(test) }
-    else
-      super.withFixture(test)
-  }
 
   case class Downstream(name: String, server: ListeningServer) {
     val address = server.boundAddress.asInstanceOf[InetSocketAddress]

--- a/linkerd/protocol/http/src/e2e/scala/io/buoyant/linkerd/protocol/HttpEndToEndTest.scala
+++ b/linkerd/protocol/http/src/e2e/scala/io/buoyant/linkerd/protocol/HttpEndToEndTest.scala
@@ -1,24 +1,34 @@
 package io.buoyant.linkerd
 package protocol
 
-import com.twitter.conversions.time._
-import com.twitter.finagle.{Http => FinagleHttp, Status => _, http => _, _}
-import com.twitter.finagle.buoyant.linkerd.Headers
-import com.twitter.finagle.http.{param => _, _}
-import com.twitter.finagle.http.Method._
-import com.twitter.finagle.stats.{InMemoryStatsReceiver, NullStatsReceiver}
-import com.twitter.finagle.tracing.{Annotation, BufferingTracer, NullTracer}
-import com.twitter.util._
-import io.buoyant.router.{Http, RoutingFactory}
-import io.buoyant.router.http.MethodAndHostIdentifier
-import io.buoyant.test.Awaits
 import java.io.File
 import java.net.InetSocketAddress
-import org.scalatest.{FunSuite, MustMatchers, OptionValues}
+import com.twitter.finagle.buoyant.linkerd.Headers
+import com.twitter.finagle.http.Method._
+import com.twitter.finagle.http.{param => _, _}
+import com.twitter.finagle.stats.{InMemoryStatsReceiver, NullStatsReceiver}
+import com.twitter.finagle.tracing.{Annotation, BufferingTracer, NullTracer}
+import com.twitter.finagle.{Http => FinagleHttp, Status => _, http => _, _}
+import com.twitter.util._
+import io.buoyant.test.Awaits
+import org.scalatest.tagobjects.Retryable
+import org.scalatest.{FunSuite, MustMatchers, OptionValues, Retries}
 import scala.io.Source
 import scala.util.Random
 
-class HttpEndToEndTest extends FunSuite with Awaits with MustMatchers with OptionValues {
+class HttpEndToEndTest
+  extends FunSuite
+    with Awaits
+    with MustMatchers
+    with OptionValues
+    with Retries {
+
+  override def withFixture(test: NoArgTest) = {
+    if (isRetryable(test))
+      withRetry { super.withFixture(test) }
+    else
+      super.withFixture(test)
+  }
 
   case class Downstream(name: String, server: ListeningServer) {
     val address = server.boundAddress.asInstanceOf[InetSocketAddress]
@@ -79,7 +89,7 @@ class HttpEndToEndTest extends FunSuite with Awaits with MustMatchers with Optio
       case Annotation.Message(m) if Seq("l5d.retryable", "l5d.failure").contains(m) => m
     }
 
-  test("linking") {
+  test("linking", Retryable) {
     val stats = NullStatsReceiver
     val tracer = new BufferingTracer
     def withAnnotations(f: Seq[Annotation] => Unit): Unit = {
@@ -150,7 +160,7 @@ class HttpEndToEndTest extends FunSuite with Awaits with MustMatchers with Optio
   }
 
 
-  test("marks 5XX as failure by default") {
+  test("marks 5XX as failure by default", Retryable) {
     val stats = new InMemoryStatsReceiver
     val tracer = NullTracer
 
@@ -207,7 +217,7 @@ class HttpEndToEndTest extends FunSuite with Awaits with MustMatchers with Optio
     }
   }
 
-  test("marks exceptions as failure by default") {
+  test("marks exceptions as failure by default", Retryable) {
     val stats = new InMemoryStatsReceiver
     val tracer = NullTracer
 
@@ -349,22 +359,22 @@ class HttpEndToEndTest extends FunSuite with Awaits with MustMatchers with Optio
     }
   }
 
-  test("retries retryableIdempotent5XX") {
+  test("retries retryableIdempotent5XX", Retryable) {
     retryTest("io.l5d.http.retryableIdempotent5XX", idempotentMethods)
   }
 
-  test("retries retryablRead5XX") {
+  test("retries retryablRead5XX", Retryable) {
     retryTest("io.l5d.http.retryableRead5XX", readMethods)
   }
 
-  test("retries nonRetryable5XX") {
+  test("retries nonRetryable5XX", Retryable) {
     retryTest("io.l5d.http.nonRetryable5XX", Set.empty)
   }
 
   val dtabReadHeaders = Seq("l5d-dtab", "l5d-ctx-dtab")
   val dtabWriteHeader = "l5d-ctx-dtab"
 
-  for (readHeader <- dtabReadHeaders) test(s"dtab read from $readHeader header") {
+  for (readHeader <- dtabReadHeaders) test(s"dtab read from $readHeader header", Retryable) {
     val stats = NullStatsReceiver
     val tracer = new BufferingTracer
 
@@ -397,7 +407,7 @@ class HttpEndToEndTest extends FunSuite with Awaits with MustMatchers with Optio
     assert(!headers.contains("dtab-local"))
   }
 
-  test("dtab-local header is ignored") {
+  test("dtab-local header is ignored", Retryable) {
     val stats = NullStatsReceiver
     val tracer = new BufferingTracer
 
@@ -427,7 +437,7 @@ class HttpEndToEndTest extends FunSuite with Awaits with MustMatchers with Optio
     assert(!headers.contains(dtabWriteHeader))
   }
 
-  test("with clearContext") {
+  test("with clearContext", Retryable) {
     val downstream = Downstream.mk("dog") { req =>
       val rsp = Response()
       rsp.contentString = req.headerMap.collect {
@@ -472,7 +482,7 @@ class HttpEndToEndTest extends FunSuite with Awaits with MustMatchers with Optio
     ))
   }
 
-  test("clearContext will remove linkerd error headers and body") {
+  test("clearContext will remove linkerd error headers and body", Retryable) {
     val yaml =
       s"""|routers:
           |- protocol: http
@@ -500,7 +510,7 @@ class HttpEndToEndTest extends FunSuite with Awaits with MustMatchers with Optio
 
   }
 
-  test("timestampHeader adds header") {
+  test("timestampHeader adds header", Retryable) {
     @volatile var headers: Option[HeaderMap] = None
     val downstream = Downstream.mk("test") {
       req =>
@@ -539,7 +549,7 @@ class HttpEndToEndTest extends FunSuite with Awaits with MustMatchers with Optio
     }
   }
 
-  test("no timestampHeader does not add timestamp header") {
+  test("no timestampHeader does not add timestamp header", Retryable) {
     @volatile var headers: Option[HeaderMap] = None
     val downstream = Downstream.mk("test") {
       req =>
@@ -576,7 +586,7 @@ class HttpEndToEndTest extends FunSuite with Awaits with MustMatchers with Optio
     }
   }
 
-  test("without clearContext") {
+  test("without clearContext", Retryable) {
     val downstream = Downstream.mk("dog") { req =>
       val rsp = Response()
       rsp.contentString = req.headerMap.collect {
@@ -623,7 +633,7 @@ class HttpEndToEndTest extends FunSuite with Awaits with MustMatchers with Optio
     assert(headers.get("l5d-ctx-dtab") == Some(localDtab))
   }
 
-  test("logs to correct files") {
+  test("logs to correct files", Retryable) {
     val downstream = Downstream.mk("test") {
       req =>
         val rsp = Response()

--- a/linkerd/protocol/http/src/e2e/scala/io/buoyant/linkerd/protocol/HttpTlsEndToEndTest.scala
+++ b/linkerd/protocol/http/src/e2e/scala/io/buoyant/linkerd/protocol/HttpTlsEndToEndTest.scala
@@ -13,19 +13,11 @@ import com.twitter.finagle.transport.Transport
 import com.twitter.finagle.{Http => FinagleHttp, Status => _, http => _, _}
 import com.twitter.util._
 import io.buoyant.config.Parser
-import io.buoyant.test.FunSuite
-import org.scalatest.Retries
+import io.buoyant.test.{BudgetedRetries, FunSuite}
 import org.scalatest.tagobjects.Retryable
 
 
-class HttpTlsEndToEndTest extends FunSuite with Retries {
-
-  override def withFixture(test: NoArgTest) = {
-    if (isRetryable(test))
-      withRetry { super.withFixture(test) }
-    else
-      super.withFixture(test)
-  }
+class HttpTlsEndToEndTest extends FunSuite with BudgetedRetries {
 
   private[this] def loadResource(p: String): InputStream =
     getClass.getResourceAsStream(p)

--- a/router/h2/src/e2e/scala/io/buoyant/router/h2/RouterEndToEndTest.scala
+++ b/router/h2/src/e2e/scala/io/buoyant/router/h2/RouterEndToEndTest.scala
@@ -1,21 +1,31 @@
 package io.buoyant.router
 package h2
 
+import java.net.InetSocketAddress
 import com.twitter.concurrent.AsyncQueue
-import com.twitter.finagle.{ChannelClosedException, Dtab, Failure, Path}
 import com.twitter.finagle.buoyant.Dst
 import com.twitter.finagle.buoyant.h2._
+import com.twitter.finagle.{ChannelClosedException, Dtab, Failure, Path}
 import com.twitter.logging.Level
 import com.twitter.util.{Future, Promise, Throw}
 import io.buoyant.router.h2.ClassifiedRetries.BufferSize
 import io.buoyant.test.FunSuite
-import java.net.InetSocketAddress
+import org.scalatest.Retries
+import org.scalatest.tagobjects.Retryable
 
 class RouterEndToEndTest
   extends FunSuite
-  with ClientServerHelpers {
+  with ClientServerHelpers
+  with Retries {
 
-  test("simple prior knowledge") {
+  override def withFixture(test: NoArgTest) = {
+    if (isRetryable(test))
+      withRetry { super.withFixture(test) }
+    else
+      super.withFixture(test)
+  }
+
+  test("simple prior knowledge", Retryable) {
     val cat = Downstream.const("cat", "meow")
     val dog = Downstream.const("dog", "woof")
     val dtab = Dtab.read(s"""
@@ -47,7 +57,7 @@ class RouterEndToEndTest
     }
   }
 
-  test("fails requests with connection-headers") {
+  test("fails requests with connection-headers", Retryable) {
     val dog = Downstream.const("dog", "woof")
     val dtab = Dtab.read(s"""
         /p/dog => /$$/inet/127.1/${dog.port} ;
@@ -73,7 +83,7 @@ class RouterEndToEndTest
     }
   }
 
-  test("resets downstream on upstream cancelation") {
+  test("resets downstream on upstream cancelation", Retryable) {
     val dogReqP = new Promise[Stream]
     val dogRspP = new Promise[Stream]
     @volatile var serverInterrupted: Option[Throwable] = None
@@ -116,7 +126,7 @@ class RouterEndToEndTest
     }
   }
 
-  test("resets downstream on upstream disconnect") {
+  test("resets downstream on upstream disconnect", Retryable) {
     val dogReqP = new Promise[Stream]
     val dogRspP = new Promise[Stream]
     val dog = Downstream.service("dog") { req =>
@@ -164,7 +174,7 @@ class RouterEndToEndTest
     }
   }
 
-  test("resets upstream on downstream failure") {
+  test("resets upstream on downstream failure", Retryable) {
     val dogReqP = new Promise[Stream]
     val dogRspP = new Promise[Stream]
     val dog = Downstream.service("dog") { req =>

--- a/router/h2/src/e2e/scala/io/buoyant/router/h2/RouterEndToEndTest.scala
+++ b/router/h2/src/e2e/scala/io/buoyant/router/h2/RouterEndToEndTest.scala
@@ -9,21 +9,13 @@ import com.twitter.finagle.{ChannelClosedException, Dtab, Failure, Path}
 import com.twitter.logging.Level
 import com.twitter.util.{Future, Promise, Throw}
 import io.buoyant.router.h2.ClassifiedRetries.BufferSize
-import io.buoyant.test.FunSuite
-import org.scalatest.Retries
+import io.buoyant.test.{BudgetedRetries, FunSuite}
 import org.scalatest.tagobjects.Retryable
 
 class RouterEndToEndTest
   extends FunSuite
   with ClientServerHelpers
-  with Retries {
-
-  override def withFixture(test: NoArgTest) = {
-    if (isRetryable(test))
-      withRetry { super.withFixture(test) }
-    else
-      super.withFixture(test)
-  }
+  with BudgetedRetries {
 
   test("simple prior knowledge", Retryable) {
     val cat = Downstream.const("cat", "meow")

--- a/router/mux/src/e2e/scala/io/buoyant/router/MuxEndToEndTest.scala
+++ b/router/mux/src/e2e/scala/io/buoyant/router/MuxEndToEndTest.scala
@@ -6,11 +6,11 @@ import com.twitter.finagle.tracing.{BufferingTracer, NullTracer}
 import com.twitter.finagle.{Mux => FinagleMux, _}
 import com.twitter.io.Buf
 import com.twitter.util._
-import io.buoyant.test.Awaits
+import io.buoyant.test.{Awaits, BudgetedRetries}
+import org.scalatest.FunSuite
 import org.scalatest.tagobjects.Retryable
-import org.scalatest.{FunSuite, Retries}
 
-class MuxEndToEndTest extends FunSuite with Awaits with Retries {
+class MuxEndToEndTest extends FunSuite with Awaits with BudgetedRetries {
 
 
   /*
@@ -84,13 +84,6 @@ class MuxEndToEndTest extends FunSuite with Awaits with Retries {
       val Buf.Utf8(body) = await(client(req)).body
       body
     }
-  }
-
-  override def withFixture(test: NoArgTest) = {
-    if (isRetryable(test))
-      withRetry { super.withFixture(test) }
-    else
-      super.withFixture(test)
   }
 
   // sanity check without router

--- a/test-util/src/main/scala/io/buoyant/test/BudgetedRetries.scala
+++ b/test-util/src/main/scala/io/buoyant/test/BudgetedRetries.scala
@@ -1,0 +1,27 @@
+package io.buoyant.test
+
+import org.scalatest.{Canceled, Failed, Outcome, Retries}
+
+/**
+ * Mixin trait for tests to support a retry budget.
+ */
+trait BudgetedRetries extends FunSuite with Retries {
+
+  /**
+   * The number of retries permitted before a test is failed.
+   *
+   * Tests that mix in `BudgetedRetries`
+   */
+  def retries = 4
+
+  override def withFixture(test: NoArgTest) =
+    if (isRetryable(test)) withRetries(test, retries)
+    else super.withFixture(test)
+
+  private[this] def withRetries (test: NoArgTest, remaining: Int): Outcome =
+    super.withFixture(test) match {
+      case Failed(_) | Canceled(_) if remaining == 1 => super.withFixture(test)
+      case Failed(_) | Canceled(_) => withRetries(test, remaining - 1)
+      case other => other
+    }
+}


### PR DESCRIPTION
A number of Linkerd's end-to-end tests are known to sometimes fail spuriously on CI (#1224, #1225, #1504, etc). If a test known to be flaky fails, the build is typically restarted, sometimes repeatedly if the test fails twice in a row. This is problematic for the following reasons:
+  This lengthens the CI feedback loop considerably, as we need to recompile Linkerd and re-run *all* the other tests, as well as re-running the failed test.
+ Furthermore, rerunning the whole test suite also creates an opportunity for *other* flaky tests to also fail, prolonging the process.
+ Spurious failures can decrease overall confidence in the test suite.
+ If a new contributor makes a minor change in a pull request and a flaky test fails, the new contributor typically doesn't know which test failures are spurious, and may assume that their changes somehow caused an unrelated part of the codebase to break. This is an uncomfortable experience, particularly if it takes a few hours for someone "in the know" to notice and restart the build.

This PR adds a retry budget to tests known to be flaky. It builds upon ScalaTest's [`Retries`](http://doc.scalatest.org/3.0.0/index.html#org.scalatest.Retries) trait, but adds the notion of a retry *budget*, rather than retrying tests only a single time. This is probably necessary as we've observed some of the flaky tests to fail spuriously multiple times in a row.

My rationale behind this is as follows: obviously we'd all like to write tests that never fail spuriously. With that said, it's proved very difficult to identify the cause behind these flaky test failures, so it doesn't seem like this problem will be fixed easily any time soon. Alternatively, we could consider skipping the known flaky tests entirely on CI.  However, a pretty large number of our E2E tests have been observed to fail spuriously at least occasionally, and I, for one, would be uncomfortable skipping such a large portion of the test suite on CI. Finally, note that the retry budget behaviour will result in more or less the same outcome as our current manual restarting of failed flaky tests, but will shorten the feedback loop significantly, and won't result in broken builds due to flaky test failures.

Fixes #1225. Fixes #1504.