### PR TITLE
Restore RequeueFilter in consul namer client stack

### DIFF
--- a/namer/consul/src/main/scala/io/buoyant/namer/consul/ConsulInitializer.scala
+++ b/namer/consul/src/main/scala/io/buoyant/namer/consul/ConsulInitializer.scala
@@ -82,9 +82,6 @@ case class ConsulConfig(
     val tlsParams = tls.map(_.params).getOrElse(Stack.Params.empty)
 
     val service = Http.client
-      // Removes the default client requeues module,
-      // (retries are handled in BaseApi.infiniteRetryFilter)
-      .withStack(Http.client.stack.remove(Retries.Role))
       .withParams(Http.client.params ++ tlsParams ++ params)
       .withLabel("client")
       .interceptInterrupts


### PR DESCRIPTION
PR #1827 simplifies Consul namer code by removing
retries on Consul API level and relying only on
polling loop in SvcAddr. However before the #1827
Consul API with retry=true was handling also
low-level errors, such as TCP NACK. After #1827
such errors started leaking to high-level polling
loop in SvcAddr. This causes a lot of noise in logs.

This commit restores default finagle Http retry
filter for consul client.

Signed-off-by: Dmytro Kostiuchenko <edio@archlinux.us>