### PR TITLE
Fix consul observations leak

### DIFF
--- a/namer/consul/src/main/scala/io/buoyant/namer/consul/LookupCache.scala
+++ b/namer/consul/src/main/scala/io/buoyant/namer/consul/LookupCache.scala
@@ -28,15 +28,18 @@ private[consul] class LookupCache(
 
   private[this] val localDcMoniker = ".local"
 
+
   private[this] val lookupCounter = stats.counter("lookups")
-  private[this] val serviceStats = SvcAddr.Stats(stats.scope("service"))
+  private val service: StatsReceiver = stats.scope("service")
+  private[this] val cachedCounter = service.counter("cached")
+  private[this] val serviceStats = SvcAddr.Stats(service)
 
   private[this] val cachedLookup: (String, SvcKey, Path, Path) => Activity[NameTree[Name]] =
     untupled(Memoize[(String, SvcKey, Path, Path), Activity[NameTree[Name]]] {
       case (dc, key, id, residual) =>
-        resolveDc(dc).join(domain).flatMap {
+        val addrFuture: Future[Var[Addr]] = resolveDc(dc).join(domain).map {
           case ((dcName, domainOption)) =>
-            val addr = SvcAddr(
+            SvcAddr(
               consulApi,
               LookupCache.DefaultBackoffs,
               dcName,
@@ -47,17 +50,32 @@ private[consul] class LookupCache(
               weights,
               serviceStats
             )
-            log.debug("consul ns %s service %s found + %s", dc, key, residual.show)
-
-            val stateVar: Var[Activity.State[NameTree[Name.Bound]]] = addr.map {
-              case Addr.Neg => Activity.Ok(NameTree.Neg)
-              case Addr.Pending => Activity.Pending
-              case Addr.Failed(why) => Activity.Failed(why)
-              case Addr.Bound(_, _) =>
-                Activity.Ok(NameTree.Leaf(Name.Bound(addr, id, residual)))
-            }
-            new Activity(stateVar)
         }
+
+        val observation = Var.async[Activity.State[NameTree[Name.Bound]]](Activity.Pending) { observationState =>
+          val closable = addrFuture.transform {
+            case Return(addr) =>
+              val closableObservation = addr.changes.respond {
+                case Addr.Neg => observationState.update(Activity.Ok(NameTree.Neg))
+                case Addr.Pending => observationState.update(Activity.Pending)
+                case Addr.Failed(why) => observationState.update(Activity.Failed(why))
+                case Addr.Bound(_, _) => observationState.update(Activity.Ok(NameTree.Leaf(Name.Bound(addr, id, residual))))
+              }
+              Future(closableObservation)
+            case Throw(cause) =>
+              // We probably failed to fetch agent config. This is critical.
+              // TODO: if this has happened only restart can restore namerd to working state. Throw exception instead?
+              observationState.update(Activity.Failed(cause))
+              Future(Closable.nop)
+          }
+
+          Closable.make { deadline =>
+            closable.flatMap(_.close(deadline))
+          }
+        }
+
+        cachedCounter.incr()
+        new Activity(observation)
     })
 
   def apply(
@@ -71,25 +89,20 @@ private[consul] class LookupCache(
     cachedLookup(dc, key, id, residual)
   }
 
-  private[this] def resolveDc(datacenter: String): Activity[String] =
+  private[this] def resolveDc(datacenter: String): Future[String] =
     if (datacenter == localDcMoniker)
       localDc.map(_.getOrElse(datacenter))
-    else Activity.value(datacenter)
+    else Future.value(datacenter)
 
-  // Note that this 3 activities are never recomputed.  We simply do a
-  // lookup for the domain and then wrap it an activity for
-  // convenience.
-  private[this] lazy val agentConfig: Activity[Option[v1.Config]] =
-    Activity.future(agentApi.localAgent(retry = true)).map(_.Config)
+  private[this] lazy val agentConfig: Future[Option[v1.Config]] = agentApi.localAgent(retry = true).map(_.Config)
 
-  private[this] lazy val domain: Activity[Option[String]] =
+  private[this] lazy val domain: Future[Option[String]] =
     if (setHost) {
       agentConfig.map { config =>
         val dom = config.flatMap(_.Domain).getOrElse("consul")
         Some(dom.stripPrefix(".").stripSuffix("."))
       }
-    } else Activity.value(None)
+    } else Future.value(None)
 
-  private[this] lazy val localDc = agentConfig.map(_.flatMap(_.Datacenter))
-
+  private[this] lazy val localDc: Future[Option[String]] = agentConfig.map(_.flatMap(_.Datacenter))
 }

--- a/namer/consul/src/test/scala/io/buoyant/namer/consul/ConsulNamerTest.scala
+++ b/namer/consul/src/test/scala/io/buoyant/namer/consul/ConsulNamerTest.scala
@@ -3,7 +3,7 @@ package io.buoyant.namer.consul
 import com.twitter.finagle._
 import com.twitter.finagle.stats.InMemoryStatsReceiver
 import com.twitter.io.Buf
-import com.twitter.util.{Activity, Future, Promise}
+import com.twitter.util.{Activity, Await, Future, Promise}
 import io.buoyant.consul.v1._
 import io.buoyant.namer.{ConfiguredDtabNamer, Metadata}
 import io.buoyant.test.Awaits

--- a/namer/consul/src/test/scala/io/buoyant/namer/consul/ConsulNamerTest.scala
+++ b/namer/consul/src/test/scala/io/buoyant/namer/consul/ConsulNamerTest.scala
@@ -3,7 +3,7 @@ package io.buoyant.namer.consul
 import com.twitter.finagle._
 import com.twitter.finagle.stats.InMemoryStatsReceiver
 import com.twitter.io.Buf
-import com.twitter.util.{Activity, Await, Future, Promise}
+import com.twitter.util.{Activity, Future, Promise}
 import io.buoyant.consul.v1._
 import io.buoyant.namer.{ConfiguredDtabNamer, Metadata}
 import io.buoyant.test.Awaits
@@ -75,6 +75,7 @@ class ConsulNamerTest extends FunSuite with Awaits {
     namer.lookup(Path.read("/dc1/servicename/residual")).states respond { state = _ }
     assert(state == Activity.Pending)
     assert(stats.counters == Map(
+      Seq("service", "cached") -> 1,
       Seq("service", "opens") -> 1,
       Seq("lookups") -> 1
     ))
@@ -99,6 +100,7 @@ class ConsulNamerTest extends FunSuite with Awaits {
 
     assert(state == Activity.Pending)
     assert(stats.counters == Map(
+      Seq("service", "cached") -> 1,
       Seq("service", "opens") -> 1,
       Seq("service", "errors") -> 1,
       Seq("lookups") -> 1
@@ -128,6 +130,7 @@ class ConsulNamerTest extends FunSuite with Awaits {
 
     assert(state == Activity.Ok(NameTree.Neg))
     assert(stats.counters == Map(
+      Seq("service", "cached") -> 1,
       Seq("service", "opens") -> 1,
       Seq("service", "updates") -> 1,
       Seq("lookups") -> 1
@@ -167,6 +170,7 @@ class ConsulNamerTest extends FunSuite with Awaits {
       NameTree.Leaf(Path(Buf.Utf8("test"), Buf.Utf8("dc1"), Buf.Utf8("servicename")))
     ))
     assert(stats.counters == Map(
+      Seq("service", "cached") -> 1,
       Seq("service", "opens") -> 1,
       Seq("service", "updates") -> 2,
       Seq("lookups") -> 1
@@ -219,6 +223,7 @@ class ConsulNamerTest extends FunSuite with Awaits {
     }
 
     assert(stats.counters == Map(
+      Seq("service", "cached") -> 1,
       Seq("service", "opens") -> 1,
       Seq("service", "updates") -> 1,
       Seq("lookups") -> 1
@@ -274,6 +279,7 @@ class ConsulNamerTest extends FunSuite with Awaits {
     }
 
     assert(stats.counters == Map(
+      Seq("service", "cached") -> 1,
       Seq("service", "opens") -> 1,
       Seq("service", "updates") -> 1,
       Seq("lookups") -> 1
@@ -335,6 +341,7 @@ class ConsulNamerTest extends FunSuite with Awaits {
     assert(state == Activity.Ok(NameTree.Neg))
 
     assert(stats.counters == Map(
+      Seq("service", "cached") -> 1,
       Seq("service", "opens") -> 1,
       Seq("service", "updates") -> 3,
       Seq("lookups") -> 1
@@ -379,6 +386,7 @@ class ConsulNamerTest extends FunSuite with Awaits {
     }
 
     assert(stats.counters == Map(
+      Seq("service", "cached") -> 1,
       Seq("service", "opens") -> 1,
       Seq("service", "updates") -> 1,
       Seq("lookups") -> 1
@@ -418,6 +426,7 @@ class ConsulNamerTest extends FunSuite with Awaits {
     }
 
     assert(stats.counters == Map(
+      Seq("service", "cached") -> 1,
       Seq("service", "opens") -> 1,
       Seq("service", "updates") -> 1,
       Seq("lookups") -> 1
@@ -465,6 +474,7 @@ class ConsulNamerTest extends FunSuite with Awaits {
     }
 
     assert(stats.counters == Map(
+      Seq("service", "cached") -> 1,
       Seq("service", "opens") -> 1,
       Seq("service", "updates") -> 1,
       Seq("lookups") -> 1


### PR DESCRIPTION
LookupCache uses Memoize to return the same instance of Activity
whenever lookup happens in Consul namer. Although returned activity is
backed by an async and lazy Var (backed by polling SvcAddr), it is
itself not async and lazy, as it is a join result of multiple
Acitivities which are not async and lazy. Hence every observer to a
returned activity triggers new SvcAddr creation and, as a result, new
connection to Consul even if Activity is cached.

This commit reworks Activity creation in LookupCache such that it is
indeed async and lazy. Activity remains pending unless all dependencies
to it are satisfied.

Tested in real environment, where previous version of namer was opening
up to 20K connections to consul agent, causing namerd unresponsiveness,
consul crashes. After the fix it's barely 300 connections.

![consul_namer_fix](https://user-images.githubusercontent.com/787439/37942176-e0bd5354-313f-11e8-9e98-fb6ab29356b9.png)
