### PR TITLE
Support extracting partial segment from path segment

### DIFF
--- a/finagle/buoyant/src/main/scala/com/twitter/finagle/buoyant/PathMatcher.scala
+++ b/finagle/buoyant/src/main/scala/com/twitter/finagle/buoyant/PathMatcher.scala
@@ -76,7 +76,7 @@ object PathMatcher {
           else if (exprSegment == pathSegment)
             _extract(pathSegments.tail, exprSegments.tail, vars)
           else
-            """\{([a-zA-Z0-9.:-]+)\}""".r.findAllIn(exprSegment) match {
+            """\{([a-zA-Z0-9\\.:-]+)\}""".r.findAllIn(exprSegment) match {
               case k if !k.isEmpty && pathSegment.startsWith(exprSegment.take(k.start)) =>
                 var keys = k.toArray
                 keys.foldLeft(exprSegment.replace(".", "\\."))(_re).r.findAllIn(pathSegment) match {

--- a/finagle/buoyant/src/main/scala/com/twitter/finagle/buoyant/PathMatcher.scala
+++ b/finagle/buoyant/src/main/scala/com/twitter/finagle/buoyant/PathMatcher.scala
@@ -82,7 +82,11 @@ object PathMatcher {
               vars + (exprSegment.substring(1, exprSegment.length - 1) -> pathSegment)
             )
           else
-            None
+            (exprSegment.split(":"), pathSegment.split(":")) match {
+              case (Array(a, b), Array(y, z)) if a.startsWith("{") && a.endsWith("}") && b == z =>
+                Some(vars + (a.substring(1, a.length - 1) -> y))
+              case _ => None
+            }
         case (_, None) => Some(vars)
         case (None, _) => None
       }

--- a/finagle/buoyant/src/test/scala/com/twitter/finagle/buoyant/PathMatcherTest.scala
+++ b/finagle/buoyant/src/test/scala/com/twitter/finagle/buoyant/PathMatcherTest.scala
@@ -45,9 +45,21 @@ class PathMatcherTest extends FunSuite {
     assert(matcher.extract(Path.read("/foo/boo/bar/bas")) == Some(Map("A" -> "boo", "B" -> "bas")))
   }
 
-  test("capture segments with endpoint and wildcards") {
-    val matcher = PathMatcher("/foo/{A}/*/{B}:http")
-    assert(matcher.extract(Path.read("/foo/boo/bar/bas:http")) == Some(Map("A" -> "boo", "B" -> "bas")))
+  test("capture segment from partial expression") {
+    val matcher = PathMatcher("/foo/bar/{A}.com/{B}")
+    assert(matcher.extract(Path.read("/foo/bar/foo.com/80")) == Some(Map("A" -> "foo", "B" -> "80")))
+
+    val matcher2 = PathMatcher("/foo/bar/{A}-{B}/{C}")
+    assert(matcher2.extract(Path.read("/foo/bar/foo-com/80")) == Some(Map("A" -> "foo", "B" -> "com", "C" -> "80")))
+
+    val matcher3 = PathMatcher("/foo/bar/{A}.{B}/{C}")
+    assert(matcher3.extract(Path.read("/foo/bar/foo.com/80")) == Some(Map("A" -> "foo", "B" -> "com", "C" -> "80")))
+
+    val matcher4 = PathMatcher("/foo/bar/{A}.{B}.{C}/{D}")
+    assert(matcher4.extract(Path.read("/foo/bar/www.foo.com/80")) == Some(Map("A" -> "www", "B" -> "foo", "C" -> "com", "D" -> "80")))
+
+    val matcher5 = PathMatcher("/foo/{A}/*/{B}:http")
+    assert(matcher5.extract(Path.read("/foo/boo/bar/bas:http")) == Some(Map("A" -> "boo", "B" -> "bas")))
   }
 
   test("failed capture") {
@@ -58,11 +70,6 @@ class PathMatcherTest extends FunSuite {
   test("failed capture with endpoint") {
     val matcher = PathMatcher("/foo/{A}:http")
     assert(matcher.extract(Path.read("/foo/bar/bas:http")) == None)
-  }
-
-  test("paritial failed capture with endpoint out of order") {
-    val matcher = PathMatcher("/foo/bar/{A}:http/{B}")
-    assert(matcher.extract(Path.read("/foo/bar/bas:http/blarg")) == Some(Map("A" -> "bas")))
   }
 
   test("substitute") {

--- a/finagle/buoyant/src/test/scala/com/twitter/finagle/buoyant/PathMatcherTest.scala
+++ b/finagle/buoyant/src/test/scala/com/twitter/finagle/buoyant/PathMatcherTest.scala
@@ -35,14 +35,34 @@ class PathMatcherTest extends FunSuite {
     assert(matcher.extract(Path.read("/foo/bar/bas")) == Some(Map("A" -> "bar")))
   }
 
+  test("capture segments with fragment") {
+    val matcher = PathMatcher("/foo/bar/{A}:http")
+    assert(matcher.extract(Path.read("/foo/bar/bas:http")) == Some(Map("A" -> "bas")))
+  }
+
   test("capture and wildcards") {
     val matcher = PathMatcher("/foo/{A}/*/{B}")
     assert(matcher.extract(Path.read("/foo/boo/bar/bas")) == Some(Map("A" -> "boo", "B" -> "bas")))
   }
 
+  test("capture segments with fragment and wildcards") {
+    val matcher = PathMatcher("/foo/{A}/*/{B}:http")
+    assert(matcher.extract(Path.read("/foo/boo/bar/bas:http")) == Some(Map("A" -> "boo", "B" -> "bas")))
+  }
+
   test("failed capture") {
     val matcher = PathMatcher("/foo/{A}/bar")
     assert(matcher.extract(Path.read("/foo/bar/bad")) == None)
+  }
+
+  test("failed capture with fragment") {
+    val matcher = PathMatcher("/foo/{A}:http")
+    assert(matcher.extract(Path.read("/foo/bar/bas:http")) == None)
+  }
+
+  test("failed capture with fragment out of order") {
+    val matcher = PathMatcher("/foo/bar/{A}:http/{B}")
+    assert(matcher.extract(Path.read("/foo/bar/bas:http/blarg")) == Some(Map("A" -> "bas")))
   }
 
   test("substitute") {

--- a/finagle/buoyant/src/test/scala/com/twitter/finagle/buoyant/PathMatcherTest.scala
+++ b/finagle/buoyant/src/test/scala/com/twitter/finagle/buoyant/PathMatcherTest.scala
@@ -60,6 +60,9 @@ class PathMatcherTest extends FunSuite {
 
     val matcher5 = PathMatcher("/foo/{A}/*/{B}:http")
     assert(matcher5.extract(Path.read("/foo/boo/bar/bas:http")) == Some(Map("A" -> "boo", "B" -> "bas")))
+
+    val matcher6 = PathMatcher("/foo/bar/{A}-{B}")
+    assert(matcher6.extract(Path.read("/foo/bar/foo-bar-baz")) == Some(Map("A" -> "foo-bar", "B" -> "baz")))
   }
 
   test("failed capture") {

--- a/finagle/buoyant/src/test/scala/com/twitter/finagle/buoyant/PathMatcherTest.scala
+++ b/finagle/buoyant/src/test/scala/com/twitter/finagle/buoyant/PathMatcherTest.scala
@@ -35,7 +35,7 @@ class PathMatcherTest extends FunSuite {
     assert(matcher.extract(Path.read("/foo/bar/bas")) == Some(Map("A" -> "bar")))
   }
 
-  test("capture segments with fragment") {
+  test("capture segments with endpoint") {
     val matcher = PathMatcher("/foo/bar/{A}:http")
     assert(matcher.extract(Path.read("/foo/bar/bas:http")) == Some(Map("A" -> "bas")))
   }
@@ -45,7 +45,7 @@ class PathMatcherTest extends FunSuite {
     assert(matcher.extract(Path.read("/foo/boo/bar/bas")) == Some(Map("A" -> "boo", "B" -> "bas")))
   }
 
-  test("capture segments with fragment and wildcards") {
+  test("capture segments with endpoint and wildcards") {
     val matcher = PathMatcher("/foo/{A}/*/{B}:http")
     assert(matcher.extract(Path.read("/foo/boo/bar/bas:http")) == Some(Map("A" -> "boo", "B" -> "bas")))
   }
@@ -55,12 +55,12 @@ class PathMatcherTest extends FunSuite {
     assert(matcher.extract(Path.read("/foo/bar/bad")) == None)
   }
 
-  test("failed capture with fragment") {
+  test("failed capture with endpoint") {
     val matcher = PathMatcher("/foo/{A}:http")
     assert(matcher.extract(Path.read("/foo/bar/bas:http")) == None)
   }
 
-  test("failed capture with fragment out of order") {
+  test("paritial failed capture with endpoint out of order") {
     val matcher = PathMatcher("/foo/bar/{A}:http/{B}")
     assert(matcher.extract(Path.read("/foo/bar/bas:http/blarg")) == Some(Map("A" -> "bas")))
   }

--- a/linkerd/docs/namer.md
+++ b/linkerd/docs/namer.md
@@ -817,6 +817,11 @@ If the name matches the pattern in the config, it will be replaced by the
 name in the config.  Additionally, any variables in the pattern will capture
 the value of the matching path segment and may be used in the final name.
 
+Note: Pattern matches are greedy.  For example patterns like "{foo}{bar}"
+are ambiguous.  With the capture implementation, {foo} would capture the
+whole segment and {bar} would be empty. Similarly, the pattern "{foo}-{bar}"
+on the segment "a-b-c" would capture "a-b" into foo and "c" into bar.
+
 Key     | Default Value    | Description
 ------- | ---------------- | -----------
 prefix  | _required_       | Resolves names with `/#/<prefix>`.

--- a/linkerd/docs/routers.md
+++ b/linkerd/docs/routers.md
@@ -221,6 +221,11 @@ If a client matches more than one config's prefix, all parameters from the
 matching configs will be applied, with parameters defined later in the
 configuration file taking precedence over those defined earlier.
 
+Note: Capture variables use greedy pattern matching.  For example (`{foo}{bar}`) is
+ambiguous.  The capture variable (`{foo}`) would capture the whole segement and
+(`{bar}`) would empty.  Similary, the pattern (`{foo}-{bar}`) on the segement
+`a-b-c` would capture `a-b` into (`{foo}`) and `c` in (`{bar}`).
+
 ### Client Parameters
 
 <aside class="notice">

--- a/linkerd/examples/serversets.yaml
+++ b/linkerd/examples/serversets.yaml
@@ -16,6 +16,15 @@ routers:
     pathPrefix: /discovery/prod
   dtab: |
     /svc => /#/io.l5d.serversets;
+    /host/www.example.com => /#/io.l5d.serversets/discovery/prod/www/example:https;
+    /host/www.example2.com => /#/io.l5d.serversets/discovery/prod/www/example2;
+    /svc/1.1 => /$/io.buoyant.http.anyMethodPfx/host;
+  client:
+    kind: io.l5d.static
+    configs:
+    - prefix: "/#/io.l5d.serversets/discovery/prod/{role}/{service}:https"
+      tls:
+        commonName: "{role}.{service}.com"
   servers:
   - port: 4140
     ip: 0.0.0.0


### PR DESCRIPTION
I use `io.l5d.serversets` for service discovery which supports named endpoints.  PathMatcher in its current form is not able to extract segments in the presence of an endpoint without also consuming the endpoint as part of the segement.  This makes it difficult to match on services that are advertised as wanting a TLS client and matching the commonName without repeating a lot of TLS client configuration.

1. I'd like to be able to extract a service name when an endpoint is present w/o including endpoint
2. I'd like to be able to use the endpoint name as a sentinel for enabling client TLS
3.  I'd like to be able to cut down on special casing TLS client configuration

Ideally I'd like to have TLS client configuration like the following.
```yaml
  client:
    kind: io.l5d.static
    configs:
    - prefix: "/#/io.l5d.serversets/sd/prod/*/{service}:https"
      tls:
        commonName: "{service}.com"
```