### PR TITLE
Tune for memory fragmentation and more optimal netty/finagle settings

### DIFF
--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -224,24 +224,30 @@ object LinkerdBuild extends Base {
   val ConfigFileRE = """^(.*)\.yaml$""".r
 
   val execScriptJvmOptions =
-    """|DEFAULT_JVM_OPTIONS="-Djava.net.preferIPv4Stack=true \
-       |   -Dsun.net.inetaddr.ttl=60                         \
-       |   -Xms${JVM_HEAP_MIN:-32M}                          \
-       |   -Xmx${JVM_HEAP_MAX:-1024M}                        \
-       |   -XX:+AggressiveOpts                               \
-       |   -XX:+UseConcMarkSweepGC                           \
-       |   -XX:+CMSParallelRemarkEnabled                     \
-       |   -XX:+CMSClassUnloadingEnabled                     \
-       |   -XX:+ScavengeBeforeFullGC                         \
-       |   -XX:+CMSScavengeBeforeRemark                      \
-       |   -XX:+UseCMSInitiatingOccupancyOnly                \
-       |   -XX:CMSInitiatingOccupancyFraction=70             \
-       |   -XX:-TieredCompilation                            \
-       |   -XX:+UseStringDeduplication                       \
-       |   -Dcom.twitter.util.events.sinkEnabled=false       \
-       |   -Dorg.apache.thrift.readLength=10485760           \
-       |   -Djdk.nio.maxCachedBufferSize=262144              \
-       |   ${LOCAL_JVM_OPTIONS:-}                            "
+    """|DEFAULT_JVM_OPTIONS="-Djava.net.preferIPv4Stack=true             \
+       |   -Dsun.net.inetaddr.ttl=60                                     \
+       |   -Xms${JVM_HEAP_MIN:-32M}                                      \
+       |   -Xmx${JVM_HEAP_MAX:-1024M}                                    \
+       |   -XX:+AggressiveOpts                                           \
+       |   -XX:+UseConcMarkSweepGC                                       \
+       |   -XX:+CMSParallelRemarkEnabled                                 \
+       |   -XX:+CMSClassUnloadingEnabled                                 \
+       |   -XX:+ScavengeBeforeFullGC                                     \
+       |   -XX:+CMSScavengeBeforeRemark                                  \
+       |   -XX:+UseCMSInitiatingOccupancyOnly                            \
+       |   -XX:CMSInitiatingOccupancyFraction=70                         \
+       |   -XX:-TieredCompilation                                        \
+       |   -XX:+UseStringDeduplication                                   \
+       |   -XX:+AlwaysPreTouch                                           \
+       |   -Dcom.twitter.util.events.sinkEnabled=false                   \
+       |   -Dorg.apache.thrift.readLength=10485760                       \
+       |   -Djdk.nio.maxCachedBufferSize=262144                          \
+       |   -Dio.netty.threadLocalDirectBufferSize=0                      \
+       |   -Dio.netty.recycler.maxCapacity=4096                          \
+       |   -Dio.netty.allocator.numHeapArenas=${FINAGLE_WORKERS:-8}      \
+       |   -Dio.netty.allocator.numDirectArenas=${FINAGLE_WORKERS:-8}    \
+       |   -Dcom.twitter.finagle.netty4.numWorkers=${FINAGLE_WORKERS:-8} \
+       |   ${LOCAL_JVM_OPTIONS:-}                                        "
        |""".stripMargin
 
   object Namerd {
@@ -333,6 +339,7 @@ object LinkerdBuild extends Base {
          |    jars="$jars:$jar"
          |  done
          |fi
+         |export MALLOC_ARENA_MAX=2
          |""" +
       execScriptJvmOptions +
       """|exec "${JAVA_HOME:-/usr}/bin/java" -XX:+PrintCommandLineFlags \
@@ -387,6 +394,7 @@ object LinkerdBuild extends Base {
          |    jars="$jars:$jar"
          |  done
          |fi
+         |export MALLOC_ARENA_MAX=2
          |""" +
       execScriptJvmOptions +
       """|if read -t 0; then
@@ -590,6 +598,7 @@ object LinkerdBuild extends Base {
          |    jars="$jars:$jar"
          |  done
          |fi
+         |export MALLOC_ARENA_MAX=2
          |""" +
       execScriptJvmOptions +
       """|exec "${JAVA_HOME:-/usr}/bin/java" -XX:+PrintCommandLineFlags \


### PR DESCRIPTION
* Added FINAGLE_WORKERS option to linkerd/namerd to tune the number of finagle workers, with a default of (eight) workers. If you send small sized requests
and need higher throughput, increase the # of workers.

* Tune netty settings to:

-Dio.netty.threadLocalDirectBufferSize=0
-Dio.netty.recycler.maxCapacity=4096

Per https://github.com/netty/netty/pull/7704 and https://github.com/netty/netty/pull/7701

* Support using MALLOC_ARENA_MAX = 2 for glibc >= 2.10, which switched to a per-thread memory pool
* Added -XX:+AlwaysPreTouch

Fixes: #1690

Signed-off-by: Chris Goffinet <chris@threecomma.io>