### PR TITLE
Exposing rotation policy configuration for http and http2 access logs…

### DIFF
--- a/linkerd/docs/protocol-h2.md
+++ b/linkerd/docs/protocol-h2.md
@@ -8,6 +8,9 @@
 routers:
 - protocol: h2
   h2AccessLog: access.log
+  h2AccessLogRollPolicy: daily
+  h2AccessLogAppend: true
+  h2AccessLogRotateCount: -1
   servers:
   - port: 4143
     tls:
@@ -57,6 +60,9 @@ Key | Default Value | Description
 --- | ------------- | -----------
 dstPrefix | `/svc` | A path prefix used by [H2-specific identifiers](#http-2-identifiers).
 h2AccessLog | none | Sets the access log path.  If not specified, no access log is written.
+h2AccessLogRollPolicy | never | When to roll the logfile. Possible values: Never, Hourly, Daily, Weekly(n) (where n is a day of the week), util-style data size strings (e.g. 3.megabytes, 1.gigabyte).
+h2AccessLogAppend | true | Append to an existing logfile, or truncate it?
+h2AccessLogRotateCount | -1 | How many rotated logfiles to keep around, maximum. -1 means to keep them all.
 identifier | The `io.l5d.header.token` identifier | An identifier or list of identifiers. See [H2-specific identifiers](#http-2-identifiers).
 loggers | none | A list of loggers.  See [H2-specific loggers](#http-2-loggers).
 

--- a/linkerd/docs/protocol-http.md
+++ b/linkerd/docs/protocol-http.md
@@ -6,6 +6,9 @@
 routers:
 - protocol: http
   httpAccessLog: access.log
+  httpAccessLogRollPolicy: daily
+  httpAccessLogAppend: true
+  httpAccessLogRotateCount: -1
   identifier:
     kind: io.l5d.methodAndHost
   maxChunkKB: 8
@@ -30,6 +33,9 @@ Key | Default Value | Description
 --- | ------------- | -----------
 dstPrefix | `/svc` | A path prefix used by [Http-specific identifiers](#http-1-1-identifiers).
 httpAccessLog | none | Sets the access log path.  If not specified, no access log is written.
+httpAccessLogRollPolicy | never | When to roll the logfile. Possible values: Never, Hourly, Daily, Weekly(n) (where n is a day of the week), util-style data size strings (e.g. 3.megabytes, 1.gigabyte).
+httpAccessLogAppend | true | Append to an existing logfile, or truncate it?
+httpAccessLogRotateCount | -1 | How many rotated logfiles to keep around, maximum. -1 means to keep them all.
 identifier | The `io.l5d.header.token` identifier | An identifier or list of identifiers.  See [Http-specific identifiers](#http-1-1-identifiers).
 loggers | none | A list of loggers.  See [Http-specific loggers](#http-1-1-loggers).
 maxChunkKB | 8 | The maximum size of an HTTP chunk.

--- a/linkerd/examples/h2.yaml
+++ b/linkerd/examples/h2.yaml
@@ -6,6 +6,9 @@ namers:
 routers:
 - protocol: h2
   h2AccessLog: logs/access.log
+  h2AccessLogRollPolicy: daily
+  h2AccessLogAppend: true
+  h2AccessLogRotateCount: -1
   dtab: |
     /srv => /#/io.l5d.fs;
     /svc/localhost:4142 => /$/inet/127.1/8888;

--- a/linkerd/examples/http.yaml
+++ b/linkerd/examples/http.yaml
@@ -6,6 +6,9 @@ namers:
 routers:
 - protocol: http
   httpAccessLog: logs/access.log
+  httpAccessLogRollPolicy: daily
+  httpAccessLogAppend: true
+  httpAccessLogRotateCount: -1
   maxChunkKB: 16
   maxHeadersKB: 16
   maxInitialLineKB: 16

--- a/linkerd/protocol/h2/src/test/scala/io/buoyant/linkerd/protocol/h2/H2ConfigTest.scala
+++ b/linkerd/protocol/h2/src/test/scala/io/buoyant/linkerd/protocol/h2/H2ConfigTest.scala
@@ -23,6 +23,10 @@ class H2ConfigTest extends FunSuite {
   test("parse config") {
     val yaml =
       s"""|protocol: h2
+          |h2AccessLog: logs/access.log
+          |h2AccessLogRollPolicy: daily
+          |h2AccessLogAppend: true
+          |h2AccessLogRotateCount: -1
           |client:
           |  windowUpdateRatio: 0.9
           |  headerTableBytes: 1024
@@ -52,6 +56,11 @@ class H2ConfigTest extends FunSuite {
           |      requireClientAuth: true
           |""".stripMargin
     val config = parse(yaml)
+
+    assert(config.h2AccessLog.get == "logs/access.log")
+    assert(config.h2AccessLogRollPolicy.get == "daily")
+    assert(config.h2AccessLogAppend.get)
+    assert(config.h2AccessLogRotateCount.get == -1)
 
     val cparams = config.client.get.clientParams.paramsFor(Path.read("/foo"))
     assert(cparams[AutoRefillConnectionWindow] == AutoRefillConnectionWindow(true))

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpConfig.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpConfig.scala
@@ -16,6 +16,7 @@ import com.twitter.finagle.liveness.FailureAccrualFactory
 import com.twitter.finagle.service.Retries
 import com.twitter.finagle.stack.nilStack
 import com.twitter.finagle.{Path, ServiceFactory, Stack, param => fparam}
+import com.twitter.logging.Policy
 import com.twitter.util.Future
 import io.buoyant.linkerd.protocol.http._
 import io.buoyant.router.{ClassifiedRetries, Http, RoutingFactory}
@@ -188,6 +189,9 @@ class HttpIdentifierConfigDeserializer extends JsonDeserializer[Option[Seq[HttpI
 
 case class HttpConfig(
   httpAccessLog: Option[String],
+  httpAccessLogRollPolicy: Option[String],
+  httpAccessLogAppend: Option[Boolean],
+  httpAccessLogRotateCount: Option[Int],
   @JsonDeserialize(using = classOf[HttpIdentifierConfigDeserializer]) identifier: Option[Seq[HttpIdentifierConfig]],
   loggers: Option[Seq[HttpRequestAuthorizerConfig]],
   maxChunkKB: Option[Int],
@@ -233,7 +237,10 @@ case class HttpConfig(
   }
   @JsonIgnore
   override def routerParams: Stack.Params = super.routerParams
-    .maybeWith(httpAccessLog.map(AccessLogger.param.File(_)))
+    .maybeWith(httpAccessLog.map(AccessLogger.param.File.apply))
+    .maybeWith(httpAccessLogRollPolicy.map(Policy.parse _ andThen AccessLogger.param.RollPolicy.apply))
+    .maybeWith(httpAccessLogAppend.map(AccessLogger.param.Append.apply))
+    .maybeWith(httpAccessLogRotateCount.map(AccessLogger.param.RotateCount.apply))
     .maybeWith(loggerParam)
     .maybeWith(combinedIdentifier)
     .maybeWith(maxChunkKB.map(kb => hparam.MaxChunkSize(kb.kilobytes)))

--- a/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/HttpConfigTest.scala
+++ b/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/HttpConfigTest.scala
@@ -22,6 +22,9 @@ class HttpConfigTest extends FunSuite with Awaits {
     val yaml = s"""
                   |protocol: http
                   |httpAccessLog: access.log
+                  |httpAccessLogRollPolicy: daily
+                  |httpAccessLogAppend: true
+                  |httpAccessLogRotateCount: -1
                   |identifier:
                   |  kind: io.l5d.methodAndHost
                   |maxChunkKB: 8
@@ -33,6 +36,10 @@ class HttpConfigTest extends FunSuite with Awaits {
                   |- port: 5000
       """.stripMargin
     val config = parse(yaml)
+    assert(config.httpAccessLog.get == "access.log")
+    assert(config.httpAccessLogRollPolicy.get == "daily")
+    assert(config.httpAccessLogAppend.get)
+    assert(config.httpAccessLogRotateCount.get == -1)
     assert(config.maxChunkKB.get == 8)
     assert(config.maxHeadersKB.get == 8)
     assert(config.maxInitialLineKB.get == 4)


### PR DESCRIPTION
It is my solution to problem requested here: https://github.com/linkerd/linkerd/issues/1865. In the original request, there are only mention about http2 but I think it will be nice if http has the same configuration.