### PR TITLE
Rename loggers to requestAuthorizers

### DIFF
--- a/linkerd/docs/protocol-h2.md
+++ b/linkerd/docs/protocol-h2.md
@@ -58,7 +58,7 @@ Key | Default Value | Description
 dstPrefix | `/svc` | A path prefix used by [H2-specific identifiers](#http-2-identifiers).
 h2AccessLog | none | Sets the access log path.  If not specified, no access log is written.
 identifier | The `io.l5d.header.token` identifier | An identifier or list of identifiers. See [H2-specific identifiers](#http-2-identifiers).
-loggers | none | A list of loggers.  See [H2-specific loggers](#http-2-loggers).
+requestAuthorizers | none | A list of request authorizers.  See [H2-specific request authorizers](#http-2-request-authorizers).
 
 When TLS is configured, h2 routers negotiate to communicate over
 HTTP/2 via ALPN.
@@ -340,29 +340,29 @@ host | N/A | The host to send the request to.
 cluster | N/A | The cluster to send the request to.
 port | N/A | The port to send the request to.
 
-## HTTP/2 Loggers
+## HTTP/2 Request Authorizers
 
-Loggers allow recording of arbitrary information about requests. Destination of
-information is specific to each logger. All HTTP/2 loggers have a `kind`. If a
-list of loggers is provided, they each log in the order they are defined.
+Request authorizers allow arbitrary rejection or modification of requests and responses. Behavior is
+specific to each request authorizer. All HTTP/2 request authorizers have a `kind`. If a
+list of request authorizers is provided, they each apply in the order they are defined.
 
 Key | Default Value | Description
 --- | ------------- | -----------
-kind | _required_ | Only [`io.l5d.k8s.istio`](#istio-logger) is currently supported.
+kind | _required_ | Only [`io.l5d.k8s.istio`](#istio-request-authorizer) is currently supported.
 
-### HTTP/2 Istio Logger
+### HTTP/2 Istio Request Authorizer
 
 kind: `io.l5d.k8s.istio`.
 
-With this logger, all H2 requests are sent to an Istio Mixer for telemetry
+With this request authorizer, all H2 requests are sent to an Istio Mixer for telemetry
 recording and aggregation.
 
-#### Logger Configuration:
+#### Request Authorizer Configuration:
 
 > Configuration example
 
 ```yaml
-loggers:
+requestAuthorizers:
 - kind: io.l5d.k8s.istio
   mixerHost: istio-mixer
   mixerPort: 9091

--- a/linkerd/docs/protocol-http.md
+++ b/linkerd/docs/protocol-http.md
@@ -31,7 +31,7 @@ Key | Default Value | Description
 dstPrefix | `/svc` | A path prefix used by [Http-specific identifiers](#http-1-1-identifiers).
 httpAccessLog | none | Sets the access log path.  If not specified, no access log is written.
 identifier | The `io.l5d.header.token` identifier | An identifier or list of identifiers.  See [Http-specific identifiers](#http-1-1-identifiers).
-loggers | none | A list of loggers.  See [Http-specific loggers](#http-1-1-loggers).
+requestAuthorizers | none | A list of request authorizers.  See [Http-specific request authorizers](#http-1-1-request-authorizers).
 maxChunkKB | 8 | The maximum size of an HTTP chunk.
 maxHeadersKB | 8 | The maximum size of all headers in an HTTP message.
 maxInitialLineKB | 4 | The maximum size of an initial HTTP message line.
@@ -475,31 +475,31 @@ Key | Default Value | Description
 dstPrefix | `/svc` | The `dstPrefix` as set in the routers block.
 path | N/A | The path given in the configuration.
 
-<a name="http-1-1-loggers"></a>
-## HTTP/1.1 Loggers
+<a name="http-1-1-request-authorizers"></a>
+## HTTP/1.1 Request Authorizers
 
-Loggers allow recording of arbitrary information about requests. Destination of
-information is specific to each logger. All HTTP/1.1 loggers have a `kind`. If a
-list of loggers is provided, they each log in the order they are defined.
+Request authorizers allow arbitrary rejection or modification of requests and responses. Behavior is
+specific to each request authorizer.  All HTTP/1.1 request authorizers have a `kind`. If a
+list of request authorizers is provided, they each apply in the order they are defined.
 
 Key | Default Value | Description
 --- | ------------- | -----------
-kind | _required_ | Only [`io.l5d.k8s.istio`](#istio-logger) is currently supported.
+kind | _required_ | Only [`io.l5d.k8s.istio`](#istio-request-authorizer) is currently supported.
 
-<a name="istio-logger"></a>
-### Istio Logger
+<a name="istio-request-authorizer"></a>
+### Istio Request Authorizer
 
 kind: `io.l5d.k8s.istio`.
 
-With this logger, all HTTP requests are sent to an Istio Mixer for telemetry
+With this request authorizer, all HTTP requests are sent to an Istio Mixer for telemetry
 recording and aggregation.
 
-#### Logger Configuration:
+#### Request Authorizer Configuration:
 
 > Configuration example
 
 ```yaml
-loggers:
+requestAuthorizers:
 - kind: io.l5d.k8s.istio
   mixerHost: istio-mixer
   mixerPort: 9091

--- a/linkerd/examples/istio.yaml
+++ b/linkerd/examples/istio.yaml
@@ -16,7 +16,7 @@ routers:
     experimental: true
     discoveryHost: localhost
     apiserverHost: localhost
-  loggers:
+  requestAuthorizers:
   - kind: io.l5d.k8s.istio
     mixerHost: localhost
   servers:

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/H2Config.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/H2Config.scala
@@ -83,7 +83,7 @@ class H2Initializer extends ProtocolInitializer.Simple {
 object H2Initializer extends H2Initializer
 
 case class H2Config(
-  loggers: Option[Seq[H2RequestAuthorizerConfig]] = None,
+  requestAuthorizers: Option[Seq[H2RequestAuthorizerConfig]] = None,
   h2AccessLog: Option[String]
 ) extends RouterConfig {
 
@@ -98,12 +98,12 @@ case class H2Config(
   override val protocol: ProtocolInitializer = H2Initializer
 
   @JsonIgnore
-  private[this] def loggerParam = loggers.map { configs =>
-    val loggerStack =
+  private[this] def loggerParam = requestAuthorizers.map { configs =>
+    val authorizerStack =
       configs.foldRight[Stack[ServiceFactory[Request, Response]]](nilStack) { (config, next) =>
         config.module.toStack(next)
       }
-    H2RequestAuthorizerConfig.param.RequestAuthorizer(loggerStack)
+    H2RequestAuthorizerConfig.param.RequestAuthorizer(authorizerStack)
   }
 
   @JsonIgnore

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpConfig.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpConfig.scala
@@ -189,7 +189,7 @@ class HttpIdentifierConfigDeserializer extends JsonDeserializer[Option[Seq[HttpI
 case class HttpConfig(
   httpAccessLog: Option[String],
   @JsonDeserialize(using = classOf[HttpIdentifierConfigDeserializer]) identifier: Option[Seq[HttpIdentifierConfig]],
-  loggers: Option[Seq[HttpRequestAuthorizerConfig]],
+  requestAuthorizers: Option[Seq[HttpRequestAuthorizerConfig]],
   maxChunkKB: Option[Int],
   maxHeadersKB: Option[Int],
   maxInitialLineKB: Option[Int],
@@ -217,12 +217,12 @@ case class HttpConfig(
   )
 
   @JsonIgnore
-  private[this] val loggerParam = loggers.map { configs =>
-    val loggerStack =
+  private[this] val loggerParam = requestAuthorizers.map { configs =>
+    val authorizerStack =
       configs.foldRight[Stack[ServiceFactory[Request, Response]]](nilStack) { (config, next) =>
         config.module.toStack(next)
       }
-    HttpRequestAuthorizerConfig.param.RequestAuthorizer(loggerStack)
+    HttpRequestAuthorizerConfig.param.RequestAuthorizer(authorizerStack)
   }
 
   @JsonIgnore


### PR DESCRIPTION
RequestAuthorizer plugins are specified in the `loggers` section of the Linkerd config.  This is an inaccurate name and a historical artifact.

Rename loggers to requestAuthorizers.

Fixes #1882

Signed-off-by: Alex Leong <alex@buoyant.io>