### PR TITLE
Introduce ClientSession configuration section that provides ways to control idleTime and lifeTime of client connections.

### DIFF
--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/ClientConfig.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/ClientConfig.scala
@@ -23,6 +23,7 @@ trait ClientConfig {
   var failureAccrual: Option[FailureAccrualConfig] = None
   var requestAttemptTimeoutMs: Option[Int] = None
   var requeueBudget: Option[RetryBudgetConfig] = None
+  var clientSession: Option[ClientSessionConfig] = None
 
   @JsonIgnore
   def params(vars: Map[String, String]): Stack.Params = Stack.Params.empty
@@ -33,6 +34,7 @@ trait ClientConfig {
     .maybeWith(failFast.map(FailFastFactory.FailFast(_)))
     .maybeWith(requeueBudget)
     .maybeWith(failureAccrual.map(FailureAccrualConfig.param))
+    .maybeWith(clientSession.map(_.param))
 }
 
 case class TlsClientConfig(
@@ -73,4 +75,19 @@ case class HostConnectionPool(
     idleTime = idleTimeMs.map(_.millis).getOrElse(default.idleTime),
     maxWaiters = maxWaiters.getOrElse(default.maxWaiters)
   )
+}
+
+case class ClientSessionConfig(
+  lifeTimeMs: Option[Int],
+  idleTimeMs: Option[Int]
+) {
+  @JsonIgnore
+  private[this] val default = ExpiringService.Param.param.default
+
+  @JsonIgnore
+  def param = ExpiringService.Param(
+    lifeTime = lifeTimeMs.map(_.millis).getOrElse(default.lifeTime),
+    idleTime = idleTimeMs.map(_.millis).getOrElse(default.idleTime)
+  )
+
 }

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/ClientSessionConfigTest.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/ClientSessionConfigTest.scala
@@ -1,0 +1,80 @@
+package io.buoyant.linkerd
+
+import com.twitter.conversions.time._
+import com.twitter.finagle.Path
+import com.twitter.finagle.service.ExpiringService
+import com.twitter.util.Duration
+import io.buoyant.linkerd.Linker.Initializers
+import io.buoyant.router.StackRouter.Client.PerClientParams
+import org.scalatest.FunSuite
+
+class ClientSessionConfigTest extends FunSuite {
+
+  test("expiring service params") {
+    // Arrange
+    val config = """
+                   |routers:
+                   |- protocol: plain
+                   |  client:
+                   |    clientSession:
+                   |      idleTimeMs: 5000
+                   |      lifeTimeMs: 7000
+                   |  servers:
+                   |  - {}
+                   |""".stripMargin
+
+    // Act
+    val linker = Linker.load(config, Initializers(protocol = Seq(TestProtocol.Plain)))
+    val params = linker.routers.head.params[PerClientParams].paramsFor(Path.read("/foo"))
+    val result = params[ExpiringService.Param]
+
+    // Assert
+    assert(result.idleTime == 5.seconds)
+    assert(result.lifeTime == 7.seconds)
+  }
+
+  test("expiring service empty idle param") {
+    // Arrange
+    val config = """
+                   |routers:
+                   |- protocol: plain
+                   |  client:
+                   |    clientSession:
+                   |      lifeTimeMs: 7000
+                   |  servers:
+                   |  - {}
+                   |""".stripMargin
+
+    // Act
+    val linker = Linker.load(config, Initializers(protocol = Seq(TestProtocol.Plain)))
+    val params = linker.routers.head.params[PerClientParams].paramsFor(Path.read("/foo"))
+    val result = params[ExpiringService.Param]
+
+    // Assert
+    assert(result.idleTime == Duration.Top)
+    assert(result.lifeTime == 7.seconds)
+  }
+
+  test("expiring service empty lifetime param") {
+    // Arrange
+    val config = """
+                   |routers:
+                   |- protocol: plain
+                   |  client:
+                   |    clientSession:
+                   |      idleTimeMs: 5000
+                   |  servers:
+                   |  - {}
+                   |""".stripMargin
+
+    // Act
+    val linker = Linker.load(config, Initializers(protocol = Seq(TestProtocol.Plain)))
+    val params = linker.routers.head.params[PerClientParams].paramsFor(Path.read("/foo"))
+    val result = params[ExpiringService.Param]
+
+    // Assert
+    assert(result.idleTime == 5.seconds)
+    assert(result.lifeTime == Duration.Top)
+  }
+
+}

--- a/linkerd/docs/routers.md
+++ b/linkerd/docs/routers.md
@@ -253,8 +253,12 @@ failFast | `false` | If `true`, connection failures are punished more aggressive
 requeueBudget | see [retry budget](#retry-budget-parameters) | A [requeue budget](#retry-budget-parameters) for connection-level retries.
 failureAccrual | 5 consecutive failures | a [failure accrual policy](#failure-accrual) for all clients created by this router.
 requestAttemptTimeoutMs | no timeout | The timeout, in milliseconds, for each attempt (original or retry) of the request made by this client.
+clientSession | An empty object | see [clientSession](#client-session)
 
 #### Host Connection Pool
+
+This section defines the behavior of [watermark connection pools](https://twitter.github.io/finagle/docs/com/twitter/finagle/client/DefaultPool) on which most of the protocols are relying.
+Note that Http2 protocol uses [SingletonPool](https://github.com/twitter/finagle/blob/master/finagle-core/src/main/scala/com/twitter/finagle/pool/SingletonPool.scala) that maintains a single connection per endpoint and will not be affected by the settings in this section. 
 
 ```yaml
 client:
@@ -269,5 +273,14 @@ Key | Default Value | Description
 --- | ------------- | -----------
 minSize | `0` | The minimum number of connections to maintain to each host.
 maxSize | Int.MaxValue | The maximum number of connections to maintain to each host.
-idleTimeMs | forever | The amount of idle time for which a connection is cached in milliseconds.
+idleTimeMs | forever | The amount of idle time for which a connection is cached in milliseconds. Only applied to connections that number greater than minSize, but fewer than maxSize.
 maxWaiters | Int.MaxValue | The maximum number of connection requests that are queued when the connection concurrency exceeds maxSize.
+
+#### Client Session
+
+Configures the behavior of established client sessions.
+
+Key | Default Value | Description
+--- | ------------- | -----------
+idleTimeMs | forever | The max amount of time for which a connection is allowed to be idle. When this time exceeded the connection will close itself.
+lifeTimeMs | forever | Max lifetime of a connection.


### PR DESCRIPTION
This PR introduces a new client configuration section that allows to control `idleTime` and `lifeTime` of the client connections.


Fixes https://github.com/linkerd/linkerd/issues/1890