### PR TITLE
De-chunking response if client reguested HTTP 1.0 (#1847)

### DIFF
--- a/router/http/src/e2e/scala/io/buoyant/router/HttpEndToEndTest.scala
+++ b/router/http/src/e2e/scala/io/buoyant/router/HttpEndToEndTest.scala
@@ -298,15 +298,14 @@ class HttpEndToEndTest extends FunSuite with Awaits {
       val rsp1 = get()
       assert(err == None)
       assert(rsp1.status == Status.Ok)
-      // downstream connection is reused but upstream is not
-      assert(downstreamCounter("connects") == Some(1))
+      assert(downstreamCounter("connects") == Some(2))
       assert(serverCounter("connects") == Some(2))
 
       retriesToDo = 1
       val rsp2 = get()
       assert(err == None)
       assert(rsp2.status == Status.Ok)
-      assert(downstreamCounter("connects") == Some(1))
+      assert(downstreamCounter("connects") == Some(4))
       assert(serverCounter("connects") == Some(3))
 
     } finally {

--- a/router/http/src/test/scala/io/buoyant/router/http/ViaHeaderAppenderFilterTest.scala
+++ b/router/http/src/test/scala/io/buoyant/router/http/ViaHeaderAppenderFilterTest.scala
@@ -17,8 +17,7 @@ class ViaHeaderAppenderFilterTest extends FunSuite with Awaits {
   }
 
   val Ok10 = Service.mk[Request, Response] { req =>
-    assert(req.version == Http11)
-    assert(req.host.nonEmpty)
+    assert(req.version == Http10)
     val rsp = Response()
     rsp.version = Http10
     Future.value(rsp)
@@ -31,6 +30,13 @@ class ViaHeaderAppenderFilterTest extends FunSuite with Awaits {
     val req = Request()
     await(service(req))
     assert(req.headerMap("Via") == "1.1 linkerd")
+  }
+
+  test("adds via header to the HTTP 1.0 request if none exists") {
+    val req = Request()
+    req.version = Http10
+    await(service10(req))
+    assert(req.headerMap("Via") == "1.0 linkerd")
   }
 
   test("appends via header to the request if one already exists") {
@@ -46,6 +52,13 @@ class ViaHeaderAppenderFilterTest extends FunSuite with Awaits {
     assert(resp.headerMap("Via") == "1.1 linkerd")
   }
 
+  test("adds via header to the HTTP 1.0 response if none exists") {
+    val req = Request()
+    req.version = Http10
+    val resp = await(service10(req))
+    assert(resp.headerMap("Via") == "1.0 linkerd")
+  }
+
   test("appends via header to the response if one already exists") {
     val nextService = Service.mk[Request, Response] { req =>
       val resp: Response = Response()
@@ -57,19 +70,5 @@ class ViaHeaderAppenderFilterTest extends FunSuite with Awaits {
     val resp = await(filter(Request()))
 
     assert(resp.headerMap("Via") == "1.0 bob, 1.1 mary, 1.1 linkerd")
-  }
-
-  test("upgrades request to HTTP/1.1") {
-    val req = Request()
-    req.version = Http10
-    val resp = await(service(req))
-    assert(resp.headerMap("Via") == "1.1 linkerd")
-  }
-
-  test("upgrades response to HTTP/1.1") {
-    val req = Request()
-    val resp = await(service10(req))
-    assert(resp.version == Http11)
-    assert(resp.headerMap("Via") == "1.0 linkerd")
   }
 }


### PR DESCRIPTION
Problem
Proxy speaks HTTP 1.1 (in both directions) and it was possible to send a chunked response that the HTTP 1.0 client can't handle.

Solution
Dechunk response and send to the client in HTTP 1.0 compatible form.

Validation
Tests were done on a locally running Linkerd instance + unit tests.