### PR TITLE
Fix dedup to not leak observations

### DIFF
--- a/namer/consul/src/main/scala/io/buoyant/namer/consul/LookupCache.scala
+++ b/namer/consul/src/main/scala/io/buoyant/namer/consul/LookupCache.scala
@@ -28,7 +28,6 @@ private[consul] class LookupCache(
 
   private[this] val localDcMoniker = ".local"
 
-
   private[this] val lookupCounter = stats.counter("lookups")
   private[this] val service: StatsReceiver = stats.scope("service")
   private[this] val cachedCounter = service.counter("cached")

--- a/namer/core/src/main/scala/io/buoyant/namer/package.scala
+++ b/namer/core/src/main/scala/io/buoyant/namer/package.scala
@@ -7,9 +7,8 @@ package object namer {
     /** A Future representing the first non-pending value of this Activity */
     def toFuture: Future[T] = activity.values.toFuture.flatMap(Future.const)
 
-    def dedup: Activity[T] = {
-      val stateVar = Var(Activity.Pending, activity.states.dedup)
-      new Activity(stateVar)
-    }
+    def dedup: Activity[T] = Activity(Var.async[Activity.State[T]](Activity.Pending) { up =>
+      activity.states.dedup.respond(up.update)
+    })
   }
 }


### PR DESCRIPTION
Expiring a client does not necessarily close service discovery watches for that client.  This means, for example, that Linkerd will maintain streaming connections to the Kubernetes API for services that it is no longer routing to and has reaped.  This is due to the use of `Var.apply` in `RichActivity.dedup`.  This variant of `Var.apply` eagerly observes the underlying Event and doesn't release the observation until it is garbage collected.  From the scaladoc for `Var.apply`:

```
   /**
   * Constructs a [[Var]] from an initial value plus an event stream of
   * changes. Note that this eagerly subscribes to the event stream;
   * it is unsubscribed whenever the returned [[Var]] is collected.
   */
```

We change `RichActivity.dedup` to use `Var.async` instead of `Var.apply` in order to do proper reference counting and therefore to only observe the underlying Event while the Activity is observed.

Verified by issuing requests through Linkerd to two different Kubernetes services and then waiting for one of the clients to expire.  Using `netstat`, verify that Linkerd has only 1 connection to the Kubernetes API (previously was 2).

Signed-off-by: Alex Leong <alex@buoyant.io>