### PR TITLE
Fix "ClassCastException" in H2FrameCodec onStreamClosed

### DIFF
--- a/finagle/h2/src/main/scala/io/netty/handler/codec/http2/H2FrameCodec.scala
+++ b/finagle/h2/src/main/scala/io/netty/handler/codec/http2/H2FrameCodec.scala
@@ -37,7 +37,7 @@ class H2FrameCodec(
     }
 
     override def onStreamClosed(stream0: Http2Stream): Unit = {
-      val stream = stream0.getProperty(streamKey)
+      val stream = stream0.getProperty(streamKey).asInstanceOf[Http2FrameStream]
       if (stream != null) {
         channelCtx.fireUserEventTriggered(Http2FrameStreamEvent.stateChanged(stream).asInstanceOf[AnyRef]); ()
       }


### PR DESCRIPTION
This is a follow-up/bug-fix PR for the finagle upgrade. When a stream is closed between Linkerd and an Http/2 server, we see "ClassCastException" in Linkerd. This PR fixes that issue but properly casting a `Http2Stream` to an `Http2FrameStream` onStreamClosed

Tests were conducted with current master and this branch. The exception no longer shows up with this fix.

fixes #1905

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>