### PR TITLE
Upgrade to finagle 18.4.0

### DIFF
--- a/finagle/buoyant/src/main/scala/com/twitter/finagle/netty4/buoyant/BufferingConnectDelay.scala
+++ b/finagle/buoyant/src/main/scala/com/twitter/finagle/netty4/buoyant/BufferingConnectDelay.scala
@@ -13,8 +13,9 @@ import java.net.SocketAddress
  */
 private[finagle] class BufferingConnectDelay
   extends ChannelDuplexHandler
-  with BufferingChannelOutboundHandler
-  with ConnectPromiseDelayListeners { self =>
+  with BufferingChannelOutboundHandler { self =>
+
+  import ConnectPromiseDelayListeners._
 
   /*
    * We manage two promises:

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/ClientTest.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/ClientTest.scala
@@ -2,7 +2,7 @@ package io.buoyant.linkerd
 
 import com.twitter.finagle.Path
 import com.twitter.finagle.liveness.{FailureAccrualFactory, FailureAccrualPolicy}
-import com.twitter.finagle.loadbalancer.{DefaultBalancerFactory, FlagBalancerFactory, LoadBalancerFactory}
+import com.twitter.finagle.loadbalancer.{FlagBalancerFactory, LoadBalancerFactory}
 import com.twitter.finagle.ssl.client.SslClientConfiguration
 import com.twitter.finagle.transport.Transport
 import com.twitter.util.Duration

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/LoadBalancerTest.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/LoadBalancerTest.scala
@@ -1,6 +1,6 @@
 package io.buoyant.linkerd
 
-import com.twitter.finagle.loadbalancer.{DefaultBalancerFactory, FlagBalancerFactory, LoadBalancerFactory}
+import com.twitter.finagle.loadbalancer.{FlagBalancerFactory, LoadBalancerFactory}
 import com.twitter.finagle.Path
 import io.buoyant.router.StackRouter.Client.PerClientParams
 import org.scalatest.FunSuite

--- a/namer/consul/src/main/scala/io/buoyant/namer/consul/LookupCache.scala
+++ b/namer/consul/src/main/scala/io/buoyant/namer/consul/LookupCache.scala
@@ -28,7 +28,6 @@ private[consul] class LookupCache(
 
   private[this] val localDcMoniker = ".local"
 
-
   private[this] val lookupCounter = stats.counter("lookups")
   private[this] val service: StatsReceiver = stats.scope("service")
   private[this] val cachedCounter = service.counter("cached")

--- a/namer/consul/src/test/scala/io/buoyant/namer/consul/ConsulNamerTest.scala
+++ b/namer/consul/src/test/scala/io/buoyant/namer/consul/ConsulNamerTest.scala
@@ -522,13 +522,13 @@ class ConsulNamerTest extends FunSuite with Awaits {
     @volatile var datacenterIsUp = false
     class TestApi extends CatalogApi(null, "/v1") {
       override def serviceNodes(
-         serviceName: String,
-         datacenter: Option[String],
-         tag: Option[String],
-         blockingIndex: Option[String],
-         consistency: Option[ConsistencyMode],
-         retry: Boolean
-       ): Future[Indexed[Seq[ServiceNode]]] = blockingIndex match {
+        serviceName: String,
+        datacenter: Option[String],
+        tag: Option[String],
+        blockingIndex: Option[String],
+        consistency: Option[ConsistencyMode],
+        retry: Boolean
+      ): Future[Indexed[Seq[ServiceNode]]] = blockingIndex match {
         case Some("0") | None =>
           if (datacenterIsUp)
             datacenterIsAvailable before Future.value(
@@ -561,12 +561,10 @@ class ConsulNamerTest extends FunSuite with Awaits {
       state = s
     }
 
-
     withClue("before datacenter is available") {
       eventually {
         assert(state == Activity.Ok(NameTree.Neg))
       }
-
 
       datacenterIsAvailable.setDone()
       eventually {

--- a/project/Base.scala
+++ b/project/Base.scala
@@ -4,7 +4,7 @@ import sbt.Keys._
 import complete.Parsers.spaceDelimited
 import sbtassembly.AssemblyKeys._
 import sbtassembly.AssemblyPlugin.assemblySettings
-import sbtassembly.MergeStrategy
+import sbtassembly.{AssemblyUtils, MergeStrategy}
 import sbtdocker._
 import sbtdocker.DockerKeys._
 import sbtdocker.DockerSettings.baseDockerSettings
@@ -133,6 +133,26 @@ class Base extends Build {
        |""".stripMargin.split("\n").toSeq
 
   val nodeModulesRE = ".*/node_modules/.*".r
+
+  // This is a workaround for https://github.com/twitter/finagle/issues/688 and should be removed
+  // once that issue is fixed.
+  val libthriftMergeStrategy = new MergeStrategy {
+    override def name: String = "libthrift-merge-strategy"
+    override def apply(
+      tempDir: File,
+      path: String,
+      files: Seq[File]
+    ): Either[String, Seq[(File, String)]] = {
+      Right {
+        files.find { f =>
+          AssemblyUtils.sourceOfFileForMerge(tempDir, f)._1.getName == "libthrift-0.10.0.jar"
+        }.map { f =>
+          f -> path
+        }.toSeq
+      }
+    }
+  }
+
   val appAssemblySettings = assemblySettings ++ Seq(
     assemblyExecScript := defaultExecScript,
     assemblyOption in assembly := (assemblyOption in assembly).value.copy(
@@ -146,6 +166,7 @@ class Base extends Build {
       case "BUILD" => MergeStrategy.discard
       case "com/twitter/common/args/apt/cmdline.arg.info.txt.1" => MergeStrategy.discard
       case "META-INF/io.netty.versions.properties" => MergeStrategy.last
+      case path if path.startsWith("org/apache/thrift/protocol") => libthriftMergeStrategy
       case path => (assemblyMergeStrategy in assembly).value(path)
     }
   )

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -8,14 +8,14 @@ object Deps {
 
   // process lifecycle
   val twitterServer =
-    ("com.twitter" %% "twitter-server" % "1.32.0")
+    ("com.twitter" %% "twitter-server" % "18.4.0")
       .exclude("com.twitter", "finagle-zipkin_2.12")
 
   def twitterUtil(mod: String) =
-    "com.twitter" %% s"util-$mod" % "18.2.0"
+    "com.twitter" %% s"util-$mod" % "18.4.0"
   // networking
   def finagle(mod: String) =
-    "com.twitter" %% s"finagle-$mod" % "18.2.0"
+    "com.twitter" %% s"finagle-$mod" % "18.4.0"
 
   def netty4(mod: String) =
     "io.netty" % s"netty-$mod" % "4.1.16.Final"

--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -218,7 +218,7 @@ object LinkerdBuild extends Base {
       .dependsOn(admin, core, Router.core)
 
     val zipkin = projectDir("telemetry/zipkin")
-      .withTwitterLibs(Deps.finagle("zipkin-core"), Deps.finagle("zipkin"))
+      .withTwitterLibs(Deps.finagle("zipkin-core"), Deps.finagle("zipkin-scribe"))
         .settings(Seq(scalacOptions -= "-Xfatal-warnings"))
       .dependsOn(core, Router.core)
       .withTests()

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -18,7 +18,7 @@ addSbtPlugin("com.eed3si9n"      % "sbt-assembly"  % "0.14.1")
 addSbtPlugin("se.marcuslonnberg" % "sbt-docker"    % "1.4.1")
 
 // scrooge
-addSbtPlugin("com.twitter" %% "scrooge-sbt-plugin" % "18.2.0")
+addSbtPlugin("com.twitter" %% "scrooge-sbt-plugin" % "18.4.0")
 
 // microbenchmarking for tests.
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.27")


### PR DESCRIPTION
Note that this includes a workaround to https://github.com/twitter/finagle/issues/688 for constructing the assembly jar.  We should remove that workaround once https://github.com/twitter/finagle/issues/688 is fixed.

Signed-off-by: Alex Leong <alex@buoyant.io>