### PR TITLE
Add TTL to inactive cache (#1779)

### DIFF
--- a/namerd/docs/interface.md
+++ b/namerd/docs/interface.md
@@ -41,10 +41,10 @@ Key | Default Value | Description
 -------------- | -------------- | --------------
 bindingCacheActive | `1000` | The size of the binding active cache.
 bindingCacheInactive | `100` | The size of the binding inactive cache.
-bindingCacheInactiveTTLSecs | `604800` | The amount of time, in seconds, to keep objects in the binding inactive cache before expiring them.
+bindingCacheInactiveTTLSecs | `600` | The amount of time, in seconds, to keep objects in the binding inactive cache before expiring them.
 addrCacheActive | `1000` | The size of the address active cache.
 addrCacheInactive | `100` | The size of the address inactive cache.
-addrCacheInactiveTTLSecs | `604800` | The amount of time, in seconds, to keep objects in the address inactive cache before expiring them.
+addrCacheInactiveTTLSecs | `600` | The amount of time, in seconds, to keep objects in the address inactive cache before expiring them.
 
 ## gRPC Mesh Interface
 

--- a/namerd/docs/interface.md
+++ b/namerd/docs/interface.md
@@ -41,8 +41,10 @@ Key | Default Value | Description
 -------------- | -------------- | --------------
 bindingCacheActive | `1000` | The size of the binding active cache.
 bindingCacheInactive | `100` | The size of the binding inactive cache.
+bindingCacheInactiveTTLSecs | `604800` | The amount of time, in seconds, to keep objects in the binding inactive cache before expiring them.
 addrCacheActive | `1000` | The size of the address active cache.
 addrCacheInactive | `100` | The size of the address inactive cache.
+addrCacheInactiveTTLSecs | `604800` | The amount of time, in seconds, to keep objects in the address inactive cache before expiring them.
 
 ## gRPC Mesh Interface
 

--- a/namerd/iface/interpreter-thrift/src/main/scala/io/buoyant/namerd/iface/ObserverCache.scala
+++ b/namerd/iface/interpreter-thrift/src/main/scala/io/buoyant/namerd/iface/ObserverCache.scala
@@ -1,10 +1,12 @@
 package io.buoyant.namerd.iface
 
-import com.google.common.cache.{CacheBuilder, RemovalListener, RemovalNotification}
+import java.util.concurrent.TimeUnit.SECONDS
+import java.util.concurrent.{Callable, ConcurrentHashMap}
+
+import com.google.common.cache.{Cache, CacheBuilder, RemovalNotification}
 import com.twitter.finagle.stats.StatsReceiver
 import com.twitter.util.{Return, Throw, Try}
 import io.buoyant.namerd.iface.ThriftNamerInterface.Observer
-import java.util.concurrent.{Callable, ConcurrentHashMap}
 
 class MaximumObservationsReached(maxObservations: Int)
   extends Exception(s"The maximum number of concurrent observations has been reached ($maxObservations)")
@@ -18,9 +20,9 @@ class MaximumObservationsReached(maxObservations: Int)
  *
  * The inactive cache is for Observers without outstanding requests against them.  These Observers
  * are kept open while in the inactive cache in case they receive a request and need to be moved
- * to the active cache.  The inactive cache has LRU eviction and Observers are closed upon
- * eviction.  Since Observers in the inactive cache have no outstanding requests against them,
- * this is safe to do.
+ * to the active cache. The inactive cache has LRU and time-based eviction and Observers are
+ * closed upon eviction.  Since Observers in the inactive cache have no outstanding requests against
+ * them, this is safe to do.
  *
  * When get is called, the Observer for that key is moved to the active cache if it exists or
  * created and placed in the active cache if it does not exist.  When the value of an Observer
@@ -32,11 +34,14 @@ class MaximumObservationsReached(maxObservations: Int)
  *                       instead.
  * @param inactiveCapacity The maximum size of the inactive cache.  LRU eviction is used to
  *                         maintain this constraint.
+ * @param inactiveTTLSecs The amount of time, in seconds, to keep observer in inactive cache before
+ *                        expiring them.
  * @param mkObserver The function to use to create new Observers if they are not in either cache.
  */
 class ObserverCache[K <: AnyRef, T](
   activeCapacity: Int,
   inactiveCapacity: Int,
+  inactiveTTLSecs: Int,
   stats: StatsReceiver,
   mkObserver: K => Observer[T]
 ) {
@@ -56,12 +61,13 @@ class ObserverCache[K <: AnyRef, T](
   private[this] val activeCache = new ConcurrentHashMap[K, Observer[T]]
   private[this] val inactiveCache = CacheBuilder.newBuilder()
     .maximumSize(inactiveCapacity)
-    .removalListener(new RemovalListener[K, Observer[T]] {
-      override def onRemoval(notification: RemovalNotification[K, Observer[T]]): Unit =
+    .expireAfterAccess(inactiveTTLSecs, SECONDS)
+    .removalListener(
+      (notification: RemovalNotification[K, Observer[T]]) =>
         if (notification.wasEvicted) {
           val _ = notification.getValue.close()
         }
-    })
+    )
     .build[K, Observer[T]]()
 
   private[this] val activeSize = stats.addGauge("active")(activeCache.size)
@@ -92,4 +98,9 @@ class ObserverCache[K <: AnyRef, T](
     }
     )
   }
+
+  // Only for testing purpose
+  // Caches built with CacheBuilder do not perform cleanup instantly after a value expires
+  // https://github.com/google/guava/wiki/CachesExplained#when-does-cleanup-happen
+  private[iface] def inactiveCacheCleanup() = inactiveCache.cleanUp()
 }

--- a/namerd/iface/interpreter-thrift/src/main/scala/io/buoyant/namerd/iface/ThriftInterpreterInterfaceConfig.scala
+++ b/namerd/iface/interpreter-thrift/src/main/scala/io/buoyant/namerd/iface/ThriftInterpreterInterfaceConfig.scala
@@ -2,19 +2,15 @@ package io.buoyant.namerd.iface
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.twitter.finagle.stats.StatsReceiver
-import com.twitter.finagle.{Namer, Path, Stack, Thrift, ThriftMux}
+import com.twitter.finagle.{Namer, Path, Stack, ThriftMux}
 import com.twitter.finagle.naming.NameInterpreter
 import com.twitter.finagle.param
 import com.twitter.scrooge.ThriftService
-import com.twitter.util.Duration
-import com.twitter.util.TimeConversions._
 import io.buoyant.namerd.iface.ThriftNamerInterface.LocalStamper
 import io.buoyant.namerd._
 import java.net.{InetAddress, InetSocketAddress}
 
 import com.twitter.finagle.tracing.NullTracer
-
-import scala.util.Random
 
 case class ThriftInterpreterInterfaceConfig(
   cache: Option[CapacityConfig] = None
@@ -65,15 +61,19 @@ case class ThriftServable(addr: InetSocketAddress, iface: ThriftService, params:
 case class CapacityConfig(
   bindingCacheActive: Option[Int] = None,
   bindingCacheInactive: Option[Int] = None,
+  bindingCacheInactiveTTLSecs: Option[Int] = None,
   addrCacheActive: Option[Int] = None,
-  addrCacheInactive: Option[Int] = None
+  addrCacheInactive: Option[Int] = None,
+  addrCacheInactiveTTLSecs: Option[Int] = None
 ) {
   private[this] val default = ThriftNamerInterface.Capacity.default
 
   def capacity = ThriftNamerInterface.Capacity(
     bindingCacheActive = bindingCacheActive.getOrElse(default.bindingCacheActive),
     bindingCacheInactive = bindingCacheInactive.getOrElse(default.bindingCacheInactive),
+    bindingCacheInactiveTTLSecs = bindingCacheInactiveTTLSecs.getOrElse(default.bindingCacheInactiveTTLSecs),
     addrCacheActive = addrCacheActive.getOrElse(default.addrCacheActive),
-    addrCacheInactive = addrCacheInactive.getOrElse(default.addrCacheInactive)
+    addrCacheInactive = addrCacheInactive.getOrElse(default.addrCacheInactive),
+    addrCacheInactiveTTLSecs = addrCacheInactiveTTLSecs.getOrElse(default.addrCacheInactiveTTLSecs)
   )
 }

--- a/namerd/iface/interpreter-thrift/src/test/scala/io/buoyant/namerd/iface/ObserverCacheTest.scala
+++ b/namerd/iface/interpreter-thrift/src/test/scala/io/buoyant/namerd/iface/ObserverCacheTest.scala
@@ -1,12 +1,14 @@
 package io.buoyant.namerd.iface
 
-import com.twitter.finagle.stats.{InMemoryStatsReceiver, NullStatsReceiver}
+import com.twitter.finagle.stats.InMemoryStatsReceiver
 import com.twitter.io.Buf
 import com.twitter.util._
-import io.buoyant.namerd.iface.ThriftNamerInterface.{Stamp, Observer}
+import io.buoyant.namerd.iface.ThriftNamerInterface.{Observer, Stamp}
 import org.scalatest.FunSuite
+import org.scalatest.concurrent.Eventually
+import org.scalatest.time.{Seconds, Span}
 
-class ObserverCacheTest extends FunSuite {
+class ObserverCacheTest extends FunSuite with Eventually {
 
   case class TestObserver[T](obs: Observer[T], event: Event[Try[T]] with Witness[Try[T]], closed: Var[Boolean])
 
@@ -43,7 +45,7 @@ class ObserverCacheTest extends FunSuite {
     var count = 0
 
     val stats = new InMemoryStatsReceiver
-    val cache = new ObserverCache[String, String](1, 0, stats, { _: String =>
+    val cache = new ObserverCache[String, String](1, 0, Int.MaxValue, stats, { _: String =>
       count += 1
       testObserver[String]().obs
     })
@@ -60,7 +62,7 @@ class ObserverCacheTest extends FunSuite {
   test("observer cache limits active observations") {
 
     val stats = new InMemoryStatsReceiver
-    val cache = new ObserverCache[String, String](2, 0, stats, _ => testObserver().obs)
+    val cache = new ObserverCache[String, String](2, 0, Int.MaxValue, stats, _ => testObserver().obs)
 
     // insert "one" and "two" into the active cache
     assert(cache.get("one").isReturn)
@@ -78,7 +80,7 @@ class ObserverCacheTest extends FunSuite {
     val two = testObserver[String]()
 
     val stats = new InMemoryStatsReceiver
-    val cache = new ObserverCache[String, String](1, 1, stats, {
+    val cache = new ObserverCache[String, String](1, 1, Int.MaxValue, stats, {
       case "one" => one.obs
       case "two" => two.obs
     })
@@ -103,7 +105,7 @@ class ObserverCacheTest extends FunSuite {
     val one = testObserver[String]()
 
     val stats = new InMemoryStatsReceiver
-    val cache = new ObserverCache[String, String](1, 1, stats, {
+    val cache = new ObserverCache[String, String](1, 1, Int.MaxValue, stats, {
       case "one" => one.obs
     })
 
@@ -133,7 +135,7 @@ class ObserverCacheTest extends FunSuite {
     val two = testObserver[String]()
 
     val stats = new InMemoryStatsReceiver
-    val cache = new ObserverCache[String, String](2, 1, stats, {
+    val cache = new ObserverCache[String, String](2, 1, Int.MaxValue, stats, {
       case "one" => one.obs
       case "two" => two.obs
     })
@@ -158,5 +160,35 @@ class ObserverCacheTest extends FunSuite {
     assert(one.closed.sample == true)
     assert(activeSize(stats) == 0)
     assert(inactiveSize(stats) == 1)
+  }
+
+  test("observer cache removes inactive observations after ttl time") {
+
+    val one = testObserver[String]()
+
+    val stats = new InMemoryStatsReceiver
+    val cache = new ObserverCache[String, String](1, 5, 1, stats, {
+      case "one" => one.obs
+    })
+
+    // insert "one" into the active cache
+    assert(cache.get("one").get eq one.obs)
+    assert(activeSize(stats) == 1)
+    assert(inactiveSize(stats) == 0)
+    // update deactivates "one"
+    one.event.notify(Return("foo"))
+
+    assert(activeSize(stats) == 0)
+    assert(inactiveSize(stats) == 1)
+    assert(!one.closed.sample)
+
+    implicit val patienceConfig: PatienceConfig = PatienceConfig(Span(3, Seconds), Span(1, Seconds))
+
+    eventually {
+      cache.inactiveCacheCleanup()
+      assert(activeSize(stats) == 0)
+      assert(inactiveSize(stats) == 0)
+      assert(one.closed.sample)
+    }
   }
 }

--- a/namerd/iface/interpreter-thrift/src/test/scala/io/buoyant/namerd/iface/ThriftInterpreterInterfaceConfigTest.scala
+++ b/namerd/iface/interpreter-thrift/src/test/scala/io/buoyant/namerd/iface/ThriftInterpreterInterfaceConfigTest.scala
@@ -11,6 +11,7 @@ class ThriftInterpreterInterfaceConfigTest extends FunSuite {
       |cache:
       |  bindingCacheActive: 5000
       |  bindingCacheInactive: 1000
+      |  bindingCacheInactiveTTLSecs: 3600
       |  addrCacheActive: 6000
     """.stripMargin
 
@@ -23,8 +24,10 @@ class ThriftInterpreterInterfaceConfigTest extends FunSuite {
     val capacity = config.cache.get.capacity
     assert(capacity.bindingCacheActive == 5000)
     assert(capacity.bindingCacheInactive == 1000)
+    assert(capacity.bindingCacheInactiveTTLSecs == 3600)
     assert(capacity.addrCacheActive == 6000)
     assert(capacity.addrCacheInactive == ThriftNamerInterface.Capacity.default.addrCacheInactive)
+    assert(capacity.addrCacheInactiveTTLSecs == ThriftNamerInterface.Capacity.default.addrCacheInactiveTTLSecs)
   }
 
   test("tls") {


### PR DESCRIPTION
Problem
Once Namerd watches a name, that observation is cached and kept open indefinitely.

Solution
Add TTL parameter to interface config.

Validation
Tests were done on a locally running Linkerd instance.

Signed-off-by: Michal Mrozek <michalmrozek@hotmail.com>