### PR TITLE
Add serverCaChainPath server TLS config setting

### DIFF
--- a/finagle/buoyant/src/main/scala/com/twitter/finagle/buoyant/TlsServerConfig.scala
+++ b/finagle/buoyant/src/main/scala/com/twitter/finagle/buoyant/TlsServerConfig.scala
@@ -8,6 +8,7 @@ import java.io.File
 
 case class TlsServerConfig(
   certPath: String,
+  serverCaChainPath: Option[String],
   keyPath: String,
   caCertPath: Option[String] = None,
   ciphers: Option[Seq[String]] = None,
@@ -34,9 +35,18 @@ case class TlsServerConfig(
       case _ => FClientAuth.Off
     }
 
+    val keyCredentials = serverCaChainPath match {
+      case Some(serverCaChain) => KeyCredentials.CertKeyAndChain(
+        new File(certPath),
+        new File(keyPath),
+        new File(serverCaChain)
+      )
+      case None => KeyCredentials.CertAndKey(new File(certPath), new File(keyPath))
+    }
+
     Stack.Params.empty + Transport.ServerSsl(Some(SslServerConfiguration(
       clientAuth = clientAuth,
-      keyCredentials = KeyCredentials.CertAndKey(new File(certPath), new File(keyPath)),
+      keyCredentials = keyCredentials,
       trustCredentials = trust,
       cipherSuites = cipherSuites,
       applicationProtocols = appProtocols

--- a/linkerd/docs/client_tls.md
+++ b/linkerd/docs/client_tls.md
@@ -22,6 +22,7 @@ Key | Default Value | Description
 --- | ------------- | -----------
 enabled | true | Enable TLS on outgoing connections.
 certPath | _required_ | File path to the TLS certificate file.
+serverCaChainPath | none | Path to a file containing a CA certificate chain to support the server certificate.
 keyPath | _required_ | File path to the TLS key file.
 requireClientAuth | false | If true, only accept requests with valid client certificates.
 caCertPath | none | File path to the CA cert to validate the client certificates.

--- a/linkerd/examples/tls.yaml
+++ b/linkerd/examples/tls.yaml
@@ -22,3 +22,4 @@ routers:
     tls:
       certPath: /foo/cert.pem
       keyPath: /foo/key.pem
+      serverCaChainPath: /foo/ca-chain.pem


### PR DESCRIPTION
There is no way to specify a supporting CA certificate chain to support a server certificate in a Linkerd server.  If a certificate chain is provided in the file specified by `certPath`, only the first certificate in the file is served.

Add a new server TLS config option `serverCaChainPath`.  This allows you to provide a supporting CA certificate chain for the server cert.

Fixes #1926

Signed-off-by: Alex Leong <alex@buoyant.io>