### PR TITLE
Fixes concurrency issue in ForwardClientCertFilter

### DIFF
--- a/router/base-http/src/main/scala/io/buoyant/router/http/ForwardClientCertFilter.scala
+++ b/router/base-http/src/main/scala/io/buoyant/router/http/ForwardClientCertFilter.scala
@@ -13,6 +13,7 @@ class ForwardClientCertFilter[Req, H: HeadersLike, Rep](implicit requestLike: Re
   val GeneralNameTypeUri = 6
   val GeneralNameTypeDns = 2
 
+  // MessageDigest is not thread-safe, so using ThreadLocal to avoid concurrency issues.
   val digest = ThreadLocal.withInitial[MessageDigest](() => MessageDigest.getInstance("SHA-256"));
 
   def apply(req: Req, svc: Service[Req, Rep]): Future[Rep] = {

--- a/router/base-http/src/main/scala/io/buoyant/router/http/ForwardClientCertFilter.scala
+++ b/router/base-http/src/main/scala/io/buoyant/router/http/ForwardClientCertFilter.scala
@@ -13,9 +13,9 @@ class ForwardClientCertFilter[Req, H: HeadersLike, Rep](implicit requestLike: Re
   val GeneralNameTypeUri = 6
   val GeneralNameTypeDns = 2
 
-  val digest: MessageDigest = MessageDigest.getInstance("SHA-256")
-
   def apply(req: Req, svc: Service[Req, Rep]): Future[Rep] = {
+    val digest: MessageDigest = MessageDigest.getInstance("SHA-256")
+
     Transport.peerCertificate.foreach(clientCert => {
       val clientCertHeader = new mutable.StringBuilder(128)
 


### PR DESCRIPTION
Problem
Server-side l5d will see rare (<1%) ArrayIndexOutOfBoundsException errors when servicing high concurrency (>couple hundred req/sec) TLS traffic with the ForwardClientCertFilter enabled. Likely cause is use of a singleton MessageDigest instance by multiple threads, which is known to be incorrect usage.

Solution
Move the unsafe MessageDigest declartion into the method block.

Validation
Ran the tests for regression.

Fixes #1936

Signed-off-by: Shakti Das shaktiprakash.das@salesforce.com