### PR TITLE
enable TLS protocols configuration

### DIFF
--- a/finagle/buoyant/src/main/scala/com/twitter/finagle/buoyant/TlsClientConfig.scala
+++ b/finagle/buoyant/src/main/scala/com/twitter/finagle/buoyant/TlsClientConfig.scala
@@ -28,7 +28,6 @@ case class TlsClientConfig(
         keyCredentials = keyCredentials(clientAuth),
         protocols = enabledProtocols.map(Protocols.Enabled).getOrElse(Protocols.Unspecified)
       )
-      val factory = Netty4ClientEngineFactory()
       Stack.Params.empty + Transport.ClientSsl(Some(tlsConfig)) +
         SslClientEngineFactory.Param(Netty4ClientEngineFactory())
 

--- a/finagle/buoyant/src/main/scala/com/twitter/finagle/buoyant/TlsServerConfig.scala
+++ b/finagle/buoyant/src/main/scala/com/twitter/finagle/buoyant/TlsServerConfig.scala
@@ -12,7 +12,8 @@ case class TlsServerConfig(
   keyPath: String,
   caCertPath: Option[String] = None,
   ciphers: Option[Seq[String]] = None,
-  requireClientAuth: Option[Boolean] = None
+  requireClientAuth: Option[Boolean] = None,
+  protocols: Option[Seq[String]] = None
 ) {
   def params(
     alpnProtocols: Option[Seq[String]],
@@ -49,7 +50,8 @@ case class TlsServerConfig(
       keyCredentials = keyCredentials,
       trustCredentials = trust,
       cipherSuites = cipherSuites,
-      applicationProtocols = appProtocols
+      applicationProtocols = appProtocols,
+      protocols = protocols.map(Protocols.Enabled).getOrElse(Protocols.Unspecified)
     ))) + SslServerEngineFactory.Param(sslServerEngine)
   }
 }

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/ClientConfig.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/ClientConfig.scala
@@ -42,7 +42,8 @@ case class TlsClientConfig(
   disableValidation: Option[Boolean],
   commonName: Option[String],
   trustCerts: Option[Seq[String]] = None,
-  clientAuth: Option[ClientAuth] = None
+  clientAuth: Option[ClientAuth] = None,
+  protocols: Option[Seq[String]] = None
 ) {
   require(
     !disableValidation.getOrElse(false) || clientAuth.isEmpty,
@@ -54,7 +55,8 @@ case class TlsClientConfig(
       disableValidation,
       commonName.map(PathMatcher.substitute(vars, _)),
       trustCerts,
-      clientAuth
+      clientAuth,
+      protocols
     ).params
 }
 

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/ClientConfigTest.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/ClientConfigTest.scala
@@ -3,6 +3,7 @@ package io.buoyant.linkerd
 import com.fasterxml.jackson.databind.JsonMappingException
 import io.buoyant.config.Parser
 import io.buoyant.test.FunSuite
+import org.scalatest.Matchers._
 
 class ClientConfigTest extends FunSuite {
 
@@ -35,6 +36,21 @@ class ClientConfigTest extends FunSuite {
       """.stripMargin
     Parser.objectMapper(yaml, Nil).readValue[TlsClientConfig](yaml)
 
+  }
+
+  test("should parse tls protocols") {
+    val yaml =
+      """
+        |commonName: foo
+        |clientAuth:
+        |  certPath: cert.pem
+        |  keyPath: key.pem
+        |protocols:
+        |  - TLSv1.0
+        |  - TLSv1.2
+      """.stripMargin
+    val config = Parser.objectMapper(yaml, Nil).readValue[TlsClientConfig](yaml)
+    config.protocols.get should contain only ("TLSv1.0", "TLSv1.2")
   }
 
 }

--- a/linkerd/docs/client_tls.md
+++ b/linkerd/docs/client_tls.md
@@ -26,6 +26,7 @@ serverCaChainPath | none | Path to a file containing a CA certificate chain to s
 keyPath | _required_ | File path to the TLS key file.
 requireClientAuth | false | If true, only accept requests with valid client certificates.
 caCertPath | none | File path to the CA cert to validate the client certificates.
+protocols | unspecified | The list of TLS protocols to enable (TLSv1.2)
 
 See [Transparent TLS with Linkerd](https://blog.buoyant.io/2016/03/24/transparent-tls-with-linkerd/) for more on how to generate certificate
 and key files.
@@ -45,6 +46,8 @@ routers:
       clientAuth:
         certPath: /certificates/cert.pem
         keyPath: /certificates/key.pem
+      protocols:
+      - TLSv1.2
 ```
 
 In order to send outgoing tls traffic, the tls parameter must be defined as a
@@ -59,6 +62,7 @@ disableValidation | false                                      | Enable this to 
 commonName        | _required_ unless disableValidation is set | The common name to use for all TLS requests.
 trustCerts        | empty list                                 | A list of file paths of CA certs to use for common name validation.
 clientAuth        | none                                       | A client auth object used to sign requests.
+protocols         | unspecified                                | The list of TLS protocols to enable
 
 If present, a client auth object must contain two properties:
 
@@ -87,6 +91,8 @@ routers:
         clientAuth:
           certPath: /certificates/cert.pem
           keyPath: /certificates/key.pem
+        protocols:
+        - TLSv1.2          
 ```
 
 ### Client TLS and transformers

--- a/linkerd/protocol/http/src/e2e/scala/io/buoyant/linkerd/protocol/HttpTlsEndToEndTest.scala
+++ b/linkerd/protocol/http/src/e2e/scala/io/buoyant/linkerd/protocol/HttpTlsEndToEndTest.scala
@@ -4,14 +4,13 @@ import java.io.{File, InputStream}
 import java.net.InetSocketAddress
 import java.nio.file.StandardCopyOption.REPLACE_EXISTING
 import java.nio.file.{Files, Paths}
-
 import com.twitter.finagle.buoyant.TlsClientConfig
 import com.twitter.finagle.http.{Method, Status, param => _, _}
-import com.twitter.finagle.ssl._
 import com.twitter.finagle.ssl.client.SslClientConfiguration
 import com.twitter.finagle.ssl.server.SslServerConfiguration
+import com.twitter.finagle.ssl.{CipherSuites, ClientAuth, KeyCredentials, Protocols, TrustCredentials}
 import com.twitter.finagle.transport.Transport
-import com.twitter.finagle.{Http => FinagleHttp, Status => _, http => _, _}
+import com.twitter.finagle.{Http => FinagleHttp, http => _, Status => _, _}
 import com.twitter.util._
 import io.buoyant.config.Parser
 import io.buoyant.test.{BudgetedRetries, FunSuite}
@@ -78,7 +77,8 @@ class HttpTlsEndToEndTest extends FunSuite with BudgetedRetries {
       FinagleHttp.server
         .configured(Transport.ServerSsl(Some(SslServerConfiguration(
           keyCredentials = KeyCredentials.CertAndKey(srvCert, srvKey),
-          cipherSuites = CipherSuites.Enabled(Seq("ECDHE-RSA-AES128-GCM-SHA256"))
+          cipherSuites = CipherSuites.Enabled(Seq("ECDHE-RSA-AES128-GCM-SHA256")),
+          protocols = Protocols.Enabled(Seq("TLSv1.2"))
         ))))
         .serve(":*", service)
     }
@@ -94,6 +94,7 @@ class HttpTlsEndToEndTest extends FunSuite with BudgetedRetries {
       val tls = Transport.ClientSsl(Some(SslClientConfiguration(
         hostname = Some("linkerd-tls-e2e"),
         trustCredentials = TrustCredentials.CertCollection(caCert),
+        cipherSuites = CipherSuites.Enabled(Seq("ECDHE-RSA-AES128-GCM-SHA256")),
         protocols = Protocols.Enabled(Seq("TLSv1.2"))
       )))
       FinagleHttp.client

--- a/linkerd/protocol/http/src/e2e/scala/io/buoyant/linkerd/protocol/HttpTlsEndToEndTest.scala
+++ b/linkerd/protocol/http/src/e2e/scala/io/buoyant/linkerd/protocol/HttpTlsEndToEndTest.scala
@@ -4,11 +4,12 @@ import java.io.{File, InputStream}
 import java.net.InetSocketAddress
 import java.nio.file.StandardCopyOption.REPLACE_EXISTING
 import java.nio.file.{Files, Paths}
+
 import com.twitter.finagle.buoyant.TlsClientConfig
 import com.twitter.finagle.http.{Method, Status, param => _, _}
+import com.twitter.finagle.ssl._
 import com.twitter.finagle.ssl.client.SslClientConfiguration
 import com.twitter.finagle.ssl.server.SslServerConfiguration
-import com.twitter.finagle.ssl.{ClientAuth, KeyCredentials, TrustCredentials}
 import com.twitter.finagle.transport.Transport
 import com.twitter.finagle.{Http => FinagleHttp, Status => _, http => _, _}
 import com.twitter.util._
@@ -56,6 +57,44 @@ class HttpTlsEndToEndTest extends FunSuite with BudgetedRetries {
       val tls = Transport.ClientSsl(Some(SslClientConfiguration(
         hostname = Some("linkerd-tls-e2e"),
         trustCredentials = TrustCredentials.CertCollection(caCert)
+      )))
+      FinagleHttp.client
+        .configured(tls)
+        .newService(srvName, id.show)
+    }
+
+    val req = Request(Method.Get, "/a/parf")
+    val rsp =
+      try await(client(req))
+      finally await(client.close().before(srv.close()))
+
+    assert(rsp.status == Status.Ok)
+  }
+
+  test("client/server works with TLSv1.2 only cipher", Retryable) {
+    val srv = {
+      val srvCert = loadPem("linkerd-tls-e2e-cert")
+      val srvKey = loadPem("linkerd-tls-e2e-key")
+      FinagleHttp.server
+        .configured(Transport.ServerSsl(Some(SslServerConfiguration(
+          keyCredentials = KeyCredentials.CertAndKey(srvCert, srvKey),
+          cipherSuites = CipherSuites.Enabled(Seq("ECDHE-RSA-AES128-GCM-SHA256"))
+        ))))
+        .serve(":*", service)
+    }
+
+    val client = {
+      val isa = srv.boundAddress.asInstanceOf[InetSocketAddress]
+      val addr = Address(isa)
+      val id = Path.read(s"/$$/inet/${isa.getAddress.getHostAddress}/${isa.getPort}")
+      val srvName = Name.Bound(Var.value(Addr.Bound(addr)), id)
+
+      val caCert = loadPem("cacert")
+
+      val tls = Transport.ClientSsl(Some(SslClientConfiguration(
+        hostname = Some("linkerd-tls-e2e"),
+        trustCredentials = TrustCredentials.CertCollection(caCert),
+        protocols = Protocols.Enabled(Seq("TLSv1.2"))
       )))
       FinagleHttp.client
         .configured(tls)


### PR DESCRIPTION
Hi,

I started using Linkerd and noticed the server TLS configuration provides an option for configuring the list of allowed ciphers. Unfortunately if one configures the Linkerd router with a strong cipher which is TLS 1.2 specific (like ECDHE-RSA-AES128-GCM-SHA256) the Linkerd client would fail to connect to it as it doesn't attempt to use TLSv1.2.

This patch adds an integration test which demonstrates that configuring a finagle server end with a TLSv1.2 specific cipher  and the client with the TLSv1.2 protocol the connection is successful as well as enables the protocol configuration option for both server and client ends.

Dan