### PR TITLE
inject stack.param into announcer init flow

### DIFF
--- a/linkerd/announcer/serversets/src/main/scala/io/buoyant/linkerd/announcer/serversets/ServersetsAnnouncerInitializer.scala
+++ b/linkerd/announcer/serversets/src/main/scala/io/buoyant/linkerd/announcer/serversets/ServersetsAnnouncerInitializer.scala
@@ -1,7 +1,7 @@
 package io.buoyant.linkerd.announcer.serversets
 
 import com.fasterxml.jackson.annotation.JsonIgnore
-import com.twitter.finagle.Path
+import com.twitter.finagle.{Path, Stack}
 import com.twitter.finagle.zookeeper.buoyant.ZkAnnouncer
 import io.buoyant.config.types.HostAndPort
 import io.buoyant.linkerd.{Announcer, AnnouncerConfig, AnnouncerInitializer}
@@ -16,5 +16,6 @@ case class ServersetsConfig(zkAddrs: Seq[HostAndPort], pathPrefix: Option[Path])
   @JsonIgnore
   override def defaultPrefix: Path = Path.read("/io.l5d.serversets")
 
-  override def mk(): Announcer = new ZkAnnouncer(zkAddrs, pathPrefix.getOrElse(Path.read("/discovery")))
+  override def mk(params: Stack.Params): Announcer = new ZkAnnouncer(zkAddrs, pathPrefix.getOrElse(Path.read("/discovery")))
+
 }

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/AnnouncerInitializer.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/AnnouncerInitializer.scala
@@ -1,8 +1,8 @@
 package io.buoyant.linkerd
 
-import com.fasterxml.jackson.annotation.{JsonIgnore, JsonProperty, JsonTypeInfo}
-import com.twitter.finagle.Path
-import io.buoyant.config.{PolymorphicConfig, ConfigInitializer}
+import com.fasterxml.jackson.annotation.{JsonIgnore, JsonProperty}
+import com.twitter.finagle.{Path, Stack}
+import io.buoyant.config.{ConfigInitializer, PolymorphicConfig}
 import io.buoyant.namer.Paths
 
 abstract class AnnouncerConfig extends PolymorphicConfig {
@@ -17,7 +17,10 @@ abstract class AnnouncerConfig extends PolymorphicConfig {
   def prefix: Path = Paths.ConfiguredNamerPrefix ++ _prefix.getOrElse(defaultPrefix)
 
   @JsonIgnore
-  def mk(): Announcer
+  def mk(): Announcer = mk(Stack.Params.empty)
+
+  @JsonIgnore
+  def mk(params: Stack.Params): Announcer
 }
 
 trait AnnouncerInitializer extends ConfigInitializer

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/Router.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/Router.scala
@@ -170,7 +170,7 @@ trait RouterConfig {
     val prms = params ++ routerParams
     val param.Label(label) = prms[param.Label]
     val announcers = _announcers.toSeq.flatten.map { announcer =>
-      announcer.prefix -> announcer.mk
+      announcer.prefix -> announcer.mk(params)
     }
     protocol.router.configured(prms)
       .serving(servers.map(_.mk(protocol, label)))

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/TestAnnouncer.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/TestAnnouncer.scala
@@ -1,7 +1,7 @@
 package io.buoyant.linkerd
 
 import com.fasterxml.jackson.annotation.JsonIgnore
-import com.twitter.finagle.{Path, Announcement}
+import com.twitter.finagle.{Announcement, Path, Stack}
 import com.twitter.util.{Closable, Future}
 import java.net.InetSocketAddress
 
@@ -17,7 +17,8 @@ class TestAnnouncerConfig extends AnnouncerConfig {
   @JsonIgnore
   override def defaultPrefix: Path = Path.read("/io.l5d.test")
 
-  override def mk(): Announcer = new TestAnnouncer
+  override def mk(params: Stack.Params): Announcer = new TestAnnouncer
+
 }
 
 class TestAnnouncer extends Announcer {


### PR DESCRIPTION
This will allow announcer to access to the run-time parameters -including stat tree.

This is a POC related to https://github.com/linkerd/linkerd/issues/1922