### PR TITLE
Run tests in forked JVM

### DIFF
--- a/namerd/iface/interpreter-thrift/src/test/scala/io/buoyant/namerd/iface/ObserverCacheTest.scala
+++ b/namerd/iface/interpreter-thrift/src/test/scala/io/buoyant/namerd/iface/ObserverCacheTest.scala
@@ -184,13 +184,13 @@ class ObserverCacheTest extends FunSuite {
         assert(inactiveSize(stats) == 1)
         assert(!one.closed.sample)
 
-        tc.advance(ttl/2)
+        tc.advance(ttl / 2)
         cache.inactiveCacheCleanup()
         assert(activeSize(stats) == 0)
         assert(inactiveSize(stats) == 1)
         assert(!one.closed.sample)
 
-        tc.advance(ttl/2)
+        tc.advance(ttl / 2)
         cache.inactiveCacheCleanup()
         assert(activeSize(stats) == 0)
         assert(inactiveSize(stats) == 0)

--- a/project/Base.scala
+++ b/project/Base.scala
@@ -281,12 +281,18 @@ class Base extends Build {
 
     /** Enable the test config for a project with basic dependencies */
     def withTests(): Project = project.dependsOn(testUtil % Test)
-    .settings(inConfig(Test)(Defaults.testSettings :+ (fork := true)))
+    .settings(inConfig(Test)(Defaults.testSettings ++ Seq(
+      fork := true,
+      baseDirectory := new File(".")
+    )))
 
     /** Enables e2e test config for a project with basic dependencies */
     def withE2e(): Project = project
       .configs(EndToEndTest)
-      .settings(inConfig(EndToEndTest)(Defaults.testSettings ++ ScoverageSbtPlugin.projectSettings :+ (fork := true)))
+      .settings(inConfig(EndToEndTest)(Defaults.testSettings ++ ScoverageSbtPlugin.projectSettings ++ Seq(
+        fork := true,
+        baseDirectory := new File(".")
+      )))
       .settings(libraryDependencies += "org.scoverage" %% "scalac-scoverage-runtime" % "1.3.0" % EndToEndTest)
       .dependsOn(testUtil % EndToEndTest)
 

--- a/project/Base.scala
+++ b/project/Base.scala
@@ -281,11 +281,12 @@ class Base extends Build {
 
     /** Enable the test config for a project with basic dependencies */
     def withTests(): Project = project.dependsOn(testUtil % Test)
+    .settings(inConfig(Test)(Defaults.testSettings :+ (fork := true)))
 
     /** Enables e2e test config for a project with basic dependencies */
     def withE2e(): Project = project
       .configs(EndToEndTest)
-      .settings(inConfig(EndToEndTest)(Defaults.testSettings ++ ScoverageSbtPlugin.projectSettings))
+      .settings(inConfig(EndToEndTest)(Defaults.testSettings ++ ScoverageSbtPlugin.projectSettings :+ (fork := true)))
       .settings(libraryDependencies += "org.scoverage" %% "scalac-scoverage-runtime" % "1.3.0" % EndToEndTest)
       .dependsOn(testUtil % EndToEndTest)
 


### PR DESCRIPTION
Running Linkerd unit tests consumes a large amount of memory, sometimes more than 4GB.  This is causing Linkerd's CI runs to be killed for exceeding their memory limits.  Because sbt runs all unit tests in its own JVM, each test causes more classes to be loaded and increases the size of metaspace.  As the number of tests grows, so does the memory footprint.

We configure sbt to run each test in a forked JVM.  This prevents the metaspace of sbt's JVM from growing for each test.

```
Running all Linkerd unit tests without forked JVM:
3481042944  maximum resident set size
Running all Linkerd unit tests with forked JVM:
1806774272  maximum resident set size
```

Signed-off-by: Alex Leong <alex@buoyant.io>