### PR TITLE
Improve dyn binding timeout exception message

### DIFF
--- a/router/core/src/main/scala/com/twitter/finagle/naming/buoyant/DstBindingFactory.scala
+++ b/router/core/src/main/scala/com/twitter/finagle/naming/buoyant/DstBindingFactory.scala
@@ -155,7 +155,8 @@ object DstBindingFactory {
       def mk(dst: Dst.Path): ServiceFactory[Req, Rsp] = {
         // dtabs aren't available when NoBrokers is thrown so we add them here
         // as well as add a binding timeout
-        val dyn = new ServiceFactoryProxy(new DynBoundFactory(dst.bind(namer), treeCache)) {
+        val underlying = new DynBoundFactory(dst.path, dst.bind(namer), treeCache, bindingTimeout.timeout)
+        val dyn = new ServiceFactoryProxy(underlying) {
           override def apply(conn: ClientConnection) = {
             val exc = new RequestTimeoutException(bindingTimeout.timeout, s"dyn binding ${dst.path.show}")
             self(conn).rescue(handleNoBrokers).raiseWithin(bindingTimeout.timeout, exc)
@@ -219,4 +220,6 @@ object DstBindingFactory {
 
     def status = Status.Open
   }
+
+  case class DynTimeout(timeout: Duration) extends Throwable
 }

--- a/router/core/src/main/scala/com/twitter/finagle/naming/buoyant/DynBoundFactory.scala
+++ b/router/core/src/main/scala/com/twitter/finagle/naming/buoyant/DynBoundFactory.scala
@@ -92,18 +92,23 @@ private[buoyant] class DynBoundFactory[Req, Rep](
     f.raiseWithin(timeout, DynBoundTimeout).rescue(handleDynBoundTimeout)
   }
 
+  // This is raised for binding timeouts.
   private val DynBoundTimeout = new DynBoundTimeoutException("dyn bound timeout")
 
-  private[this] val handleDynBoundTimeout: PartialFunction[Throwable, Future[Nothing]] = {
-    case DynBoundTimeout =>
-      state match {
-        case Pending(_) =>
-          Future.exception(new DynBoundTimeoutException(s"Exceeded $timeout binding timeout while resolving name: ${path.show}"))
-        case Named(name) =>
-          Future.exception(new DynBoundTimeoutException(s"Exceeded $timeout binding timeout while connecting to ${name.show} for name: ${path.show}"))
-        case _ =>
-          Future.exception(DynBoundTimeout)
-      }
+  /* If we receive a DynBoundTimeout while in a Pending or Named state, we transform the exception
+   * into a DynBoundTimeoutException with a nice error message which depends on the current state.
+   */
+  private[this] val handleDynBoundTimeout: PartialFunction[Throwable, Future[Nothing]] = new PartialFunction[Throwable, Future[Nothing]] {
+
+    val exceptionPf: PartialFunction[State, Throwable] = {
+      case Pending(_) =>
+        new DynBoundTimeoutException(s"Exceeded $timeout binding timeout while resolving name: ${path.show}")
+      case Named(name) =>
+        new DynBoundTimeoutException(s"Exceeded $timeout binding timeout while connecting to ${name.show} for name: ${path.show}")
+    }
+
+    override def isDefinedAt(e: Throwable): Boolean = e == DynBoundTimeout && exceptionPf.isDefinedAt(state)
+    override def apply(v1: Throwable): Future[Nothing] = Future.exception(exceptionPf(state))
   }
 
   private[this] def applySync(conn: ClientConnection): Future[Service[Req, Rep]] = synchronized {

--- a/router/core/src/test/scala/com/twitter/finagle/naming/buoyant/DstBindingFactoryTest.scala
+++ b/router/core/src/test/scala/com/twitter/finagle/naming/buoyant/DstBindingFactoryTest.scala
@@ -176,7 +176,7 @@ class DstBindingFactoryTest extends FunSuite with Awaits with Exceptions {
       time.advance(1.second)
       timer.tick()
       assert(result.isDefined)
-      assertThrows[RequestTimeoutException](await(0.seconds)(result))
+      assertThrows[DynBoundTimeoutException](await(0.seconds)(result))
     }
   }
 }


### PR DESCRIPTION
The dyn binding timeout exception message is cryptic and doesn't differentiate between timeouts resolving the name and timeouts establishing the connection.

Move this dyn binding timeout into DynBindingFactory so that we can differentiate and improve the error message.

Old message:
```
$ curl localhost:4140
exceeded 10.seconds to unspecified while dyn binding /svc/localhost:4140. Remote Info: Not Available
```

New message:
```
$ curl localhost:4140
Exceeded 10.seconds binding timeout while resolving name: /svc/localhost:4140
```

Fixes #1949 

Signed-off-by: Alex Leong <alex@buoyant.io>