### PR TITLE
linkerd and namerd should honor shutdown grace period in config

### DIFF
--- a/linkerd/docs/config.md
+++ b/linkerd/docs/config.md
@@ -84,6 +84,7 @@ Key | Default Value | Description
 ip | loopback address | IP for the admin interface. A value like 0.0.0.0 configures admin to listen on all local IPv4 interfaces.
 port | `9990` | Port for the admin interface.
 httpIdentifierPort | none | Port for the http identifier debug endpoint.
+shutdownGraceMs | 10000 | maximum grace period before the Linkerd process exits
 tls | no tls | The admin interface will serve over TLS if this parameter is provided. see [TLS](#server-tls).
 
 #### Administrative endpoints

--- a/namerd/main/src/main/scala/io/buoyant/namerd/Main.scala
+++ b/namerd/main/src/main/scala/io/buoyant/namerd/Main.scala
@@ -1,9 +1,10 @@
 package io.buoyant.namerd
 
-import com.twitter.util.{Await, Closable}
+import com.twitter.util.{Await, Closable, Duration}
 import io.buoyant.admin.{App, Build}
 import java.io.File
 import scala.io.Source
+import sun.misc.{Signal, SignalHandler}
 
 object Main extends App {
 
@@ -11,6 +12,10 @@ object Main extends App {
    * Flag to validate a configuration.
    */
   private val validate = flag.apply("validate", false, "Only validate a configuration and finish with a proper status code")
+  private[this] val DefaultShutdownGrace =
+    Duration.fromSeconds(10)
+
+  private[this] var shutdownGracePeriod: Option[Int] = null
 
   def main(): Unit = {
     val build = Build.load("/io/buoyant/namerd/build.properties")
@@ -23,6 +28,7 @@ object Main extends App {
           return
 
         val namerd = config.mk()
+        shutdownGracePeriod = config.admin.flatMap(_.shutdownGraceMs)
 
         val admin = namerd.admin.serve(this, NamerdAdmin(config, namerd))
         log.info("serving %s on %s", namerd.admin.scheme, admin.boundAddress)
@@ -33,7 +39,7 @@ object Main extends App {
           server
         }
         val telemeters = namerd.telemeters.map(_.run())
-
+        registerTerminationSignalHandler(shutdownGracePeriod)
         closeOnExit(Closable.sequence(
           Closable.all(servers: _*),
           Closable.all(telemeters: _*),
@@ -60,4 +66,21 @@ object Main extends App {
     NamerdConfig.loadNamerd(configText)
   }
 
+  private def registerTerminationSignalHandler(shutdownGraceMs: Option[Int]): Unit = {
+    val shutdownHandler = new SignalHandler {
+      override def handle(sig: Signal): Unit = {
+        log.info("Received %s. Shutting down ...", sig)
+        val closeTimeOut = shutdownGraceMs.map(Duration.fromMilliseconds(_)).getOrElse(DefaultShutdownGrace)
+        Await.result(close(closeTimeOut))
+      }
+    }
+
+    Signal.handle(new Signal("INT"), shutdownHandler)
+    val _ = Signal.handle(new Signal("TERM"), shutdownHandler)
+  }
+
+  override def defaultCloseGracePeriod: Duration =
+    shutdownGracePeriod
+      .map(Duration.fromMilliseconds(_))
+      .getOrElse(DefaultShutdownGrace)
 }


### PR DESCRIPTION
Linkerd's `admin/shutdown` endpoint does not use the `shutdownGraceMs` value set in the admin config section. This causes Linkerd to shut down before requests are drained from the request queue. In addition, Namerd does not take advantage of the `SIGTERM` and `SIGINT` os signal hooks like  Linkerd. This means Namerd is unable to wait for the maximum set grace period whenever the Namerd process receives the above-mentioned os signals.

This PR sets the Linkerd's `defaultShutdownGracePeriod` to be the value configured in the admin section, or, a default value of `10.seconds`. The PR also adds documentation that describes how to configure the `shutdownGraceMs` field. Finally, we add `SignalHandler` functionality to handle `SIGTERM` and `SIGINT` graceful shutdown in Namerd.

Tests were conducted manually. I set Linkerd's `shutdownGraceMs` to 20 seconds, sent a request to be routed by Linkerd (request had a 20-second latency) and, I simultaneously called Linkerd's `admin/shutdown` webhook. Linkerd terminated gracefully after the configured duration.

fixes #1807, #1852 

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>