### PR TITLE
Fixes #1552 - Rework TLS client configuration trust store to use a CA…

### DIFF
--- a/finagle/buoyant/src/main/scala/com/twitter/finagle/buoyant/TlsClientConfig.scala
+++ b/finagle/buoyant/src/main/scala/com/twitter/finagle/buoyant/TlsClientConfig.scala
@@ -1,13 +1,11 @@
 package com.twitter.finagle.buoyant
 
 import java.io._
-
 import com.twitter.finagle.Stack
 import com.twitter.finagle.netty4.ssl.client.Netty4ClientEngineFactory
-import com.twitter.finagle.ssl.client.{SslClientConfiguration, SslClientEngineFactory}
 import com.twitter.finagle.ssl.{KeyCredentials, Protocols, TrustCredentials}
+import com.twitter.finagle.ssl.client.{SslClientConfiguration, SslClientEngineFactory}
 import com.twitter.finagle.transport.Transport
-import com.twitter.io.StreamIO
 
 import scala.util.control.NoStackTrace
 
@@ -15,7 +13,7 @@ case class TlsClientConfig(
   enabled: Option[Boolean],
   disableValidation: Option[Boolean],
   commonName: Option[String],
-  trustCerts: Option[Seq[String]] = None,
+  trustCerts: Option[String] = None,
   clientAuth: Option[ClientAuth] = None,
   protocols: Option[Seq[String]] = None
 ) {
@@ -32,36 +30,9 @@ case class TlsClientConfig(
         SslClientEngineFactory.Param(Netty4ClientEngineFactory())
 
     case TlsClientConfig(_, _, Some(cn), certs, clientAuth, enabledProtocols) =>
-      // map over the optional certs parameter - we want to pass
-      // `TrustCredentials.CertCollection` if we were given a list of certs,
-      // but `TrustCredentials.Unspecified` (rather than an empty cert
-      // collection file) if we were not.
-      val credentials = certs.map { certs =>
-        // a temporary file to hold the collection of certificates
-        val certCollection = File.createTempFile("certCollection", null)
-        // open the cert paths as Streams...
-        val f = new FileOutputStream(certCollection)
-        for {
-          cert <- certs
-          certStream = new FileInputStream(cert)
-        } { // ...and copy the certs into the cert collection
-          // TODO: can this be made more concise with scala.io?
-          StreamIO.copy(certStream, f)
-        }
-        f.flush()
-        f.close()
-        certCollection.deleteOnExit()
-        // the credentials we'll pass to `SslClientConfiguration` will
-        // be a collection of certificates
-        TrustCredentials.CertCollection(certCollection)
-      } getOrElse {
-        // otherwise, we want to pass `TrustCredentials.Unspecified`
-        TrustCredentials.Unspecified
-      }
-
       val tlsConfig = SslClientConfiguration(
         hostname = Some(cn),
-        trustCredentials = credentials,
+        trustCredentials = certs.map(c => TrustCredentials.CertCollection(new File(c))).getOrElse(TrustCredentials.Unspecified),
         keyCredentials = keyCredentials(clientAuth),
         protocols = enabledProtocols.map(Protocols.Enabled).getOrElse(Protocols.Unspecified)
       )

--- a/interpreter/mesh/src/test/scala/io/buoyant/interpreter/MeshInterpreterInitializerTest.scala
+++ b/interpreter/mesh/src/test/scala/io/buoyant/interpreter/MeshInterpreterInitializerTest.scala
@@ -24,8 +24,7 @@ class MeshInterpreterInitializerTest extends FunSuite {
                    |tls:
                    |  disableValidation: false
                    |  commonName: "{service}"
-                   |  trustCerts:
-                   |  - /foo/caCert.pem
+                   |  trustCerts: /foo/caCert.pem
                    |  clientAuth:
                    |    certPath: /namerd-cert.pem
                    |    keyPath: /namerd-key.pk8
@@ -41,7 +40,7 @@ class MeshInterpreterInitializerTest extends FunSuite {
     val tls = namerd.tls.get
     assert(tls.disableValidation == Some(false))
     assert(tls.commonName == Some("{service}"))
-    assert(tls.trustCerts == Some(List("/foo/caCert.pem")))
+    assert(tls.trustCerts == Some("/foo/caCert.pem"))
     assert(tls.clientAuth.get.certPath == "/namerd-cert.pem")
     assert(tls.clientAuth.get.keyPath == "/namerd-key.pk8")
   }

--- a/interpreter/namerd/src/main/scala/io/buoyant/namerd/iface/NamerdInterpreterInitializer.scala
+++ b/interpreter/namerd/src/main/scala/io/buoyant/namerd/iface/NamerdInterpreterInitializer.scala
@@ -45,7 +45,7 @@ case class ClientTlsConfig(commonName: String, caCert: Option[String]) {
       enabled = Some(true),
       disableValidation = Some(false),
       commonName = Some(commonName),
-      trustCerts = caCert.map(Seq(_)),
+      trustCerts = caCert,
       clientAuth = None
     ).params
   }

--- a/interpreter/namerd/src/test/scala/io/buoyant/namerd/iface/NamerdHttpTest.scala
+++ b/interpreter/namerd/src/test/scala/io/buoyant/namerd/iface/NamerdHttpTest.scala
@@ -25,8 +25,7 @@ class NamerdHttpTest extends FunSuite {
                    |tls:
                    |  disableValidation: false
                    |  commonName: "{service}"
-                   |  trustCerts:
-                   |  - /foo/caCert.pem
+                   |  trustCerts: /foo/caCert.pem
                    |  clientAuth:
                    |    certPath: /namerd-cert.pem
                    |    keyPath: /namerd-key.pk8
@@ -42,7 +41,7 @@ class NamerdHttpTest extends FunSuite {
     val tls = namerd.tls.get
     assert(tls.disableValidation == Some(false))
     assert(tls.commonName == Some("{service}"))
-    assert(tls.trustCerts == Some(List("/foo/caCert.pem")))
+    assert(tls.trustCerts == Some("/foo/caCert.pem"))
     assert(tls.clientAuth.get.certPath == "/namerd-cert.pem")
     assert(tls.clientAuth.get.keyPath == "/namerd-key.pk8")
   }
@@ -54,8 +53,7 @@ class NamerdHttpTest extends FunSuite {
                    |tls:
                    |  disableValidation: false
                    |  commonName: "{service}"
-                   |  trustCerts:
-                   |  - /foo/caCert.pem
+                   |  trustCerts: /foo/caCert.pem
                    |  clientAuth:
                    |    certPath: /namerd-cert.pem
                    |    keyPath: /namerd-key.pk8

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/ClientConfig.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/ClientConfig.scala
@@ -41,7 +41,7 @@ case class TlsClientConfig(
   enabled: Option[Boolean],
   disableValidation: Option[Boolean],
   commonName: Option[String],
-  trustCerts: Option[Seq[String]] = None,
+  trustCerts: Option[String] = None,
   clientAuth: Option[ClientAuth] = None,
   protocols: Option[Seq[String]] = None
 ) {

--- a/linkerd/docs/client_tls.md
+++ b/linkerd/docs/client_tls.md
@@ -60,7 +60,7 @@ Key               | Default Value                              | Description
 ----------------- | ------------------------------------------ | -----------
 disableValidation | false                                      | Enable this to skip hostname validation (unsafe). Setting `disableValidation: true` is incompatible with `clientAuth`.
 commonName        | _required_ unless disableValidation is set | The common name to use for all TLS requests.
-trustCerts        | empty list                                 | A list of file paths of CA certs to use for common name validation.
+trustCerts        | none                                       | A path to CA certs bundle to use for validation.
 clientAuth        | none                                       | A client auth object used to sign requests.
 protocols         | unspecified                                | The list of TLS protocols to enable
 
@@ -86,8 +86,7 @@ routers:
     - prefix: /#/io.l5d.fs/{service}
       tls:
         commonName: "{service}.linkerd.io"
-        trustCerts:
-        - /certificates/cacert.pem
+        trustCerts: /certificates/cacert.pem
         clientAuth:
           certPath: /certificates/cert.pem
           keyPath: /certificates/key.pem
@@ -119,8 +118,7 @@ routers:
     - prefix: /%/io.l5d.port/4141/#/io.l5d.fs/
       tls:
         commonName: "linkerd.io"
-        trustCerts:
-        - /certificates/cacert.pem
+        trustCerts: /certificates/cacert.pem
         clientAuth:
           certPath: /certificates/cert.pem
           keyPath: /certificates/key.pem

--- a/linkerd/examples/namerd-tls.yaml
+++ b/linkerd/examples/namerd-tls.yaml
@@ -28,8 +28,7 @@ routers:
     tls:
       disableValidation: false
       commonName: namerd
-      trustCerts:
-      - namerd/examples/certs/namerd-cacert.pem
+      trustCerts: namerd/examples/certs/namerd-cacert.pem
   servers:
   - port: 4141
     ip: 0.0.0.0
@@ -43,8 +42,7 @@ routers:
     tls:
       disableValidation: false
       commonName: linkerd-tls-e2e
-      trustCerts:
-      - finagle/h2/src/e2e/resources/cacert.pem
+      trustCerts: finagle/h2/src/e2e/resources/cacert.pem
       clientAuth:
         certPath: finagle/h2/src/e2e/resources/linkerd-tls-e2e-cert.pem
         keyPath: finagle/h2/src/e2e/resources/linkerd-tls-e2e-key.pem
@@ -60,8 +58,7 @@ routers:
     tls:
       disableValidation: false
       commonName: linkerd-tls-e2e
-      trustCerts:
-      - finagle/h2/src/e2e/resources/cacert.pem
+      trustCerts: finagle/h2/src/e2e/resources/cacert.pem
       clientAuth:
         certPath: finagle/h2/src/e2e/resources/linkerd-tls-e2e-cert.pem
         keyPath: finagle/h2/src/e2e/resources/linkerd-tls-e2e-key.pem

--- a/linkerd/examples/tls.yaml
+++ b/linkerd/examples/tls.yaml
@@ -13,8 +13,7 @@ routers:
     configs:
     - prefix: "/#/io.l5d.fs/{service}"
       tls:
-        trustCerts:
-        - /foo/caCert.pem
+        trustCerts: /foo/caCert.pem
         commonName: "{service}"
   servers:
   - port: 4140

--- a/linkerd/protocol/http/src/integration/scala/io/buoyant/linkerd/protocol/ClientAuthTest.scala
+++ b/linkerd/protocol/http/src/integration/scala/io/buoyant/linkerd/protocol/ClientAuthTest.scala
@@ -44,8 +44,7 @@ class ClientAuthTest extends FunSuite {
          |  client:
          |   tls:
          |     commonName: server
-         |     trustCerts:
-         |     - ${certs.caCert.getPath}
+         |     trustCerts: ${certs.caCert.getPath}
          |     clientAuth:
          |       certPath: ${clientCerts.cert.getPath}
          |       keyPath: ${clientCerts.key.getPath}
@@ -109,8 +108,7 @@ class ClientAuthTest extends FunSuite {
                             |  client:
                             |   tls:
                             |     commonName: server
-                            |     trustCerts:
-                            |     - ${certs.caCert.getPath}
+                            |     trustCerts: ${certs.caCert.getPath}
        """.stripMargin
       val clientLinker = Linker.load(clientConfig)
       val clientRouter = clientLinker.routers.head.initialize()

--- a/linkerd/protocol/http/src/integration/scala/io/buoyant/linkerd/protocol/TlsBoundPathTest.scala
+++ b/linkerd/protocol/http/src/integration/scala/io/buoyant/linkerd/protocol/TlsBoundPathTest.scala
@@ -52,8 +52,7 @@ class TlsBoundPathTest extends FunSuite with Awaits {
              |    - prefix: "/#/io.l5d.fs/{host}"
              |      tls:
              |        commonName: "{host}.buoyant.io"
-             |        trustCerts:
-             |        - ${certs.caCert.getPath}
+             |        trustCerts: ${certs.caCert.getPath}
              |""".
               stripMargin
           withLinkerdClient(linkerConfig) { client =>
@@ -113,8 +112,7 @@ class TlsBoundPathTest extends FunSuite with Awaits {
             |    - prefix: "/#/io.l5d.fs/bill"
             |      tls:
             |        commonName: "bill.buoyant.io"
-            |        trustCerts:
-            |        - ${certs.caCert.getPath}
+            |        trustCerts: ${certs.caCert.getPath}
             |""".
             stripMargin
           withLinkerdClient(linkerConfig) { client =>
@@ -179,13 +177,11 @@ class TlsBoundPathTest extends FunSuite with Awaits {
             |    - prefix: "/#/io.l5d.fs/bill"
             |      tls:
             |        commonName: excellent
-            |        trustCerts:
-            |        - ${certs.caCert.getPath}
+            |        trustCerts: ${certs.caCert.getPath}
             |    - prefix: "/#/io.l5d.fs/ted"
             |      tls:
             |        commonName: righteous
-            |        trustCerts:
-            |        - ${certs.caCert.getPath}            
+            |        trustCerts: ${certs.caCert.getPath}
             |""".
             stripMargin
           withLinkerdClient(linkerConfig) { client =>
@@ -255,8 +251,7 @@ class TlsBoundPathTest extends FunSuite with Awaits {
              |    - prefix: "/#/io.l5d.fs/{host}"
              |      tls:
              |        commonName: "{host}.buoyant.io"
-             |        trustCerts:
-             |        - ${certs.caCert.getPath}             
+             |        trustCerts: ${certs.caCert.getPath}
              |""".stripMargin
           withLinkerdClient(linkerConfig) { client =>
             val billRsp = {

--- a/linkerd/protocol/http/src/integration/scala/io/buoyant/linkerd/protocol/TlsCertReloadingTest.scala
+++ b/linkerd/protocol/http/src/integration/scala/io/buoyant/linkerd/protocol/TlsCertReloadingTest.scala
@@ -47,8 +47,7 @@ class TlsCertReloadingTest extends FunSuite with Awaits {
         |  client:
         |   tls:
         |     commonName: bar
-        |     trustCerts:
-        |     - ${certs.caCert.getPath}
+        |     trustCerts: ${certs.caCert.getPath}
        """.stripMargin
       val outgoingLinker = Linker.load(outgoingConfig)
       val outgoingRouter = outgoingLinker.routers.head.initialize()

--- a/linkerd/protocol/http/src/integration/scala/io/buoyant/linkerd/protocol/TlsStaticValidationTest.scala
+++ b/linkerd/protocol/http/src/integration/scala/io/buoyant/linkerd/protocol/TlsStaticValidationTest.scala
@@ -31,8 +31,7 @@ class TlsStaticValidationTest extends FunSuite with Awaits {
              |  client:
              |    tls:
              |      commonName: linkerd
-             |      trustCerts:
-             |      - ${certs.caCert.getPath}
+             |      trustCerts: ${certs.caCert.getPath}
              |""".stripMargin
         val linker = init.load(linkerConfig)
         val router = linker.routers.head.initialize()
@@ -78,8 +77,7 @@ class TlsStaticValidationTest extends FunSuite with Awaits {
              |  client:
              |    tls:
              |      commonName: wrong
-             |      trustCerts:
-             |      - ${certs.caCert.getPath}
+             |      trustCerts: ${certs.caCert.getPath}
              |""".stripMargin
         val linker = init.load(linkerConfig)
         val router = linker.routers.head.initialize()

--- a/namer/consul/src/test/scala/io/buoyant/namer/consul/ConsulTest.scala
+++ b/namer/consul/src/test/scala/io/buoyant/namer/consul/ConsulTest.scala
@@ -52,8 +52,7 @@ class ConsulTest extends FunSuite {
                     |tls:
                     |  disableValidation: false
                     |  commonName: consul.io
-                    |  trustCerts:
-                    |  - /certificates/cacert.pem
+                    |  trustCerts: /certificates/cacert.pem
                     |  clientAuth:
                     |    certPath: /certificates/cert.pem
                     |    keyPath: /certificates/key.pem
@@ -73,7 +72,7 @@ class ConsulTest extends FunSuite {
     assert(consul.preferServiceAddress == Some(false))
     assert(consul.weights == Some(Seq(TagWeight("primary", 100.0))))
     val clientAuth = ClientAuth("/certificates/cert.pem", "/certificates/key.pem")
-    val tlsConfig = TlsClientConfig(None, Some(false), Some("consul.io"), Some(List("/certificates/cacert.pem")), Some(clientAuth))
+    val tlsConfig = TlsClientConfig(None, Some(false), Some("consul.io"), Some("/certificates/cacert.pem"), Some(clientAuth))
     assert(consul.tls == Some(tlsConfig))
     assert(!consul.disabled)
   }

--- a/namer/marathon/src/test/scala/io/buoyant/namer/marathon/MarathonTest.scala
+++ b/namer/marathon/src/test/scala/io/buoyant/namer/marathon/MarathonTest.scala
@@ -92,8 +92,7 @@ class MarathonTest extends FunSuite {
                   |tls:
                   |  disableValidation: false
                   |  commonName: master.mesos
-                  |  trustCerts:
-                  |    - /foo/caCert.pem
+                  |  trustCerts: /foo/caCert.pem
       """.stripMargin
 
     val mapper = Parser.objectMapper(yaml, Iterable(Seq(MarathonInitializer)))
@@ -108,7 +107,7 @@ class MarathonTest extends FunSuite {
     val tls = marathon.tls.get
     assert(tls.disableValidation.contains(false))
     assert(tls.commonName.contains("master.mesos"))
-    assert(tls.trustCerts.contains(List("/foo/caCert.pem")))
+    assert(tls.trustCerts == Some("/foo/caCert.pem"))
 
     assert(!marathon.disabled)
   }

--- a/namerd/storage/consul/src/test/scala/io/buoyant/namerd/storage/consul/ConsulConfigTest.scala
+++ b/namerd/storage/consul/src/test/scala/io/buoyant/namerd/storage/consul/ConsulConfigTest.scala
@@ -27,8 +27,7 @@ class ConsulConfigTest extends FunSuite with OptionValues {
          |tls:
          |  disableValidation: false
          |  commonName: consul.io
-         |  trustCerts:
-         |  - /certificates/cacert.pem
+         |  trustCerts: /certificates/cacert.pem
          |  clientAuth:
          |    certPath: /certificates/cert.pem
          |    keyPath: /certificates/key.pem
@@ -43,7 +42,7 @@ class ConsulConfigTest extends FunSuite with OptionValues {
     assert(consul.readConsistencyMode == Some(ConsistencyMode.Stale))
     assert(consul.writeConsistencyMode == Some(ConsistencyMode.Consistent))
     val clientAuth = ClientAuth("/certificates/cert.pem", "/certificates/key.pem")
-    val tlsConfig = TlsClientConfig(None, Some(false), Some("consul.io"), Some(List("/certificates/cacert.pem")), Some(clientAuth))
+    val tlsConfig = TlsClientConfig(None, Some(false), Some("consul.io"), Some("/certificates/cacert.pem"), Some(clientAuth))
     assert(consul.tls == Some(tlsConfig))
   }
 


### PR DESCRIPTION
… bundle instead of dropping all ca certs to a bundle in the temp folder. This simplifies the client TLS code, removes a dependency on the temporary folder and aligns client TLS configuration with server TLS configuration

Breaking change: this modifies trustCerts from an optional list of strings to an optional string

Signed-off-by: Dan Vulpe <dvulpe@gmail.com>