### PR TITLE
Ensure H2 client writes l5d-ctx headers

### DIFF
--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/DelayedReleaseService.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/DelayedReleaseService.scala
@@ -7,7 +7,7 @@ import com.twitter.util.{Future, Promise, Return, Time}
 import java.util.concurrent.atomic.AtomicBoolean
 
 object DelayedRelease {
-  val role = StackClient.Role.prepFactory
+  val role = StackClient.Role.prepConn
   val description = "Prevents an H2 service from being closed until its response stream completes"
   val module: Stackable[ServiceFactory[Request, Response]] =
     new Stack.Module0[ServiceFactory[Request, Response]] {


### PR DESCRIPTION
HTTP/2 requests sent by Linkerd are missing the `l5d-ctx-*` headers such as `l5d-ctx-dtab` and `l5d-ctx-trace`.

When the H2 client stack is configured, the PrepConn module is replaced with the DelayedRelease module.  However, since the DelayedReleaseModule has the PrepFactory role, this resulted in the client stack no longer having a PrepConn role which caused the dtab client module to not be added.  We fix this by simply changing the role of the DelayedReleaseModule to PrepConn so that the role does not change when the PrepConn module is replaced.

Fixes #1945 

Signed-off-by: Alex Leong <alex@buoyant.io>