### PR TITLE
Avoid adding node_modules to admin.jar

### DIFF
--- a/project/Base.scala
+++ b/project/Base.scala
@@ -106,7 +106,15 @@ class Base extends Build {
         Some("snapshots" at nexus + "content/repositories/snapshots")
       else
         Some("releases"  at nexus + "service/local/staging/deploy/maven2")
-    }
+    },
+    mappings in (Compile, packageBin) ~= { (ms: Seq[(File,String)]) => ms filter {
+      case (file,toPath) => {
+        file.getPath match {
+          case nodeModulesRE() => false
+          case _ => true
+        }
+      }
+    }}
   )
 
   val aggregateSettings = Seq(


### PR DESCRIPTION
It looks like somewhere between 1.3.6 and 1.3.7 the node_modules folder was accidentally added to the admin_2.12.jar resulting in a much bigger artifact:
```
494574 /Users/rpanzer/.m2/repository/io/buoyant/admin_2.12/1.3.6/admin_2.12-1.3.6.jar
12980121 /Users/rpanzer/.m2/repository/io/buoyant/admin_2.12/1.3.7/admin_2.12-1.3.7.jar
```
While the settings for the full assembly seem to filter these out again, they are still somewhat disturbing when creating own assemblies/fat jars.

This PR changes the base settings for every module to also exclude any node_modules directories.

Disclaimer: My knowledge of sbt is barely existing, if at all.