### PR TITLE
Add clientCaChainPath client auth TLS config setting

### DIFF
--- a/finagle/buoyant/src/main/scala/com/twitter/finagle/buoyant/TlsClientConfig.scala
+++ b/finagle/buoyant/src/main/scala/com/twitter/finagle/buoyant/TlsClientConfig.scala
@@ -75,9 +75,16 @@ case class TlsClientConfig(
 
   private[this] def keyCredentials(clientAuth: Option[ClientAuth]): KeyCredentials =
     clientAuth match {
-      case Some(ClientAuth(cert, key)) => KeyCredentials.CertAndKey(new File(cert), new File(key))
+      case Some(ClientAuth(cert, None, key)) =>
+        KeyCredentials.CertAndKey(new File(cert), new File(key))
+      case Some(ClientAuth(cert, Some(clientCaChain), key)) =>
+        KeyCredentials.CertKeyAndChain(new File(cert), new File(key), new File(clientCaChain))
       case None => KeyCredentials.Unspecified
     }
 }
 
-case class ClientAuth(certPath: String, keyPath: String)
+case class ClientAuth(
+  certPath: String,
+  clientCaChainPath: Option[String],
+  keyPath: String
+)

--- a/linkerd/docs/client_tls.md
+++ b/linkerd/docs/client_tls.md
@@ -66,10 +66,11 @@ protocols         | unspecified                                | The list of TLS
 
 If present, a client auth object must contain two properties:
 
-Key      | Default Value | Description
----------|---------------|-------------
-certPath | _required_    | File path to the TLS certificate file.
-keyPath  | _required_    | File path to the TLS key file.  Must be in PKCS#8 format.
+Key               | Default Value | Description
+------------------|---------------|-------------
+certPath          | _required_    | File path to the TLS certificate file.
+clientCaChainPath | none          | Path to a file containing a CA certificate chain to support the client certificate.
+keyPath           | _required_    | File path to the TLS key file.  Must be in PKCS#8 format.
 
 <aside class="warning">
 Setting `disableValidation: true` will force the use of the JDK SSL provider which does not support client auth. Therefore, `disableValidation: true` and `clientAuth` are incompatible.

--- a/linkerd/examples/mutualTls.yaml
+++ b/linkerd/examples/mutualTls.yaml
@@ -7,6 +7,15 @@ routers:
 - protocol: http
   dtab: |
     /svc => /#/io.l5d.fs
+  client:
+    tls:
+      commonName: foo
+      trustCerts:
+      - /foo/cacert.pem
+      clientAuth:
+        certPath: /foo/clientCert.pem
+        keyPath: /foo/clientKey.pem
+        clientCaChainPath: /foo/intermediateCa.pem
   servers:
   - port: 4140
     # Expect the incoming connection to be encryped.
@@ -16,4 +25,4 @@ routers:
       # clients must provide a valid certificate
       requireClientAuth: true 
       # the authority used to validate client certificates
-      caCertPath: /foo/cacert.pem 
+      caCertPath: /foo/cacert.pem


### PR DESCRIPTION
There is no way to specify a supporting CA certificate chain to support a client certificate when Linkerd is using client auth.  If a certificate chain is provided in the file specified by `certPath`, only the first certificate in the file is served.

Add a new client auth TLS config option `clientCaChainPath`.  This allows you to provide a supporting CA certificate chain for the client cert.

Fixes #1957 

Signed-off-by: Alex Leong <alex@buoyant.io>