### PR TITLE
Enable any identifier implements HttpIdentifierConfig to access Stack.params from its top level Router

### DIFF
--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpConfig.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpConfig.scala
@@ -255,5 +255,4 @@ case class HttpConfig(
 
   @JsonIgnore
   override def routerParams = routerParamsPartial.maybeWith(combinedIdentifier(routerParamsPartial))
-
 }

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpConfig.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpConfig.scala
@@ -232,19 +232,19 @@ case class HttpConfig(
   }
 
   @JsonIgnore
-  private[this] val combinedIdentifier = identifier.map { configs =>
+  private[this] def combinedIdentifier(params: Stack.Params) = identifier.map { configs =>
     Http.param.HttpIdentifier { (prefix, dtab) =>
-      RoutingFactory.Identifier.compose(configs.map(_.newIdentifier(prefix, dtab)))
+      RoutingFactory.Identifier.compose(configs.map(_.newIdentifier(prefix, dtab, params)))
     }
   }
+
   @JsonIgnore
-  override def routerParams: Stack.Params = super.routerParams
+  private[this] def routerParamsPartial: Stack.Params = super.routerParams
     .maybeWith(httpAccessLog.map(AccessLogger.param.File.apply))
     .maybeWith(httpAccessLogRollPolicy.map(Policy.parse _ andThen AccessLogger.param.RollPolicy.apply))
     .maybeWith(httpAccessLogAppend.map(AccessLogger.param.Append.apply))
     .maybeWith(httpAccessLogRotateCount.map(AccessLogger.param.RotateCount.apply))
     .maybeWith(loggerParam)
-    .maybeWith(combinedIdentifier)
     .maybeWith(maxChunkKB.map(kb => hparam.MaxChunkSize(kb.kilobytes)))
     .maybeWith(maxHeadersKB.map(kb => hparam.MaxHeaderSize(kb.kilobytes)))
     .maybeWith(maxInitialLineKB.map(kb => hparam.MaxInitialLineSize(kb.kilobytes)))
@@ -252,4 +252,8 @@ case class HttpConfig(
     .maybeWith(maxResponseKB.map(kb => hparam.MaxResponseSize(kb.kilobytes)))
     .maybeWith(streamingEnabled.map(hparam.Streaming(_)))
     .maybeWith(compressionLevel.map(hparam.CompressionLevel(_)))
+
+  @JsonIgnore
+  override def routerParams = routerParamsPartial.maybeWith(combinedIdentifier(routerParamsPartial))
+
 }

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpIdentifierConfig.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpIdentifierConfig.scala
@@ -2,7 +2,7 @@ package io.buoyant.linkerd.protocol
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.twitter.finagle.http.Request
-import com.twitter.finagle.{Dtab, Path}
+import com.twitter.finagle.{Dtab, Path, Stack}
 import io.buoyant.config.PolymorphicConfig
 import io.buoyant.router.RoutingFactory.Identifier
 
@@ -10,6 +10,7 @@ abstract class HttpIdentifierConfig extends PolymorphicConfig {
   @JsonIgnore
   def newIdentifier(
     prefix: Path,
-    baseDtab: () => Dtab = () => Dtab.base
+    baseDtab: () => Dtab = () => Dtab.base,
+    routerParams: Stack.Params = Stack.Params.empty
   ): Identifier[Request]
 }

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/HeaderIdentifierConfig.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/HeaderIdentifierConfig.scala
@@ -2,7 +2,7 @@ package io.buoyant.linkerd.protocol.http
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.twitter.finagle.buoyant.linkerd.Headers
-import com.twitter.finagle.{Dtab, Path}
+import com.twitter.finagle.{Dtab, Path, Stack}
 import io.buoyant.linkerd.IdentifierInitializer
 import io.buoyant.linkerd.protocol.HttpIdentifierConfig
 import io.buoyant.router.http.HeaderIdentifier
@@ -26,7 +26,8 @@ case class HeaderIdentifierConfig(
   @JsonIgnore
   override def newIdentifier(
     prefix: Path,
-    baseDtab: () => Dtab = () => Dtab.base
+    baseDtab: () => Dtab = () => Dtab.base,
+    routerParams: Stack.Params = Stack.Params.empty
   ) = HeaderIdentifier(
     prefix,
     header.getOrElse(HeaderIdentifierConfig.defaultHeader),

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/HeaderTokenIdentifierConfig.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/HeaderTokenIdentifierConfig.scala
@@ -2,7 +2,7 @@ package io.buoyant.linkerd.protocol.http
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.twitter.finagle.http.Fields
-import com.twitter.finagle.{Dtab, Path}
+import com.twitter.finagle.{Dtab, Path, Stack}
 import io.buoyant.linkerd.IdentifierInitializer
 import io.buoyant.linkerd.protocol.HttpIdentifierConfig
 import io.buoyant.router.http.HeaderIdentifier
@@ -26,7 +26,8 @@ case class HeaderTokenIdentifierConfig(
   @JsonIgnore
   override def newIdentifier(
     prefix: Path,
-    baseDtab: () => Dtab = () => Dtab.base
+    baseDtab: () => Dtab = () => Dtab.base,
+    routerParams: Stack.Params = Stack.Params.empty
   ) = HeaderIdentifier(
     prefix,
     header.getOrElse(HeaderTokenIdentifierConfig.defaultHeader),

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/IngressIdentifier.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/IngressIdentifier.scala
@@ -5,7 +5,7 @@ import com.twitter.finagle.Stack.Params
 import com.twitter.finagle.buoyant.Dst
 import com.twitter.finagle.http.Request
 import com.twitter.finagle.param.Label
-import com.twitter.finagle.{Dtab, Path, Service, http}
+import com.twitter.finagle._
 import com.twitter.util.Future
 import io.buoyant.config.types.Port
 import io.buoyant.k8s.{ClientConfig, IngressCache}
@@ -52,7 +52,8 @@ case class IngressIdentifierConfig(
 
   override def newIdentifier(
     prefix: Path,
-    baseDtab: () => Dtab = () => Dtab.base
+    baseDtab: () => Dtab = () => Dtab.base,
+    routerParams: Stack.Params = Stack.Params.empty
   ): Identifier[Request] = {
     val client = mkClient(Params.empty).configured(Label("ingress-identifier"))
     new IngressIdentifier(prefix, baseDtab, namespace, client.newService(dst), ingressClassAnnotation.getOrElse("linkerd"), ignoreDefaultBackends.getOrElse(false))

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/MethodAndHostIdentifierConfig.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/MethodAndHostIdentifierConfig.scala
@@ -1,7 +1,7 @@
 package io.buoyant.linkerd.protocol.http
 
 import com.fasterxml.jackson.annotation.JsonIgnore
-import com.twitter.finagle.{Dtab, Path}
+import com.twitter.finagle.{Dtab, Path, Stack}
 import io.buoyant.linkerd.IdentifierInitializer
 import io.buoyant.linkerd.protocol.HttpIdentifierConfig
 import io.buoyant.router.http.MethodAndHostIdentifier
@@ -23,6 +23,7 @@ class MethodAndHostIdentifierConfig extends HttpIdentifierConfig {
   @JsonIgnore
   override def newIdentifier(
     prefix: Path,
-    baseDtab: () => Dtab = () => Dtab.base
+    baseDtab: () => Dtab = () => Dtab.base,
+    routerParams: Stack.Params = Stack.Params.empty
   ) = MethodAndHostIdentifier(prefix, httpUriInDst.getOrElse(false), baseDtab)
 }

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/PathIdentifierConfig.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/PathIdentifierConfig.scala
@@ -1,7 +1,7 @@
 package io.buoyant.linkerd.protocol.http
 
 import com.fasterxml.jackson.annotation.JsonIgnore
-import com.twitter.finagle.{Dtab, Path}
+import com.twitter.finagle.{Dtab, Path, Stack}
 import io.buoyant.linkerd.IdentifierInitializer
 import io.buoyant.linkerd.protocol.HttpIdentifierConfig
 import io.buoyant.router.http.PathIdentifier
@@ -24,6 +24,7 @@ class PathIdentifierConfig extends HttpIdentifierConfig {
   @JsonIgnore
   override def newIdentifier(
     prefix: Path,
-    baseDtab: () => Dtab = () => Dtab.base
+    baseDtab: () => Dtab = () => Dtab.base,
+    routerParams: Stack.Params = Stack.Params.empty
   ) = PathIdentifier(prefix, segments.getOrElse(1), consume.getOrElse(false), baseDtab)
 }

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/StaticIdentifierConfig.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/StaticIdentifierConfig.scala
@@ -2,7 +2,7 @@ package io.buoyant.linkerd.protocol.http
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.twitter.finagle.http.Request
-import com.twitter.finagle.{Dtab, Path}
+import com.twitter.finagle.{Dtab, Path, Stack}
 import io.buoyant.linkerd.IdentifierInitializer
 import io.buoyant.linkerd.protocol.HttpIdentifierConfig
 import io.buoyant.router.RoutingFactory.Identifier
@@ -21,6 +21,7 @@ case class StaticIdentifierConfig(path: Path) extends HttpIdentifierConfig {
   @JsonIgnore
   override def newIdentifier(
     prefix: Path,
-    baseDtab: () => Dtab = () => Dtab.base
+    baseDtab: () => Dtab = () => Dtab.base,
+    routerParams: Stack.Params = Stack.Params.empty
   ): Identifier[Request] = new StaticIdentifier(prefix ++ path, baseDtab)
 }

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/istio/IstioIdentifier.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/istio/IstioIdentifier.scala
@@ -1,7 +1,7 @@
 package io.buoyant.linkerd.protocol.http.istio
 
 import com.twitter.finagle.http.Request
-import com.twitter.finagle.{Dtab, Path}
+import com.twitter.finagle.{Dtab, Path, Stack}
 import com.twitter.util.Future
 import io.buoyant.config.types.Port
 import io.buoyant.k8s.istio._
@@ -43,7 +43,8 @@ case class IstioIdentifierConfig(
 
   override def newIdentifier(
     prefix: Path,
-    baseDtab: () => Dtab = () => Dtab.base
+    baseDtab: () => Dtab = () => Dtab.base,
+    routerParams: Stack.Params = Stack.Params.empty
   ): Identifier[Request] = {
 
     new IstioIdentifier(

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/istio/IstioIngressIdentifier.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/istio/IstioIngressIdentifier.scala
@@ -56,7 +56,8 @@ case class IstioIngressIdentifierConfig(
 
   override def newIdentifier(
     prefix: Path,
-    baseDtab: () => Dtab = () => Dtab.base
+    baseDtab: () => Dtab = () => Dtab.base,
+    routerParams: Stack.Params = Stack.Params.empty
   ): Identifier[Request] = {
 
     val k8sApiserverClient: Http.Client = mkK8sApiClient()


### PR DESCRIPTION
Firstcut for solving #1963 - asking for feedback


**Goal: Enable any identifier implements  `HttpIdentifierConfig` to access Stack.params of its top level Router**

What have been done:
1. pass `Stack.Params` from router to identifier.
2. perform plumbing through and add the new param to all subclasses

Question: 
Is it safe to pass down the whole `Stack.Param` (I think it is fine) - in my case, I just need to use the `StatsReceiver`

