### PR TITLE
Add admin-names project to 'all' target

### DIFF
--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -789,6 +789,7 @@ object LinkerdBuild extends Base {
     .settings(aggregateSettings ++ unidocSettings)
     .aggregate(
       admin,
+      adminNames,
       configCore,
       consul,
       etcd,


### PR DESCRIPTION
The admin-names project was not part of the `all` target in the SBT build file.  This caused this project's artifacts to not be published as part of the `./sbt publishSigned` command.

Add the project to the target.

Signed-off-by: Alex Leong <alex@buoyant.io>