### PR TITLE
Allow underscores in segment capture variable names

### DIFF
--- a/finagle/buoyant/src/main/scala/com/twitter/finagle/buoyant/PathMatcher.scala
+++ b/finagle/buoyant/src/main/scala/com/twitter/finagle/buoyant/PathMatcher.scala
@@ -67,7 +67,7 @@ object PathMatcher {
     override def extract(path: Path): Option[Map[String, String]] =
       _extract(path.showElems, rawSegments, Map.empty)
 
-    private[this] val segmentRegex = """\{([a-zA-Z0-9\.:-]+)\}""".r
+    private[this] val segmentRegex = """\{([a-zA-Z0-9\.:-_]+)\}""".r
 
     private[this] val rawSegments: Seq[MatchSegment] = {
       expr.split("/").dropWhile(_.isEmpty).map { exprSegment =>

--- a/finagle/buoyant/src/test/scala/com/twitter/finagle/buoyant/PathMatcherTest.scala
+++ b/finagle/buoyant/src/test/scala/com/twitter/finagle/buoyant/PathMatcherTest.scala
@@ -35,6 +35,11 @@ class PathMatcherTest extends FunSuite {
     assert(matcher.extract(Path.read("/foo/bar/bas")) == Some(Map("A" -> "bar")))
   }
 
+  test("capture segment with underscore name") {
+    val matcher = PathMatcher("/foo/{A_B_C}")
+    assert(matcher.extract(Path.read("/foo/bar/bas")) == Some(Map("A_B_C" -> "bar")))
+  }
+
   test("capture segments with endpoint") {
     val matcher = PathMatcher("/foo/bar/{A}:http")
     assert(matcher.extract(Path.read("/foo/bar/bas:http")) == Some(Map("A" -> "bas")))


### PR DESCRIPTION
Underscores in match patterns of io.l5d.rewrite do not work.  They considered valid characters for match pattern variables in previous Linkerd releases.

Update the regex to allow underscores.

Fixes #1969

Signed-off-by: Alex Leong <alex@buoyant.io>