### PR TITLE
Improve the No Hosts Available Exception message

### DIFF
--- a/linkerd/protocol/http/src/e2e/scala/io/buoyant/linkerd/protocol/HttpEndToEndTest.scala
+++ b/linkerd/protocol/http/src/e2e/scala/io/buoyant/linkerd/protocol/HttpEndToEndTest.scala
@@ -141,7 +141,7 @@ class HttpEndToEndTest
       }
 
       get("ralph-machio") { rsp =>
-        assert(rsp.status == Status.BadRequest)
+        assert(rsp.status == Status.BadGateway)
         assert(rsp.headerMap.contains(Headers.Err.Key))
         ()
       }

--- a/linkerd/protocol/http/src/e2e/scala/io/buoyant/linkerd/protocol/HttpEndToEndTest.scala
+++ b/linkerd/protocol/http/src/e2e/scala/io/buoyant/linkerd/protocol/HttpEndToEndTest.scala
@@ -141,7 +141,7 @@ class HttpEndToEndTest
       }
 
       get("ralph-machio") { rsp =>
-        assert(rsp.status == Status.BadGateway)
+        assert(rsp.status == Status.BadRequest)
         assert(rsp.headerMap.contains(Headers.Err.Key))
         ()
       }

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/ErrorResponder.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/ErrorResponder.scala
@@ -26,7 +26,7 @@ class ErrorResponder(maxHeaderSize: Int)
         case ErrorResponder.HttpResponseException(rsp) =>
           rsp
         case e: RichNoBrokersAvailableException =>
-          Headers.Err.respond(e.exceptionMessage(), Status.BadRequest, maxHeaderSize)
+          Headers.Err.respond(e.exceptionMessage(), Status.BadGateway, maxHeaderSize)
         case _ =>
           val message = e.getMessage match {
             case null => e.getClass.getName

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/FramingFilter.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/FramingFilter.scala
@@ -2,7 +2,7 @@ package io.buoyant.linkerd.protocol.http
 
 import com.twitter.finagle._
 import com.twitter.finagle.buoyant.linkerd.Headers
-import com.twitter.finagle.http.{Status, _}
+import com.twitter.finagle.http.{Status, param => hparam, _}
 import com.twitter.util.{Future, Return, Throw}
 import com.twitter.logging.Logger
 import io.buoyant.linkerd.ProtocolException
@@ -39,7 +39,7 @@ object FramingFilter {
   /**
    * A filter that fails badly-framed requests.
    */
-  val clientFilter = new SimpleFilter[Request, Response] {
+  def clientFilter(maxHeaderSize: Int) = new SimpleFilter[Request, Response] {
     // unlike the server filter, this needs its own logger, since
     // it responds to bad requests directly, rather than bubbling up
     // exceptions to an ErrorResponder
@@ -55,7 +55,7 @@ object FramingFilter {
             // if the exception was a FramingException, turn the Future into
             // a success by responding with Bad Request
             log.error("framing error in request", e)
-            Future.value(Headers.Err.respond(e.reason, Status.BadRequest))
+            Future.value(Headers.Err.respond(e.reason, Status.BadRequest, maxHeaderSize))
           case Throw(e) =>
             // other exceptions should be propagated
             Future.exception(e)
@@ -85,11 +85,11 @@ object FramingFilter {
     }
 
   val clientModule: Stackable[ServiceFactory[Request, Response]] =
-    new Stack.Module0[ServiceFactory[Request, Response]] {
+    new Stack.Module1[hparam.MaxHeaderSize, ServiceFactory[Request, Response]] {
       override val role: Stack.Role = FramingFilter.role
       override val description = "Fails badly-framed HTTP responses"
-      override def make(factory: ServiceFactory[Request, Response]): ServiceFactory[Request, Response] =
-        clientFilter.andThen(factory)
+      override def make(maxHeaderSize: hparam.MaxHeaderSize, factory: ServiceFactory[Request, Response]): ServiceFactory[Request, Response] =
+        clientFilter(maxHeaderSize.size.bytes.toInt).andThen(factory)
     }
 
   case class FramingException(reason: String) extends ProtocolException(reason)

--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -56,63 +56,6 @@ object LinkerdBuild extends Base {
     .withLibs(Deps.jackson)
     .withTests()
 
-  object Router {
-    val core = projectDir("router/core")
-      .dependsOn(Finagle.buoyantCore)
-      .withTwitterLib(Deps.finagle("core"))
-      .withTests()
-      .withE2e()
-      .settings(coverageExcludedPackages := ".*XXX_.*")
-
-    val baseHttp = projectDir("router/base-http")
-      .dependsOn(core)
-
-    val h2 = projectDir("router/h2")
-      .dependsOn(baseHttp, Finagle.h2 % "compile->compile;test->test")
-      .withTests()
-      .withE2e()
-
-    val http = projectDir("router/http")
-      .dependsOn(baseHttp)
-      .withTwitterLibs(Deps.finagle("http"))
-      .withLib(Deps.boringssl)
-      .withTests()
-      .withE2e()
-
-    val mux = projectDir("router/mux")
-      .dependsOn(core)
-      .withTwitterLib(Deps.finagle("mux"))
-      .withE2e()
-
-    val thriftIdl = projectDir("router/thrift-idl")
-      .withTwitterLib(Deps.finagle("thrift"))
-      .settings(Seq(
-        coverageExcludedPackages := ".*thriftscala.*",
-        scalacOptions -= "-Xfatal-warnings")
-      )
-
-    val thrift = projectDir("router/thrift")
-      .withTwitterLib(Deps.finagle("thrift"))
-      .withTests()
-      .withE2e()
-      .dependsOn(
-        core,
-        thriftIdl % "test,e2e"
-      )
-
-    val thriftMux = projectDir("router/thriftmux")
-      .withTwitterLib(Deps.finagle("thriftmux"))
-      .withTests()
-      .withE2e()
-      .dependsOn(
-        core,
-        thrift,
-        thriftIdl % "test,e2e"
-      )
-
-    val all = aggregateDir("router", core, baseHttp, h2, http, mux, thrift, thriftMux)
-  }
-
   object Mesh {
     val core = projectDir("mesh/core")
       .dependsOn(Grpc.runtime)
@@ -181,6 +124,63 @@ object LinkerdBuild extends Base {
 
     val all = aggregateDir("namer", core, consul, curator, dnssrv, fs, k8s, istio, marathon, serversets, zkLeader, rancher)
 
+  }
+
+  object Router {
+    val core = projectDir("router/core")
+      .dependsOn(Finagle.buoyantCore, Namer.core)
+      .withTwitterLib(Deps.finagle("core"))
+      .withTests()
+      .withE2e()
+      .settings(coverageExcludedPackages := ".*XXX_.*")
+
+    val baseHttp = projectDir("router/base-http")
+      .dependsOn(core)
+
+    val h2 = projectDir("router/h2")
+      .dependsOn(baseHttp, Finagle.h2 % "compile->compile;test->test")
+      .withTests()
+      .withE2e()
+
+    val http = projectDir("router/http")
+      .dependsOn(baseHttp)
+      .withTwitterLibs(Deps.finagle("http"))
+      .withLib(Deps.boringssl)
+      .withTests()
+      .withE2e()
+
+    val mux = projectDir("router/mux")
+      .dependsOn(core)
+      .withTwitterLib(Deps.finagle("mux"))
+      .withE2e()
+
+    val thriftIdl = projectDir("router/thrift-idl")
+      .withTwitterLib(Deps.finagle("thrift"))
+      .settings(Seq(
+        coverageExcludedPackages := ".*thriftscala.*",
+        scalacOptions -= "-Xfatal-warnings")
+      )
+
+    val thrift = projectDir("router/thrift")
+      .withTwitterLib(Deps.finagle("thrift"))
+      .withTests()
+      .withE2e()
+      .dependsOn(
+        core,
+        thriftIdl % "test,e2e"
+      )
+
+    val thriftMux = projectDir("router/thriftmux")
+      .withTwitterLib(Deps.finagle("thriftmux"))
+      .withTests()
+      .withE2e()
+      .dependsOn(
+        core,
+        thrift,
+        thriftIdl % "test,e2e"
+      )
+
+    val all = aggregateDir("router", core, baseHttp, h2, http, mux, thrift, thriftMux)
   }
 
   val adminNames = projectDir("admin/names")

--- a/router/core/src/e2e/scala/io/buoyant/router/EchoEndToEndTest.scala
+++ b/router/core/src/e2e/scala/io/buoyant/router/EchoEndToEndTest.scala
@@ -4,11 +4,12 @@ import com.twitter.conversions.time._
 import com.twitter.finagle._
 import com.twitter.finagle.buoyant.{Echo => FinagleEcho, _}
 import com.twitter.finagle.client.StackClient
+import com.twitter.finagle.naming.buoyant.RichNoBrokersAvailableException
 import com.twitter.finagle.param.ProtocolLibrary
 import com.twitter.finagle.server.StackServer
 import com.twitter.finagle.stack.nilStack
-import com.twitter.finagle.stats.{NullStatsReceiver, InMemoryStatsReceiver}
-import com.twitter.finagle.tracing.{Annotation, BufferingTracer, Trace, NullTracer}
+import com.twitter.finagle.stats.{InMemoryStatsReceiver, NullStatsReceiver}
+import com.twitter.finagle.tracing.{Annotation, BufferingTracer, NullTracer, Trace}
 import com.twitter.util._
 import io.buoyant.router.RoutingFactory.{IdentifiedRequest, RequestIdentification}
 import io.buoyant.test.Awaits
@@ -250,7 +251,7 @@ object Echo extends Router[String, String] with Server[String, String] {
       def make(factory: ServiceFactory[String, String]) = filter andThen factory
       val filter = Filter.mk[String, String, String, String] { (req, svc) =>
         svc(req).handle {
-          case nbae: NoBrokersAvailableException => "NOBROKERS"
+          case nbae: RichNoBrokersAvailableException => "NOBROKERS"
           case e: Throwable => s"ERROR ${e.getMessage}"
         }
       }

--- a/router/core/src/main/scala/com/twitter/finagle/naming/buoyant/DstBindingFactory.scala
+++ b/router/core/src/main/scala/com/twitter/finagle/naming/buoyant/DstBindingFactory.scala
@@ -163,14 +163,9 @@ object DstBindingFactory {
           }
 
           private val handleNoBrokers: PartialFunction[Throwable, Future[Service[Req, Rsp]]] = {
-            case e: NoBrokersAvailableException => nbae
+            case e: NoBrokersAvailableException => RichNoBrokersAvailableException(dst, namer)
           }
 
-          private lazy val nbae = Future.exception(new NoBrokersAvailableException(
-            dst.path.show,
-            dst.baseDtab,
-            dst.localDtab
-          ))
         }
 
         pathMk(dst, dyn)

--- a/router/core/src/main/scala/com/twitter/finagle/naming/buoyant/RichNoBrokersAvailableException.scala
+++ b/router/core/src/main/scala/com/twitter/finagle/naming/buoyant/RichNoBrokersAvailableException.scala
@@ -1,0 +1,76 @@
+package com.twitter.finagle.naming.buoyant
+
+import com.twitter.finagle._
+import com.twitter.finagle.buoyant.Dst
+import com.twitter.finagle.naming.NameInterpreter
+import com.twitter.util.Future
+import io.buoyant.namer.{DelegateTree, Delegator, RichActivity}
+
+class RichNoBrokersAvailableException(
+  path: Dst.Path,
+  dtab: Option[Dtab],
+  resolutions: Option[Seq[String]]
+) extends RequestException {
+
+  private[this] def formatDtab(d: Dtab): String =
+    d.map { dentry =>
+      s"  ${dentry.prefix.show} => ${dentry.dst.show}"
+    }.mkString("\n")
+
+  override def exceptionMessage(): String =
+    s"""Unable to route request!
+
+service name: ${path.path.show}
+resolutions considered:
+${resolutions.getOrElse(Seq("unknown")).map("  " + _).mkString("\n")}
+dtab:
+${formatDtab(dtab.getOrElse(Dtab.empty))}
+base dtab:
+${formatDtab(path.baseDtab)}
+override dtab:
+${formatDtab(path.localDtab)}
+""".stripMargin
+}
+
+object RichNoBrokersAvailableException {
+
+  def apply(path: Dst.Path, namer: NameInterpreter): Future[Nothing] = {
+    namer match {
+      case delegator: Delegator =>
+
+        val dtab = delegator.dtab.toFuture
+        val res = delegator.delegate(path.dtab, path.path).flatMap(resolutions)
+
+        dtab.join(res).flatMap {
+          case (d, r) => Future.exception(new RichNoBrokersAvailableException(path, Some(d), Some(r)))
+        }
+      case _ => Future.exception(new RichNoBrokersAvailableException(path, None, None))
+    }
+  }
+
+  def resolutions(tree: DelegateTree[Name.Bound]): Future[Seq[String]] = {
+    tree match {
+      case DelegateTree.Leaf(path, _, Name.Bound(vaddr)) =>
+        vaddr.changes.toFuture().map {
+          case Addr.Bound(_, _) => Seq(s"${path.show} (bound)")
+          case Addr.Failed(e) => Seq(s"${path.show} (exception: ${e.getMessage}")
+          case Addr.Neg => Seq(s"${path.show} (neg)")
+          case Addr.Pending => Seq(s"${path.show} (pending)")
+        }
+      case DelegateTree.Exception(path, _, e) => Future.value(Seq(s"${path.show} (exception: ${e.getMessage}"))
+      case DelegateTree.Empty(path, _) => Future.value(Seq(s"${path.show} (empty)"))
+      case DelegateTree.Fail(path, _) => Future.value(Seq(s"${path.show} (fail)"))
+      case DelegateTree.Neg(path, _) => Future.value(Seq(s"${path.show} (neg)"))
+      case DelegateTree.Delegate(_, _, next) => resolutions(next)
+      case DelegateTree.Transformation(_, _, _, next) => resolutions(next)
+      case DelegateTree.Union(_, _, children@_*) =>
+        Future.collect {
+          children.map { child =>
+            resolutions(child.tree)
+          }
+        }.map(_.flatten)
+      case DelegateTree.Alt(_, _, children@_*) =>
+        Future.collect(children.map(resolutions)).map(_.flatten)
+    }
+  }
+}

--- a/router/core/src/test/scala/com/twitter/finagle/naming/buoyant/DstBindingFactoryTest.scala
+++ b/router/core/src/test/scala/com/twitter/finagle/naming/buoyant/DstBindingFactoryTest.scala
@@ -139,21 +139,15 @@ class DstBindingFactoryTest extends FunSuite with Awaits with Exceptions {
     val baseDtab = Dtab.read("/usa => /people")
     val localDtab = Dtab.read("/usa => /money")
 
-    val e0 = intercept[NoBrokersAvailableException] {
+    assertThrows[RichNoBrokersAvailableException] {
       val svc = await(cache(Dst.Path(Path.read("/usa/ca/la"), baseDtab, localDtab)))
       val _ = await(svc("the 101"))
     }
-    assert(e0.name == "/usa/ca/la")
-    assert(e0.baseDtab == baseDtab)
-    assert(e0.localDtab == localDtab)
 
-    val e1 = intercept[NoBrokersAvailableException] {
+    assertThrows[RichNoBrokersAvailableException] {
       val svc = await(cache(Dst.Path(Path.read("/usa/ca/sf"), baseDtab, localDtab)))
       val _ = await(svc("101"))
     }
-    assert(e1.name == "/usa/ca/sf")
-    assert(e1.baseDtab == baseDtab)
-    assert(e1.localDtab == localDtab)
   }
 
   test("Binding timeout is respected") {


### PR DESCRIPTION
When Linkerd is unable to route a request, it returns a cryptic "No Hosts Available Exception" error message.

We update this error message to give more contextual information about the request and why it could not be routed.

Old output:
```
$ curl localhost:4140 -H "Host: alex" -H "l5d-dtab: /svc/alex => /svc/leong"
No hosts are available for /svc/alex, Dtab.base=[], Dtab.local=[/svc/alex=>/svc/leong]. Remote Info: Not Available
```

New output:
```
$ curl -v localhost:4140 -H "Host: alex" -H "l5d-dtab: /svc/alex => /svc/leong"
* Rebuilt URL to: localhost:4140/
*   Trying ::1...
* TCP_NODELAY set
* Connection failed
* connect to ::1 port 4140 failed: Connection refused
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 4140 (#0)
> GET / HTTP/1.1
> Host: alex
> User-Agent: curl/7.54.0
> Accept: */*
> l5d-dtab: /svc/alex => /svc/leong
>
< HTTP/1.1 400 Bad Request
< l5d-err: Unable+to+route+request%21%0A%0Aservice+name%3A+%2Fsvc%2Falex%0Aresolutions+considered%3A%0A++%2F%23%2Fio.l5d.fs%2Fleong+%28neg%29%0A++%2F%23%2Fio.l5d.fs%2Fblork+%28neg%29%0A++%2F%23%2Fio.l5d.fs%2Falex+%28neg%29%0A++%2F%23%2Fio.l5d.fs%2Fblork+%28neg%29%0Adtab%3A%0A++%2Fsvc%2F*+%3D%3E+%2F%23%2Fio.l5d.fs%2Fblork%0A++%2Fsvc+%3D%3E+%2F%23%2Fio.l5d.fs%0Abase+dtab%3A%0A%0Aoverride+dtab%3A%0A++%2Fsvc%2Falex+%3D%3E+%2Fsvc%2Fleong%0A
< Content-Length: 294
< Content-Type: text/plain
<
Unable to route request!

service name: /svc/alex
resolutions considered:
  /#/io.l5d.fs/leong (neg)
  /#/io.l5d.fs/blork (neg)
  /#/io.l5d.fs/alex (neg)
  /#/io.l5d.fs/blork (neg)
dtab:
  /svc/* => /#/io.l5d.fs/blork
  /svc => /#/io.l5d.fs
base dtab:

override dtab:
  /svc/alex => /svc/leong
* Connection #0 to host localhost left intact
```

Fixes #1948 

Signed-off-by: Alex Leong <alex@buoyant.io>