### PR TITLE
Fixes #1552 - Rework TLS client configuration trust store to use a CA…

### DIFF
--- a/finagle/buoyant/src/main/scala/com/twitter/finagle/buoyant/TlsClientConfig.scala
+++ b/finagle/buoyant/src/main/scala/com/twitter/finagle/buoyant/TlsClientConfig.scala
@@ -1,11 +1,10 @@
 package com.twitter.finagle.buoyant
 
 import java.io._
-
 import com.twitter.finagle.Stack
 import com.twitter.finagle.netty4.ssl.client.Netty4ClientEngineFactory
-import com.twitter.finagle.ssl.client.{SslClientConfiguration, SslClientEngineFactory}
 import com.twitter.finagle.ssl.{KeyCredentials, Protocols, TrustCredentials}
+import com.twitter.finagle.ssl.client.{SslClientConfiguration, SslClientEngineFactory}
 import com.twitter.finagle.transport.Transport
 import com.twitter.io.StreamIO
 
@@ -16,13 +15,14 @@ case class TlsClientConfig(
   disableValidation: Option[Boolean],
   commonName: Option[String],
   trustCerts: Option[Seq[String]] = None,
+  trustCertsBundle: Option[String] = None,
   clientAuth: Option[ClientAuth] = None,
   protocols: Option[Seq[String]] = None
 ) {
   def params: Stack.Params = this match {
-    case TlsClientConfig(Some(false), _, _, _, _, _) =>
+    case TlsClientConfig(Some(false), _, _, _, _, _, _) =>
       Stack.Params.empty + Transport.ClientSsl(None)
-    case TlsClientConfig(_, Some(true), _, _, clientAuth, enabledProtocols) =>
+    case TlsClientConfig(_, Some(true), _, _, _, clientAuth, enabledProtocols) =>
       val tlsConfig = SslClientConfiguration(
         trustCredentials = TrustCredentials.Insecure,
         keyCredentials = keyCredentials(clientAuth),
@@ -31,33 +31,17 @@ case class TlsClientConfig(
       Stack.Params.empty + Transport.ClientSsl(Some(tlsConfig)) +
         SslClientEngineFactory.Param(Netty4ClientEngineFactory())
 
-    case TlsClientConfig(_, _, Some(cn), certs, clientAuth, enabledProtocols) =>
-      // map over the optional certs parameter - we want to pass
-      // `TrustCredentials.CertCollection` if we were given a list of certs,
-      // but `TrustCredentials.Unspecified` (rather than an empty cert
-      // collection file) if we were not.
-      val credentials = certs.map { certs =>
-        // a temporary file to hold the collection of certificates
-        val certCollection = File.createTempFile("certCollection", null)
-        // open the cert paths as Streams...
-        val f = new FileOutputStream(certCollection)
-        for {
-          cert <- certs
-          certStream = new FileInputStream(cert)
-        } { // ...and copy the certs into the cert collection
-          // TODO: can this be made more concise with scala.io?
-          StreamIO.copy(certStream, f)
+    case TlsClientConfig(_, _, Some(cn), certs, bundle, clientAuth, enabledProtocols) =>
+      val credentials = bundle.map(b => TrustCredentials.CertCollection(new File(b)))
+        // map over the optional certs parameter - we want to pass
+        // `TrustCredentials.CertCollection` if we were given a list of certs,
+        // but `TrustCredentials.Unspecified` (rather than an empty cert
+        // collection file) if we were not.
+        .orElse(certs.map(convertCertsToBundle))
+        .getOrElse {
+          // otherwise, we want to pass `TrustCredentials.Unspecified`
+          TrustCredentials.Unspecified
         }
-        f.flush()
-        f.close()
-        certCollection.deleteOnExit()
-        // the credentials we'll pass to `SslClientConfiguration` will
-        // be a collection of certificates
-        TrustCredentials.CertCollection(certCollection)
-      } getOrElse {
-        // otherwise, we want to pass `TrustCredentials.Unspecified`
-        TrustCredentials.Unspecified
-      }
 
       val tlsConfig = SslClientConfiguration(
         hostname = Some(cn),
@@ -68,9 +52,29 @@ case class TlsClientConfig(
       Stack.Params.empty + Transport.ClientSsl(Some(tlsConfig)) +
         SslClientEngineFactory.Param(Netty4ClientEngineFactory())
 
-    case TlsClientConfig(_, Some(false) | None, None, _, _, _) =>
+    case TlsClientConfig(_, Some(false) | None, None, _, _, _, _) =>
       val msg = "tls is configured with validation but `commonName` is not set"
       throw new IllegalArgumentException(msg) with NoStackTrace
+  }
+
+  private def convertCertsToBundle(certs: Seq[String]): TrustCredentials.CertCollection = {
+    // a temporary file to hold the collection of certificates
+    val certCollection = File.createTempFile("certCollection", null)
+    // open the cert paths as Streams...
+    val f = new FileOutputStream(certCollection)
+    for {
+      cert <- certs
+      certStream = new FileInputStream(cert)
+    } { // ...and copy the certs into the cert collection
+      // TODO: can this be made more concise with scala.io?
+      StreamIO.copy(certStream, f)
+    }
+    f.flush()
+    f.close()
+    certCollection.deleteOnExit()
+    // the credentials we'll pass to `SslClientConfiguration` will
+    // be a collection of certificates
+    TrustCredentials.CertCollection(certCollection)
   }
 
   private[this] def keyCredentials(clientAuth: Option[ClientAuth]): KeyCredentials =

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/ClientConfigTest.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/ClientConfigTest.scala
@@ -35,7 +35,33 @@ class ClientConfigTest extends FunSuite {
         |  keyPath: key.pem
       """.stripMargin
     Parser.objectMapper(yaml, Nil).readValue[TlsClientConfig](yaml)
+  }
 
+  test("should use configured trust bundle") {
+    val yaml =
+      """
+        |commonName: foo
+        |clientAuth:
+        |  certPath: cert.pem
+        |  keyPath: key.pem
+        |trustCertsBundle: trust-certs.pem
+      """.stripMargin
+    val config = Parser.objectMapper(yaml, Nil).readValue[TlsClientConfig](yaml)
+    config.trustCertsBundle.get should equal("trust-certs.pem")
+  }
+
+  test("should use configured trust certs") {
+    val yaml =
+      """
+        |commonName: foo
+        |clientAuth:
+        |  certPath: cert.pem
+        |  keyPath: key.pem
+        |trustCerts:
+        |  - trust-certs.pem
+      """.stripMargin
+    val config = Parser.objectMapper(yaml, Nil).readValue[TlsClientConfig](yaml)
+    config.trustCerts.get should contain only "trust-certs.pem"
   }
 
   test("should parse tls protocols") {

--- a/linkerd/docs/client_tls.md
+++ b/linkerd/docs/client_tls.md
@@ -41,8 +41,7 @@ routers:
   client:
     tls:
       commonName: linkerd.io
-      trustCerts:
-      - /certificates/cacert.pem
+      trustCertsBundle: /certificates/cacert.pem
       clientAuth:
         certPath: /certificates/cert.pem
         keyPath: /certificates/key.pem
@@ -60,7 +59,8 @@ Key               | Default Value                              | Description
 ----------------- | ------------------------------------------ | -----------
 disableValidation | false                                      | Enable this to skip hostname validation (unsafe). Setting `disableValidation: true` is incompatible with `clientAuth`.
 commonName        | _required_ unless disableValidation is set | The common name to use for all TLS requests.
-trustCerts        | empty list                                 | A list of file paths of CA certs to use for common name validation.
+trustCerts        | empty list                                 | A file path of CA certs bundle to use for common name validation.
+trustCertsBundle  | empty                                      | A list of file paths of CA certs to use for common name validation (deprecated, please use trustCertsBundle).
 clientAuth        | none                                       | A client auth object used to sign requests.
 protocols         | unspecified                                | The list of TLS protocols to enable
 

--- a/linkerd/docs/namer.md
+++ b/linkerd/docs/namer.md
@@ -244,8 +244,7 @@ namers:
   tls:
     disableValidation: false
     commonName: consul.io
-    trustCerts:
-    - /certificates/cacert.pem
+    trustCertsBundle: /certificates/cacert.pem
     clientAuth:
       certPath: /certificates/cert.pem
       keyPath: /certificates/key.pem
@@ -257,7 +256,8 @@ Key               | Default Value                              | Description
 ----------------- | ------------------------------------------ | -----------
 disableValidation | false                                      | Enable this to skip hostname validation (unsafe). Setting `disableValidation: true` is incompatible with `clientAuth`.
 commonName        | _required_ unless disableValidation is set | The common name to use for all TLS requests.
-trustCerts        | empty list                                 | A list of file paths of CA certs to use for common name validation.
+trustCerts        | empty list                                 | A list of file paths of CA certs to use for common name validation (deprecated, please use trustCertsBundle).
+trustCertsBundle  | empty                                      | A file path of CA certs bundle to use for common name validation.
 clientAuth        | none                                       | A client auth object used to sign requests.
 
 If present, a clientAuth object must contain two properties:

--- a/linkerd/examples/mutualTls.yaml
+++ b/linkerd/examples/mutualTls.yaml
@@ -10,8 +10,7 @@ routers:
   client:
     tls:
       commonName: foo
-      trustCerts:
-      - /foo/cacert.pem
+      trustCertsBundle: /foo/cacert.pem
       clientAuth:
         certPath: /foo/clientCert.pem
         keyPath: /foo/clientKey.pem
@@ -23,6 +22,6 @@ routers:
       certPath: /foo/cert.pem
       keyPath: /foo/key.pem
       # clients must provide a valid certificate
-      requireClientAuth: true 
+      requireClientAuth: true
       # the authority used to validate client certificates
       caCertPath: /foo/cacert.pem

--- a/linkerd/examples/namerd-tls.yaml
+++ b/linkerd/examples/namerd-tls.yaml
@@ -28,8 +28,7 @@ routers:
     tls:
       disableValidation: false
       commonName: namerd
-      trustCerts:
-      - namerd/examples/certs/namerd-cacert.pem
+      trustCertsBundle: namerd/examples/certs/namerd-cacert.pem
   servers:
   - port: 4141
     ip: 0.0.0.0
@@ -43,8 +42,7 @@ routers:
     tls:
       disableValidation: false
       commonName: linkerd-tls-e2e
-      trustCerts:
-      - finagle/h2/src/e2e/resources/cacert.pem
+      trustCertsBundle: finagle/h2/src/e2e/resources/cacert.pem
       clientAuth:
         certPath: finagle/h2/src/e2e/resources/linkerd-tls-e2e-cert.pem
         keyPath: finagle/h2/src/e2e/resources/linkerd-tls-e2e-key.pem
@@ -60,8 +58,7 @@ routers:
     tls:
       disableValidation: false
       commonName: linkerd-tls-e2e
-      trustCerts:
-      - finagle/h2/src/e2e/resources/cacert.pem
+      trustCertsBundle: finagle/h2/src/e2e/resources/cacert.pem
       clientAuth:
         certPath: finagle/h2/src/e2e/resources/linkerd-tls-e2e-cert.pem
         keyPath: finagle/h2/src/e2e/resources/linkerd-tls-e2e-key.pem

--- a/linkerd/examples/tls.yaml
+++ b/linkerd/examples/tls.yaml
@@ -13,8 +13,7 @@ routers:
     configs:
     - prefix: "/#/io.l5d.fs/{service}"
       tls:
-        trustCerts:
-        - /foo/caCert.pem
+        trustCertsBundle: /foo/caCert.pem
         commonName: "{service}"
   servers:
   - port: 4140

--- a/linkerd/protocol/http/src/integration/scala/io/buoyant/linkerd/protocol/ClientAuthTest.scala
+++ b/linkerd/protocol/http/src/integration/scala/io/buoyant/linkerd/protocol/ClientAuthTest.scala
@@ -44,8 +44,7 @@ class ClientAuthTest extends FunSuite {
          |  client:
          |   tls:
          |     commonName: server
-         |     trustCerts:
-         |     - ${certs.caCert.getPath}
+         |     trustCertsBundle: ${certs.caCert.getPath}
          |     clientAuth:
          |       certPath: ${clientCerts.cert.getPath}
          |       keyPath: ${clientCerts.key.getPath}
@@ -109,8 +108,7 @@ class ClientAuthTest extends FunSuite {
                             |  client:
                             |   tls:
                             |     commonName: server
-                            |     trustCerts:
-                            |     - ${certs.caCert.getPath}
+                            |     trustCertsBundle: ${certs.caCert.getPath}
        """.stripMargin
       val clientLinker = Linker.load(clientConfig)
       val clientRouter = clientLinker.routers.head.initialize()

--- a/linkerd/protocol/http/src/integration/scala/io/buoyant/linkerd/protocol/TlsBoundPathTest.scala
+++ b/linkerd/protocol/http/src/integration/scala/io/buoyant/linkerd/protocol/TlsBoundPathTest.scala
@@ -52,8 +52,7 @@ class TlsBoundPathTest extends FunSuite with Awaits {
              |    - prefix: "/#/io.l5d.fs/{host}"
              |      tls:
              |        commonName: "{host}.buoyant.io"
-             |        trustCerts:
-             |        - ${certs.caCert.getPath}
+             |        trustCertsBundle: ${certs.caCert.getPath}
              |""".
               stripMargin
           withLinkerdClient(linkerConfig) { client =>
@@ -113,8 +112,7 @@ class TlsBoundPathTest extends FunSuite with Awaits {
             |    - prefix: "/#/io.l5d.fs/bill"
             |      tls:
             |        commonName: "bill.buoyant.io"
-            |        trustCerts:
-            |        - ${certs.caCert.getPath}
+            |        trustCertsBundle: ${certs.caCert.getPath}
             |""".
             stripMargin
           withLinkerdClient(linkerConfig) { client =>
@@ -179,13 +177,11 @@ class TlsBoundPathTest extends FunSuite with Awaits {
             |    - prefix: "/#/io.l5d.fs/bill"
             |      tls:
             |        commonName: excellent
-            |        trustCerts:
-            |        - ${certs.caCert.getPath}
+            |        trustCertsBundle: ${certs.caCert.getPath}
             |    - prefix: "/#/io.l5d.fs/ted"
             |      tls:
             |        commonName: righteous
-            |        trustCerts:
-            |        - ${certs.caCert.getPath}            
+            |        trustCertsBundle: ${certs.caCert.getPath}
             |""".
             stripMargin
           withLinkerdClient(linkerConfig) { client =>
@@ -255,8 +251,7 @@ class TlsBoundPathTest extends FunSuite with Awaits {
              |    - prefix: "/#/io.l5d.fs/{host}"
              |      tls:
              |        commonName: "{host}.buoyant.io"
-             |        trustCerts:
-             |        - ${certs.caCert.getPath}             
+             |        trustCertsBundle: ${certs.caCert.getPath}
              |""".stripMargin
           withLinkerdClient(linkerConfig) { client =>
             val billRsp = {

--- a/linkerd/protocol/http/src/integration/scala/io/buoyant/linkerd/protocol/TlsCertReloadingTest.scala
+++ b/linkerd/protocol/http/src/integration/scala/io/buoyant/linkerd/protocol/TlsCertReloadingTest.scala
@@ -47,8 +47,7 @@ class TlsCertReloadingTest extends FunSuite with Awaits {
         |  client:
         |   tls:
         |     commonName: bar
-        |     trustCerts:
-        |     - ${certs.caCert.getPath}
+        |     trustCertsBundle: ${certs.caCert.getPath}
        """.stripMargin
       val outgoingLinker = Linker.load(outgoingConfig)
       val outgoingRouter = outgoingLinker.routers.head.initialize()

--- a/linkerd/protocol/http/src/integration/scala/io/buoyant/linkerd/protocol/TlsStaticValidationTest.scala
+++ b/linkerd/protocol/http/src/integration/scala/io/buoyant/linkerd/protocol/TlsStaticValidationTest.scala
@@ -14,7 +14,48 @@ class TlsStaticValidationTest extends FunSuite with Awaits {
     protocol = Seq(HttpInitializer)
   )
 
-  test("tls router + plain upstream with static validation") {
+  test("tls router + plain upstream with static validation and trustCertsBundle") {
+    withCerts("linkerd") { certs =>
+      val dog = Downstream.constTls("dogs", "woof", certs.serviceCerts("linkerd").cert,
+        certs.serviceCerts("linkerd").key)
+      try {
+        val linkerConfig =
+          s"""
+             |routers:
+             |- protocol: http
+             |  dtab: |
+             |    /p/dog => /$$/inet/127.1/${dog.port} ;
+             |    /svc/clifford => /p/dog ;
+             |  servers:
+             |  - port: 0
+             |  client:
+             |    tls:
+             |      commonName: linkerd
+             |      trustCertsBundle: ${certs.caCert.getPath}
+             |""".stripMargin
+        val linker = init.load(linkerConfig)
+        val router = linker.routers.head.initialize()
+        try {
+          val server = router.servers.head.serve()
+          try {
+            val client = Upstream.mk(server)
+            try {
+              val rsp = {
+                val req = Request()
+                req.host = "clifford"
+                await(client(req))
+              }
+              assert(rsp.contentString == "woof")
+              ()
+
+            } finally await(client.close())
+          } finally await(server.close())
+        } finally await(router.close())
+      } finally await(dog.server.close())
+    }
+  }
+
+  test("tls router + plain upstream with static validation and trustCerts") {
     withCerts("linkerd") { certs =>
       val dog = Downstream.constTls("dogs", "woof", certs.serviceCerts("linkerd").cert,
         certs.serviceCerts("linkerd").key)
@@ -78,8 +119,7 @@ class TlsStaticValidationTest extends FunSuite with Awaits {
              |  client:
              |    tls:
              |      commonName: wrong
-             |      trustCerts:
-             |      - ${certs.caCert.getPath}
+             |      trustCertsBundle: ${certs.caCert.getPath}
              |""".stripMargin
         val linker = init.load(linkerConfig)
         val router = linker.routers.head.initialize()

--- a/namer/consul/src/main/scala/io/buoyant/namer/consul/ConsulInitializer.scala
+++ b/namer/consul/src/main/scala/io/buoyant/namer/consul/ConsulInitializer.scala
@@ -34,8 +34,7 @@ import io.buoyant.namer.{NamerConfig, NamerInitializer}
  *   tls:
  *     disableValidation: false
  *     commonName: consul.io
- *     trustCerts:
- *     - /certificates/cacert.pem
+ *     trustCertsBundle: /certificates/cacert.pem
  *     clientAuth:
  *       certPath: /certificates/cert.pem
  *       keyPath: /certificates/key.pem

--- a/namer/consul/src/test/scala/io/buoyant/namer/consul/ConsulTest.scala
+++ b/namer/consul/src/test/scala/io/buoyant/namer/consul/ConsulTest.scala
@@ -52,8 +52,7 @@ class ConsulTest extends FunSuite {
                     |tls:
                     |  disableValidation: false
                     |  commonName: consul.io
-                    |  trustCerts:
-                    |  - /certificates/cacert.pem
+                    |  trustCertsBundle: /certificates/cacerts-bundle.pem
                     |  clientAuth:
                     |    certPath: /certificates/cert.pem
                     |    keyPath: /certificates/key.pem
@@ -73,7 +72,7 @@ class ConsulTest extends FunSuite {
     assert(consul.preferServiceAddress == Some(false))
     assert(consul.weights == Some(Seq(TagWeight("primary", 100.0))))
     val clientAuth = ClientAuth("/certificates/cert.pem", None, "/certificates/key.pem")
-    val tlsConfig = TlsClientConfig(None, Some(false), Some("consul.io"), Some(List("/certificates/cacert.pem")), Some(clientAuth))
+    val tlsConfig = TlsClientConfig(None, Some(false), Some("consul.io"), None, Some("/certificates/cacerts-bundle.pem"), Some(clientAuth))
     assert(consul.tls == Some(tlsConfig))
     assert(!consul.disabled)
   }

--- a/namer/marathon/src/test/scala/io/buoyant/namer/marathon/MarathonTest.scala
+++ b/namer/marathon/src/test/scala/io/buoyant/namer/marathon/MarathonTest.scala
@@ -92,8 +92,7 @@ class MarathonTest extends FunSuite {
                   |tls:
                   |  disableValidation: false
                   |  commonName: master.mesos
-                  |  trustCerts:
-                  |    - /foo/caCert.pem
+                  |  trustCertsBundle: /foo/caCert.pem
       """.stripMargin
 
     val mapper = Parser.objectMapper(yaml, Iterable(Seq(MarathonInitializer)))
@@ -108,7 +107,7 @@ class MarathonTest extends FunSuite {
     val tls = marathon.tls.get
     assert(tls.disableValidation.contains(false))
     assert(tls.commonName.contains("master.mesos"))
-    assert(tls.trustCerts.contains(List("/foo/caCert.pem")))
+    assert(tls.trustCertsBundle.contains("/foo/caCert.pem"))
 
     assert(!marathon.disabled)
   }
@@ -171,6 +170,5 @@ class MarathonTest extends FunSuite {
     // assert that we're generating a reasonable amount of distinct TTLs –
     // see above for what constitutes "reasonable"
     assert(jitters.take(300).toSet.size >= MinUniqueTTLs)
-
   }
 }

--- a/namerd/docs/storage.md
+++ b/namerd/docs/storage.md
@@ -198,8 +198,7 @@ namers:
   tls:
     disableValidation: false
     commonName: consul.io
-    trustCerts:
-    - /certificates/cacert.pem
+    trustCertsBundle: /certificates/cacert.pem
     clientAuth:
       certPath: /certificates/cert.pem
       keyPath: /certificates/key.pem
@@ -211,7 +210,8 @@ Key               | Default Value                              | Description
 ----------------- | ------------------------------------------ | -----------
 disableValidation | false                                      | Enable this to skip hostname validation (unsafe). Setting `disableValidation: true` is incompatible with `clientAuth`.
 commonName        | _required_ unless disableValidation is set | The common name to use for all TLS requests.
-trustCerts        | empty list                                 | A list of file paths of CA certs to use for common name validation.
+trustCerts        | empty list                                 | A list of file paths of CA certs to use for common name validation (deprecated, please use trustCertsBundle).
+trustCertsBundle  | empty                                      | A file path of CA certs bundle to use for common name validation.
 clientAuth        | none                                       | A client auth object used to sign requests.
 
 If present, a clientAuth object must contain two properties:

--- a/namerd/storage/consul/src/test/scala/io/buoyant/namerd/storage/consul/ConsulConfigTest.scala
+++ b/namerd/storage/consul/src/test/scala/io/buoyant/namerd/storage/consul/ConsulConfigTest.scala
@@ -27,8 +27,7 @@ class ConsulConfigTest extends FunSuite with OptionValues {
          |tls:
          |  disableValidation: false
          |  commonName: consul.io
-         |  trustCerts:
-         |  - /certificates/cacert.pem
+         |  trustCertsBundle: /certificates/cacert-bundle.pem
          |  clientAuth:
          |    certPath: /certificates/cert.pem
          |    keyPath: /certificates/key.pem
@@ -43,7 +42,7 @@ class ConsulConfigTest extends FunSuite with OptionValues {
     assert(consul.readConsistencyMode == Some(ConsistencyMode.Stale))
     assert(consul.writeConsistencyMode == Some(ConsistencyMode.Consistent))
     val clientAuth = ClientAuth("/certificates/cert.pem", None, "/certificates/key.pem")
-    val tlsConfig = TlsClientConfig(None, Some(false), Some("consul.io"), Some(List("/certificates/cacert.pem")), Some(clientAuth))
+    val tlsConfig = TlsClientConfig(None, Some(false), Some("consul.io"), None, Some("/certificates/cacert-bundle.pem"), Some(clientAuth))
     assert(consul.tls == Some(tlsConfig))
   }
 


### PR DESCRIPTION
… bundle instead of dropping all ca certs to a bundle in the temp folder. This simplifies the client TLS code, removes a dependency on the temporary folder and aligns client TLS configuration with server TLS configuration.

TLS client configuration still supports the former trustCerts option which if it's used it will cause a warning to be logged.

Sample from the logs:
```
W 0610 17:49:05.788 BST THREAD1: trustCerts configuration option is deprecated, please consider using trustCertsBundle
```

Signed-off-by: Dan Vulpe <dvulpe@gmail.com>