### PR TITLE
Linkerd 1.4.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
           command: |
             set -x
             if [ ! -f docker-17.03.0-ce.tgz ]; then
-              curl -sLO https://get.docker.com/builds/Linux/x86_64/docker-17.03.0-ce.tgz
+              curl -sLO https://download.docker.com/linux/static/stable/x86_64/docker-17.03.0-ce.tgz
             fi
             tar -xz -C /tmp -f docker-17.03.0-ce.tgz
             mv /tmp/docker/* /usr/bin

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,11 +1,12 @@
 ## 1.4.3 2018-06-12
 
-This is a follow up release that  includes diagnostic tracing for H2 requests. The feature was 
-scheduled for version 1.4.2 but did not make it in time for the release.
+This is a follow up release that includes diagnostic tracing for H2 requests.
 
 Full release notes:
 
-* Enables third-party identifiers to emit router stats.  
+* Add diagnostic tracing for H2 requests, allowing Linkerd to add h2 request routing information at
+the end of h2 streams to downstream services.
+* Pass stack params to announcer plugins, allowing them to report metrics correctly. 
 
 ## 1.4.2 2018-06-11
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+## 1.4.3 2018-06-12
+
+This is a follow up release that  includes diagnostic tracing for H2 requests. The feature was 
+scheduled for version 1.4.2 but did not make it in time for the release.
+
+Full release notes:
+
+* Enables third-party identifiers to emit router stats.  
+
 ## 1.4.2 2018-06-11
 
 Linkerd 1.4.2 continues its focus on diagnostics and stability. This release introduces Diagnostic 

--- a/project/Base.scala
+++ b/project/Base.scala
@@ -32,7 +32,7 @@ object Base {
 class Base extends Build {
   import Base._
 
-  val headVersion = "1.4.2"
+  val headVersion = "1.4.3"
   val openJdkVersion = "8u151"
 
   object Git {


### PR DESCRIPTION
This is a follow up release that includes diagnostic tracing for H2 requests.

Full release notes:

* Add diagnostic tracing for H2 requests, allowing Linkerd to add h2 request routing information at
the end of h2 streams to downstream services.
* Pass stack params to announcer plugins, allowing them to report metrics correctly. 

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>