### PR TITLE
Refactor formatDelegation into DelegateTree.find for easier reuse

### DIFF
--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/RouterContextFormatter.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/RouterContextFormatter.scala
@@ -69,9 +69,9 @@ object RouterContextFormatter {
         ) match {
             case Some(delegation) => delegation.map {
               case (path, "") =>
-                s"  ${path.show}"
+                s"    ${path.show}"
               case (path, dentry) =>
-                s"  ${path.show} ($dentry)"
+                s"    ${path.show} ($dentry)"
             }
             case None => Nil
           }

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/RouterContextFormatter.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/RouterContextFormatter.scala
@@ -11,17 +11,7 @@ import io.buoyant.router.RoutingFactory.BaseDtab
 
 object RouterContextFormatter {
 
-  // Ensure we use an empty string over the Dentry.nop default string
-  private[this] val checkDentryNop = (dentry: Dentry) => if (dentry == Dentry.nop) "" else dentry.show
   private[this] val EmptyDelegateTree = DelegateTree.Empty(Path.empty, Dentry.nop)
-
-  private[this] case class DelegationNode(
-    path: String,
-    dentry: String,
-    dTreeNode: DelegateTree[_] = DelegateTree.Empty(Path.empty, Dentry.nop)
-  ) {
-    override def toString: String = if (dentry.length == 0) path else s"$path ($dentry)"
-  }
 
   def formatCtx(
     routerLabel: String,
@@ -73,7 +63,18 @@ object RouterContextFormatter {
 
     dtreeF.joinWith(addresses) {
       case (dTree, addrSet) =>
-        val tree = formatDelegation(dTree.getOrElse(EmptyDelegateTree), List.empty, clientPath)
+        val tree = DelegateTree.find[Name.Bound](
+          dTree.getOrElse(EmptyDelegateTree),
+          _.id == clientPath
+        ) match {
+            case Some(delegation) => delegation.map {
+              case (path, "") =>
+                s"  ${path.show}"
+              case (path, dentry) =>
+                s"  ${path.show} ($dentry)"
+            }
+            case None => Nil
+          }
         formatRouterContext(
           routerLabel,
           elapsed,
@@ -81,64 +82,8 @@ object RouterContextFormatter {
           clientPath.show,
           addrSet,
           selectedEndpoint,
-          tree.map(_.toString)
+          tree
         )
-    }
-  }
-
-  /**
-   * Returns a list of DelegationNode that represents a delegate tree path that identifies how a
-   * router binds a service name.
-   *
-   * @param dTree DelegateTree with a bound name.
-   * @param nodes an accumulator of DelegationNode that reveal the path to a client name.
-   * @param clientName the client path name this method is searching for in a DelegateTree
-   * @return list of DelegationNode. An empty list if no path was found.
-   */
-  private[this] def formatDelegation(
-    dTree: DelegateTree[Name.Bound],
-    nodes: List[DelegationNode],
-    clientName: Path
-  ): List[DelegationNode] = {
-
-    //walk the delegate tree to find the path of the clientName path.
-    dTree match {
-
-      //when we reach a DelegateTree.Leaf we may have found a path.
-      case l@Leaf(leafPath, dentry, bound) if bound.id == clientName =>
-
-        // We need to check if the last node in 'nodes' is of type DelegationTree.Transformation.
-        // If so, we need to switch the transformation's dentry with
-        // the current leaf's dentry. We do this to make sure that the node list is more readable
-        // when it is added to the diagnostic tracer's response.
-        val finalPath = nodes.lastOption.collect {
-          case DelegationNode(nodePath, nodeDentry, _: Transformation[_]) => // check if is transformation
-
-            // Switch dentries
-            val transformerNode = DelegationNode(nodePath, checkDentryNop(dentry))
-            val leafNode = DelegationNode(leafPath.show, nodeDentry)
-
-            nodes.dropRight(1) :+ transformerNode :+ leafNode
-          case _ =>
-            // If the last node is not a transformation, it's safe to add the leaf node
-            // as the last element of nodes
-            val leafNode = DelegationNode(leafPath.show, dentry.show, l)
-            nodes :+ leafNode
-        }
-        finalPath.getOrElse(List.empty) // otherwise return  an empty list indicating there is no path.
-      case t@Transformation(path, name, _, remainingTree) =>
-        formatDelegation(remainingTree, nodes :+ DelegationNode(path.show, name, t), clientName)
-      case d@Delegate(path, dentry, remainingTree) =>
-        formatDelegation(remainingTree, nodes :+ DelegationNode(path.show, checkDentryNop(dentry), d), clientName)
-      case u@Union(path, dentry, remainingWeightedTrees@_*) =>
-        remainingWeightedTrees.map { wd =>
-          formatDelegation(wd.tree, nodes :+ DelegationNode(path.show, checkDentryNop(dentry), u), clientName)
-        }.find(!_.isEmpty).toList.flatten
-      case a@Alt(path, dentry, remainingTrees@_*) =>
-        remainingTrees.map { d =>
-          formatDelegation(d, nodes :+ DelegationNode(path.show, checkDentryNop(dentry), a), clientName)
-        }.find(!_.isEmpty).toList.flatten
-      case _ => List.empty
     }
   }
 

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/H2DiagnosticTracer.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/H2DiagnosticTracer.scala
@@ -46,7 +46,8 @@ class H2DiagnosticTracer(
       DstBoundCtx.current,
       endpoint,
       namers,
-      dtab)
+      dtab
+    )
 
     routerCtxF.map { ctx =>
       // format current router context


### PR DESCRIPTION
The `formatDelegation` method returns the delegation steps toward a particular leaf in a delegation tree.  This is generally useful but cannot be reused because it's a private member of `RouterContextFormatter`.

We refactor this method into `DelegateTree` itself, renaming it to `find` so that it can be more easily reused.  We also simplify the method, removing the need for an accumulator and add a test.

Signed-off-by: Alex Leong <alex@buoyant.io>