### PR TITLE
Handle close terminated HTTP/1.0 responses

### DIFF
--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/H2DiagnosticTracer.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/H2DiagnosticTracer.scala
@@ -46,7 +46,8 @@ class H2DiagnosticTracer(
       DstBoundCtx.current,
       endpoint,
       namers,
-      dtab)
+      dtab
+    )
 
     routerCtxF.map { ctx =>
       // format current router context

--- a/router/http/src/main/scala/io/buoyant/router/Http.scala
+++ b/router/http/src/main/scala/io/buoyant/router/Http.scala
@@ -82,8 +82,12 @@ object Http extends Router[Request, Response] with FinagleServer[Request, Respon
 
   object Server {
     val stack: Stack[ServiceFactory[Request, Response]] =
-      (AddForwardedHeader.module +: TimestampHeaderFilter.module +: FinagleHttp.server.stack)
-        .insertBefore(TracingFilter.role, ProxyRewriteFilter.module)
+      (
+        ContentLengthFilter.module +:
+        AddForwardedHeader.module +:
+        TimestampHeaderFilter.module +:
+        FinagleHttp.server.stack
+      ).insertBefore(TracingFilter.role, ProxyRewriteFilter.module)
 
     private val serverResponseClassifier = ClassifiedRetries.orElse(
       ClassifierFilter.successClassClassifier,

--- a/router/http/src/main/scala/io/buoyant/router/http/ContentLengthFilter.scala
+++ b/router/http/src/main/scala/io/buoyant/router/http/ContentLengthFilter.scala
@@ -1,0 +1,57 @@
+package io.buoyant.router.http
+
+import com.twitter.finagle.Stack.Module0
+import com.twitter.finagle.{Service, ServiceFactory, SimpleFilter, Stack}
+import com.twitter.finagle.http.{Fields, Request, Response, Version}
+import com.twitter.io.Reader
+import com.twitter.util.Future
+
+/**
+ * When Linkerd receives an HTTP/1.0 response that is terminated by closing the connection, the
+ * request will not have a Content-Length header.  This causes Linkerd to interpret the response
+ * as chunk encoded.  To avoid sending chunk encoded responses to HTTP/1.0 clients, we fully buffer
+ * such responses and set the Content-Length header.
+ */
+object ContentLengthFilter {
+
+  object module extends Module0[ServiceFactory[Request, Response]] {
+
+    override def role: Stack.Role = Stack.Role("content-length")
+
+    override def description: String = "Add a content-length header for HTTP/1.0 responses that need one"
+
+    override def make(next: ServiceFactory[Request, Response]): ServiceFactory[Request, Response] =
+      filter.andThen(next)
+  }
+
+  object filter extends SimpleFilter[Request, Response] {
+
+    def hasTransferEncoding(response: Response): Boolean =
+      response.headerMap.get(Fields.TransferEncoding) match {
+        case None => false
+        case Some(te) if te.toLowerCase == "identity" => false
+        case Some(_) => true
+      }
+
+    override def apply(
+      request: Request,
+      service: Service[Request, Response]
+    ): Future[Response] = {
+      service(request).flatMap { response =>
+
+        if (response.version == Version.Http10
+          && !hasTransferEncoding(response)
+          && response.contentLength.isEmpty) {
+          Reader.readAll(response.reader).map { buf =>
+            response.setChunked(false)
+            response.contentLength = buf.length
+            response.content = buf
+            response
+          }
+        } else {
+          Future.value(response)
+        }
+      }
+    }
+  }
+}

--- a/router/http/src/main/scala/io/buoyant/router/http/ContentLengthFilter.scala
+++ b/router/http/src/main/scala/io/buoyant/router/http/ContentLengthFilter.scala
@@ -8,7 +8,7 @@ import com.twitter.util.Future
 
 /**
  * When Linkerd receives an HTTP/1.0 response that is terminated by closing the connection, the
- * request will not have a Content-Length header.  This causes Linkerd to interpret the response
+ * response will not have a Content-Length header.  This causes Linkerd to interpret the response
  * as chunk encoded.  To avoid sending chunk encoded responses to HTTP/1.0 clients, we fully buffer
  * such responses and set the Content-Length header.
  */

--- a/router/http/src/main/scala/io/buoyant/router/http/ContentLengthFilter.scala
+++ b/router/http/src/main/scala/io/buoyant/router/http/ContentLengthFilter.scala
@@ -40,8 +40,8 @@ object ContentLengthFilter {
       service(request).flatMap { response =>
 
         if (response.version == Version.Http10
-          && !hasTransferEncoding(response)
-          && response.contentLength.isEmpty) {
+            && !hasTransferEncoding(response)
+            && response.contentLength.isEmpty) {
           Reader.readAll(response.reader).map { buf =>
             response.setChunked(false)
             response.contentLength = buf.length


### PR DESCRIPTION
When Linkerd receives an HTTP/1.0 response that is terminated by closing the connection, the response will not have a Content-Length header.  This causes Linkerd to interpret the response as chunk encoded.  Since Linkerd keeps persistent connections open to its clients, clients will not have a content-length header or connection termination to signal the end of the response.  This causes them to hang, waiting for the response to complete.

This issue was introduced in #1904 when we stopped upgrading responses to HTTP/1.1.

For HTTP/1.0 responses with no transfer-coding and no content-length, we fully buffer the response and set the content-length header. 

Fixes #1978 

Signed-off-by: Alex Leong <alex@buoyant.io>