### PR TITLE
Implement a gRPC standards-compliant response classifier

### DIFF
--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/Message.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/Message.scala
@@ -140,6 +140,9 @@ object Response {
   def apply(headers: Headers, stream: Stream): Response =
     Impl(headers, stream)
 
+  def unapply(arg: Response): Option[Status] =
+    Some(arg.status)
+
   private case class Impl(
     headers: Headers,
     stream: Stream

--- a/linkerd/docs/response_classifier.md
+++ b/linkerd/docs/response_classifier.md
@@ -77,7 +77,17 @@ Since H2 routing is experimental, all gRPC response classifiers are also marked 
 
 kind:  `io.l5d.h2.grpc.default`
 
-Status code 14 (`Unavailable`) is considered retryable, all other errors are non-retryable.
+Only status code 14 (`Unavailable`) is considered retryable, all other errors are non-retryable.
+
+## gRPC Compliant
+
+kind:  `io.l5d.h2.grpc.compliant`
+
+Strictly complies with gRPC specifications for retryability. 
+
+* Status code 14 (`Unavailable`) is considered retryable.
+* HTTP/2 RST_STREAM:REFUSED_STREAM is [considered retryable](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#errors).
+* HTTP/2 429, 502, 503, and 504 responses are [considered retryable](https://github.com/grpc/grpc/blob/master/doc/http-grpc-status-mapping.md)
 
 ## gRPC Always Retryable
 

--- a/linkerd/protocol/h2/src/main/resources/META-INF/services/io.buoyant.linkerd.protocol.h2.H2ClassifierInitializer
+++ b/linkerd/protocol/h2/src/main/resources/META-INF/services/io.buoyant.linkerd.protocol.h2.H2ClassifierInitializer
@@ -4,5 +4,6 @@ io.buoyant.linkerd.protocol.h2.RetryableRead5XXInitializer
 io.buoyant.linkerd.protocol.h2.AllSuccessfulInitializer
 io.buoyant.linkerd.protocol.h2.grpc.AlwaysRetryableInitializer
 io.buoyant.linkerd.protocol.h2.grpc.DefaultInitializer
+io.buoyant.linkerd.protocol.h2.grpc.CompliantInitializer
 io.buoyant.linkerd.protocol.h2.grpc.NeverRetryableInitializer
 io.buoyant.linkerd.protocol.h2.grpc.RetryableStatusCodesInitializer

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/H2ClassifierConfig.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/H2ClassifierConfig.scala
@@ -37,6 +37,10 @@ abstract class H2ClassifierInitializer extends ConfigInitializer
     name = "io.l5d.h2.grpc.default"
   ),
   new Type(
+    value = classOf[grpc.CompliantConfig],
+    name = "io.l5d.h2.grpc.compliant"
+  ),
+  new Type(
     value = classOf[grpc.RetryableStatusCodesConfig],
     name = "io.l5d.h2.grpc.retryableStatusCodes"
   )

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/H2DiagnosticTracer.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/H2DiagnosticTracer.scala
@@ -46,7 +46,8 @@ class H2DiagnosticTracer(
       DstBoundCtx.current,
       endpoint,
       namers,
-      dtab)
+      dtab
+    )
 
     routerCtxF.map { ctx =>
       // format current router context

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/grpc/GrpcClassifierConfig.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/grpc/GrpcClassifierConfig.scala
@@ -36,6 +36,17 @@ class DefaultInitializer extends H2ClassifierInitializer {
 
 object DefaultInitializer extends DefaultInitializer
 
+class CompliantConfig extends H2ClassifierConfig {
+  override def mk: H2Classifier = GrpcClassifiers.Compliant
+}
+
+class CompliantInitializer extends H2ClassifierInitializer {
+  val configClass = classOf[DefaultConfig]
+  override val configId = "io.l5d.h2.grpc.Compliant"
+}
+
+object CompliantInitializer extends CompliantInitializer
+
 // TODO: support parsing the status codes by name rather than by number?
 class RetryableStatusCodesConfig(val retryableStatusCodes: Set[Int]) extends H2ClassifierConfig {
   override def mk: H2Classifier = new GrpcClassifiers.RetryableStatusCodes(retryableStatusCodes)

--- a/linkerd/protocol/h2/src/test/scala/io/buoyant/linkerd/protocol/h2/CompliantGrpcClassifierTest.scala
+++ b/linkerd/protocol/h2/src/test/scala/io/buoyant/linkerd/protocol/h2/CompliantGrpcClassifierTest.scala
@@ -1,0 +1,153 @@
+package io.buoyant.linkerd.protocol.h2
+
+import com.twitter.finagle.buoyant.h2.Frame.Trailers
+import com.twitter.finagle.buoyant.h2.service.{H2ReqRep, H2ReqRepFrame}
+import com.twitter.finagle.buoyant.h2.{Headers, Request, Reset, Response, Status, Stream => FStream}
+import com.twitter.finagle.service.ResponseClass
+import com.twitter.util.{Return, Throw}
+import io.buoyant.grpc.runtime.GrpcStatus
+import io.buoyant.linkerd.protocol.h2.grpc.GrpcClassifiers.Compliant
+import org.scalacheck.Arbitrary
+import org.scalatest.FunSuite
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+
+class CompliantGrpcClassifierTest extends FunSuite with GeneratorDrivenPropertyChecks {
+  implicit val arbitraryStatus: Arbitrary[GrpcStatus] = Arbitrary(for {
+    code <- Arbitrary.arbitrary[Int]
+    msg <- Arbitrary.arbitrary[String]
+  } yield { GrpcStatus(code, msg) })
+
+  // Single tests
+  test("Compliant classifies UNAVAILABLE as retryable") {
+    forAll("status") { status: GrpcStatus =>
+      val reqrep = H2ReqRep(
+        Request(Headers.empty, FStream.empty()),
+        Return(Response(status.toTrailers, FStream.empty()))
+      )
+      assert(Compliant.responseClassifier.isDefinedAt(reqrep))
+      if (status.code != 0) {
+        assert(Compliant.responseClassifier(reqrep) == ResponseClass.NonRetryableFailure)
+      } else if (status.code == 14) {
+        assert(Compliant.responseClassifier(reqrep) == ResponseClass.RetryableFailure)
+      } else {
+        assert(Compliant.responseClassifier(reqrep) == ResponseClass.Success)
+      }
+    }
+  }
+
+  test("Compliant classifies Reset:Refused as retryable") {
+    val reqrep = H2ReqRep(
+      Request(Headers.empty, FStream.empty()),
+      Throw(Reset.Refused)
+    )
+    assert(Compliant.responseClassifier.isDefinedAt(reqrep))
+    assert(Compliant.responseClassifier(reqrep) == ResponseClass.RetryableFailure)
+  }
+
+  test("Compliant classifies Reset:Other as non-retryable") {
+    val reqrep = H2ReqRep(
+      Request(Headers.empty, FStream.empty()),
+      Throw(Reset.EnhanceYourCalm)
+    )
+    assert(Compliant.responseClassifier.isDefinedAt(reqrep))
+    assert(Compliant.responseClassifier(reqrep) == ResponseClass.NonRetryableFailure)
+  }
+
+  test("Compliant classifies retryable http responses") {
+    List(Status.ServiceUnavailable, Status.BadGateway, Status.GatewayTimeout, Status.TooManyRequests
+    ).foreach(status => {
+      val reqrep = H2ReqRep(
+        Request(Headers.empty, FStream.empty()),
+        Return(Response(status, FStream.empty()))
+      )
+      assert(Compliant.responseClassifier.isDefinedAt(reqrep))
+      assert(Compliant.responseClassifier(reqrep) == ResponseClass.RetryableFailure)
+    })
+  }
+
+  test("Compliant classifies non-retryable http responses") {
+    List(Status.Forbidden, Status.Unauthorized, Status.InternalServerError).foreach(status => {
+      val reqrep = H2ReqRep(
+        Request(Headers.empty, FStream.empty()),
+        Return(Response(status, FStream.empty()))
+      )
+      assert(Compliant.responseClassifier.isDefinedAt(reqrep))
+      assert(Compliant.responseClassifier(reqrep) == ResponseClass.NonRetryableFailure)
+    })
+  }
+
+  // Streaming tests
+  test("Compliant classifies UNAVAILABLE stream as retryable") {
+    forAll("status") { status: GrpcStatus =>
+      val trailers = status.toTrailers
+      val reqrep = H2ReqRepFrame(
+        Request(Headers.empty, FStream.empty()),
+        Return((
+          Response(Headers.empty, FStream.empty()),
+          Some(Return(trailers))
+        ))
+      )
+      assert(Compliant.streamClassifier.isDefinedAt(reqrep))
+      if (status.code != 0) {
+        assert(Compliant.streamClassifier(reqrep) == ResponseClass.NonRetryableFailure)
+      } else if (status.code == 14) {
+        assert(Compliant.streamClassifier(reqrep) == ResponseClass.RetryableFailure)
+      } else {
+        assert(Compliant.streamClassifier(reqrep) == ResponseClass.Success)
+      }
+    }
+  }
+
+  test("Compliant classifies Reset:Refused stream as retryable") {
+    val reqrep = H2ReqRepFrame(
+      Request(Headers.empty, FStream.empty()),
+      Return((
+        Response(Status.Ok, FStream.empty()),
+        Some(Throw(Reset.Refused))
+      ))
+    )
+    assert(Compliant.streamClassifier.isDefinedAt(reqrep))
+    assert(Compliant.streamClassifier(reqrep) == ResponseClass.RetryableFailure)
+  }
+
+  test("Compliant classifies Reset:Other stream as non-retryable") {
+    val reqrep = H2ReqRepFrame(
+      Request(Headers.empty, FStream.empty()),
+      Return((
+        Response(Status.Ok, FStream.empty()),
+        Some(Throw(Reset.EnhanceYourCalm))
+      ))
+    )
+    assert(Compliant.streamClassifier.isDefinedAt(reqrep))
+    assert(Compliant.streamClassifier(reqrep) == ResponseClass.NonRetryableFailure)
+  }
+
+  test("Compliant classifies retryable stream http responses") {
+    List(Status.ServiceUnavailable, Status.BadGateway, Status.GatewayTimeout, Status.TooManyRequests
+    ).foreach(status => {
+      val reqrep = H2ReqRepFrame(
+        Request(Headers.empty, FStream.empty()),
+        Return((
+          Response(status, FStream.empty()),
+          Some(Return(Trailers()))
+        ))
+      )
+      assert(Compliant.streamClassifier.isDefinedAt(reqrep))
+      assert(Compliant.streamClassifier(reqrep) == ResponseClass.RetryableFailure)
+    })
+  }
+
+  test("Compliant classifies non-retryable stream http responses") {
+    List(Status.Forbidden, Status.Unauthorized, Status.InternalServerError).foreach(status => {
+      val reqrep = H2ReqRepFrame(
+        Request(Headers.empty, FStream.empty()),
+        Return((
+          Response(status, FStream.empty()),
+          Some(Return(Trailers()))
+        ))
+      )
+      assert(Compliant.streamClassifier.isDefinedAt(reqrep))
+      assert(Compliant.streamClassifier(reqrep) == ResponseClass.NonRetryableFailure)
+    })
+  }
+}

--- a/linkerd/protocol/h2/src/test/scala/io/buoyant/linkerd/protocol/h2/GrpcClassifierTest.scala
+++ b/linkerd/protocol/h2/src/test/scala/io/buoyant/linkerd/protocol/h2/GrpcClassifierTest.scala
@@ -85,7 +85,8 @@ class GrpcClassifierTest extends FunSuite with GeneratorDrivenPropertyChecks {
     init <- Seq(
       AlwaysRetryableInitializer,
       NeverRetryableInitializer,
-      DefaultInitializer
+      DefaultInitializer,
+      CompliantInitializer
     )
     kind = init.configId
   } {


### PR DESCRIPTION
The `io.l5d.h2.grpc.default` response classifier is incomplete in its classification of retryable gRPC responses.

This commit adds the `io.l5d.h2.grpc.compliant` response classifier, with an expanded set of retryable gRPC responses.
- Status code 14 (`Unavailable`) is considered retryable - same as default
- HTTP/2 RST_STREAM:REFUSED_STREAM is considered retryable - per https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#errors
- HTTP/2 429, 502, 503, and 504 responses are considered retryable - per https://github.com/grpc/grpc/blob/master/doc/http-grpc-status-mapping.md

Implements #1993

Signed-off-by Ryan Michela <rmichela@salesforce.com>