### PR TITLE
Disable statistics exported by the JVM for hsprefdata

### DIFF
--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -256,7 +256,6 @@ object LinkerdBuild extends Base {
        |   -Dio.netty.allocator.numHeapArenas=${FINAGLE_WORKERS:-8}      \
        |   -Dio.netty.allocator.numDirectArenas=${FINAGLE_WORKERS:-8}    \
        |   -Dcom.twitter.finagle.netty4.numWorkers=${FINAGLE_WORKERS:-8} \
-       |   -XX:+PerfDisableSharedMem                                     \
        |   ${LOCAL_JVM_OPTIONS:-}                                        "
        |""".stripMargin
 
@@ -348,6 +347,7 @@ object LinkerdBuild extends Base {
       """|#!/bin/sh
          |
          |jars="$0"
+         |HSPREF_SETTING=$([ ! -z "$ENABLE_HSPREF" ] && echo "" || echo "-XX:+PerfDisableSharedMem")
          |if [ -n "$NAMERD_HOME" ] && [ -d $NAMERD_HOME/plugins ]; then
          |  for jar in $NAMERD_HOME/plugins/*.jar ; do
          |    jars="$jars:$jar"
@@ -357,7 +357,7 @@ object LinkerdBuild extends Base {
          |""" +
       execScriptJvmOptions +
       """|exec "${JAVA_HOME:-/usr}/bin/java" -XX:+PrintCommandLineFlags \
-         |     ${JVM_OPTIONS:-$DEFAULT_JVM_OPTIONS} -cp $jars -server \
+         |     ${JVM_OPTIONS:-$DEFAULT_JVM_OPTIONS} $HSPREF_SETTING -cp $jars -server \
          |     io.buoyant.namerd.Main "$@"
          |"""
       ).stripMargin
@@ -403,6 +403,7 @@ object LinkerdBuild extends Base {
       """|#!/bin/bash
          |
          |jars="$0"
+         |HSPREF_SETTING=$([ ! -z "$ENABLE_HSPREF" ] && echo "" || echo "-XX:+PerfDisableSharedMem")
          |if [ -n "$NAMERD_HOME" ] && [ -d $NAMERD_HOME/plugins ]; then
          |  for jar in $NAMERD_HOME/plugins/*.jar ; do
          |    jars="$jars:$jar"
@@ -417,7 +418,7 @@ object LinkerdBuild extends Base {
          |
          |echo $CONFIG_INPUT | \
          |${JAVA_HOME:-/usr}/bin/java -XX:+PrintCommandLineFlags \
-         |${JVM_OPTIONS:-$DEFAULT_JVM_OPTIONS} -cp $jars -server \
+         |${JVM_OPTIONS:-$DEFAULT_JVM_OPTIONS} $HSPREF_SETTING -cp $jars -server \
          |io.buoyant.namerd.DcosBootstrap "$@"
          |
          |echo $CONFIG_INPUT | \
@@ -607,6 +608,7 @@ object LinkerdBuild extends Base {
       """|#!/bin/sh
          |
          |jars="$0"
+         |HSPREF_SETTING=$([ ! -z "$ENABLE_HSPREF" ] && echo "" || echo "-XX:+PerfDisableSharedMem")
          |if [ -n "$L5D_HOME" ] && [ -d $L5D_HOME/plugins ]; then
          |  for jar in $L5D_HOME/plugins/*.jar ; do
          |    jars="$jars:$jar"
@@ -616,7 +618,7 @@ object LinkerdBuild extends Base {
          |""" +
       execScriptJvmOptions +
       """|exec "${JAVA_HOME:-/usr}/bin/java" -XX:+PrintCommandLineFlags \
-         |     ${JVM_OPTIONS:-$DEFAULT_JVM_OPTIONS} -cp $jars -server \
+         |     ${JVM_OPTIONS:-$DEFAULT_JVM_OPTIONS} $HSPREF_SETTING -cp $jars -server \
          |     io.buoyant.linkerd.Main "$@"
          |"""
       ).stripMargin

--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -256,6 +256,7 @@ object LinkerdBuild extends Base {
        |   -Dio.netty.allocator.numHeapArenas=${FINAGLE_WORKERS:-8}      \
        |   -Dio.netty.allocator.numDirectArenas=${FINAGLE_WORKERS:-8}    \
        |   -Dcom.twitter.finagle.netty4.numWorkers=${FINAGLE_WORKERS:-8} \
+       |   -XX:+PerfDisableSharedMem                                     \
        |   ${LOCAL_JVM_OPTIONS:-}                                        "
        |""".stripMargin
 


### PR DESCRIPTION
The JVM by default exports statistics by mmap-ing a file in /tmp (hsperfdata).
On Linux, modifying a memory mapped file can block until disk I/O completes, which can be hundreds of milliseconds. Since the JVM modifies these statistics during garbage collection and safepoints, this causes pauses that are hundreds of milliseconds long on spinning disks.

This will break tools that read this file, such as jcmd, jstat, jconsole. If you *really* need those, and you are running /tmp backed by tmpfs or an SSD, it's okay to enable this feature.

References:

http://www.evanjones.ca/jvm-mmap-pause.html
https://engineering.linkedin.com/blog/2016/02/eliminating-large-jvm-gc-pauses-caused-by-background-io-traffic

Note: this is a problem for writing gc logs as well (out of scope), so make sure if you are enabling GC logs for Linkerd, to write them to an SSD or tmpfs.

Fixes #1996

Signed-off-by: Chris Goffinet <chris@threecomma.io>