### PR TITLE
Change ordering of the server stack

### DIFF
--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpConfig.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpConfig.scala
@@ -75,6 +75,8 @@ class HttpInitializer extends ProtocolInitializer.Simple {
       .remove(Headers.Ctx.serverModule.role)
       .prepend(http.ErrorResponder.module)
       .prepend(http.StatusCodeStatsFilter.module)
+      // Headers.Ctx.serverModule needs to be before the ErrorResponder module
+      // so that errors responses from the ErrorResponder will be cleared when clearContext is set
       .prepend(Headers.Ctx.serverModule)
       // ensure the server-stack framing filter is placed below the stats filter
       // so that any malframed requests it fails are counted as errors

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpConfig.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpConfig.scala
@@ -72,9 +72,10 @@ class HttpInitializer extends ProtocolInitializer.Simple {
   protected val defaultServer = {
     val stk = Http.server.stack
       .replace(HttpTraceInitializer.role, HttpTraceInitializer.serverModule)
-      .replace(Headers.Ctx.serverModule.role, Headers.Ctx.serverModule)
+      .remove(Headers.Ctx.serverModule.role)
       .prepend(http.ErrorResponder.module)
       .prepend(http.StatusCodeStatsFilter.module)
+      .prepend(Headers.Ctx.serverModule)
       // ensure the server-stack framing filter is placed below the stats filter
       // so that any malframed requests it fails are counted as errors
       .insertAfter(StatsFilter.role, FramingFilter.serverModule)


### PR DESCRIPTION
The linkerd provides an option to turn off the error messages via the `contextClear` setting. Even with `contextClear` setting set we get verbose errors from linkerd. This happens because of the ordering of the server stack. Exceptions are turned into error responses in the `ErrorResponder.module` and bodies are scrubbed by the `Headers.Ctx.serverModule`. But because bodies are scrubbed before exceptions are turned into error responses, the error bodies can escape. `Headers.Ctx.serverModule` needs to be before the `http.ErrorResponder.module` so that errors responses from the ErrorResponder will be cleared when `clearContext` is set.

Fixes: #1163 