### PR TITLE
Expose interpreter state for interpreters with transformers

### DIFF
--- a/finagle/buoyant/src/main/scala/com/twitter/finagle/buoyant/TlsClientConfig.scala
+++ b/finagle/buoyant/src/main/scala/com/twitter/finagle/buoyant/TlsClientConfig.scala
@@ -7,7 +7,6 @@ import com.twitter.finagle.ssl.{KeyCredentials, Protocols, TrustCredentials}
 import com.twitter.finagle.ssl.client.{SslClientConfiguration, SslClientEngineFactory}
 import com.twitter.finagle.transport.Transport
 import com.twitter.io.StreamIO
-
 import scala.util.control.NoStackTrace
 
 case class TlsClientConfig(

--- a/linkerd/docs/interpreter.md
+++ b/linkerd/docs/interpreter.md
@@ -40,7 +40,7 @@ interpreter uses Namerd's long-poll thrift interface
 uses to talk to Namerd is unrelated to the protocols of Linkerd's routers.
 
 The internal state of the Namerd interpreter can be viewed at the
-admin endpoint: `/interpreter_state/io.l5d.namerd/<namespace>.json`.
+admin endpoint: `/<router>/interpreter_state/io.l5d.namerd/<namespace>.json`.
 
 Key | Default Value | Description
 --- | ------------- | -----------
@@ -105,7 +105,7 @@ protocol that the interpreter uses to talk to Namerd is unrelated to the
 protocols of Linkerd's routers.
 
 The internal state of the Namerd interpreter can be viewed at the admin endpoint:
-`/interpreter_state/io.l5d.mesh/<root>.json`.
+`/<router>/interpreter_state/io.l5d.mesh/<root>.json`.
 
 Key | Default Value | Description
 --- | ------------- | -----------

--- a/linkerd/main/src/e2e/scala/io/buoyant/linkerd/EndToEndTest.scala
+++ b/linkerd/main/src/e2e/scala/io/buoyant/linkerd/EndToEndTest.scala
@@ -1,0 +1,73 @@
+package io.buoyant.linkerd
+
+import com.twitter.finagle.Http
+import com.twitter.finagle.http.{Request, Status}
+import io.buoyant.linkerd.Linker.Initializers
+import io.buoyant.linkerd.protocol.HttpInitializer
+import io.buoyant.namerd.iface.NamerdInterpreterInitializer
+import io.buoyant.test.FunSuite
+import io.buoyant.transformer.perHost.{LocalhostTransformerInitializer, PortTransformerInitializer}
+import java.net.ServerSocket
+
+class EndToEndTest extends FunSuite {
+
+  test("interpreter state") {
+
+    // A somewhat racey and unsafe way of getting an ephemeral port.
+    val ss = new ServerSocket(0)
+    val adminPort = ss.getLocalPort
+    ss.close()
+
+    val config =
+      s"""namers: []
+        |admin:
+        |  port: $adminPort
+        |routers:
+        |- protocol: http
+        |  label: out
+        |  interpreter:
+        |    kind: io.l5d.namerd
+        |    namespace: dtab-out
+        |    dst: /$$/inet/localhost/4100
+        |    transformers:
+        |    - kind: io.l5d.port
+        |      port: 4141
+        |  servers:
+        |  - port: 4140
+        |
+        |- protocol: http
+        |  label: in
+        |  interpreter:
+        |    kind: io.l5d.namerd
+        |    namespace: dtab-in
+        |    dst: /$$/inet/localhost/4100
+        |    transformers:
+        |    - kind: io.l5d.localhost
+        |  servers:
+        |  - port: 4141
+    """.stripMargin
+
+    val linkerConfig = Linker.parse(config, Initializers(
+      protocol = Seq(HttpInitializer),
+      interpreter = Seq(NamerdInterpreterInitializer),
+      transformer = Seq(new PortTransformerInitializer, new LocalhostTransformerInitializer)
+    ))
+    val linker = linkerConfig.mk()
+
+    val closables = Main.initAdmin(linkerConfig, linker)
+
+    try {
+      val client = Http.newService(s"/$$/inet/localhost/$adminPort")
+      assert(
+        await(client(Request("/out/interpreter_state/io.l5d.namerd/dtab-out.json"))).status ==
+          Status.Ok
+      )
+      assert(
+        await(client(Request("/in/interpreter_state/io.l5d.namerd/dtab-in.json"))).status ==
+          Status.Ok
+      )
+    } finally {
+      for(c <- closables) c.close()
+    }
+  }
+}

--- a/linkerd/main/src/main/scala/io/buoyant/linkerd/Main.scala
+++ b/linkerd/main/src/main/scala/io/buoyant/linkerd/Main.scala
@@ -72,7 +72,7 @@ object Main extends App {
     Linker.parse(configText)
   }
 
-  private def initAdmin(
+  private[linkerd] def initAdmin(
     config: Linker.LinkerConfig,
     linker: Linker
   ): Seq[Closable with Awaitable[Unit]] = {

--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -72,7 +72,7 @@ object LinkerdBuild extends Base {
 
   object Namer {
     val core = projectDir("namer/core")
-      .dependsOn(configCore)
+      .dependsOn(configCore, admin)
       .withLib(Deps.jacksonCore)
       .withTests()
 
@@ -585,11 +585,12 @@ object LinkerdBuild extends Base {
       .dependsOn(Protocol.thrift % "test", Interpreter.perHost % "test")
 
     val main = projectDir("linkerd/main")
-      .dependsOn(admin, configCore, core)
+      .dependsOn(admin, configCore, core, Protocol.http % "e2e", Interpreter.namerd % "e2e", Interpreter.perHost % "e2e")
       .withTwitterLib(Deps.twitterServer)
       .withLibs(Deps.jacksonCore, Deps.jacksonDatabind, Deps.jacksonYaml)
       .withBuildProperties("io/buoyant/linkerd")
       .settings(coverageExcludedPackages := ".*")
+      .withE2e()
 
     /*
      * linkerd packaging configurations.


### PR DESCRIPTION
If an interpreter is configured with a transformer, the `interpreter_state` admin endpoint is not available for that interpreter.  Additionally, if interpreters are configured on multiple routers, each interpreter will attempt to register a handler at the same URL and override the others.

We update transformers to pass through the admin handlers of the underlying interpreter so that the `interpreter_state` remains available.  We also update the URL structure of the `interpreter_state` endpoint to be prefixed with the router name.  This avoids any cross-router conflicts.

Fixes #1999 
Fixes #2000

Signed-off-by: Alex Leong <alex@buoyant.io>