### PR TITLE
Add l5d-err header to H2 responses when Linkerd generates error.

### DIFF
--- a/linkerd/protocol/h2/src/main/scala/com/twitter/finagle/buoyant/h2/LinkerdHeaders.scala
+++ b/linkerd/protocol/h2/src/main/scala/com/twitter/finagle/buoyant/h2/LinkerdHeaders.scala
@@ -3,9 +3,12 @@ package com.twitter.finagle.buoyant.h2
 import com.twitter.finagle.{Dtab => FDtab, Status => _, _}
 import com.twitter.finagle.buoyant.{Dst => BuoyantDst}
 import com.twitter.finagle.context.{Contexts, Deadline => FDeadline}
+import com.twitter.finagle.http.MediaType
 import com.twitter.finagle.tracing._
 import com.twitter.io.Buf
 import com.twitter.util.{Future, Return, Throw, Time, Try}
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets.ISO_8859_1
 import java.util.Base64
 import scala.collection.breakOut
 
@@ -454,10 +457,14 @@ object LinkerdHeaders {
     val Key = Prefix + "err"
 
     def respond(msg: String, status: Status = Status.InternalServerError): Response = {
-      val rsp = Response(status, Stream.const(Buf.Utf8(msg)))
-      rsp.headers.add(Key, msg)
-      rsp.headers.set("content-type", "text/plain")
-      rsp
+      Response(
+        Headers(
+          Headers.Status -> status.code.toString,
+          Key -> URLEncoder.encode(msg, ISO_8859_1.toString),
+          "content-type" -> MediaType.PlainText,
+          "content-length" -> msg.length.toString
+        ), Stream.const(Buf.Utf8(msg))
+      )
     }
   }
 }

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/ErrorReseter.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/ErrorReseter.scala
@@ -1,6 +1,6 @@
 package io.buoyant.linkerd.protocol.h2
 
-import com.twitter.finagle.buoyant.h2.{Request, Reset, Response, Status, Stream}
+import com.twitter.finagle.buoyant.h2.{LinkerdHeaders, Request, Reset, Response, Status, Stream}
 import com.twitter.finagle.naming.buoyant.{RichConnectionFailedExceptionWithPath, RichNoBrokersAvailableException}
 import com.twitter.finagle.{Status => _, _}
 import com.twitter.logging.{Level, Logger}
@@ -26,13 +26,9 @@ class ErrorReseter extends SimpleFilter[Request, Response] {
       log.info("unroutable request: %s: %s", req, reason)
       RefusedF
     case e: RichNoBrokersAvailableException =>
-      Future.value(
-        Response(Status.BadGateway, Stream.const(e.exceptionMessage()))
-      )
+      Future.value(LinkerdHeaders.Err.respond(e.exceptionMessage(), Status.BadGateway))
     case e: RichConnectionFailedExceptionWithPath =>
-      Future.value(
-        Response(Status.BadGateway, Stream.const(e.exceptionMessage))
-      )
+      Future.value(LinkerdHeaders.Err.respond(e.exceptionMessage, Status.BadGateway))
     case H2ResponseException(rsp) =>
       Future.value(rsp)
   }


### PR DESCRIPTION
When Linkerd is unable to route a request to a service due to it being unavailable, Linkerd returns a response with an `l5d-err` header that explains why the error occurred. This is true for HTTP requests. however, H2 responses do not have this `l5d-err` header added when an error occurs. 

This PR modifies the `ErrorReseter` to send responses with the correct header. Tests were done by setting up linkerd to proxy H2 traffic to a service that does not exist. Sending an H2 request with `nghttp` yields:

```bash
[ERROR] Could not connect to the address ::1
Trying next address 127.0.0.1
[  0.002] Connected
[  0.003] send SETTINGS frame <length=12, flags=0x00, stream_id=0>
          (niv=2)
          [SETTINGS_MAX_CONCURRENT_STREAMS(0x03):100]
          [SETTINGS_INITIAL_WINDOW_SIZE(0x04):65535]
...
[  0.546] recv (stream_id=13) :status: 502
[  0.546] recv (stream_id=13) l5d-err: Unable+to+establish+connection+to+127.0.0.1%3A9999.%0A%0Aservice+name%3A+%2Fsvc%2Fdog%0Aclient+name%3A+%2F%24%2Finet%2F127.1%2F9999%0Aaddresses%3A+%5B127.0.0.1%3A9999%5D%0Aselected+address%3A+127.0.0.1%3A9999%0Adtab+resolution%3A%0A++%2Fsvc%2Fdog%0A++%2F%24%2Finet%2F127.1%2F9999+%28%2Fsvc%2F*%3D%3E%2F%24%2Finet%2F127.1%2F9999%29%0A
[  0.546] recv (stream_id=13) content-type: text/plain
[  0.546] recv (stream_id=13) content-length: 245
[  0.546] recv HEADERS frame <length=282, flags=0x24, stream_id=13>
          ; END_HEADERS | PRIORITY
          (padlen=0, dep_stream_id=0, weight=16, exclusive=0)
          ; First response header
Unable to establish connection to 127.0.0.1:9999.

service name: /svc/dog
client name: /$/inet/127.1/9999
addresses: [127.0.0.1:9999]
selected address: 127.0.0.1:9999
dtab resolution:
  /svc/dog
  /$/inet/127.1/9999 (/svc/*=>/$/inet/127.1/9999)
[  0.563] recv DATA frame <length=245, flags=0x01, stream_id=13>
          ; END_STREAM
[  0.563] send GOAWAY frame <length=8, flags=0x00, stream_id=0>
          (last_stream_id=0, error_code=NO_ERROR(0x00), opaque_data(0)=[])
```

fixes #2001

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>