### PR TITLE
Use a separate threadpool for the admin server

### DIFF
--- a/admin/src/main/scala/io/buoyant/admin/AdminConfig.scala
+++ b/admin/src/main/scala/io/buoyant/admin/AdminConfig.scala
@@ -1,6 +1,7 @@
 package io.buoyant.admin
 
 import com.twitter.finagle.buoyant.TlsServerConfig
+import com.twitter.finagle.stats.StatsReceiver
 import java.net.{InetAddress, InetSocketAddress}
 import io.buoyant.config.types.Port
 
@@ -9,13 +10,14 @@ case class AdminConfig(
   port: Option[Port] = None,
   shutdownGraceMs: Option[Int] = None,
   tls: Option[TlsServerConfig] = None,
-  httpIdentifierPort: Option[Port] = None
+  httpIdentifierPort: Option[Port] = None,
+  workerThreads: Option[Int] = None
 ) {
 
-  def mk(defaultAddr: InetSocketAddress): Admin = {
+  def mk(defaultAddr: InetSocketAddress, stats: StatsReceiver): Admin = {
     val adminIp = ip.getOrElse(defaultAddr.getAddress)
     val adminPort = port.map(_.port).getOrElse(defaultAddr.getPort)
     val addr = new InetSocketAddress(adminIp, adminPort)
-    new Admin(addr, tls)
+    new Admin(addr, tls, workerThreads.getOrElse(2), stats)
   }
 }

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/Linker.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/Linker.scala
@@ -139,7 +139,7 @@ object Linker {
 
       val routerImpls = mkRouters(params + Namers(namersByPrefix) + fparam.Stats(stats.scope("rt")))
 
-      val adminImpl = admin.getOrElse(DefaultAdminConfig).mk(DefaultAdminAddress)
+      val adminImpl = admin.getOrElse(DefaultAdminConfig).mk(DefaultAdminAddress, stats)
 
       Impl(routerImpls, namersByPrefix, tracer, telemeters, adminImpl)
     }

--- a/linkerd/docs/config.md
+++ b/linkerd/docs/config.md
@@ -86,6 +86,7 @@ port | `9990` | Port for the admin interface.
 httpIdentifierPort | none | Port for the http identifier debug endpoint.
 shutdownGraceMs | 10000 | maximum grace period before the Linkerd process exits
 tls | no tls | The admin interface will serve over TLS if this parameter is provided. see [TLS](#server-tls).
+workerThreads | 2 | The number of worker threads used to serve the admin interface.
 
 #### Administrative endpoints
 

--- a/linkerd/examples/admin.yaml
+++ b/linkerd/examples/admin.yaml
@@ -6,6 +6,7 @@
 admin:
   ip: 0.0.0.0
   port: 9990
+  workerThreads: 3
 
 telemetry:
 - kind: io.l5d.recentRequests

--- a/namerd/core/src/main/scala/io/buoyant/namerd/NamerdConfig.scala
+++ b/namerd/core/src/main/scala/io/buoyant/namerd/NamerdConfig.scala
@@ -59,7 +59,7 @@ private[namerd] case class NamerdConfig(
     val dtabStore = storage.mkDtabStore(Stack.Params.empty + param.Stats(stats.scope("dtabstore")))
     val namersByPfx = mkNamers(Stack.Params.empty + param.Stats(stats.scope("namer")))
     val ifaces = mkInterfaces(dtabStore, namersByPfx, stats.scope("interface"))
-    val adminImpl = admin.getOrElse(DefaultAdminConfig).mk(DefaultAdminAddress)
+    val adminImpl = admin.getOrElse(DefaultAdminConfig).mk(DefaultAdminAddress, stats)
 
     new Namerd(ifaces, dtabStore, namersByPfx, adminImpl, telemeters)
   }

--- a/namerd/docs/config.md
+++ b/namerd/docs/config.md
@@ -54,7 +54,10 @@ IP are configurable via a top-level `admin` section.
 Key | Default Value | Description
 --- | ------------- | -----------
 ip | loopback address | IP for the admin interface. A value like 0.0.0.0 configures admin to listen on all local IPv4 interfaces.
-port | `9991` | Port for the admin interface.
+port | `9990` | Port for the admin interface.
+shutdownGraceMs | 10000 | maximum grace period before the Namerd process exits
+tls | no tls | The admin interface will serve over TLS if this parameter is provided. see [TLS](#server-tls).
+workerThreads | 2 | The number of worker threads used to serve the admin interface.
 
 #### Administrative endpoints
 

--- a/router/http/src/main/scala/io/buoyant/router/http/ContentLengthFilter.scala
+++ b/router/http/src/main/scala/io/buoyant/router/http/ContentLengthFilter.scala
@@ -40,8 +40,8 @@ object ContentLengthFilter {
       service(request).flatMap { response =>
 
         if (response.version == Version.Http10
-            && !hasTransferEncoding(response)
-            && response.contentLength.isEmpty) {
+          && !hasTransferEncoding(response)
+          && response.contentLength.isEmpty) {
           Reader.readAll(response.reader).map { buf =>
             response.setChunked(false)
             response.contentLength = buf.length


### PR DESCRIPTION
Linkerd's admin server uses the same worker threadpool as Linkerd uses for serving requests in the data plane.  This means that if there are many admin requests or admin requests take a long time to complete, this can tie up all of the available threads and delay processing of data plane requests.  This can be observed as an increase in tail latency when there are a large number of stats and there are frequent requests to the stats endpoint.

We use a separate worker pool for the admin server, with a configurable number of worker threads (2 by default).  This prevents admin requests from tying up data plane workers.  To improve visibility, we also expose stats about the admin server itself in the metrics.

Signed-off-by: Alex Leong <alex@buoyant.io>