### PR TITLE
Add clear context functionality for H2 requests

### DIFF
--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/Stream.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/Stream.scala
@@ -107,6 +107,28 @@ object Stream {
   }
 
   /**
+   * Read a [[Stream]] to the end, [[Frame.release release()]]ing each
+   * [[Frame]] before reading the next one.
+   *
+   * The value of each frame is discarded, but assertions can be made about
+   * their contents by attaching an [[Stream.onFrame onFrame()]] callback
+   * before calling `readAll()`.
+   *
+   * @param stream the [[Stream]] to read to the end
+   * @return a [[Future]] that will finish when the whole stream is read
+   */
+
+  def readToEnd(stream: Stream): Future[Unit] =
+    if (stream.isEmpty) Future.Unit
+    else
+      stream.read().flatMap { frame =>
+        val end = frame.isEnd
+        frame.release().before {
+          if (end) Future.Unit else readToEnd(stream)
+        }
+      }
+
+  /**
    * In order to create a stream, we need a mechanism to write to it.
    */
   trait Writer {

--- a/finagle/h2/src/test/scala/io/buoyant/test/h2/StreamTestUtils.scala
+++ b/finagle/h2/src/test/scala/io/buoyant/test/h2/StreamTestUtils.scala
@@ -6,26 +6,6 @@ import com.twitter.util.Future
 import io.netty.handler.codec.http2._
 
 object StreamTestUtils {
-  /**
-   * Read a [[Stream]] to the end, [[Frame.release release()]]ing each
-   * [[Frame]] before reading the next one.
-   *
-   * The value of each frame is discarded, but assertions can be made about
-   * their contents by attaching an [[Stream.onFrame onFrame()]] callback
-   * before calling `readAll()`.
-   *
-   * @param stream the [[Stream]] to read to the end
-   * @return a [[Future]] that will finish when the whole stream is read
-   */
-  final def readToEnd(stream: Stream): Future[Unit] =
-    if (stream.isEmpty) Future.Unit
-    else
-      stream.read().flatMap { frame =>
-        val end = frame.isEnd
-        frame.release().before {
-          if (end) Future.Unit else readToEnd(stream)
-        }
-      }
 
   def readDataStream(stream: Stream): Future[Buf] = {
     stream.read().flatMap {
@@ -57,7 +37,7 @@ object StreamTestUtils {
    * @param stream the underlying [[Stream]]
    */
   implicit class ReadAllStream(val stream: Stream) extends AnyVal {
-    @inline def readToEnd: Future[Unit] = StreamTestUtils.readToEnd(stream)
+    @inline def readToEnd: Future[Unit] = Stream.readToEnd(stream)
     @inline def readDataString: Future[String] = StreamTestUtils.readDataString(stream)
   }
 

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/H2Config.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/H2Config.scala
@@ -66,8 +66,9 @@ class H2Initializer extends ProtocolInitializer.Simple {
   protected val defaultServer = {
     val stk = H2.server.stack
       .replace(H2TraceInitializer.role, H2TraceInitializer.serverModule)
-      .prepend(LinkerdHeaders.Ctx.serverModule)
+      //ErrorReseter must precede LinkerdHeaders in order to clear l5d context from responses.
       .prepend(h2.ErrorReseter.module)
+      .prepend(LinkerdHeaders.Ctx.serverModule)
       .insertBefore(H2AddForwardedHeader.module.role, AddForwardedHeaderConfig.module[Request, Response])
 
     H2.server.withStack(stk)


### PR DESCRIPTION
When `clearContext: true` is set to true in a Linkerd config, H2 requests fail to clear any `l5d-` and also fails to clear any data frames that may reveal the internal state of Linkerd. 

This PR clears any `l5d-*` headers present in an H2 response and clears any data frames when a response with an `l5d-err` is encountered.

Tests were done locally, using a local H2 and Linkerd set to `clearContext: true`.

fixes #2002

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>