### PR TITLE
Use existing opentracing context

### DIFF
--- a/linkerd/protocol/http/src/main/scala/com/twitter/finagle/buoyant/linkerd/LinkerdHeaders.scala
+++ b/linkerd/protocol/http/src/main/scala/com/twitter/finagle/buoyant/linkerd/LinkerdHeaders.scala
@@ -343,9 +343,7 @@ object Headers {
           service(req)
         }
       }
-
     }
-
   }
 
   /**
@@ -397,7 +395,6 @@ object Headers {
         service(req)
       }
     }
-
   }
 
   /**
@@ -469,7 +466,6 @@ object Headers {
             new BoundFilter(dst.name).andThen(factory)
         }
     }
-
   }
 
   class ClearMiscServerFilter extends SimpleFilter[Request, Response] {


### PR DESCRIPTION
Hi,

As we wanted to have the ability for linkerd to propagate the opentracing context that was originated outside linkerd, and it wasn't clearly in your roadmap, we went ahead and modified linkerd to do this. 
I'm a scala newbie, so the code may be less than optimal. Any change you feel would fit better, feel more than free to tell me. The change consists basically in adding an if when getting tracing context to get opentracing headers, and to propagate the context in the same headers in the next step. 
This is very important for us to be able to have the full trace for a request, as it is originated outside the platform that is running linkerd as service mesh.

We have tested this in our deployment and it's working as expected.

This should fix #1447 with standard opentracing headers

Thanks!
