### PR TITLE
Upgrade to Finagle 18.5.0 and switch from Buf to ByteBuf

### DIFF
--- a/finagle/benchmark/src/main/scala/com/twitter/finagle/buoyant/h2/BufferedStreamBenchmark.scala
+++ b/finagle/benchmark/src/main/scala/com/twitter/finagle/buoyant/h2/BufferedStreamBenchmark.scala
@@ -2,7 +2,6 @@ package com.twitter.finagle.buoyant.h2
 
 import com.twitter.conversions.storage._
 import com.twitter.concurrent.AsyncQueue
-import com.twitter.io.Buf
 import com.twitter.util.StdBenchAnnotations
 import io.buoyant.test.Awaits
 import io.netty.buffer.Unpooled

--- a/finagle/benchmark/src/main/scala/com/twitter/finagle/buoyant/h2/BufferedStreamBenchmark.scala
+++ b/finagle/benchmark/src/main/scala/com/twitter/finagle/buoyant/h2/BufferedStreamBenchmark.scala
@@ -5,6 +5,7 @@ import com.twitter.concurrent.AsyncQueue
 import com.twitter.io.Buf
 import com.twitter.util.StdBenchAnnotations
 import io.buoyant.test.Awaits
+import io.netty.buffer.Unpooled
 import org.openjdk.jmh.annotations._
 
 trait StreamBase {
@@ -12,7 +13,7 @@ trait StreamBase {
   final val StreamLength = 8
   final val FrameSize = 1.kilobyte
   final val BufferCapacity = FrameSize * StreamLength
-  final val Data = Buf.ByteArray(Array.fill(FrameSize.bytes.toInt)(0.toByte): _*)
+  final val Data = Unpooled.wrappedBuffer(Array.fill(FrameSize.bytes.toInt)(0.toByte))
 }
 
 // ./sbt 'project finagle-benchmark' 'jmh:run -i 20 -prof gc .*StreamBaselineBenchmark.*'

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/H2Transport.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/H2Transport.scala
@@ -1,7 +1,7 @@
 package com.twitter.finagle.buoyant.h2
 
-import com.twitter.io.Buf
 import com.twitter.util.{Future, Time}
+import io.netty.buffer.ByteBuf
 import java.net.SocketAddress
 import io.netty.handler.codec.http2.H2FrameStream
 
@@ -18,7 +18,7 @@ object H2Transport {
     def remoteAddress: SocketAddress
 
     def write(frameStream: H2FrameStream, orig: Headers, eos: Boolean): Future[Unit]
-    def write(frameStream: H2FrameStream, buf: Buf, eos: Boolean): Future[Unit]
+    def write(frameStream: H2FrameStream, buf: ByteBuf, eos: Boolean): Future[Unit]
     def write(frameStream: H2FrameStream, frame: Frame): Future[Unit]
 
     /**

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/Stream.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/Stream.scala
@@ -1,10 +1,9 @@
 package com.twitter.finagle.buoyant.h2
 
 import com.twitter.concurrent.AsyncQueue
-import com.twitter.io.Buf
 import com.twitter.util.{Future, Promise, Return, Throw, Try}
 import io.netty.buffer.{ByteBuf, Unpooled}
-import java.nio.charset.{Charset, StandardCharsets => JChar}
+import java.nio.charset.{StandardCharsets => JChar}
 
 /**
  * A Stream represents a stream of Data frames, optionally

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/Stream.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/Stream.scala
@@ -3,6 +3,8 @@ package com.twitter.finagle.buoyant.h2
 import com.twitter.concurrent.AsyncQueue
 import com.twitter.io.Buf
 import com.twitter.util.{Future, Promise, Return, Throw, Try}
+import io.netty.buffer.{ByteBuf, Unpooled}
+import java.nio.charset.{Charset, StandardCharsets => JChar}
 
 /**
  * A Stream represents a stream of Data frames, optionally
@@ -180,11 +182,13 @@ object Stream {
     apply(q)
   }
 
-  def const(buf: Buf): Stream =
+  def const(buf: ByteBuf): Stream =
     const(Frame.Data.eos(buf))
 
-  def const(s: String): Stream =
-    const(Buf.Utf8(s))
+  def const(s: String): Stream = {
+    val bytes = s.getBytes(JChar.UTF_8)
+    const(Unpooled.wrappedBuffer(bytes))
+  }
 
   def empty(): Stream = new Stream {
     override def isEmpty = true
@@ -218,13 +222,13 @@ object Frame {
    * `release()` MUST be called so that the producer may manage flow control.
    */
   trait Data extends Frame {
-    override def toString = s"Frame.Data(length=${buf.length}, isEnd=$isEnd)"
-    def buf: Buf
+    override def toString = s"Frame.Data(length=${buf.readableBytes()}, isEnd=$isEnd)"
+    def buf: ByteBuf
   }
 
   object Data {
 
-    def apply(buf0: Buf, eos: Boolean, release0: () => Future[Unit]): Data = new Data {
+    def apply(buf0: ByteBuf, eos: Boolean, release0: () => Future[Unit]): Data = new Data {
       def buf = buf0
       private[this] val releaseP = new Promise[Unit]
       def onRelease = releaseP
@@ -240,16 +244,20 @@ object Frame {
       override def apply(): Future[Unit] = Future.Unit
     }
 
-    def apply(buf: Buf, eos: Boolean): Data =
+    def apply(buf: ByteBuf, eos: Boolean): Data =
       apply(buf, eos, NoopRelease)
 
-    def apply(s: String, eos: Boolean, release: () => Future[Unit]): Data =
-      apply(Buf.Utf8(s), eos, release)
+    def apply(s: String, eos: Boolean, release: () => Future[Unit]): Data = {
+      val bytes = s.getBytes(JChar.UTF_8)
+      apply(Unpooled.wrappedBuffer(bytes), eos, release)
+    }
 
-    def apply(s: String, eos: Boolean): Data =
-      apply(Buf.Utf8(s), eos)
+    def apply(s: String, eos: Boolean): Data = {
+      val bytes = s.getBytes(JChar.UTF_8)
+      apply(Unpooled.wrappedBuffer(bytes), eos)
+    }
 
-    def eos(buf: Buf): Data = apply(buf, true)
+    def eos(buf: ByteBuf): Data = apply(buf, true)
     def eos(s: String): Data = apply(s, true)
 
     def copy(frame: Data, eos: Boolean): Data = new Data {

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4H2Writer.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4H2Writer.scala
@@ -2,11 +2,10 @@ package com.twitter.finagle.buoyant.h2
 package netty4
 
 import com.twitter.finagle.WriteException
-import com.twitter.finagle.netty4.BufAsByteBuf
 import com.twitter.finagle.transport.Transport
-import com.twitter.io.Buf
 import com.twitter.logging.Logger
 import com.twitter.util.{Future, Time}
+import io.netty.buffer.ByteBuf
 import io.netty.handler.codec.http2._
 import java.net.SocketAddress
 
@@ -31,9 +30,8 @@ private[netty4] trait Netty4H2Writer extends H2Transport.Writer {
     case tlrs: Frame.Trailers => write(stream, tlrs, eos = true)
   }
 
-  override def write(stream: H2FrameStream, buf: Buf, eos: Boolean): Future[Unit] = {
-    val bb = BufAsByteBuf(buf)
-    val nettyFrame = new DefaultHttp2DataFrame(bb, eos)
+  override def write(stream: H2FrameStream, buf: ByteBuf, eos: Boolean): Future[Unit] = {
+    val nettyFrame = new DefaultHttp2DataFrame(buf.duplicate, eos)
     if (stream.id >= 0) nettyFrame.stream(stream)
     write(nettyFrame.retain())
   }

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4StreamTransport.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4StreamTransport.scala
@@ -543,7 +543,7 @@ object Netty4StreamTransport {
     val recordLocalFrame: Frame => Unit = {
       case d: Frame.Data =>
         localDataFrames.incr()
-        localDataBytes.add(d.buf.length)
+        localDataBytes.add(d.buf.readableBytes())
       case t: Frame.Trailers => localTrailersCount.incr()
     }
 
@@ -555,7 +555,7 @@ object Netty4StreamTransport {
     val recordRemoteFrame: Frame => Unit = {
       case d: Frame.Data =>
         remoteDataFrames.incr()
-        remoteDataBytes.add(d.buf.length)
+        remoteDataBytes.add(d.buf.readableBytes())
       case _: Frame.Trailers => remoteTrailersCount.incr()
     }
 

--- a/finagle/h2/src/test/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4ServerDispatcherTest.scala
+++ b/finagle/h2/src/test/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4ServerDispatcherTest.scala
@@ -113,7 +113,7 @@ class Netty4ServerDispatcherTest extends FunSuite {
     }
     sentq = sentq.tail
 
-    assert(bartmanStream.offer(Frame.Data(Buf.Utf8("0"), false)))
+    assert(bartmanStream.offer(Frame.Data("0", false)))
     eventually {
       sentq.headOption match {
         case Some(f: Http2DataFrame) =>
@@ -125,7 +125,7 @@ class Netty4ServerDispatcherTest extends FunSuite {
     }
     sentq = sentq.tail
 
-    assert(elBartoStream.offer(Frame.Data(Buf.Utf8("0"), true)))
+    assert(elBartoStream.offer(Frame.Data("0", true)))
     eventually {
       sentq.headOption match {
         case Some(f: Http2DataFrame) =>
@@ -137,7 +137,7 @@ class Netty4ServerDispatcherTest extends FunSuite {
     }
     sentq = sentq.tail
 
-    assert(bartmanStream.offer(Frame.Data(Buf.Utf8("0"), true)))
+    assert(bartmanStream.offer(Frame.Data("0", true)))
     eventually {
       sentq.headOption match {
         case Some(f: Http2DataFrame) =>

--- a/finagle/h2/src/test/scala/io/buoyant/test/h2/StreamTestUtils.scala
+++ b/finagle/h2/src/test/scala/io/buoyant/test/h2/StreamTestUtils.scala
@@ -3,7 +3,9 @@ package io.buoyant.test.h2
 import com.twitter.finagle.buoyant.h2.{Frame, Stream}
 import com.twitter.io.Buf
 import com.twitter.util.Future
+import io.netty.buffer.{ByteBuf, Unpooled}
 import io.netty.handler.codec.http2._
+import java.nio.charset.StandardCharsets
 
 object StreamTestUtils {
   /**
@@ -27,28 +29,28 @@ object StreamTestUtils {
         }
       }
 
-  def readDataStream(stream: Stream): Future[Buf] = {
+  def readDataStream(stream: Stream): Future[ByteBuf] = {
     stream.read().flatMap {
       case frame: Frame.Data if frame.isEnd =>
         // Copy the data so that the underlying buffer can be released.
-        val bbCopy = Buf.ByteBuffer.Shared.extract(frame.buf)
+        val bbCopy = frame.buf.copy()
         val _ = frame.release()
-        Future.value(Buf.ByteBuffer.Owned(bbCopy))
+        Future.value(bbCopy)
       case frame: Frame.Data =>
         // Copy the data so that the underlying buffer can be released.
-        val bbCopy = Buf.ByteBuffer.Shared.extract(frame.buf)
+        val bbCopy = frame.buf.copy()
         val _ = frame.release()
         readDataStream(stream).map { rest =>
-          Buf.ByteBuffer.Owned(bbCopy).concat(rest)
+          Unpooled.copiedBuffer(bbCopy, rest)
         }
       case frame: Frame.Trailers =>
         val _ = frame.release()
-        Future.value(Buf.Empty)
+        Future.value(Unpooled.EMPTY_BUFFER)
     }
   }
 
   def readDataString(stream: Stream): Future[String] =
-    readDataStream(stream).map(Buf.Utf8.unapply).map(_.get)
+    readDataStream(stream).map(_.toString(StandardCharsets.UTF_8))
 
   /**
    * Enhances a [[Stream]] by providing the [[readToEnd()]] function in the

--- a/grpc/runtime/src/main/scala/io/buoyant/grpc/runtime/DecodingStream.scala
+++ b/grpc/runtime/src/main/scala/io/buoyant/grpc/runtime/DecodingStream.scala
@@ -1,9 +1,9 @@
 package io.buoyant.grpc.runtime
 
-import com.twitter.concurrent.{AsyncMutex, Permit}
+import com.twitter.concurrent.AsyncMutex
 import com.twitter.finagle.buoyant.h2
-import com.twitter.io.Buf
-import com.twitter.util.{Future, Return, Promise, Throw, Try}
+import com.twitter.util.{Future, Return, Throw, Try}
+import io.netty.buffer.{ByteBuf, CompositeByteBuf, Unpooled}
 import java.nio.ByteBuffer
 import scala.util.control.NoStackTrace
 
@@ -16,7 +16,7 @@ import scala.util.control.NoStackTrace
  * invoked serially, i.e. when there are no pending `recv()` calls on
  * the stream.
  */
-private[runtime] trait DecodingStream[+T] extends Stream[T] {
+private[runtime] trait DecodingStream[T] extends Stream[T] {
   import DecodingStream._
 
   protected[this] def frames: h2.Stream
@@ -27,13 +27,15 @@ private[runtime] trait DecodingStream[+T] extends Stream[T] {
   private[this]type Releasable = Stream.Releasable[T]
 
   /**
-   * Holds HTTP/2 data that has not yet been returned from recv().
-   *
-   * These states hold a ByteBuffer-backed Buf, as well as a
-   * `Releaser`, which manages when HTTP/2 frames are released
-   * (i.e. for flow control).
+   * This state holds a `Releaser`, which manages when HTTP/2 frames
+   * are released (i.e. for flow control).
    */
   private[this] var recvState: RecvState = RecvState.Empty
+
+  /**
+   * This holds all the bytes read from data frames.
+   */
+  private[this] val buf: CompositeByteBuf = Unpooled.compositeBuffer()
 
   /**
    * Ensures that at most one recv call is actively being processed,
@@ -54,7 +56,7 @@ private[runtime] trait DecodingStream[+T] extends Stream[T] {
       // completes. Start by trying to obtain a message directly from
       // the buffer. If a message isn't buffered, read() it from the
       // h2.Stream.
-      decode(recvState, decoder) match {
+      decode(recvState) match {
         case Decoded(s, Some(msg)) => _updateBuffer(s -> Return(msg))
         case Decoded(s, None) => read(s).flatMap(_updateBuffer)
       }
@@ -82,7 +84,7 @@ private[runtime] trait DecodingStream[+T] extends Stream[T] {
         t.release()
         Future.exception(status)
       case Return(f: h2.Frame.Data) =>
-        decodeFrame(s0, f, decoder) match {
+        decodeFrame(s0, f) match {
           case Decoded(s1, Some(msg)) => Future.value(s1 -> Return(msg))
           case Decoded(s1, None) =>
             if (f.isEnd) Future.value(s1 -> Throw(GrpcStatus.Ok()))
@@ -90,6 +92,81 @@ private[runtime] trait DecodingStream[+T] extends Stream[T] {
         }
     }
   }
+
+  private[this] def decodeHeader(bb0: ByteBuf): Option[Header] =
+    if (bb0.readableBytes() < GrpcFrameHeaderSz) None
+    else {
+      val compressed = bb0.readByte() == 1
+      val sz = bb0.readInt()
+      Some(Header(compressed, sz))
+    }
+
+  private case class Decoded(
+    state: RecvState,
+    result: Option[Stream.Releasable[T]]
+  )
+
+  private[this] def decode(
+    s0: RecvState
+  ): Decoded = s0 match {
+    case rst@RecvState.Reset(_) => Decoded(rst, None)
+
+    case RecvState.Buffer(Some(hdr), releaser) =>
+      decodeMessage(hdr, releaser)
+
+    case RecvState.Buffer(None, releaser) =>
+      decodeHeader(buf) match {
+        case None => Decoded(s0, None)
+        case Some(hdr) =>
+          val r = releaser.consume(GrpcFrameHeaderSz)
+          decodeMessage(hdr, r)
+      }
+  }
+
+  private[this] def decodeFrame(
+    s0: RecvState,
+    frame: h2.Frame.Data
+  ): Decoded = s0 match {
+    case rst@RecvState.Reset(_) => Decoded(rst, None)
+
+    case RecvState.Buffer(None, releaser0) =>
+      // We don't want the composite buf to be able to release this buf component until the frame
+      // has been released, so we call retain() here.  This component should be fully released once
+      // both the frame has been released and when the composite buf has fully read and discarded
+      // this component.
+      buf.addComponent(true, frame.buf.retain())
+      val releaser = releaser0.track(frame)
+      decodeHeader(buf) match {
+        case None => Decoded(RecvState.Buffer(None, releaser), None)
+        case Some(hdr) =>
+          val r = releaser.consume(GrpcFrameHeaderSz)
+          decodeMessage(hdr, r)
+      }
+
+    case RecvState.Buffer(Some(hdr), releaser) =>
+      // We've already decoded a header, but not its message. Try to
+      // decode the message.
+      buf.addComponent(true, frame.buf.retain())
+      decodeMessage(hdr, releaser.track(frame))
+  }
+
+  private[this] def decodeMessage(
+    hdr: Header,
+    releaser: Releaser
+  ): Decoded =
+    if (hdr.compressed) throw new IllegalArgumentException("compression not supported yet")
+    else if (hdr.size <= buf.readableBytes()) {
+      // The message is fully encoded in the buffer, so decode it.
+      val (nextReleaser, release) = releaser.consume(hdr.size).releasable()
+      // Copy the buffered message into a nio buffer so that it can be decoded.
+      val nioBuf = buf.nioBuffer(buf.readerIndex(), hdr.size)
+      val msg = decoder(nioBuf)
+      // Advance the reader index past the message and release any fully read components.
+      buf.skipBytes(hdr.size)
+      buf.discardReadComponents()
+
+      Decoded(RecvState.Buffer(None, nextReleaser), Some(Stream.Releasable(msg, release)))
+    } else Decoded(RecvState.Buffer(Some(hdr), releaser), None)
 }
 
 object DecodingStream {
@@ -119,8 +196,6 @@ object DecodingStream {
     case class Buffer(
       /** The current gRPC message header, if one has been parsed */
       header: Option[Header] = None,
-      /** Unparsed bytes */
-      buf: Buf = Buf.Empty,
       /** Tracks how many bytes are consumed and when the underling data may be released */
       releaser: Releaser = Releaser.Nil
     ) extends RecvState
@@ -275,102 +350,11 @@ object DecodingStream {
         FrameReleaser(SegmentLatch(f.release _), 0, 0, Nil)
 
       case f: h2.Frame.Data =>
-        FrameReleaser(SegmentLatch(f.release _), 0, f.buf.length, Nil)
+        FrameReleaser(SegmentLatch(f.release _), 0, f.buf.readableBytes(), Nil)
     }
   }
 
-  private[this] case class Header(compressed: Boolean, size: Int)
+  private case class Header(compressed: Boolean, size: Int)
 
-  /*
-   * Decoders utilities
-   */
-
-  private[this] val GrpcFrameHeaderSz = Codec.GrpcFrameHeaderSz
-
-  private def decodeHeader[T](bb0: ByteBuffer): Option[Header] =
-    if (bb0.remaining < GrpcFrameHeaderSz) None
-    else {
-      val bb = bb0.duplicate()
-      bb.limit(bb0.position + GrpcFrameHeaderSz)
-      val compressed = (bb.get == 1)
-      val sz = bb.getInt
-      Some(Header(compressed, sz))
-    }
-
-  private case class Decoded[T](
-    state: RecvState,
-    result: Option[Stream.Releasable[T]]
-  )
-
-  private def decode[T](
-    s0: RecvState,
-    decoder: ByteBuffer => T
-  ): Decoded[T] = s0 match {
-    case rst@RecvState.Reset(_) => Decoded(rst, None)
-
-    case RecvState.Buffer(Some(hdr), buf, releaser) =>
-      val Buf.ByteBuffer.Owned(bb0) = Buf.ByteBuffer.coerce(buf)
-      decodeMessage(hdr, bb0.duplicate(), releaser, decoder)
-
-    case RecvState.Buffer(None, buf, releaser) =>
-      val Buf.ByteBuffer.Owned(bb0) = Buf.ByteBuffer.coerce(buf)
-      val bb = bb0.duplicate()
-      decodeHeader(bb) match {
-        case None => Decoded(s0, None)
-        case Some(hdr) =>
-          bb.position(bb.position + GrpcFrameHeaderSz)
-          val r = releaser.consume(GrpcFrameHeaderSz)
-          decodeMessage(hdr, bb, r, decoder)
-      }
-  }
-
-  private def decodeFrame[T](
-    s0: RecvState,
-    frame: h2.Frame.Data,
-    decoder: ByteBuffer => T
-  ): Decoded[T] = s0 match {
-    case rst@RecvState.Reset(_) => Decoded(rst, None)
-
-    case RecvState.Buffer(None, initbuf, releaser0) =>
-      val buf = initbuf.concat(frame.buf)
-      val Buf.ByteBuffer.Owned(bb0) = Buf.ByteBuffer.coerce(buf)
-      val bb = bb0.duplicate()
-      val releaser = releaser0.track(frame)
-      decodeHeader(bb.duplicate()) match {
-        case None => Decoded(RecvState.Buffer(None, buf, releaser), None)
-        case Some(hdr) =>
-          bb.position(bb.position + GrpcFrameHeaderSz)
-          val r = releaser.consume(GrpcFrameHeaderSz)
-          decodeMessage(hdr, bb, r, decoder)
-      }
-
-    case RecvState.Buffer(Some(hdr), initbuf, releaser) =>
-      // We've already decoded a header, but not its message. Try to
-      // decode the message.
-      val Buf.ByteBuffer.Owned(bb0) = Buf.ByteBuffer.coerce(initbuf.concat(frame.buf))
-      decodeMessage(hdr, bb0.duplicate(), releaser.track(frame), decoder)
-  }
-
-  private def decodeMessage[T](
-    hdr: Header,
-    bb: ByteBuffer,
-    releaser: Releaser,
-    decoder: ByteBuffer => T
-  ): Decoded[T] =
-    if (hdr.compressed) throw new IllegalArgumentException("compression not supported yet")
-    else if (hdr.size <= bb.remaining) {
-      // The message is fully encoded in the buffer, so decode it.
-      val end = bb.position + hdr.size
-      val (nextReleaser, release) = releaser.consume(hdr.size).releasable()
-      val msg = {
-        val msgbb = bb.duplicate()
-        msgbb.limit(end)
-        val msg = decoder(msgbb)
-        Some(Stream.Releasable(msg, release))
-      }
-      // Update the unparsed buffer to point after the parsed message.
-      bb.position(end)
-      Decoded(RecvState.Buffer(None, Buf.ByteBuffer.Owned(bb), nextReleaser), msg)
-    } else Decoded(RecvState.Buffer(Some(hdr), Buf.ByteBuffer.Owned(bb), releaser), None)
-
+  private val GrpcFrameHeaderSz = Codec.GrpcFrameHeaderSz
 }

--- a/grpc/runtime/src/main/scala/io/buoyant/grpc/runtime/ServerDispatcher.scala
+++ b/grpc/runtime/src/main/scala/io/buoyant/grpc/runtime/ServerDispatcher.scala
@@ -2,7 +2,6 @@ package io.buoyant.grpc.runtime
 
 import com.twitter.finagle.{Failure, Service => FinagleService}
 import com.twitter.finagle.buoyant.h2
-import com.twitter.io.Buf
 import com.twitter.util.{Future, Return, Throw, Try}
 
 object ServerDispatcher {

--- a/grpc/runtime/src/main/scala/io/buoyant/grpc/runtime/ServerDispatcher.scala
+++ b/grpc/runtime/src/main/scala/io/buoyant/grpc/runtime/ServerDispatcher.scala
@@ -76,7 +76,7 @@ object ServerDispatcher {
 
     private[this] def acceptUnary[Req](codec: Codec[Req], req: h2.Request): Future[Req] =
       Codec.bufferWithStatus(req.stream).map {
-        case (buf, _) => codec.decodeBuf(Codec.decodeGrpcFrame(buf))
+        case (buf, _) => codec.decodeByteBuffer(Codec.decodeGrpcFrame(buf))
       }
 
     private[this] def acceptStreaming[Req](codec: Codec[Req], req: h2.Request): Stream[Req] =

--- a/grpc/runtime/src/test/scala/io/buoyant/grpc/runtime/DecodingStreamTest.scala
+++ b/grpc/runtime/src/test/scala/io/buoyant/grpc/runtime/DecodingStreamTest.scala
@@ -2,9 +2,9 @@ package io.buoyant.grpc.runtime
 
 import com.twitter.concurrent.AsyncQueue
 import com.twitter.finagle.buoyant.h2
-import com.twitter.io.Buf
 import com.twitter.util._
 import io.buoyant.test.FunSuite
+import io.netty.buffer.Unpooled
 
 class DecodingStreamTest extends FunSuite {
 
@@ -30,7 +30,7 @@ class DecodingStreamTest extends FunSuite {
         0, 0, 0, 0, 5, 1, 2, 3, 4 // one by short
       )
       val rel = () => { released0 = true; Future.Unit }
-      h2.Frame.Data(Buf.ByteArray.Owned(b), false, rel)
+      h2.Frame.Data(Unpooled.wrappedBuffer(b), false, rel)
     }
 
     @volatile var released1 = false
@@ -40,14 +40,14 @@ class DecodingStreamTest extends FunSuite {
         5, // finishes last message
         0, 0, 0, 0, 3, 1, 2, 3
       )
-      h2.Frame.Data(Buf.ByteArray.Owned(b), false, rel)
+      h2.Frame.Data(Unpooled.wrappedBuffer(b), false, rel)
     }
 
     @volatile var released2 = false
     val frame2 = {
       val rel = () => { released2 = true; Future.Unit }
       val b: Array[Byte] = Array(0, 0, 0, 0, 4, 1, 2, 3, 4)
-      h2.Frame.Data(Buf.ByteArray.Owned(b), false, rel)
+      h2.Frame.Data(Unpooled.wrappedBuffer(b), false, rel)
     }
 
     val status = GrpcStatus.Unknown("idk man")

--- a/linkerd/protocol/h2/src/e2e/scala/io/buoyant/linkerd/protocol/h2/H2EndToEndTest.scala
+++ b/linkerd/protocol/h2/src/e2e/scala/io/buoyant/linkerd/protocol/h2/H2EndToEndTest.scala
@@ -7,7 +7,6 @@ import com.twitter.finagle.buoyant.h2._
 import com.twitter.finagle.param.Stats
 import com.twitter.finagle.service.ExpiringService
 import com.twitter.finagle.stats.InMemoryStatsReceiver
-import com.twitter.io.Buf
 import com.twitter.logging.Level
 import com.twitter.util.{Duration, Future, Throw}
 import io.buoyant.linkerd.protocol.H2Initializer
@@ -16,6 +15,7 @@ import io.buoyant.router.StackRouter.Client.PerClientParams
 import io.buoyant.test.FunSuite
 import io.buoyant.test.h2.StreamTestUtils._
 import java.io.File
+import java.nio.charset.StandardCharsets
 import org.scalatest.time.{Millis, Seconds, Span}
 import scala.io.Source
 import scala.util.Random
@@ -405,7 +405,7 @@ class H2EndToEndTest extends FunSuite {
     assert(rsp.status == Status.Ok)
     assert(q.offer(Frame.Data("one", eos = false)))
     val frame = await(rsp.stream.read())
-    val Buf.Utf8(s) = frame.asInstanceOf[Frame.Data].buf
+    val s = frame.asInstanceOf[Frame.Data].buf.toString(StandardCharsets.UTF_8)
     assert(s == "one")
 
     rsp.stream.cancel(Reset.Cancel)

--- a/linkerd/protocol/h2/src/main/scala/com/twitter/finagle/buoyant/h2/LinkerdHeaders.scala
+++ b/linkerd/protocol/h2/src/main/scala/com/twitter/finagle/buoyant/h2/LinkerdHeaders.scala
@@ -5,7 +5,6 @@ import com.twitter.finagle.buoyant.{Dst => BuoyantDst}
 import com.twitter.finagle.context.{Contexts, Deadline => FDeadline}
 import com.twitter.finagle.http.MediaType
 import com.twitter.finagle.tracing._
-import com.twitter.io.Buf
 import com.twitter.util.{Future, Return, Throw, Time, Try}
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets.ISO_8859_1
@@ -463,7 +462,7 @@ object LinkerdHeaders {
           Key -> URLEncoder.encode(msg, ISO_8859_1.toString),
           "content-type" -> MediaType.PlainText,
           "content-length" -> msg.length.toString
-        ), Stream.const(Buf.Utf8(msg))
+        ), Stream.const(msg)
       )
     }
   }

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -8,14 +8,14 @@ object Deps {
 
   // process lifecycle
   val twitterServer =
-    ("com.twitter" %% "twitter-server" % "18.4.0")
+    ("com.twitter" %% "twitter-server" % "18.5.0")
       .exclude("com.twitter", "finagle-zipkin_2.12")
 
   def twitterUtil(mod: String) =
-    "com.twitter" %% s"util-$mod" % "18.4.0"
+    "com.twitter" %% s"util-$mod" % "18.5.0"
   // networking
   def finagle(mod: String) =
-    "com.twitter" %% s"finagle-$mod" % "18.4.0"
+    "com.twitter" %% s"finagle-$mod" % "18.5.0"
 
   def netty4(mod: String) =
     "io.netty" % s"netty-$mod" % "4.1.16.Final"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -18,7 +18,7 @@ addSbtPlugin("com.eed3si9n"      % "sbt-assembly"  % "0.14.1")
 addSbtPlugin("se.marcuslonnberg" % "sbt-docker"    % "1.4.1")
 
 // scrooge
-addSbtPlugin("com.twitter" %% "scrooge-sbt-plugin" % "18.4.0")
+addSbtPlugin("com.twitter" %% "scrooge-sbt-plugin" % "18.5.0")
 
 // microbenchmarking for tests.
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.27")

--- a/router/h2/src/e2e/scala/io/buoyant/router/h2/FlowControlEndToEndTest.scala
+++ b/router/h2/src/e2e/scala/io/buoyant/router/h2/FlowControlEndToEndTest.scala
@@ -44,9 +44,9 @@ class FlowControlEndToEndTest
     // be released until all of the data has been flushed.  This
     // cannot happen until the reader reads and releases some of the
     // data.
-    val frame0 = Frame.Data(mkBuf(WindowSize + 1024), false)
-    val frame1 = Frame.Data(mkBuf(WindowSize - 1024), false)
-    val frame2 = Frame.Data(mkBuf(WindowSize), true)
+    val frame0 = Frame.Data(mkByteBuf(WindowSize + 1024), false)
+    val frame1 = Frame.Data(mkByteBuf(WindowSize - 1024), false)
+    val frame2 = Frame.Data(mkByteBuf(WindowSize), true)
 
     log.debug("offering 2 frames with %d", 2 * WindowSize)
     val wrote0 = writer.write(frame0)
@@ -62,8 +62,8 @@ class FlowControlEndToEndTest
       await(reader.read()) match {
         case d: Frame.Data =>
           // frames += d
-          read += d.buf.length
-          log.debug("~~~ read %d = %d/%d", d.buf.length, read, WindowSize)
+          read += d.buf.readableBytes
+          log.debug("~~~ read %d = %d/%d", d.buf.readableBytes, read, WindowSize)
           await(d.release())
 
         case f => fail(s"unexpected frame: $f")
@@ -80,8 +80,8 @@ class FlowControlEndToEndTest
       if (read > WindowSize + 1024) assert(wrote0.isDefined)
       await(reader.read()) match {
         case d: Frame.Data =>
-          read += d.buf.length
-          log.debug("reader releasing %dB from 1 frame", d.buf.length)
+          read += d.buf.readableBytes
+          log.debug("reader releasing %dB from 1 frame", d.buf.readableBytes)
           await(d.release())
 
         case f => fail(s"unexpected frame: $f")
@@ -96,8 +96,8 @@ class FlowControlEndToEndTest
         read, 3 * WindowSize, wrote2.isDefined)
       await(reader.read()) match {
         case d: Frame.Data =>
-          read += d.buf.length
-          log.debug("reader releasing %dB from 1 frame", d.buf.length)
+          read += d.buf.readableBytes
+          log.debug("reader releasing %dB from 1 frame", d.buf.readableBytes)
           await(d.release())
           assert(d.isEnd == (read == 3 * WindowSize))
 

--- a/router/h2/src/e2e/scala/io/buoyant/router/h2/LargeStreamEndToEndTest.scala
+++ b/router/h2/src/e2e/scala/io/buoyant/router/h2/LargeStreamEndToEndTest.scala
@@ -69,9 +69,9 @@ class LargeStreamEndToEndTest
           d.release().onSuccess(_ => log.debug("released %s", d))
 
         case Return(d: Frame.Data) =>
-          val eos = bytesWritten + d.buf.length >= streamLen
+          val eos = bytesWritten + d.buf.readableBytes >= streamLen
           val len = math.min(frameSize, streamLen - bytesWritten)
-          val frame = Frame.Data(mkBuf(len.toInt), eos)
+          val frame = Frame.Data(mkByteBuf(len.toInt), eos)
           log.debug("releasing %s", d)
           val releaseF = d.release()
           releaseF.onSuccess(_ => log.debug("released %s", d))
@@ -82,7 +82,7 @@ class LargeStreamEndToEndTest
       }
     }
 
-    writer.write(Frame.Data(mkBuf(frameSize), false))
+    writer.write(Frame.Data(mkByteBuf(frameSize), false))
       .before(loop(frameSize, false))
   }
 

--- a/router/h2/src/main/scala/io/buoyant/router/h2/StreamStatsFilter.scala
+++ b/router/h2/src/main/scala/io/buoyant/router/h2/StreamStatsFilter.scala
@@ -105,7 +105,7 @@ class StreamStatsFilter(
           case Return(frame) =>
             frame match {
               case data: Frame.Data =>
-                val _ = streamFrameBytes.addAndGet(data.buf.length)
+                val _ = streamFrameBytes.addAndGet(data.buf.readableBytes)
               case _ =>
             }
             if (frame.isEnd) onFinalFrame(Some(Return(frame)))


### PR DESCRIPTION
Upgrade to Finagle 18.5.0.  In this version of Finagle, certain utility methods for converting between Buf and ByteBuf were removed.  This gives us the perfect opportunity to change the type of the `buf` field of `Frame.Data` from Buf to ByteBuf.

Netty uses ByteBuf as its byte buffer type throughout.  In our H2 implementation we wrap Netty's ByteBufs in Buf, Finagle's byte buffer type.  Buf is type that provides a nice API and abstracts over a variety of byte buffer types such as Array[Byte], ByteBuffer, and ByteBuf.  However, since we only use byte buffers from Netty, our Bufs always contain a Netty ByteBuf.  Not only does this make the abstraction unnecessary but the abstraction is also leaky because we require that the Bufs contain a ByteBuf in order for Netty's ByteBuf reference counting to work correctly.

We change `Frame.Data` to hold a Netty ByteBuf directly instead of a Buf which wraps a ByteBuf.  This avoids the need to convert between the two and eliminates a pointless abstraction.