### PR TITLE
Fix Linkerd to stop failing at routing H2 responses with invalid status codes

### DIFF
--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/Status.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/Status.scala
@@ -5,7 +5,6 @@ package com.twitter.finagle.buoyant.h2
  */
 
 case class Status(code: Int) {
-  require(100 <= code && code < 600)
   override def toString = code.toString
 }
 


### PR DESCRIPTION
When Linkerd receives a Header frame with a malformed status code, it fails to route the frame to the intended service and throws an exception forcibly resetting the stream to the service.

This PR removes an assertion that would throw an `IllegalArgumentException` when an invalid status code was encountered. Instead, we let Linkerd route the malformed header frame to its intended upstream service to allow it to decide what it should do with the malformed H2 response.

Tested with a locally running Linkerd instance, the test server provided by @rmichela and `nghttp`.

fixes #2004

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>