### PR TITLE
Use custom RetryFilter to retry consul connection refused exceptions

### DIFF
--- a/consul/src/main/scala/io/buoyant/consul/v1/BaseApi.scala
+++ b/consul/src/main/scala/io/buoyant/consul/v1/BaseApi.scala
@@ -3,8 +3,9 @@ package io.buoyant.consul.v1
 import com.fasterxml.jackson.databind.{DeserializationFeature, ObjectMapper}
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
+import com.twitter.finagle.buoyant.RetryFilter
 import com.twitter.finagle.param.HighResTimer
-import com.twitter.finagle.service.{RetryBudget, RetryFilter, RetryPolicy}
+import com.twitter.finagle.service.{RetryBudget, RetryPolicy}
 import com.twitter.finagle.stats.StatsReceiver
 import com.twitter.finagle.tracing.Trace
 import com.twitter.finagle.{ConnectionFailedException, Failure, Filter, http}
@@ -42,7 +43,8 @@ trait BaseApi extends Closable {
     },
     HighResTimer.Default,
     stats,
-    RetryBudget.Infinite
+    RetryBudget.Infinite,
+    _.reader.discard()
   )
 
   def getClient(retry: Boolean) = {


### PR DESCRIPTION
When Linkerd is configured to use `io.l5d.consul` and it is unable to connect to consul because of a `ConnectionRefused` exception, it is supposed to retry the connection infinitely. Currently, after Linkerd makes an attempt to the local consul agent, it fails to retry the connection. This is because Finagle's `RetryFilter` considers `ConnectionRefused` exceptions as `NonRetryable`.

This PR uses a custom `RetryFilter` to retry all HTTP interactions to a consul. The custom filter is not restrictive in its determination of what exceptions are retryable and only relies on the `RetryPolicy` configured for that filter.

Tests were conducted locally with the help of @aywrite's [repo](https://github.com/aywrite/linkerd-consul-test) and a locally running consul agent.

fixes #2003

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>