### PR TITLE
Expose k8s dtab storage state on admin endpoint

### DIFF
--- a/namerd/core/src/main/scala/io/buoyant/namerd/DtabStore.scala
+++ b/namerd/core/src/main/scala/io/buoyant/namerd/DtabStore.scala
@@ -2,7 +2,7 @@ package io.buoyant.namerd
 
 import com.twitter.finagle.Dtab
 import com.twitter.io.Buf
-import com.twitter.util.{Activity, Base64StringEncoder, Future, Base64StringEncoder}
+import com.twitter.util.{Activity, Base64StringEncoder, Future}
 
 case class VersionedDtab(dtab: Dtab, version: DtabStore.Version)
 

--- a/namerd/core/src/main/scala/io/buoyant/namerd/DtabStore.scala
+++ b/namerd/core/src/main/scala/io/buoyant/namerd/DtabStore.scala
@@ -2,7 +2,7 @@ package io.buoyant.namerd
 
 import com.twitter.finagle.Dtab
 import com.twitter.io.Buf
-import com.twitter.util.{Activity, Future, Base64StringEncoder}
+import com.twitter.util.{Activity, Base64StringEncoder, Future, Base64StringEncoder}
 
 case class VersionedDtab(dtab: Dtab, version: DtabStore.Version)
 
@@ -87,5 +87,4 @@ object DtabStore {
     buf.write(versionBytes, 0)
     Base64StringEncoder.encode(versionBytes)
   }
-
 }

--- a/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/DtabHandler.scala
+++ b/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/DtabHandler.scala
@@ -73,7 +73,7 @@ class DtabHandler(storage: DtabStore) extends Service[Request, Response] {
         case Some(dtab) =>
           val rsp = Response()
           rsp.contentType = mediaType
-          rsp.headerMap.add(Fields.Etag, DtabHandler.versionString(dtab.version))
+          rsp.headerMap.add(Fields.Etag, DtabStore.versionString(dtab.version))
           rsp.content = codec.write(dtab.dtab).concat(newline)
           rsp
 
@@ -86,7 +86,7 @@ class DtabHandler(storage: DtabStore) extends Service[Request, Response] {
     storage.observe(ns).toFuture.map {
       case Some(dtab) =>
         val rsp = Response()
-        rsp.headerMap.add(Fields.Etag, DtabHandler.versionString(dtab.version))
+        rsp.headerMap.add(Fields.Etag, DtabStore.versionString(dtab.version))
         rsp
 
       case None => Response(Status.NotFound)

--- a/namerd/iface/control-http/src/test/scala/io/buoyant/namerd/iface/HttpControlServiceTest.scala
+++ b/namerd/iface/control-http/src/test/scala/io/buoyant/namerd/iface/HttpControlServiceTest.scala
@@ -22,7 +22,7 @@ class HttpControlServiceTest extends FunSuite with Awaits {
     "tlop" -> Dtab.read("/yeezy => /pablo")
   )
 
-  val v1Stamp = DtabHandler.versionString(InMemoryDtabStore.InitialVersion)
+  val v1Stamp = DtabStore.versionString(InMemoryDtabStore.InitialVersion)
 
   def newDtabStore(dtabs: Map[String, Dtab] = defaultDtabs): DtabStore =
     new InMemoryDtabStore(dtabs)

--- a/namerd/storage/k8s/src/main/scala/io/buoyant/namerd/storage/K8sDtabStore.scala
+++ b/namerd/storage/k8s/src/main/scala/io/buoyant/namerd/storage/K8sDtabStore.scala
@@ -56,10 +56,6 @@ class K8sDtabStore(client: Http.Client, dst: String, namespace: String)
     (name(dtab), versionedDtab)
   }
 
-  private[this] case class InstrumentedDtabStorage(
-    act: InstrumentedActivity[NsMap],
-    watchState: WatchState[DtabList, DtabWatch])
-
   private[this]type NsMap = Map[String, VersionedDtab]
   private[this] val dtabListToNsMap: Option[DtabList] => NsMap = {
     case Some(dtabs) => dtabs.items.map(toDtabMap)(breakOut)
@@ -188,9 +184,9 @@ class K8sDtabStore(client: Http.Client, dst: String, namespace: String)
       val state = Map(
         "state" -> instrumentedDtabStorage.stateSnapshot().map {
           case Some(ns) => ns.map {
-            case (dtabName, dtab) => dtabName -> Map(
-              "version" -> DtabStore.versionString(dtab.version),
-              "dtab" -> dtab.dtab.show
+            case (dtabName, versionedDtab) => dtabName -> Map(
+              "version" -> DtabStore.versionString(versionedDtab.version),
+              "dtab" -> versionedDtab.dtab.show
             )
           }
           case _ => Map.empty


### PR DESCRIPTION
When using Namerd with k8s dtab storage, it can be difficult to observe the internal dtab state that is used by Linkerd instances. This can make things difficult to debug when Namerd is used with Linkerd.

This PR exposes the internal dtab states that Namerd has stored in k8s.

![screen shot 2018-07-03 at 2 23 51 pm](https://user-images.githubusercontent.com/2197104/42245253-f054981a-7ecc-11e8-94b4-029723ddd5a3.png)


fixes #1916

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>