### PR TITLE
fix consul namer, which returns all IPs intead of one

### DIFF
--- a/namer/consul/src/main/scala/io/buoyant/namer/consul/SvcAddr.scala
+++ b/namer/consul/src/main/scala/io/buoyant/namer/consul/SvcAddr.scala
@@ -7,7 +7,8 @@ import com.twitter.logging.Level
 import com.twitter.util._
 import io.buoyant.consul.v1
 import io.buoyant.namer.{Metadata, InstrumentedVar}
-import java.net.InetSocketAddress
+import java.net.{InetAddress, InetSocketAddress}
+
 import scala.util.control.NoStackTrace
 
 private[consul] case class SvcKey(name: String, tag: Option[String]) {
@@ -178,7 +179,10 @@ private[consul] object SvcAddr {
       case Some(ws) => ws.max
     }
     val meta = Addr.Metadata((Metadata.endpointWeight, weight))
-    Try(Address.Inet(new InetSocketAddress(ip, port), meta)).toOption
+    Try(InetAddress.getAllByName(ip)
+      .toTraversable
+      .map(singleIP => Address.Inet(new InetSocketAddress(singleIP, port), meta)))
+      .getOrElse(Seq())
   }
 
   private[this] val NoIndexException =


### PR DESCRIPTION
A fix for Linkerd Issue https://github.com/linkerd/linkerd/issues/2030

Essentially instead of return a single IP we return a list of the IPs for the host.

Potential problem: as discussed in issue [2030](https://github.com/linkerd/linkerd/issues/2030), depends on the JVM setup, it is possible to return both IPv4 and IPv6 addresses of a DNS.

I am not sure what the best way to solve this beside adding additional parameters somewhere (possibly on Namer level) to define the DNS resolving policy.. 