### PR TITLE
check Dtab for null entries and fail Http POST request to update Dtab

### DIFF
--- a/namerd/core/src/main/scala/io/buoyant/namerd/DtabStore.scala
+++ b/namerd/core/src/main/scala/io/buoyant/namerd/DtabStore.scala
@@ -54,8 +54,8 @@ object DtabStore {
 
   class DtabNamespaceInvalidException(ns: Ns)
     extends Exception(s"invalid dtab namespace $ns: namespace must contain only letter, number or '-' characters")
-  class DtabContainsInvalidDentriesException(dentries: IndexedSeq[Dentry])
-    extends Exception(s"The dtab contains invalid dentries: $dentries")
+  class DtabContainsInvalidDentriesException(invalidDentries: String)
+    extends Exception(s"The dtab contains invalid dentries: $invalidDentries")
 
   object Forbidden extends Exception("You do not have sufficient permissions")
 

--- a/namerd/core/src/main/scala/io/buoyant/namerd/DtabStore.scala
+++ b/namerd/core/src/main/scala/io/buoyant/namerd/DtabStore.scala
@@ -1,6 +1,6 @@
 package io.buoyant.namerd
 
-import com.twitter.finagle.Dtab
+import com.twitter.finagle.{Dentry, Dtab}
 import com.twitter.io.Buf
 import com.twitter.util.{Activity, Future}
 
@@ -54,6 +54,8 @@ object DtabStore {
 
   class DtabNamespaceInvalidException(ns: Ns)
     extends Exception(s"invalid dtab namespace $ns: namespace must contain only letter, number or '-' characters")
+  class DtabContainsInvalidDentriesException(dentries: IndexedSeq[Dentry])
+    extends Exception(s"The dtab contains invalid dentries: $dentries")
 
   object Forbidden extends Exception("You do not have sufficient permissions")
 

--- a/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/DtabHandler.scala
+++ b/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/DtabHandler.scala
@@ -148,7 +148,7 @@ class DtabHandler(storage: DtabStore) extends Service[Request, Response] {
             }
           case Throw(e: DtabContainsInvalidDentriesException) =>
             val rep = Response(Status.BadRequest)
-            rep.contentString = s"${e.getMessage}"
+            rep.contentString = e.getMessage
             rep.contentLength(rep.contentString.size)
             Future.value(rep)
           // invalid dtab

--- a/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/DtabHandler.scala
+++ b/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/DtabHandler.scala
@@ -1,11 +1,11 @@
 package io.buoyant.namerd.iface
 
-import com.twitter.finagle.Service
+import com.twitter.finagle.{Dtab, Service}
 import com.twitter.finagle.http._
 import com.twitter.io.Buf
 import com.twitter.util._
 import io.buoyant.namer.RichActivity
-import io.buoyant.namerd.DtabStore.{DtabNamespaceAlreadyExistsException, DtabNamespaceDoesNotExistException, DtabVersionMismatchException, Forbidden}
+import io.buoyant.namerd.DtabStore._
 import io.buoyant.namerd.{DtabStore, Ns, VersionedDtab}
 
 object DtabUri {
@@ -144,8 +144,13 @@ class DtabHandler(storage: DtabStore) extends Service[Request, Response] {
                 Future.value(Response(Status.Conflict))
               case Throw(_) =>
                 Future.value(Response(Status.InternalServerError))
-            }
 
+            }
+          case Throw(e: DtabContainsInvalidDentriesException) =>
+            val rep = Response(Status.BadRequest)
+            rep.contentString = s"${e.getMessage}"
+            rep.contentLength(rep.contentString.size)
+            Future.value(rep)
           // invalid dtab
           case Throw(_) => Future.value(Response(Status.BadRequest))
         }

--- a/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/Json.scala
+++ b/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/Json.scala
@@ -7,6 +7,7 @@ import com.twitter.finagle.http._
 import com.twitter.finagle.{Status => _, _}
 import com.twitter.io.Buf
 import com.twitter.util._
+import io.buoyant.namerd.DtabStore.DtabContainsInvalidDentriesException
 import io.buoyant.namerd.{DtabCodec => DtabModule}
 
 object Json {
@@ -35,8 +36,13 @@ object DtabCodec {
   object JsonCodec extends DtabCodec {
     val mediaTypes = Set(MediaType.Json)
     def write(dtab: Dtab) = Json.write(dtab)
-    def read(buf: Buf) =
-      Json.read[IndexedSeq[Dentry]](buf).map(Dtab(_))
+    def read(buf: Buf) = {
+      Json.read[IndexedSeq[Dentry]](buf).map { dentries =>
+        if (dentries.contains(null)) {
+          throw new DtabContainsInvalidDentriesException(dentries)
+        } else Dtab(dentries)
+      }
+    }
   }
 
   object TextCodec extends DtabCodec {

--- a/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/Json.scala
+++ b/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/Json.scala
@@ -39,7 +39,8 @@ object DtabCodec {
     def read(buf: Buf) = {
       Json.read[IndexedSeq[Dentry]](buf).map { dentries =>
         if (dentries.contains(null)) {
-          throw new DtabContainsInvalidDentriesException(dentries)
+          val Buf.Utf8(str) = buf
+          throw new DtabContainsInvalidDentriesException(str)
         } else Dtab(dentries)
       }
     }


### PR DESCRIPTION
When using the Namerd HTTP API to update dtabs, a null `Dentry` value updates successfully.

This PR ensures that Namerd responds with an `HTTP BadRequest` when it receives a null Dentry in a JSON payload.

Before:
```bash
 curl -v -X 'POST' -d '[null, {"prefix":"/foo","dst":"/#/io.l5d.fs"}]' -H 'Content-Type: application/json' http://127.0.0.1:4180/api/1/dtabs/secondary

*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to 127.0.0.1 (127.0.0.1) port 4180 (#0)
> POST /api/1/dtabs/secondary HTTP/1.1
> Host: 127.0.0.1:4180
> User-Agent: curl/7.58.0
> Accept: */*
> Content-Type: application/json
> Content-Length: 46
>
* upload completely sent off: 46 out of 46 bytes
< HTTP/1.1 204 No Content
<
* Connection #0 to host 127.0.0.1 left intact
```
After:
```bash
$ curl -v -X 'POST' -d '[null, {"prefix":"/foo","dst":"/#/io.l5d.fs"}]' -H 'Content-Type: application/json' http://127.0.0.1:4180/api/1/dtabs/secondary

*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to 127.0.0.1 (127.0.0.1) port 4180 (#0)
> POST /api/1/dtabs/secondary HTTP/1.1
> Host: 127.0.0.1:4180
> User-Agent: curl/7.58.0
> Accept: */*
> Content-Type: application/json
> Content-Length: 46
>
* upload completely sent off: 46 out of 46 bytes
< HTTP/1.1 400 Bad Request
< Content-Length: 76
<
* Connection #0 to host 127.0.0.1 left intact
The dtab contains invalid dentries: Vector(null, Dentry(/foo=>/#/io.l5d.fs))
```

fixes #1974 

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>