### PR TITLE
#2033 Add config param to disable shutdown endpoint

### DIFF
--- a/admin/src/main/scala/io/buoyant/admin/Admin.scala
+++ b/admin/src/main/scala/io/buoyant/admin/Admin.scala
@@ -117,7 +117,13 @@ object Admin {
   }
 }
 
-class Admin(val address: InetSocketAddress, tlsCfg: Option[TlsServerConfig], workers: Int, stats: StatsReceiver, securityConfig: Option[AdminSecurityConfig]) {
+class Admin(
+  val address: InetSocketAddress,
+  tlsCfg: Option[TlsServerConfig],
+  workers: Int,
+  stats: StatsReceiver,
+  securityConfig: Option[AdminSecurityConfig]) {
+  
   import Admin._
 
   private[this] val notFoundView = new NotFoundView()

--- a/admin/src/main/scala/io/buoyant/admin/AdminConfig.scala
+++ b/admin/src/main/scala/io/buoyant/admin/AdminConfig.scala
@@ -29,31 +29,22 @@ object AdminSecurityConfig {
 }
 
 case class AdminSecurityConfig(
-  uiEnabled: Option[Boolean] = Some(true),
-  controlEnabled: Option[Boolean] = Some(true),
-  diagnosticsEnabled: Option[Boolean] = Some(true),
+  uiEnabled: Option[Boolean] = None,
+  controlEnabled: Option[Boolean] = None,
+  diagnosticsEnabled: Option[Boolean] = None,
   pathWhitelist: Option[List[String]] = None,
   pathBlacklist: Option[List[String]] = None
 ) {
 
   def mkFilter(): SecurityFilter = {
-    var securityFilter = SecurityFilter()
-      .withUiEndpoints(uiEnabled.getOrElse(true))
-      .withControlEndpoints(controlEnabled.getOrElse(true))
-      .withDiagnosticsEndpoints(diagnosticsEnabled.getOrElse(true))
+    val securityFilter = SecurityFilter(
+      uiEnabled = uiEnabled.getOrElse(true),
+      controlEnabled = controlEnabled.getOrElse(true),
+      diagnosticsEnabled = diagnosticsEnabled.getOrElse(true),
+      whitelist = pathWhitelist.getOrElse(Nil).map(_.r),
+      blacklist = pathBlacklist.getOrElse(Nil).map(_.r)
+    )
 
-    securityFilter = pathWhitelist match {
-      case Some(elems) =>
-        elems.foldLeft(securityFilter) { (f, elem) => f.withWhitelistedElement(elem) }
-      case None =>
-        securityFilter
-    }
-    securityFilter = pathBlacklist match {
-      case Some(elems) =>
-        elems.foldLeft(securityFilter) { (f, elem) => f.withBlacklistedElement(elem) }
-      case None =>
-        securityFilter
-    }
     AdminSecurityConfig.log.debug("Created admin security filter %s", securityFilter)
     securityFilter
   }

--- a/admin/src/main/scala/io/buoyant/admin/AdminConfig.scala
+++ b/admin/src/main/scala/io/buoyant/admin/AdminConfig.scala
@@ -2,6 +2,7 @@ package io.buoyant.admin
 
 import com.twitter.finagle.buoyant.TlsServerConfig
 import com.twitter.finagle.stats.StatsReceiver
+import com.twitter.logging.Logger
 import java.net.{InetAddress, InetSocketAddress}
 import io.buoyant.config.types.Port
 
@@ -9,6 +10,7 @@ case class AdminConfig(
   ip: Option[InetAddress] = None,
   port: Option[Port] = None,
   shutdownGraceMs: Option[Int] = None,
+  security: Option[AdminSecurityConfig] = None,
   tls: Option[TlsServerConfig] = None,
   httpIdentifierPort: Option[Port] = None,
   workerThreads: Option[Int] = None
@@ -18,6 +20,41 @@ case class AdminConfig(
     val adminIp = ip.getOrElse(defaultAddr.getAddress)
     val adminPort = port.map(_.port).getOrElse(defaultAddr.getPort)
     val addr = new InetSocketAddress(adminIp, adminPort)
-    new Admin(addr, tls, workerThreads.getOrElse(2), stats)
+    new Admin(addr, tls, workerThreads.getOrElse(2), stats, security)
+  }
+}
+
+object AdminSecurityConfig {
+  private val log = Logger.get(Admin.label)
+}
+
+case class AdminSecurityConfig(
+  uiEnabled: Option[Boolean] = Some(true),
+  controlEnabled: Option[Boolean] = Some(true),
+  diagnosticsEnabled: Option[Boolean] = Some(true),
+  pathWhitelist: Option[List[String]] = None,
+  pathBlacklist: Option[List[String]] = None
+) {
+
+  def mkFilter(): SecurityFilter = {
+    var securityFilter = SecurityFilter()
+      .withUiEndpoints(uiEnabled.getOrElse(true))
+      .withControlEndpoints(controlEnabled.getOrElse(true))
+      .withDiagnosticsEndpoints(diagnosticsEnabled.getOrElse(true))
+
+    securityFilter = pathWhitelist match {
+      case Some(elems) =>
+        elems.foldLeft(securityFilter) { (f, elem) => f.withWhitelistedElement(elem) }
+      case None =>
+        securityFilter
+    }
+    securityFilter = pathBlacklist match {
+      case Some(elems) =>
+        elems.foldLeft(securityFilter) { (f, elem) => f.withBlacklistedElement(elem) }
+      case None =>
+        securityFilter
+    }
+    AdminSecurityConfig.log.debug("Created admin security filter %s", securityFilter)
+    securityFilter
   }
 }

--- a/admin/src/main/scala/io/buoyant/admin/SecurityFilter.scala
+++ b/admin/src/main/scala/io/buoyant/admin/SecurityFilter.scala
@@ -5,17 +5,6 @@ import com.twitter.finagle.http.{Request, Response, Status}
 import com.twitter.util.Future
 import scala.util.matching.Regex
 
-object SecurityFilter {
-  def apply(
-    uiEnabled: Boolean = true,
-    controlEnabled: Boolean = true,
-    diagnosticsEnabled: Boolean = true,
-    whitelist: Seq[Regex] = List.empty,
-    blacklist: Seq[Regex] = List.empty
-  ): SecurityFilter =
-    new SecurityFilter(uiEnabled, controlEnabled, diagnosticsEnabled, whitelist, blacklist)
-}
-
 object Category {
   val categories = Seq(UiCategory, ControlCategory)
 }
@@ -24,8 +13,6 @@ sealed trait Category {
   def urls: Seq[Regex]
 
   def contains(path: String): Boolean = urls.exists(_.pattern.matcher(path).matches())
-
-  def isEnabled(securityFilter: SecurityFilter): Boolean
 }
 
 object UiCategory extends Category {
@@ -42,8 +29,6 @@ object UiCategory extends Category {
     "/logging",
     "/help"
   ).map(s => s"^$s$$".r)
-
-  override def isEnabled(securityFilter: SecurityFilter): Boolean = securityFilter.uiEnabled
 }
 
 object ControlCategory extends Category {
@@ -51,63 +36,47 @@ object ControlCategory extends Category {
     "/admin/shutdown",
     "/logging[.]json"
   ).map(s => s"^$s$$".r)
-
-  override def isEnabled(securityFilter: SecurityFilter): Boolean = securityFilter.controlEnabled
 }
 
 object DiagnosticsCategory extends Category {
   val urls: Seq[Regex] = Seq.empty
 
   override def contains(path: String): Boolean = true
-
-  override def isEnabled(securityFilter: SecurityFilter): Boolean = securityFilter.diagnosticsEnabled
 }
 
-class SecurityFilter(
-  val uiEnabled: Boolean,
-  val controlEnabled: Boolean,
-  val diagnosticsEnabled: Boolean,
-  val whitelist: Seq[Regex] = List.empty,
-  val blacklist: Seq[Regex] = List.empty
+case class SecurityFilter(
+  uiEnabled: Boolean = true,
+  controlEnabled: Boolean = true,
+  diagnosticsEnabled: Boolean = true,
+  whitelist: Seq[Regex] = List.empty,
+  blacklist: Seq[Regex] = List.empty
 ) extends SimpleFilter[Request, Response] {
   import Category._
 
   override def apply(request: Request, service: Service[Request, Response]): Future[Response] = {
     val category = categories.find(_.contains(request.path)).getOrElse(DiagnosticsCategory)
-    val categoryEnabled = category.isEnabled(this)
+    val categoryEnabled = category match {
+      case UiCategory => uiEnabled
+      case ControlCategory => controlEnabled
+      case DiagnosticsCategory => diagnosticsEnabled
+    }
 
-    if (categoryEnabled && !isRejectedByBlacklist(request)
-      || !categoryEnabled && isAllowedByWhiteList(request)) {
+    if (isRejectedByBlacklist(request)) {
+      reject(request)
+    } else if (categoryEnabled || isAllowedByWhiteList(request)) {
       service(request)
     } else {
       reject(request)
     }
   }
 
-  private def isAllowedByWhiteList(request: Request) = whitelist.exists(whitelistedUri => whitelistedUri.pattern.matcher(request.path).matches())
+  private[this] def isAllowedByWhiteList(request: Request) = whitelist.exists(whitelistedUri => whitelistedUri.pattern.matcher(request.path).matches())
 
-  private def isRejectedByBlacklist(request: Request) = blacklist.exists(blacklistedUri => blacklistedUri.pattern.matcher(request.path).matches())
+  private[this] def isRejectedByBlacklist(request: Request) = blacklist.exists(blacklistedUri => blacklistedUri.pattern.matcher(request.path).matches())
 
-  private def reject(request: Request): Future[Response] = {
+  private[this] def reject(request: Request): Future[Response] = {
     val rep = Response(request)
     rep.status = Status.NotFound
     Future.value(rep)
   }
-
-  def withUiEndpoints(uiEnabled: Boolean = true): SecurityFilter =
-    SecurityFilter(uiEnabled = uiEnabled, controlEnabled, diagnosticsEnabled, whitelist, blacklist)
-
-  def withControlEndpoints(controlEnabled: Boolean = true): SecurityFilter =
-    SecurityFilter(uiEnabled, controlEnabled = controlEnabled, diagnosticsEnabled, whitelist, blacklist)
-
-  def withDiagnosticsEndpoints(diagnosticsEnabled: Boolean = true): SecurityFilter =
-    SecurityFilter(uiEnabled, controlEnabled, diagnosticsEnabled = diagnosticsEnabled, whitelist, blacklist)
-
-  def withWhitelistedElement(whitelistedRegex: String): SecurityFilter =
-    SecurityFilter(uiEnabled, controlEnabled, diagnosticsEnabled, whitelist :+ whitelistedRegex.r, blacklist)
-
-  def withBlacklistedElement(blacklistedRegex: String): SecurityFilter =
-    SecurityFilter(uiEnabled, controlEnabled, diagnosticsEnabled, whitelist, blacklist :+ blacklistedRegex.r)
-
-  override def toString = s"SecurityFilter(uiEnabled=$uiEnabled, controlEnabled=$controlEnabled, diagnosticsEnabled=$diagnosticsEnabled, whitelist=$whitelist, blacklist=$blacklist)"
 }

--- a/admin/src/main/scala/io/buoyant/admin/SecurityFilter.scala
+++ b/admin/src/main/scala/io/buoyant/admin/SecurityFilter.scala
@@ -1,0 +1,113 @@
+package io.buoyant.admin
+
+import com.twitter.finagle.{Service, SimpleFilter}
+import com.twitter.finagle.http.{Request, Response, Status}
+import com.twitter.util.Future
+import scala.util.matching.Regex
+
+object SecurityFilter {
+  def apply(
+    uiEnabled: Boolean = true,
+    controlEnabled: Boolean = true,
+    diagnosticsEnabled: Boolean = true,
+    whitelist: Seq[Regex] = List.empty,
+    blacklist: Seq[Regex] = List.empty
+  ): SecurityFilter =
+    new SecurityFilter(uiEnabled, controlEnabled, diagnosticsEnabled, whitelist, blacklist)
+}
+
+object Category {
+  val categories = Seq(UiCategory, ControlCategory)
+}
+
+sealed trait Category {
+  def urls: Seq[Regex]
+
+  def contains(path: String): Boolean = urls.exists(_.pattern.matcher(path).matches())
+
+  def isEnabled(securityFilter: SecurityFilter): Boolean
+}
+
+object UiCategory extends Category {
+  val urls: Seq[Regex] = Seq(
+    "/",
+    "/files/.*",
+    "/admin/files/.*",
+    "/config[.]json",
+    "/metrics[.]json",
+    "/admin/metrics[.]json",
+    "/admin/metrics",
+    "/delegator",
+    "/delegator[.]json",
+    "/logging",
+    "/help"
+  ).map(s => s"^$s$$".r)
+
+  override def isEnabled(securityFilter: SecurityFilter): Boolean = securityFilter.uiEnabled
+}
+
+object ControlCategory extends Category {
+  val urls: Seq[Regex] = Seq(
+    "/admin/shutdown",
+    "/logging[.]json"
+  ).map(s => s"^$s$$".r)
+
+  override def isEnabled(securityFilter: SecurityFilter): Boolean = securityFilter.controlEnabled
+}
+
+object DiagnosticsCategory extends Category {
+  val urls: Seq[Regex] = Seq.empty
+
+  override def contains(path: String): Boolean = true
+
+  override def isEnabled(securityFilter: SecurityFilter): Boolean = securityFilter.diagnosticsEnabled
+}
+
+class SecurityFilter(
+  val uiEnabled: Boolean,
+  val controlEnabled: Boolean,
+  val diagnosticsEnabled: Boolean,
+  val whitelist: Seq[Regex] = List.empty,
+  val blacklist: Seq[Regex] = List.empty
+) extends SimpleFilter[Request, Response] {
+  import Category._
+
+  override def apply(request: Request, service: Service[Request, Response]): Future[Response] = {
+    val category = categories.find(_.contains(request.path)).getOrElse(DiagnosticsCategory)
+    val categoryEnabled = category.isEnabled(this)
+
+    if (categoryEnabled && !isRejectedByBlacklist(request)
+      || !categoryEnabled && isAllowedByWhiteList(request)) {
+      service(request)
+    } else {
+      reject(request)
+    }
+  }
+
+  private def isAllowedByWhiteList(request: Request) = whitelist.exists(whitelistedUri => whitelistedUri.pattern.matcher(request.path).matches())
+
+  private def isRejectedByBlacklist(request: Request) = blacklist.exists(blacklistedUri => blacklistedUri.pattern.matcher(request.path).matches())
+
+  private def reject(request: Request): Future[Response] = {
+    val rep = Response(request)
+    rep.status = Status.NotFound
+    Future.value(rep)
+  }
+
+  def withUiEndpoints(uiEnabled: Boolean = true): SecurityFilter =
+    SecurityFilter(uiEnabled = uiEnabled, controlEnabled, diagnosticsEnabled, whitelist, blacklist)
+
+  def withControlEndpoints(controlEnabled: Boolean = true): SecurityFilter =
+    SecurityFilter(uiEnabled, controlEnabled = controlEnabled, diagnosticsEnabled, whitelist, blacklist)
+
+  def withDiagnosticsEndpoints(diagnosticsEnabled: Boolean = true): SecurityFilter =
+    SecurityFilter(uiEnabled, controlEnabled, diagnosticsEnabled = diagnosticsEnabled, whitelist, blacklist)
+
+  def withWhitelistedElement(whitelistedRegex: String): SecurityFilter =
+    SecurityFilter(uiEnabled, controlEnabled, diagnosticsEnabled, whitelist :+ whitelistedRegex.r, blacklist)
+
+  def withBlacklistedElement(blacklistedRegex: String): SecurityFilter =
+    SecurityFilter(uiEnabled, controlEnabled, diagnosticsEnabled, whitelist, blacklist :+ blacklistedRegex.r)
+
+  override def toString = s"SecurityFilter(uiEnabled=$uiEnabled, controlEnabled=$controlEnabled, diagnosticsEnabled=$diagnosticsEnabled, whitelist=$whitelist, blacklist=$blacklist)"
+}

--- a/admin/src/test/scala/io/buoyant/admin/SecurityFilterTest.scala
+++ b/admin/src/test/scala/io/buoyant/admin/SecurityFilterTest.scala
@@ -1,0 +1,138 @@
+package io.buoyant.admin
+
+import com.twitter.finagle.Service
+import com.twitter.finagle.http._
+import com.twitter.util.{Await, Future}
+import org.scalatest.prop.TableDrivenPropertyChecks._
+import org.scalatest.{FlatSpec, Matchers, Status => _}
+
+class SecurityFilterTest extends FlatSpec with Matchers {
+
+  private[this] val ok = Service.mk[Request, Response] { request => Future.value(Response(request)) }
+
+  it should "let pass ui requests" in {
+
+    val service = SecurityFilter().withUiEndpoints().withControlEndpoints(false).withDiagnosticsEndpoints(false) andThen ok
+
+    val params = Table(
+      ("uri", "response status"),
+      ("/?router=out", Status.Ok),
+      ("/files/css/lib/bootstrap.min.css", Status.Ok),
+      ("/files/css/lib/fonts.css", Status.Ok),
+      ("/files/images/linkerd-horizontal-white-transbg-vectorized.svg", Status.Ok),
+      ("/files/js/lib/require.js", Status.Ok),
+      ("/files/css/fonts/SourceSansPro-300.woff2", Status.Ok),
+      ("/config.json", Status.Ok),
+      ("/metrics.json", Status.Ok),
+      ("/delegator?router=out", Status.Ok),
+      ("/logging", Status.Ok),
+      ("/help", Status.Ok),
+
+      ("/admin/shutdown", Status.NotFound),
+      ("/admin/threads", Status.NotFound)
+    )
+
+    forAll(params) { (uri, status) =>
+      val req = Request(Version.Http11, Method.Get, uri)
+      val rep = Await.result(service(req))
+      assert(rep.status == status)
+    }
+  }
+
+  it should "let pass configured requests" in {
+
+    val service = SecurityFilter()
+      .withControlEndpoints(false)
+      .withDiagnosticsEndpoints(false)
+      .withWhitelistedElement("^/fooba[rz]$")
+      .withWhitelistedElement("^/abc/def/.*$")
+      .withUiEndpoints() andThen ok
+
+    val params = Table(
+      ("uri", "response status"),
+      ("/?router=out", Status.Ok),
+      ("/files/css/lib/bootstrap.min.css", Status.Ok),
+      ("/config.json", Status.Ok),
+      ("/foobar", Status.Ok),
+      ("/foobaz", Status.Ok),
+      ("/foobaf", Status.NotFound),
+      ("/abc/def", Status.NotFound),
+      ("/abc/def/ghi", Status.Ok),
+      ("/admin/shutdown", Status.NotFound),
+      ("/admin/threads", Status.NotFound)
+    )
+
+    forAll(params) { (uri, status) =>
+      val req = Request(Version.Http11, Method.Get, uri)
+      val rep = Await.result(service(req))
+      assert(rep.status == status)
+    }
+  }
+
+  it should "not let pass ui requests if not permitted" in {
+    val service = SecurityFilter()
+      .withUiEndpoints(false)
+      .withControlEndpoints(false)
+      .withDiagnosticsEndpoints(false)
+      .withWhitelistedElement("^/fooba[rz]$")
+      .withWhitelistedElement("^/abc/def/.*$") andThen ok
+
+    val params = Table(
+      ("uri", "response status"),
+      ("/?router=out", Status.NotFound),
+      ("/files/css/lib/bootstrap.min.css", Status.NotFound),
+      ("/foobar", Status.Ok),
+      ("/foobaz", Status.Ok),
+      ("/foobaf", Status.NotFound),
+      ("/abc/def", Status.NotFound),
+      ("/abc/def/ghi", Status.Ok),
+      ("/admin/shutdown", Status.NotFound),
+      ("/admin/threads", Status.NotFound)
+    )
+
+    forAll(params) { (uri, status) =>
+      val req = Request(Version.Http11, Method.Get, uri)
+      val rep = Await.result(service(req))
+      assert(rep.status == status)
+    }
+  }
+
+  it should "let pass control requests if permitted" in {
+    val service = SecurityFilter()
+      .withControlEndpoints()
+      .withDiagnosticsEndpoints(false) andThen ok
+
+    val params = Table(
+      ("uri", "response status"),
+      ("/admin/shutdown", Status.Ok),
+      ("/logging.json", Status.Ok),
+      ("/sth/else", Status.NotFound)
+    )
+
+    forAll(params) { (uri, status) =>
+      val req = Request(Version.Http11, Method.Get, uri)
+      val rep = Await.result(service(req))
+      assert(rep.status == status)
+    }
+  }
+
+  it should "block blacklisted URLs" in {
+    val service = SecurityFilter()
+      .withUiEndpoints()
+      .withBlacklistedElement("^/help$") andThen ok
+
+    val params = Table(
+      ("uri", "response status"),
+      ("/files/css/lib/bootstrap.min.css", Status.Ok),
+      ("/files/css/lib/fonts.css", Status.Ok),
+      ("/help", Status.NotFound)
+    )
+
+    forAll(params) { (uri, status) =>
+      val req = Request(Version.Http11, Method.Get, uri)
+      val rep = Await.result(service(req))
+      assert(rep.status == status)
+    }
+  }
+
+}

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/LinkerTest.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/LinkerTest.scala
@@ -1,14 +1,18 @@
 package io.buoyant.linkerd
 
-import com.twitter.finagle.param
+import java.net.{InetAddress, InetSocketAddress}
+
+import com.twitter.finagle.http.{Request, Response, Status}
 import com.twitter.finagle.stats.InMemoryStatsReceiver
 import com.twitter.finagle.tracing._
+import com.twitter.finagle.{Service, param}
+import com.twitter.util.{Await, Future}
+import io.buoyant.admin.Admin.Handler
 import io.buoyant.config.{ConflictingLabels, ConflictingPorts, ConflictingSubtypes}
 import io.buoyant.namer.Param.Namers
 import io.buoyant.namer.{ConflictingNamerInitializer, NamerInitializer, TestNamer, TestNamerInitializer}
 import io.buoyant.telemetry._
 import io.buoyant.test.Exceptions
-import java.net.{InetAddress, InetSocketAddress}
 import org.scalatest.FunSuite
 
 class LinkerTest extends FunSuite with Exceptions {
@@ -254,6 +258,40 @@ class LinkerTest extends FunSuite with Exceptions {
     assert(linker.admin.address.asInstanceOf[InetSocketAddress].getHostString == "localhost")
     assert(linker.admin.address.asInstanceOf[InetSocketAddress].getPort == 9990)
   }
+
+  test("with admin security") {
+    val ok = new Service[Request, Response] {
+      override def apply(request: Request): Future[Response] = Future.value(Response(request))
+    }
+
+    val app = new com.twitter.app.App {}
+
+    val yaml =
+      """|admin:
+         |  ip: 0.0.0.0
+         |  port: 42000
+         |  security:
+         |    diagnosticsEnabled: false
+         |    pathWhitelist:
+         |    - ^/foo/bar$
+         |    pathBlacklist:
+         |    - ^/logging$
+         |routers:
+         |- protocol: plain
+         |  servers:
+         |  - port: 1
+         |""".stripMargin
+    val linker = parse(yaml)
+    assert(linker.admin.address.asInstanceOf[InetSocketAddress].getHostString == "0.0.0.0")
+    assert(linker.admin.address.asInstanceOf[InetSocketAddress].getPort == 42000)
+    val svc = linker.admin.mkService(app, Seq(Handler("/", ok)))
+    assert(Await.result(svc(Request("/foo/bar"))).status == Status.Ok)
+    assert(Await.result(svc(Request("/metrics.json"))).status == Status.Ok)
+    assert(Await.result(svc(Request("/admin/threads"))).status == Status.NotFound)
+    assert(Await.result(svc(Request("/logging"))).status == Status.NotFound)
+    assert(Await.result(svc(Request("/logging.json"))).status == Status.Ok)
+  }
+
 
   test("conflicting subtypes") {
     val yaml =

--- a/linkerd/docs/config.md
+++ b/linkerd/docs/config.md
@@ -85,7 +85,8 @@ ip | loopback address | IP for the admin interface. A value like 0.0.0.0 configu
 port | `9990` | Port for the admin interface.
 httpIdentifierPort | none | Port for the http identifier debug endpoint.
 shutdownGraceMs | 10000 | maximum grace period before the Linkerd process exits
-tls | no tls | The admin interface will serve over TLS if this parameter is provided. see [TLS](#server-tls).
+tls | no tls | The admin interface will serve over TLS if this parameter is provided. See [TLS](#server-tls).
+security | no restrictions | The admin interface can block sensitive endpoints if configured. See [Admin Security](#admin-security)
 workerThreads | 2 | The number of worker threads used to serve the admin interface.
 
 #### Administrative endpoints
@@ -143,6 +144,46 @@ This administrative interface was originally based on
 [TwitterServer](https://twitter.github.io/twitter-server), more information may
 be found at
 [TwitterServer HTTP Admin interface](https://twitter.github.io/twitter-server/Admin.html).
+
+#### Admin security
+
+> Example to disable the endpoint `/admin/shutdown` exclusively
+
+```yaml
+admin:
+  ip: 127.0.0.1
+  port: 9990
+  security:
+    pathBlacklist:
+    - ^/admin/shutdown$
+```
+
+By default all administrative endpoints are accessible.
+This might not always be desired as this allows for example everybody to shutdown the process if the administrative port is not closed because metrics should be polled from Linkerd.
+The admin security configuration allows to whitelist or blacklist dedicated administrative endpoints.
+
+```yaml
+admin:
+  ip: 127.0.0.1
+  port: 9990
+  security:
+    uiEnabled: true
+    controlEnabled: false
+    pathWhitelist:
+    - ^/logging[.]json$
+```
+
+The security configuration supports these parameters allowing fine grained control over the administrative endpoints that are available.
+
+Key | Default Value | Description
+--- | ------------- | -----------
+uiEnabled | true | Configures if all endpoints that belong to the category required to run the administrative ui are available
+controlEnabled | true | Configures if the endpoints that belong to the category to control Linkerd are available, i.e. `/admin/shutdown` and `/logging.json`
+diagnosticsEnabled | true | Configures if all other endpoints are available.
+pathWhitelist | empty list | Configures paths via regular expressions that should be available for disabled endpoint categories
+pathBlacklist | empty list | Configures additional paths via regular expressions that should not be available for enabled categories
+
+An administrative endpoint is available if its category is enabled and it is not on the blacklist or if its category is disabled and it is on the whitelist.
 
 ### Routers Intro
 

--- a/linkerd/examples/admin.yaml
+++ b/linkerd/examples/admin.yaml
@@ -7,6 +7,14 @@ admin:
   ip: 0.0.0.0
   port: 9990
   workerThreads: 3
+  security:
+    uiEnabled: true
+    controlEnabled: false
+    diagnosticsEnabled: false
+    pathWhitelist:
+    - "/admin/threads"
+    pathBlacklist:
+    - "/help"
 
 telemetry:
 - kind: io.l5d.recentRequests


### PR DESCRIPTION
This PR implements the first solution suggested in the comment to #2033.
It adds a config param that allows to disable the `/admin/shutdown` endpoint.

With this PR, if I configure Linkerd like this:

```yaml
admin:
  port: 9990
  ip: 0.0.0.0
  shutdownEnabled: false
```

and post to the `/admin/shutdown` endpoint, the request fails with 404:

```
$ curl -v -X POST localhost:9990/admin/shutdown
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 9990 (#0)
> POST /admin/shutdown HTTP/1.1
> Host: localhost:9990
> User-Agent: curl/7.54.0
> Accept: */*
> 
< HTTP/1.1 404 Not Found
< Content-Length: 0
< 
* Connection #0 to host localhost left intact
```

If the second solution is preferred I can also provide a PR for it.