### PR TITLE
Expose namer state for namers with transformers

### DIFF
--- a/namer/core/src/main/scala/io/buoyant/namer/NameTreeTransformer.scala
+++ b/namer/core/src/main/scala/io/buoyant/namer/NameTreeTransformer.scala
@@ -50,12 +50,8 @@ trait NameTreeTransformer {
     }
 
     override def adminHandlers: Seq[Admin.Handler] = underlying match {
-      case withHandlers: Admin.WithHandlers =>
-        println(s"$this gets underlying $underlying admin handlers (${withHandlers.adminHandlers.size}")
-        withHandlers.adminHandlers
-      case _ =>
-        println(s"$this gets no handlers from underlying $underlying")
-        Nil
+      case withHandlers: Admin.WithHandlers => withHandlers.adminHandlers
+      case _ => Nil
     }
   }
 }

--- a/namer/core/src/main/scala/io/buoyant/namer/NameTreeTransformer.scala
+++ b/namer/core/src/main/scala/io/buoyant/namer/NameTreeTransformer.scala
@@ -19,12 +19,17 @@ trait NameTreeTransformer {
    * Create a new NameInterpreter by applying this transformer to the output of
    * an existing one.
    */
-  def wrap(underlying: NameInterpreter): NameInterpreter = new NameInterpreter {
+  def wrap(underlying: NameInterpreter): NameInterpreter = new NameInterpreter with Admin.WithHandlers {
     override def bind(dtab: Dtab, path: Path): Activity[NameTree[Bound]] =
       underlying.bind(dtab, path).flatMap(transform)
+
+    override def adminHandlers: Seq[Admin.Handler] = underlying match {
+      case withHandlers: Admin.WithHandlers => withHandlers.adminHandlers
+      case _ => Nil
+    }
   }
 
-  def wrap(underlying: Namer): Namer = new Namer {
+  def wrap(underlying: Namer): Namer = new Namer with Admin.WithHandlers {
     private[this] def isBound(tree: NameTree[Name]): Boolean = {
       tree match {
         case NameTree.Neg | NameTree.Empty | NameTree.Fail => true
@@ -42,6 +47,15 @@ trait NameTreeTransformer {
         else
           Activity.value(tree)
       }
+    }
+
+    override def adminHandlers: Seq[Admin.Handler] = underlying match {
+      case withHandlers: Admin.WithHandlers =>
+        println(s"$this gets underlying $underlying admin handlers (${withHandlers.adminHandlers.size}")
+        withHandlers.adminHandlers
+      case _ =>
+        println(s"$this gets no handlers from underlying $underlying")
+        Nil
     }
   }
 }

--- a/namer/core/src/main/scala/io/buoyant/namer/NamerInitializer.scala
+++ b/namer/core/src/main/scala/io/buoyant/namer/NamerInitializer.scala
@@ -2,7 +2,6 @@ package io.buoyant.namer
 
 import com.fasterxml.jackson.annotation.{JsonIgnore, JsonProperty}
 import com.twitter.finagle._
-import io.buoyant.admin.Admin
 import io.buoyant.config.{ConfigInitializer, PolymorphicConfig}
 
 /**

--- a/namer/core/src/main/scala/io/buoyant/namer/NamerInitializer.scala
+++ b/namer/core/src/main/scala/io/buoyant/namer/NamerInitializer.scala
@@ -2,6 +2,7 @@ package io.buoyant.namer
 
 import com.fasterxml.jackson.annotation.{JsonIgnore, JsonProperty}
 import com.twitter.finagle._
+import io.buoyant.admin.Admin
 import io.buoyant.config.{ConfigInitializer, PolymorphicConfig}
 
 /**
@@ -65,7 +66,18 @@ abstract class NamerConfig extends PolymorphicConfig {
         config.mk(Stack.Params.empty + stats)
       }
       .foldLeft(underlying) { (namer, transformer) =>
-        transformer.wrap(namer)
+
+        val res = transformer.wrap(namer)
+        println(s"wrapping $namer in $res")
+        namer match {
+          case w: Admin.WithHandlers => println(s"$namer has handlers: ${w.adminHandlers.size}")
+          case _ => println(s"$namer has no handlers")
+        }
+        res match {
+          case w: Admin.WithHandlers => println(s"$res has handlers: ${w.adminHandlers.size}")
+          case _ => println(s"$res has no handlers")
+        }
+        res
       }
   }
 }

--- a/namer/core/src/main/scala/io/buoyant/namer/NamerInitializer.scala
+++ b/namer/core/src/main/scala/io/buoyant/namer/NamerInitializer.scala
@@ -66,18 +66,7 @@ abstract class NamerConfig extends PolymorphicConfig {
         config.mk(Stack.Params.empty + stats)
       }
       .foldLeft(underlying) { (namer, transformer) =>
-
-        val res = transformer.wrap(namer)
-        println(s"wrapping $namer in $res")
-        namer match {
-          case w: Admin.WithHandlers => println(s"$namer has handlers: ${w.adminHandlers.size}")
-          case _ => println(s"$namer has no handlers")
-        }
-        res match {
-          case w: Admin.WithHandlers => println(s"$res has handlers: ${w.adminHandlers.size}")
-          case _ => println(s"$res has no handlers")
-        }
-        res
+        transformer.wrap(namer)
       }
   }
 }


### PR DESCRIPTION
If a namer is configured with a transformer, the `namer_state` admin endpoint is not available for that namer.  This is similar to #1999.

We update transformers to pass through the admin handlers of the underlying namer so that the `namer_state` remains available.

Fixes #2029 

Signed-off-by: Alex Leong <alex@buoyant.io>