### PR TITLE
Fixes #2040. Apply AdminFilter to admin pages coming from Namers, Rou…

### DIFF
--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/LinkerdAdmin.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/LinkerdAdmin.scala
@@ -115,11 +115,12 @@ object LinkerdAdmin {
 
     val adminHandler = new AdminHandler(uniqBy(navItems)(_.name))
 
-    val extHandlers = Admin.extractHandlers(
+    val extHandlers = (Admin.extractHandlers(
       linker.namers.map(_._2) ++
         linker.routers ++
         linker.telemeters
-    ) ++ extractInterpreterHandlers(linker.routers).map {
+    ) ++ extractInterpreterHandlers(linker.routers))
+      .map {
         case Handler(url, service, css) =>
           val adminFilter = new AdminFilter(adminHandler, css)
           Handler(url, adminFilter.andThen(service), css)


### PR DESCRIPTION
…ters and Telemeters

Signed-off-by: Robert Panzer <robert.panzer@me.com>

This PR fixes the scope of the `.map()` operation to also apply the AdminFilter to the handlers returned by Namers, Telemeters and Routers.