### PR TITLE
Allow POST requests to be retried

### DIFF
--- a/linkerd/docs/response_classifier.md
+++ b/linkerd/docs/response_classifier.md
@@ -19,7 +19,7 @@ These parameters are available to the classifier regardless of kind. Classifiers
 
 Key | Default Value | Description
 --- | ------------- | -----------
-kind | `io.l5d.http.nonRetryable5XX` | Either [`io.l5d.http.nonRetryable5XX`](#non-retryable-5xx), [`io.l5d.h2.nonRetryable5XX`](#non-retryable-5xx), [`io.l5d.http.retryableRead5XX`](#retryable-read-5xx), [`io.l5d.h2.retryableRead5XX`](#retryable-read-5xx), [`io.l5d.http.retryableIdempotent5XX`](#retryable-idempotent-5xx), or [`io.l5d.h2.retryableIdempotent5XX`](#retryable-idempotent-5xx).
+kind | `io.l5d.http.nonRetryable5XX` | Either [`io.l5d.http.nonRetryable5XX`](#non-retryable-5xx), [`io.l5d.h2.nonRetryable5XX`](#non-retryable-5xx), [`io.l5d.http.retryableRead5XX`](#retryable-read-5xx), [`io.l5d.h2.retryableRead5XX`](#retryable-read-5xx), [`io.l5d.http.retryableIdempotent5XX`](#retryable-idempotent-5xx), [`io.l5d.h2.retryableIdempotent5XX`](#retryable-idempotent-5xx), [`io.l5d.http.retryableAll5XX`](#retryable-all-5xx), or [`io.l5d.h2.retryableAll5XX`](#retryable-all-5xx).
 
 
 ## Non-Retryable 5XX
@@ -52,6 +52,19 @@ kind: `io.l5d.h2.retryableIdempotent5XX`
 
 Like _io.l5d.http.retryableRead5XX_/_io.l5d.h2.retryableRead5XX_, but `PUT` and
 `DELETE` requests may also be retried.
+
+<aside class="warning">
+Requests with chunked bodies are NEVER considered to be retryable.
+</aside>
+
+## Retryable All 5XX
+
+kind: `io.l5d.http.retryableAll5XX`
+
+kind: `io.l5d.h2.retryableAll5XX`
+
+Like _io.l5d.http.retryableIdempotent5XX_/_io.l5d.h2.retryableIdempotent5XX_, but `POST` and
+`PATCH` requests may also be retried.
 
 <aside class="warning">
 Requests with chunked bodies are NEVER considered to be retryable.

--- a/linkerd/protocol/h2/src/main/resources/META-INF/services/io.buoyant.linkerd.ResponseClassifierInitializer
+++ b/linkerd/protocol/h2/src/main/resources/META-INF/services/io.buoyant.linkerd.ResponseClassifierInitializer
@@ -1,4 +1,5 @@
 io.buoyant.linkerd.protocol.h2.NonRetryable5XXInitializer
+io.buoyant.linkerd.protocol.h2.RetryableAll5XXInitializer
 io.buoyant.linkerd.protocol.h2.RetryableIdempotent5XXInitializer
 io.buoyant.linkerd.protocol.h2.RetryableRead5XXInitializer
 io.buoyant.linkerd.protocol.h2.AllSuccessfulInitializer

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/H2Classifiers.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/H2Classifiers.scala
@@ -15,6 +15,18 @@ class RetryableIdempotent5XXInitializer extends ResponseClassifierInitializer {
 
 object RetryableIdempotent5XXInitializer extends RetryableIdempotent5XXInitializer
 
+class RetryableAll5XXConfig extends H2ClassifierConfig {
+  def mk: H2Classifier =
+    H2Classifiers.RetryableAllFailures
+}
+
+class RetryableAll5XXInitializer extends ResponseClassifierInitializer {
+  val configClass = classOf[RetryableAll5XXConfig]
+  override val configId = "io.l5d.h2.retryableAll5XX"
+}
+
+object RetryableAll5XXInitializer extends RetryableAll5XXInitializer
+
 class RetryableRead5XXConfig extends H2ClassifierConfig {
   def mk: H2Classifier =
     H2Classifiers.RetryableReadFailures

--- a/linkerd/protocol/h2/src/test/scala/io/buoyant/linkerd/protocol/h2/H2ClassifiersTest.scala
+++ b/linkerd/protocol/h2/src/test/scala/io/buoyant/linkerd/protocol/h2/H2ClassifiersTest.scala
@@ -42,6 +42,8 @@ class H2ClassifiersTest extends FunSuite {
 
   for (
     (classifier, retryMethods) <- Map(
+      new RetryableAll5XXConfig().mk ->
+        Set(Method.Get, Method.Head, Method.Put, Method.Delete, Method.Options, Method.Trace, Method.Post, Method.Patch),
       new RetryableIdempotent5XXConfig().mk ->
         Set(Method.Get, Method.Head, Method.Put, Method.Delete, Method.Options, Method.Trace),
       new RetryableRead5XXConfig().mk ->
@@ -198,6 +200,7 @@ class H2ClassifiersTest extends FunSuite {
     init <- Seq(
       NonRetryable5XXInitializer,
       RetryableIdempotent5XXInitializer,
+      RetryableAll5XXInitializer,
       RetryableRead5XXInitializer
     )
   ) {

--- a/linkerd/protocol/http/src/main/resources/META-INF/services/io.buoyant.linkerd.ResponseClassifierInitializer
+++ b/linkerd/protocol/http/src/main/resources/META-INF/services/io.buoyant.linkerd.ResponseClassifierInitializer
@@ -2,3 +2,4 @@ io.buoyant.linkerd.protocol.http.NonRetryable5XXInitializer
 io.buoyant.linkerd.protocol.http.RetryableIdempotent5XXInitializer
 io.buoyant.linkerd.protocol.http.RetryableRead5XXInitializer
 io.buoyant.linkerd.protocol.http.AllSuccessfulInitializer
+io.buoyant.linkerd.protocol.http.RetryableAll5XXInitializer

--- a/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/ResponseClassifiersTest.scala
+++ b/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/ResponseClassifiersTest.scala
@@ -42,6 +42,8 @@ class ResponseClassifiersTest extends FunSuite {
 
   for (
     (classifier, retryMethods) <- Map(
+      ResponseClassifiers.RetryableAllFailures ->
+        Set(Method.Get, Method.Head, Method.Put, Method.Delete, Method.Options, Method.Trace, Method.Post, Method.Patch),
       ResponseClassifiers.RetryableIdempotentFailures ->
         Set(Method.Get, Method.Head, Method.Put, Method.Delete, Method.Options, Method.Trace),
       ResponseClassifiers.RetryableReadFailures ->
@@ -138,7 +140,8 @@ class ResponseClassifiersTest extends FunSuite {
     init <- Seq(
       NonRetryable5XXInitializer,
       RetryableIdempotent5XXInitializer,
-      RetryableRead5XXInitializer
+      RetryableRead5XXInitializer,
+      RetryableAll5XXInitializer
     )
   ) {
     val kind = init.configId


### PR DESCRIPTION
## Tasks 
 - [x] Http Implementing code change
 - [x] Http Manual Tests
 - [x] Http Add UnitTests
 - [x] Http Add E2E Tests
 - [x] H2 Implementing code change
 - [x] H2 Manual Tests
 - [x] H2 Add UnitTests
 - [x] H2 Add E2E Tests
 - [x] Add Documentation 

## Description 
Allow post requests to be retried on timeout and failure in a similar
way to the existing functionality for a PUT request.

Resolves #2035

Signed-off-by: AMCR <antonio.rodrigues@form3.tech>