### PR TITLE
Fix NPE during validation

### DIFF
--- a/linkerd/main/src/main/scala/io/buoyant/linkerd/Main.scala
+++ b/linkerd/main/src/main/scala/io/buoyant/linkerd/Main.scala
@@ -36,6 +36,7 @@ object Main extends App {
     args match {
       case Array(path) =>
         val config = loadLinker(path)
+        shutdownGracePeriod = config.admin.flatMap(_.shutdownGraceMs)
         if (validate())
           return
 
@@ -45,7 +46,6 @@ object Main extends App {
         val routers = linker.routers.map(initRouter(_))
 
         log.info("initialized")
-        shutdownGracePeriod = config.admin.flatMap(_.shutdownGraceMs)
         registerTerminationSignalHandler(shutdownGracePeriod)
         closeOnExit(Closable.sequence(
           Closable.all(routers: _*),


### PR DESCRIPTION
When the `validate` flag is set, Linkerd returns from its main method early and does not set the shutdownGracePeriod.  This leads to a NullPointerException.

Move the setting of shutdownGracePeriod up to before the early return.

Fixes #2052 

Signed-off-by: Alex Leong <alex@buoyant.io>