### PR TITLE
Discard chunked response when running diagnostic tracing

### DIFF
--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/DiagnosticTracer.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/DiagnosticTracer.scala
@@ -58,8 +58,8 @@ class DiagnosticTracer(
 
     routerCtxF.map { ctx =>
       if (resp.isChunked) {
-        resp.setChunked(false)
         resp.reader.discard()
+        resp.setChunked(false)
         resp.contentString = ChunkedResponsePlaceholderMsg(resp.headerMap, resp.status)
       }
       val content = s"${resp.contentString.trim}\n\n$ctx"

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/DiagnosticTracer.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/DiagnosticTracer.scala
@@ -35,6 +35,15 @@ class DiagnosticTracer(
   routerLabel: String
 ) extends SimpleFilter[Request, Response] {
   private[this] val AddRouterContextHeader = "l5d-add-context"
+
+  private[this] def ChunkedResponsePlaceholderMsg(headers: HeaderMap, status: Status) = {
+    val headerStr = headers.map {
+      case (headerKey, headerValue) => s"$headerKey: $headerValue"
+    }.mkString("\n")
+
+    s"$headerStr\nHTTP ${status.code} - ${status.reason}\nDiagnostic trace encountered chunked response. Response content discarded."
+  }
+
   private[this] def getRequestTraceResponse(resp: Response, stopwatch: Stopwatch.Elapsed) = {
 
     val routerCtxF = RouterContextFormatter.formatCtx(
@@ -48,6 +57,10 @@ class DiagnosticTracer(
     )
 
     routerCtxF.map { ctx =>
+      if (resp.isChunked) {
+        resp.setChunked(false)
+        resp.contentString = ChunkedResponsePlaceholderMsg(resp.headerMap, resp.status)
+      }
       val content = s"${resp.contentString.trim}\n\n$ctx"
       resp.contentString = content
       //We set the content length of the response in order to view the content string in the response

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/DiagnosticTracer.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/DiagnosticTracer.scala
@@ -59,6 +59,7 @@ class DiagnosticTracer(
     routerCtxF.map { ctx =>
       if (resp.isChunked) {
         resp.setChunked(false)
+        resp.reader.discard()
         resp.contentString = ChunkedResponsePlaceholderMsg(resp.headerMap, resp.status)
       }
       val content = s"${resp.contentString.trim}\n\n$ctx"


### PR DESCRIPTION
When running a diagnostic trace to a server that responds with chunked messages, Linkerd returns an HTTP 500 Bad Gateway response because the `DiagnosticTracer` filter is unable to handle chunked responses. 

This PR fixes the issue by discarded the contents of the chunked response and sending a place holder message like:

```bash
Transfer-Encoding: chunked
HTTP 200 - OK
Diagnostic trace encountered chunked response. Response content discarded.
``` 

The message prints the response headers and status code just in case some additional contextual information is intended to be propagated by any chunked response server present along the trace path.

Integration tests were added to as well local tests were done on to vet this PR.

fixes #2038 

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>