### PR TITLE
Zipkin trace propagation plugin

### DIFF
--- a/admin/src/main/scala/io/buoyant/admin/Admin.scala
+++ b/admin/src/main/scala/io/buoyant/admin/Admin.scala
@@ -122,8 +122,9 @@ class Admin(
   tlsCfg: Option[TlsServerConfig],
   workers: Int,
   stats: StatsReceiver,
-  securityConfig: Option[AdminSecurityConfig]) {
-  
+  securityConfig: Option[AdminSecurityConfig]
+) {
+
   import Admin._
 
   private[this] val notFoundView = new NotFoundView()

--- a/linkerd/protocol/h2/src/main/resources/META-INF/services/io.buoyant.linkerd.TracePropagatorInitializer
+++ b/linkerd/protocol/h2/src/main/resources/META-INF/services/io.buoyant.linkerd.TracePropagatorInitializer
@@ -1,1 +1,2 @@
 io.buoyant.linkerd.protocol.h2.LinkerdTracePropagatorInitializer
+io.buoyant.linkerd.protocol.h2.ZipkinTracePropagatorInitializer

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/ZipkinTracePropagator.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/ZipkinTracePropagator.scala
@@ -77,8 +77,8 @@ object ZipkinTrace {
     val _ = headers.set(ZipkinSpanHeader, id.spanId.toString)
     val __ = headers.set(ZipkinTraceHeader, id.traceId.toString)
     val ___ = headers.set(ZipkinParentHeader, id.parentId.toString)
-    val ____ = headers.set(ZipkinSampleHeader, id.sampled.toString)
-    val _____ = headers.set(ZipkinFlagsHeader, id.flags.toString)
+    val ____ = headers.set(ZipkinSampleHeader, (if ((id.sampled exists { _ == true })) 1 else 0).toString)
+    val _____ = headers.set(ZipkinFlagsHeader, id.flags.toLong.toString)
   }
 
   def getSampler(headers: Headers): Option[Float] =

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/ZipkinTracePropagator.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/ZipkinTracePropagator.scala
@@ -1,0 +1,91 @@
+package io.buoyant.linkerd.protocol.h2
+
+import java.util.Base64
+
+import com.twitter.finagle.Stack
+import com.twitter.finagle.buoyant.Sampler
+import com.twitter.finagle.buoyant.h2.{Headers, LinkerdHeaders, Request}
+import com.twitter.finagle.tracing.{Flags, SpanId, TraceId}
+import com.twitter.util.Try
+import io.buoyant.linkerd.{TracePropagator, TracePropagatorInitializer}
+
+class ZipkinTracePropagatorInitializer extends TracePropagatorInitializer {
+  override val configClass = classOf[ZipkinTracePropagatorConfig]
+  override val configId = "io.l5d.zipkin"
+}
+
+case class ZipkinTracePropagatorConfig() extends H2TracePropagatorConfig {
+  override def mk(params: Stack.Params): TracePropagator[Request] = new ZipkinTracePropagator
+}
+
+class ZipkinTracePropagator extends LinkerdTracePropagator {
+  /**
+   * Read the trace id from the request, if it has one.
+   */
+  override def traceId(req: Request): Option[TraceId] = {
+    var traceId = ZipkinTrace.get(req.headers)
+    // retro compatible.
+    if (traceId.isEmpty) {
+      traceId = super.traceId(req)
+    } else {
+      LinkerdHeaders.Ctx.Trace.clear(req.headers)
+    }
+    traceId
+  }
+
+  /**
+   * Return a sampler which decides if the given request should be sampled, based on properties
+   * of the request (zipkin or linkerd if zipkin not present).  If None is returned, the decision of whether to sample the request is deferred
+   * to the tracer.
+   */
+  override def sampler(req: Request): Option[Sampler] = {
+    var sampler = ZipkinTrace.getSampler(req.headers).map(Sampler(_))
+    // retro compatible
+    if (sampler.isEmpty) {
+      sampler = super.sampler(req)
+    } else {
+      LinkerdHeaders.Sample.clear(req.headers)
+    }
+    sampler
+  }
+
+  /**
+   * Write the trace id onto a request.
+   */
+  override def setContext(
+    req: Request,
+    traceId: TraceId
+  ): Unit = {
+    super.setContext(req, traceId)
+    //always set header from here on
+    ZipkinTrace.set(req.headers, traceId)
+  }
+}
+
+object ZipkinTrace {
+
+  val ZipkinSpanHeader = "x-b3-spanid"
+  val ZipkinParentHeader = "x-b3-parentspanid"
+  val ZipkinTraceHeader = "x-b3-traceid"
+  val ZipkinSampleHeader = "x-b3-sampled"
+  val ZipkinFlagsHeader = "x-b3-flags"
+
+  def get(headers: Headers): Option[TraceId] =
+    Try(TraceId.apply(SpanId.fromString(headers.get(ZipkinTraceHeader).get), SpanId.fromString(headers.get(ZipkinParentHeader).get), SpanId.fromString(headers.get(ZipkinSpanHeader).get).get, Some(if (headers.get(ZipkinSampleHeader).get.toInt == 1) true else false), Flags.apply(headers.get(ZipkinFlagsHeader).get.toInt))).toOption
+
+  def set(headers: Headers, id: TraceId): Unit = {
+    val _ = headers.set(ZipkinSpanHeader, id.spanId.toString)
+    val __ = headers.set(ZipkinTraceHeader, id.traceId.toString)
+    val ___ = headers.set(ZipkinParentHeader, id.parentId.toString)
+  }
+
+  def getSampler(headers: Headers): Option[Float] =
+    headers.get(ZipkinSampleHeader).flatMap { s =>
+      Try(s.toFloat).toOption.map {
+        case v if v < 0 => 0.0f
+        case v if v > 1 => 1.0f
+        case v => v
+      }
+    }
+
+}

--- a/linkerd/protocol/http/src/main/resources/META-INF/services/io.buoyant.linkerd.TracePropagatorInitializer
+++ b/linkerd/protocol/http/src/main/resources/META-INF/services/io.buoyant.linkerd.TracePropagatorInitializer
@@ -1,1 +1,2 @@
 io.buoyant.linkerd.protocol.LinkerdTracePropagatorInitializer
+io.buoyant.linkerd.protocol.ZipkinTracePropagatorInitializer

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/ZipkinTracePropagator.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/ZipkinTracePropagator.scala
@@ -5,6 +5,7 @@ import java.util.Base64
 import com.twitter.finagle.Stack
 import com.twitter.finagle.buoyant.Sampler
 import com.twitter.finagle.buoyant.linkerd.Headers
+import com.twitter.finagle.http.util.StringUtil
 import com.twitter.finagle.http.{HeaderMap, Request}
 import com.twitter.finagle.tracing.{Flags, SpanId, TraceId}
 import com.twitter.util.Try
@@ -19,18 +20,13 @@ case class ZipkinTracePropagatorConfig() extends HttpTracePropagatorConfig {
   override def mk(params: Stack.Params): TracePropagator[Request] = new ZipkinTracePropagator
 }
 
-class ZipkinTracePropagator extends LinkerdTracePropagator {
+class ZipkinTracePropagator extends TracePropagator[Request] {
   /**
    * Read the trace id from the request, if it has one.
    */
   override def traceId(req: Request): Option[TraceId] = {
     var traceId = ZipkinTrace.get(req.headerMap)
-    // retro compatible.
-    if (traceId.isEmpty) {
-      traceId = super.traceId(req)
-    } else {
-      Headers.Ctx.Trace.clear(req.headerMap)
-    }
+    Headers.Ctx.Trace.clear(req.headerMap)
     traceId
   }
 
@@ -41,12 +37,7 @@ class ZipkinTracePropagator extends LinkerdTracePropagator {
    */
   override def sampler(req: Request): Option[Sampler] = {
     var sampler = ZipkinTrace.getSampler(req.headerMap).map(Sampler(_))
-    // retro compatible
-    if (sampler.isEmpty) {
-      sampler = super.sampler(req)
-    } else {
-      Headers.Sample.clear(req.headerMap)
-    }
+    Headers.Sample.clear(req.headerMap)
     sampler
   }
 
@@ -57,10 +48,9 @@ class ZipkinTracePropagator extends LinkerdTracePropagator {
     req: Request,
     traceId: TraceId
   ): Unit = {
-    super.setContext(req, traceId)
-    //always set header from here on
     ZipkinTrace.set(req.headerMap, traceId)
   }
+
 }
 
 object ZipkinTrace {
@@ -71,13 +61,26 @@ object ZipkinTrace {
   val ZipkinSampleHeader = "x-b3-sampled"
   val ZipkinFlagsHeader = "x-b3-flags"
 
-  def get(headers: HeaderMap): Option[TraceId] =
-    Try(TraceId.apply(SpanId.fromString(headers.get(ZipkinTraceHeader).get), SpanId.fromString(headers.get(ZipkinParentHeader).get), SpanId.fromString(headers.get(ZipkinSpanHeader).get).get, Some(if (headers.get(ZipkinSampleHeader).get.toInt == 1) true else false), Flags.apply(headers.get(ZipkinFlagsHeader).get.toInt))).toOption
+  def get(headers: HeaderMap): Option[TraceId] = {
+    val trace = caseInsensitiveGet(headers, ZipkinTraceHeader).flatMap(SpanId.fromString)
+    val parent = caseInsensitiveGet(headers, ZipkinParentHeader).flatMap(SpanId.fromString)
+    val span = caseInsensitiveGet(headers, ZipkinSpanHeader).flatMap(SpanId.fromString)
+    val sample = caseInsensitiveGet(headers, ZipkinSampleHeader).map(StringUtil.toBoolean)
+    val flags = caseInsensitiveGet(headers, ZipkinFlagsHeader).map(StringUtil.toSomeLong) match {
+      case Some(f) => Flags(f)
+      case None => Flags()
+    }
+    span.map { s =>
+      TraceId(trace, parent, s, sample, flags)
+    }
+  }
 
   def set(headers: HeaderMap, id: TraceId): Unit = {
     val _ = headers.set(ZipkinSpanHeader, id.spanId.toString)
     val __ = headers.set(ZipkinTraceHeader, id.traceId.toString)
     val ___ = headers.set(ZipkinParentHeader, id.parentId.toString)
+    val ____ = headers.set(ZipkinSampleHeader, id.sampled.toString)
+    val _____ = headers.set(ZipkinFlagsHeader, id.flags.toString)
   }
 
   def getSampler(headers: HeaderMap): Option[Float] =
@@ -89,4 +92,6 @@ object ZipkinTrace {
       }
     }
 
+  private def caseInsensitiveGet(headers: HeaderMap, key: String): Option[String] =
+    headers.iterator.collectFirst { case (k, v) if key.equalsIgnoreCase(k) => v }
 }

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/ZipkinTracePropagator.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/ZipkinTracePropagator.scala
@@ -79,8 +79,8 @@ object ZipkinTrace {
     val _ = headers.set(ZipkinSpanHeader, id.spanId.toString)
     val __ = headers.set(ZipkinTraceHeader, id.traceId.toString)
     val ___ = headers.set(ZipkinParentHeader, id.parentId.toString)
-    val ____ = headers.set(ZipkinSampleHeader, id.sampled.toString)
-    val _____ = headers.set(ZipkinFlagsHeader, id.flags.toString)
+    val ____ = headers.set(ZipkinSampleHeader, (if ((id.sampled exists { _ == true })) 1 else 0).toString)
+    val _____ = headers.set(ZipkinFlagsHeader, id.flags.toLong.toString)
   }
 
   def getSampler(headers: HeaderMap): Option[Float] =

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/ZipkinTracePropagator.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/ZipkinTracePropagator.scala
@@ -1,0 +1,92 @@
+package io.buoyant.linkerd.protocol
+
+import java.util.Base64
+
+import com.twitter.finagle.Stack
+import com.twitter.finagle.buoyant.Sampler
+import com.twitter.finagle.buoyant.linkerd.Headers
+import com.twitter.finagle.http.{HeaderMap, Request}
+import com.twitter.finagle.tracing.{Flags, SpanId, TraceId}
+import com.twitter.util.Try
+import io.buoyant.linkerd.{TracePropagator, TracePropagatorInitializer}
+
+class ZipkinTracePropagatorInitializer extends TracePropagatorInitializer {
+  override val configClass = classOf[ZipkinTracePropagatorConfig]
+  override val configId = "io.l5d.zipkin"
+}
+
+case class ZipkinTracePropagatorConfig() extends HttpTracePropagatorConfig {
+  override def mk(params: Stack.Params): TracePropagator[Request] = new ZipkinTracePropagator
+}
+
+class ZipkinTracePropagator extends LinkerdTracePropagator {
+  /**
+   * Read the trace id from the request, if it has one.
+   */
+  override def traceId(req: Request): Option[TraceId] = {
+    var traceId = ZipkinTrace.get(req.headerMap)
+    // retro compatible.
+    if (traceId.isEmpty) {
+      traceId = super.traceId(req)
+    } else {
+      Headers.Ctx.Trace.clear(req.headerMap)
+    }
+    traceId
+  }
+
+  /**
+   * Return a sampler which decides if the given request should be sampled, based on properties
+   * of the request (zipkin or linkerd if zipkin not present).  If None is returned, the decision of whether to sample the request is deferred
+   * to the tracer.
+   */
+  override def sampler(req: Request): Option[Sampler] = {
+    var sampler = ZipkinTrace.getSampler(req.headerMap).map(Sampler(_))
+    // retro compatible
+    if (sampler.isEmpty) {
+      sampler = super.sampler(req)
+    } else {
+      Headers.Sample.clear(req.headerMap)
+    }
+    sampler
+  }
+
+  /**
+   * Write the trace id onto a request.
+   */
+  override def setContext(
+    req: Request,
+    traceId: TraceId
+  ): Unit = {
+    super.setContext(req, traceId)
+    //always set header from here on
+    ZipkinTrace.set(req.headerMap, traceId)
+  }
+}
+
+object ZipkinTrace {
+
+  val ZipkinSpanHeader = "x-b3-spanid"
+  val ZipkinParentHeader = "x-b3-parentspanid"
+  val ZipkinTraceHeader = "x-b3-traceid"
+  val ZipkinSampleHeader = "x-b3-sampled"
+  val ZipkinFlagsHeader = "x-b3-flags"
+
+  def get(headers: HeaderMap): Option[TraceId] =
+    Try(TraceId.apply(SpanId.fromString(headers.get(ZipkinTraceHeader).get), SpanId.fromString(headers.get(ZipkinParentHeader).get), SpanId.fromString(headers.get(ZipkinSpanHeader).get).get, Some(if (headers.get(ZipkinSampleHeader).get.toInt == 1) true else false), Flags.apply(headers.get(ZipkinFlagsHeader).get.toInt))).toOption
+
+  def set(headers: HeaderMap, id: TraceId): Unit = {
+    val _ = headers.set(ZipkinSpanHeader, id.spanId.toString)
+    val __ = headers.set(ZipkinTraceHeader, id.traceId.toString)
+    val ___ = headers.set(ZipkinParentHeader, id.parentId.toString)
+  }
+
+  def getSampler(headers: HeaderMap): Option[Float] =
+    headers.get(ZipkinSampleHeader).flatMap { s =>
+      Try(s.toFloat).toOption.map {
+        case v if v < 0 => 0.0f
+        case v if v > 1 => 1.0f
+        case v => v
+      }
+    }
+
+}


### PR DESCRIPTION
Hi,
This is the first implementation of the interface that you provided to use Zipkin B3 headers to continue an existing trace context in case it exists. If not, fallbacks to the default behaviour. 
As I told you in the other PR, I'm not a scala expert, so please bear with me and feel free to make any amends you find are useful.

I've tested the HTTP implementation. We do not have an H2 env where to test the H2 Tracer, but I provide it for completeness.

Thank you,

Jose Maria.