### PR TITLE
Add TLS support to etcd HTTP client

### DIFF
--- a/namerd/docs/storage.md
+++ b/namerd/docs/storage.md
@@ -166,6 +166,7 @@ experimental | _required_ | Because this storage is still considered experimenta
 host | `localhost` | The location of the etcd API.
 port | `2379` | The port used to connect to the etcd API.
 pathPrefix | `/namerd/dtabs` | The key path under which dtabs should be stored.
+tls | no tls | Use TLS encryption for connections to Etcd. See [Namer TLS](#namer-tls).
 
 ## Consul
 
@@ -187,17 +188,16 @@ readConsistencyMode | `default` | Select between [Consul API consistency modes](
 writeConsistencyMode | `default` | Select between [Consul API consistency modes](https://www.consul.io/docs/agent/http.html) such as `default`, `stale` and `consistent` for writes.
 failFast | `false` | If `false`, disable fail fast and failure accrual for Consul client. Keep it `false` when using a local agent but change it to `true` when talking directly to an HA Consul API.
 backoff |  exponential backoff from 1ms to 1min | Object that determines which backoff algorithm should be used. See [retry backoff](https://linkerd.io/config/head/linkerd#retry-backoff-parameters)
-tls | no tls | Use TLS during connection with Consul. see [Consul Encryption](https://www.consul.io/docs/agent/encryption.html) and [TLS](#consul-tls).
+tls | no tls | Use TLS during connection with Consul. see [Consul Encryption](https://www.consul.io/docs/agent/encryption.html) and [Namer TLS](#namer-tls).
 
-### Consul TLS
+### Namer TLS
 
->Linkerd supports encrypted communication via TLS to Consul.
+> Linkerd supports encrypted communication via TLS to `io.l5d.consul` and `io.l5d.etcd` namer backends.
 
 ```yaml
 namers:
-- kind: io.l5d.consul
-  host: localhost
-  port: 8500
+- kind: ...
+  host: ...
   tls:
     disableValidation: false
     commonName: consul.io

--- a/namerd/docs/storage.md
+++ b/namerd/docs/storage.md
@@ -158,7 +158,7 @@ perms | _required_ | A subset of the string "crwda" representing the permissions
 
 kind: `io.l5d.etcd`
 
-Stores the dtab in Etcd.
+Stores the dtab in etcd.
 
 Key | Default Value | Description
 --- | ------------- | -----------
@@ -166,7 +166,7 @@ experimental | _required_ | Because this storage is still considered experimenta
 host | `localhost` | The location of the etcd API.
 port | `2379` | The port used to connect to the etcd API.
 pathPrefix | `/namerd/dtabs` | The key path under which dtabs should be stored.
-tls | no tls | Use TLS encryption for connections to Etcd. See [Namer TLS](#namer-tls).
+tls | no tls | Use TLS encryption for connections to etcd. See [Namer TLS](#namer-tls).
 
 ## Consul
 

--- a/namerd/storage/etcd/src/main/scala/io/buoyant/namerd/storage/etcd/EtcdDtabStoreInitializer.scala
+++ b/namerd/storage/etcd/src/main/scala/io/buoyant/namerd/storage/etcd/EtcdDtabStoreInitializer.scala
@@ -23,7 +23,7 @@ case class EtcdConfig(
   override def mkDtabStore(params: Stack.Params): DtabStore = {
     val tlsParams = tls match {
       case Some(tlsConfig) => tlsConfig.params
-      case _ => Stack.Params.empty
+      case None => Stack.Params.empty
     }
     new EtcdDtabStore(new Key(
       pathPrefix.getOrElse(Path.read("/namerd/dtabs")),

--- a/namerd/storage/etcd/src/test/scala/io/buoyant/namerd/storage/etcd/EtcdConfigTest.scala
+++ b/namerd/storage/etcd/src/test/scala/io/buoyant/namerd/storage/etcd/EtcdConfigTest.scala
@@ -7,8 +7,13 @@ import io.buoyant.namerd.DtabStoreConfig
 import org.scalatest.{FunSuite, OptionValues}
 
 class EtcdConfigTest extends FunSuite with OptionValues {
+
+  def parsedEtcdConfig(yaml: String) = {
+    val mapper = Parser.objectMapper(yaml, Iterable(Seq(EtcdDtabStoreInitializer)))
+    mapper.readValue[DtabStoreConfig](yaml).asInstanceOf[EtcdConfig]
+  }
   test("sanity") {
-    val store = EtcdConfig(None, None, Some(Path.read("/foo/bar"))).mkDtabStore(Stack.Params.empty)
+    val store = EtcdConfig(None, None, Some(Path.read("/foo/bar")), None).mkDtabStore(Stack.Params.empty)
   }
 
   test("parse config") {
@@ -19,11 +24,37 @@ class EtcdConfigTest extends FunSuite with OptionValues {
          |host: etcd.dentist
          |port: 80
       """.stripMargin
-    val mapper = Parser.objectMapper(yaml, Iterable(Seq(EtcdDtabStoreInitializer)))
-    val etcd = mapper.readValue[DtabStoreConfig](yaml).asInstanceOf[EtcdConfig]
+    val etcd = parsedEtcdConfig(yaml)
     assert(etcd.host.value == "etcd.dentist")
     assert(etcd.port.value == Port(80))
     assert(etcd.pathPrefix == Some(Path.read("/foo/bar")))
+  }
+
+  test("parse tls config"){
+    val yaml =
+      """|kind: io.l5d.etcd
+         |experimental: true
+         |pathPrefix: /foo/bar
+         |host: etcd.dentist
+         |port: 80
+         |tls:
+         |  disableValidation: false
+         |  commonName: "{service}"
+         |  trustCerts:
+         |  - /foo/caCert.pem
+         |  clientAuth:
+         |    certPath: /etcd-cert.pem
+         |    keyPath: /etcd-key.pk8
+      """.stripMargin
+
+    parsedEtcdConfig(yaml).tls.foreach { etcdTLS =>
+      assert(etcdTLS.disableValidation == Some(false))
+      assert(etcdTLS.commonName == Some("{service}"))
+      assert(etcdTLS.trustCerts == Some(List("/foo/caCert.pem")))
+      assert(etcdTLS.clientAuth.get.certPath == "/etcd-cert.pem")
+      assert(etcdTLS.clientAuth.get.keyPath == "/etcd-key.pk8")
+    }
+
   }
 
 }


### PR DESCRIPTION
The HTTP client used with an etcd instance in Namerd's dtab storage module is not configured to send TLS encrypted requests. 

This PR add TLS support to `io.l5d.etcd` dtab storage client.

Tests were done with a locally running etcd server with TLS enabled.

fixes #2070

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>