### PR TITLE
Format h2 response classifier config id to not have leading capital letter

### DIFF
--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/grpc/GrpcClassifierConfig.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/grpc/GrpcClassifierConfig.scala
@@ -32,7 +32,7 @@ class DefaultConfig extends H2ClassifierConfig {
 
 class DefaultInitializer extends ResponseClassifierInitializer {
   val configClass = classOf[DefaultConfig]
-  override val configId = "io.l5d.h2.grpc.Default"
+  override val configId = "io.l5d.h2.grpc.default"
 }
 
 object DefaultInitializer extends DefaultInitializer
@@ -43,7 +43,7 @@ class CompliantConfig extends H2ClassifierConfig {
 
 class CompliantInitializer extends ResponseClassifierInitializer {
   val configClass = classOf[DefaultConfig]
-  override val configId = "io.l5d.h2.grpc.Compliant"
+  override val configId = "io.l5d.h2.grpc.compliant"
 }
 
 object CompliantInitializer extends CompliantInitializer

--- a/linkerd/protocol/h2/src/test/scala/io/buoyant/linkerd/protocol/h2/H2ClassifiersTest.scala
+++ b/linkerd/protocol/h2/src/test/scala/io/buoyant/linkerd/protocol/h2/H2ClassifiersTest.scala
@@ -7,6 +7,7 @@ import com.twitter.finagle.util.LoadService
 import com.twitter.finagle.{ChannelClosedException, RequestTimeoutException}
 import com.twitter.util._
 import io.buoyant.config.Parser
+import io.buoyant.linkerd.protocol.h2.grpc.DefaultInitializer
 import io.buoyant.linkerd.{ResponseClassifierInitializer, RouterConfig}
 import io.buoyant.linkerd.protocol.{H2DefaultSvc, H2Initializer}
 import org.scalatest.FunSuite
@@ -201,7 +202,8 @@ class H2ClassifiersTest extends FunSuite {
       NonRetryable5XXInitializer,
       RetryableIdempotent5XXInitializer,
       RetryableAll5XXInitializer,
-      RetryableRead5XXInitializer
+      RetryableRead5XXInitializer,
+      DefaultInitializer
     )
   ) {
     val kind = init.configId


### PR DESCRIPTION
This PR fixes an issue where the default grpc classifier fails to load when given `kind: io.l5d.h2.grpc.default` in a linkerd yaml config.

Tests were performed with a locally running Linkerd.

fixes #2075

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>