### PR TITLE
fix typo in client_tls.md

### DIFF
--- a/linkerd/docs/client_tls.md
+++ b/linkerd/docs/client_tls.md
@@ -59,8 +59,8 @@ Key               | Default Value                              | Description
 ----------------- | ------------------------------------------ | -----------
 disableValidation | false                                      | Enable this to skip hostname validation (unsafe). Setting `disableValidation: true` is incompatible with `clientAuth`.
 commonName        | _required_ unless disableValidation is set | The common name to use for all TLS requests.
-trustCerts        | empty list                                 | A file path of CA certs bundle to use for common name validation (deprecated, please use trustCertsBundle).
-trustCertsBundle  | empty                                      | A list of file paths of CA certs to use for common name validation.
+trustCerts        | empty list                                 | A list of file paths of CA certs to use for common name validation (deprecated, please use trustCertsBundle).
+trustCertsBundle  | empty                                      | A file path of CA certs bundle to use for common name validation
 clientAuth        | none                                       | A client auth object used to sign requests.
 protocols         | unspecified                                | The list of TLS protocols to enable
 


### PR DESCRIPTION
the description about trustCert & trustCertsBundle corrected in the client_tls.md

Signed-off-by: zillani shaik <shaikzillani@gmail.com>