### PR TITLE
Add a new Marathon watch state endpoint for diagnostics

### DIFF
--- a/marathon/src/main/scala/io/buoyant/marathon/v2/WatchState.scala
+++ b/marathon/src/main/scala/io/buoyant/marathon/v2/WatchState.scala
@@ -10,11 +10,6 @@ import io.buoyant.marathon.v2.Api.AppRsp
 
 class WatchState {
 
-  private[this] val mapper = new ObjectMapper with ScalaObjectMapper
-
-  mapper.registerModule(DefaultScalaModule)
-  mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-
   @JsonIgnore
   def recordApiCall(req: Request): Unit = synchronized {
     request = Some(s"${req.method} ${req.uri}")

--- a/marathon/src/main/scala/io/buoyant/marathon/v2/WatchState.scala
+++ b/marathon/src/main/scala/io/buoyant/marathon/v2/WatchState.scala
@@ -1,0 +1,37 @@
+package io.buoyant.marathon.v2
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.databind.{DeserializationFeature, ObjectMapper}
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
+import com.twitter.finagle.http.Request
+import com.twitter.util.Time
+import io.buoyant.marathon.v2.Api.AppRsp
+
+class WatchState {
+
+  private[this] val mapper = new ObjectMapper with ScalaObjectMapper
+
+  mapper.registerModule(DefaultScalaModule)
+  mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+
+  @JsonIgnore
+  def recordApiCall(req: Request): Unit = synchronized {
+    request = Some(s"${req.method} ${req.uri}")
+    lastRequestAt = Some(Time.now.toString)
+  }
+
+  @JsonIgnore
+  def recordResponse(apps: AppRsp): Unit = synchronized {
+    lastResponseAt = Some(Time.now.toString)
+    response = Some(apps)
+  }
+
+  // These fields exist to be serialized.
+  protected var request: Option[String] = None
+  protected var lastRequestAt: Option[String] = None
+  protected var response: Option[AppRsp] = None
+  protected var error: Option[Throwable] = None
+  protected var lastResponseAt: Option[String] = None
+  protected var lastStreamEndAt: Option[String] = None
+}

--- a/namer/marathon/src/main/scala/io/buoyant/namer/marathon/AppIdNamer.scala
+++ b/namer/marathon/src/main/scala/io/buoyant/namer/marathon/AppIdNamer.scala
@@ -2,7 +2,7 @@ package io.buoyant.namer.marathon
 
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.twitter.finagle._
-import com.twitter.finagle.http.{Request, Response, Status}
+import com.twitter.finagle.http.{MediaType, Request, Response, Status}
 import com.twitter.finagle.tracing.Trace
 import com.twitter.finagle.util.DefaultTimer
 import com.twitter.util._
@@ -30,7 +30,7 @@ class AppIdNamer(
     marathonWatchState: WatchState
   )
   private[this] implicit val _timer = timer
-  private[this] lazy val handlerPrefix = prefix.drop(1).show.drop(1)
+  private[this] val handlerPrefix = prefix.drop(1).show.drop(1)
   private[this] var appToAddrMap: Map[Path, InstrumentedMarathonWatch] = Map.empty
 
   /**
@@ -188,6 +188,7 @@ class AppIdNamer(
       }
       val json = mapper.writeValueAsString(currentState)
       val rep = Response(request.version, Status.Ok)
+      rep.mediaType = MediaType.Json
       rep.contentString = json
       Future.value(rep)
     }

--- a/namer/marathon/src/main/scala/io/buoyant/namer/marathon/AppIdNamer.scala
+++ b/namer/marathon/src/main/scala/io/buoyant/namer/marathon/AppIdNamer.scala
@@ -1,9 +1,15 @@
-package io.buoyant.marathon.v2
+package io.buoyant.namer.marathon
 
+import com.fasterxml.jackson.databind.SerializationFeature
 import com.twitter.finagle._
+import com.twitter.finagle.http.{Request, Response, Status}
 import com.twitter.finagle.tracing.Trace
 import com.twitter.finagle.util.DefaultTimer
 import com.twitter.util._
+import io.buoyant.admin.Admin
+import io.buoyant.config.Parser
+import io.buoyant.marathon.v2.{Api, WatchState}
+import io.buoyant.namer.InstrumentedVar
 import scala.util.control.NonFatal
 
 object AppIdNamer {
@@ -15,11 +21,17 @@ class AppIdNamer(
   prefix: Path,
   ttl: => Duration,
   timer: Timer = DefaultTimer
-) extends Namer {
+) extends Namer with Admin.WithHandlers {
 
   import AppIdNamer._
 
+  private[this] case class InstrumentedMarathonWatch(
+    instrumentedAddrs: InstrumentedVar[Addr],
+    marathonWatchState: WatchState
+  )
   private[this] implicit val _timer = timer
+  private[this] lazy val handlerPrefix = prefix.drop(1).show.drop(1)
+  private[this] var appToAddrMap: Map[Path, InstrumentedMarathonWatch] = Map.empty
 
   /**
    * Accepts names in the form:
@@ -111,12 +123,13 @@ class AppIdNamer(
       case Some(addr) => addr
 
       case None =>
-        val addr = Var.async[Addr](Addr.Pending) { addr =>
+        val watch = new WatchState()
+        val addr = InstrumentedVar[Addr](Addr.Pending) { addr =>
           @volatile var initialized, stopped = false
           @volatile var pending: Future[_] = Future.never
 
           def loop(): Unit = if (!stopped) {
-            pending = api.getAddrs(app).respond {
+            pending = api.getAddrs(app, Some(watch)).respond {
               case Return(addrs) =>
                 initialized = true
                 addr() = if (addrs.isEmpty) Addr.Neg else Addr.Bound(addrs)
@@ -147,9 +160,37 @@ class AppIdNamer(
             Future.Unit
           }
         }
+        appToAddrMap += (app -> InstrumentedMarathonWatch(addr, watch))
+        appMonitors += (app -> addr.underlying)
+        addr.underlying
+    }
+  }
 
-        appMonitors += (app -> addr)
-        addr
+  override def adminHandlers: Seq[Admin.Handler] = {
+    Seq(Admin.Handler(
+      s"namer_state/$handlerPrefix.json",
+      new MarathonNamerHandler
+    ))
+  }
+
+  private[AppIdNamer] class MarathonNamerHandler extends Service[Request, Response] {
+    private[this] val mapper = Parser.jsonObjectMapper(Nil)
+      .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
+
+    override def apply(request: Request): Future[Response] = {
+      val currentState = appToAddrMap.map {
+        case (path, marathonAddr) => Map(
+          s"${path.show}" -> Map(
+            "state" -> marathonAddr.instrumentedAddrs.stateSnapshot(),
+            "watch" -> marathonAddr.marathonWatchState
+          )
+        )
+      }
+      val json = mapper.writeValueAsString(currentState)
+      val rep = Response(request.version, Status.Ok)
+      rep.contentString = json
+      Future.value(rep)
     }
   }
 }
+

--- a/namer/marathon/src/main/scala/io/buoyant/namer/marathon/MarathonInitializer.scala
+++ b/namer/marathon/src/main/scala/io/buoyant/namer/marathon/MarathonInitializer.scala
@@ -8,9 +8,8 @@ import com.twitter.finagle.tracing.NullTracer
 import com.twitter.io.Buf
 import com.twitter.util.{Duration, Return, Throw}
 import io.buoyant.config.types.Port
+import io.buoyant.marathon.v2.Api
 import io.buoyant.namer.{NamerConfig, NamerInitializer}
-import io.buoyant.marathon.v2.{Api, AppIdNamer}
-
 import scala.util.control.NoStackTrace
 import scala.util.Random
 

--- a/namer/marathon/src/test/scala/io/buoyant/namer/marathon/AppIdNamerTest.scala
+++ b/namer/marathon/src/test/scala/io/buoyant/namer/marathon/AppIdNamerTest.scala
@@ -1,10 +1,10 @@
-package io.buoyant.marathon.v2
+package io.buoyant.namer.marathon
 
 import com.twitter.conversions.time._
 import com.twitter.finagle._
-import com.twitter.util.{Activity, Future, MockTimer, Promise, Time, Var}
+import com.twitter.util._
+import io.buoyant.marathon.v2.{Api, WatchState}
 import io.buoyant.test.Awaits
-import java.net.{InetSocketAddress, SocketAddress}
 import org.scalatest.FunSuite
 
 class AppIdNamerTest extends FunSuite with Awaits {
@@ -25,7 +25,7 @@ class AppIdNamerTest extends FunSuite with Awaits {
 
     def getAppIds(): Future[Api.AppIds] =
       if (idsAlive) ids else exc
-    def getAddrs(app: Path): Future[Set[Address]] =
+    def getAddrs(app: Path, watchState: Option[WatchState] = None): Future[Set[Address]] =
       if (addrsAlive) addrs else exc
   }
 

--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -104,7 +104,7 @@ object LinkerdBuild extends Base {
       .withTests()
 
     val marathon = projectDir("namer/marathon")
-      .dependsOn(LinkerdBuild.marathon, core)
+      .dependsOn(LinkerdBuild.marathon, core, admin)
       .withLib(Deps.jwt)
       .withTests()
 


### PR DESCRIPTION
There currently is no watch state endpoint for the Marathon namer in Linkerd. Just like the Kubernetes watch state endpoint, it would be useful to show the internal state of the Activities that are responsible for service discovery with a Marathon API.

This PR adds a new endpoint `namer_state/io.l5d.marathon.json` that shows information about each service that Linkerd is aware of and displays Marathon API responses and the current set of addresses per service.

Tests were done with a locally running DC/OS environment and Linkerd.

<img width="796" alt="screen shot 2018-07-25 at 1 45 52 pm" src="https://user-images.githubusercontent.com/2197104/43226598-21e6337a-9011-11e8-966d-d9200ac8436b.png">

fixes #1995

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>