### PR TITLE
Add instrumentation for fs namer

### DIFF
--- a/interpreter/fs/src/main/scala/io/buoyant/interpreter/fs/FsInterpreterConfig.scala
+++ b/interpreter/fs/src/main/scala/io/buoyant/interpreter/fs/FsInterpreterConfig.scala
@@ -17,7 +17,7 @@ case class FsInterpreterConfig(dtabFile: File) extends InterpreterConfig {
 
   @JsonIgnore
   private[this] def dtab: Activity[Dtab] =
-    Watcher(path.getParent).children.flatMap { children =>
+    Watcher(path.getParent).children.underlying.flatMap { children =>
       children.get(path.getFileName.toString) match {
         case Some(file: Watcher.File.Reg) => file.data
         case _ => Activity.pending

--- a/namer/fs/src/main/resources/META-INF/services/io.buoyant.config.ConfigSerializer
+++ b/namer/fs/src/main/resources/META-INF/services/io.buoyant.config.ConfigSerializer
@@ -1,0 +1,1 @@
+io.buoyant.namer.fs.UpRegSerializer

--- a/namer/fs/src/main/scala/io/buoyant/namer/fs/UpRegSerializer.scala
+++ b/namer/fs/src/main/scala/io/buoyant/namer/fs/UpRegSerializer.scala
@@ -1,0 +1,22 @@
+package io.buoyant.namer.fs
+
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.databind.SerializerProvider
+import com.twitter.io.Buf
+import com.twitter.util.Activity
+import io.buoyant.config.ConfigSerializer
+
+class UpRegSerializer extends ConfigSerializer[Watcher.File.UpReg] {
+
+  override def serialize(
+    value: Watcher.File.UpReg,
+    gen: JsonGenerator,
+    provider: SerializerProvider
+  ): Unit = {
+    value.buf.sample() match {
+      case Activity.Ok(Buf.Utf8(s)) => gen.writeString(s)
+      case Activity.Pending => gen.writeString("pending")
+      case Activity.Failed(e) => gen.writeString("error: " + e.getMessage)
+    }
+  }
+}

--- a/namer/fs/src/main/scala/io/buoyant/namer/fs/WatchState.scala
+++ b/namer/fs/src/main/scala/io/buoyant/namer/fs/WatchState.scala
@@ -1,0 +1,22 @@
+package io.buoyant.namer.fs
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.twitter.util.Time
+import java.nio.file.{Path, WatchEvent}
+
+class WatchState {
+  @JsonIgnore
+  def recordEvent(ev: WatchEvent[_]): Unit = synchronized {
+    lastEventKind = Some(ev.kind().name())
+    ev.context() match {
+      case p: Path => lastEventName = Some(p.toString)
+      case _ =>
+    }
+    lastEventAt = Some(Time.now.toString)
+  }
+
+  // These fields exist to be serialized.
+  protected var lastEventKind: Option[String] = None
+  protected var lastEventName: Option[String] = None
+  protected var lastEventAt: Option[String] = None
+}


### PR DESCRIPTION
It can be difficult to determine the cause of the problem when service discovery information is out of date.  

For the io.l5d.fs namer, we add instrumentation so that we can see the current state of the file system watches and the most recent events received from the OS.  This state can be viewed at `/namer_state/io.l5d.fs.json` in the admin server.

<img width="700" alt="screen shot 2018-07-25 at 1 42 22 pm" src="https://user-images.githubusercontent.com/3979810/43227281-1df51586-9013-11e8-9cda-c6ad4d616467.png">

Fixes #1912 

Signed-off-by: Alex Leong <alex@buoyant.io>