### PR TITLE
Always clear the x-forwarded-client-cert header

### DIFF
--- a/linkerd/protocol/http/src/integration/scala/io/buoyant/linkerd/protocol/ForwardClientCertTest.scala
+++ b/linkerd/protocol/http/src/integration/scala/io/buoyant/linkerd/protocol/ForwardClientCertTest.scala
@@ -102,7 +102,8 @@ class ForwardClientCertTest extends FunSuite {
       val rsp = {
         val req = Request()
         req.host = "clifford"
-        req.headerMap(ForwardClientCertFilter.Header) = "totally_bogus"
+        req.headerMap.add(ForwardClientCertFilter.Header, "Hash=17595BEB34A925D9D5D74E581A47883B6969DF6102227ED4770F5121458684EF;SAN=https://buoyant.io;DNS=upstream;DNS=linkerd;Subject=\"C=US,CN=upstream\"")
+        req.headerMap.add(ForwardClientCertFilter.Header, "Hash=0CE1279F4A837E6BE60110B59EE852F86DDBEFE6011802B8151512342DAB3FE6;SAN=https://buoyant.io;DNS=upstream;DNS=linkerd2;Subject=\"C=US,CN=upstream\"")
         await(client(req))
       }
 

--- a/linkerd/protocol/http/src/integration/scala/io/buoyant/linkerd/protocol/ForwardClientCertTest.scala
+++ b/linkerd/protocol/http/src/integration/scala/io/buoyant/linkerd/protocol/ForwardClientCertTest.scala
@@ -3,6 +3,7 @@ package io.buoyant.linkerd.protocol
 import com.twitter.finagle.http.{Request, Response}
 import io.buoyant.linkerd.Linker
 import io.buoyant.linkerd.tls.TlsUtils.withCerts
+import io.buoyant.router.http.ForwardClientCertFilter
 import io.buoyant.test.FunSuite
 import java.io.FileInputStream
 import java.security.MessageDigest
@@ -54,7 +55,7 @@ class ForwardClientCertTest extends FunSuite {
         }
 
         assert(rsp.contentString == "woof")
-        assert(downstreamRequest.headerMap("x-forwarded-client-cert") == {
+        assert(downstreamRequest.headerMap(ForwardClientCertFilter.Header) == {
           val cf = CertificateFactory.getInstance("X.509")
           val cert = cf.generateCertificate(new FileInputStream(upstreamServiceCert.cert))
           val digest = MessageDigest.getInstance("SHA-256")
@@ -67,6 +68,51 @@ class ForwardClientCertTest extends FunSuite {
         await(router.close())
         await(dog.server.close())
       }
+    }
+  }
+
+  test("clears incoming client certificate") {
+    var downstreamRequest: Request = null
+    val dog = Downstream.mk("dogs") { req =>
+      downstreamRequest = req
+      val rsp = Response()
+      rsp.contentString = "woof"
+      rsp
+    }
+
+    val linkerConfig =
+      s"""
+         |routers:
+         |- protocol: http
+         |  dtab: |
+         |    /p/dog => /$$/inet/127.1/${dog.port} ;
+         |    /svc/clifford => /p/dog ;
+         |  servers:
+         |  - port: 0
+         |  client:
+         |    kind: io.l5d.global
+         |""".stripMargin
+    val linker = Linker.load(linkerConfig)
+    val router = linker.routers.head.initialize()
+    val server = router.servers.head.serve()
+
+    val client = Upstream.mk(server)
+
+    try {
+      val rsp = {
+        val req = Request()
+        req.host = "clifford"
+        req.headerMap(ForwardClientCertFilter.Header) = "totally_bogus"
+        await(client(req))
+      }
+
+      assert(rsp.contentString == "woof")
+      assert(!downstreamRequest.headerMap.contains(ForwardClientCertFilter.Header))
+    } finally {
+      await(client.close())
+      await(server.close())
+      await(router.close())
+      await(dog.server.close())
     }
   }
 }


### PR DESCRIPTION
When Linkerd receives a x-forwarded-client-cert header field in a request, it must remove it or it must reject the request. It must never forward the x-forwarded-client-cert header field because that would allow any client to forge the identity of other clients if the inner application is relying on the x-forwarded-client-cert header field. (Also some applications may look at the x-forwarded-client-cert to determine if the request was sent over HTTPS or HTTP.)

Always clear any incoming x-forwarded-client-cert header.

Fixes #2068 

Signed-off-by: Alex Leong <alex@buoyant.io>