### PR TITLE
Add a ConfigMap interpreter watch state endpoint

### DIFF
--- a/namer/core/src/main/scala/io/buoyant/namer/ConfiguredDtabNamer.scala
+++ b/namer/core/src/main/scala/io/buoyant/namer/ConfiguredDtabNamer.scala
@@ -2,13 +2,17 @@ package io.buoyant.namer
 
 import com.twitter.finagle.Name.Bound
 import com.twitter.finagle._
+import com.twitter.finagle.http.{Request, Response, Status}
 import com.twitter.finagle.naming.NameInterpreter
 import com.twitter.util.{Activity, Future, Var}
+import io.buoyant.admin.Admin
 
 case class ConfiguredDtabNamer(
   configuredDtab: Activity[Dtab],
-  namers: Seq[(Path, Namer)] = Nil
-) extends NameInterpreter with Delegator {
+  namers: Seq[(Path, Namer)] = Nil,
+  uri: Option[String] = None,
+  handler: Option[Service[Request, Response]] = None
+) extends NameInterpreter with Delegator with Admin.WithHandlers {
 
   def bind(localDtab: Dtab, path: Path): Activity[NameTree[Name.Bound]] =
     configuredDtab.flatMap { configuredDtab =>
@@ -51,4 +55,23 @@ case class ConfiguredDtabNamer(
     }
 
   override def dtab: Activity[Dtab] = configuredDtab
+
+  override def adminHandlers: Seq[Admin.Handler] = {
+    val adminUri = uri match {
+      case Some(str) => str
+      case None => "/interpreter_state"
+    }
+
+    val interpreterHandler = handler match {
+      case Some(configuredHandler) => configuredHandler
+      case None => new Service[Request, Response] {
+        override def apply(request: Request): Future[Response] = {
+          val rep = Response(Status.NotFound)
+          rep.contentString = "Interpreter watch state not configured"
+          Future.value(rep)
+        }
+      }
+    }
+    Seq(Admin.Handler(adminUri, interpreterHandler))
+  }
 }

--- a/namerd/core/src/test/scala/io/buoyant/namerd/ConfiguredDtabNamerTest.scala
+++ b/namerd/core/src/test/scala/io/buoyant/namerd/ConfiguredDtabNamerTest.scala
@@ -46,4 +46,14 @@ class ConfiguredDtabNamerTest extends FunSuite {
       ))))
     } finally Await.result(closer.close())
   }
+
+  test("use default interpreter_state"){
+    val dtabState = Var[Activity.State[Dtab]](Activity.Pending)
+    val interpreter = ConfiguredDtabNamer(Activity(dtabState))
+    interpreter.adminHandlers.headOption match {
+      case Some(handler) =>
+        assert(handler.url == "/interpreter_state")
+      case None => fail("invalid uri used for default interpreter state")
+    }
+  }
 }

--- a/namerd/core/src/test/scala/io/buoyant/namerd/ConfiguredDtabNamerTest.scala
+++ b/namerd/core/src/test/scala/io/buoyant/namerd/ConfiguredDtabNamerTest.scala
@@ -46,14 +46,4 @@ class ConfiguredDtabNamerTest extends FunSuite {
       ))))
     } finally Await.result(closer.close())
   }
-
-  test("use default interpreter_state"){
-    val dtabState = Var[Activity.State[Dtab]](Activity.Pending)
-    val interpreter = ConfiguredDtabNamer(Activity(dtabState))
-    interpreter.adminHandlers.headOption match {
-      case Some(handler) =>
-        assert(handler.url == "/interpreter_state")
-      case None => fail("invalid uri used for default interpreter state")
-    }
-  }
 }


### PR DESCRIPTION
This PR adds a watch state endpoint for the ConfigMap interpreter to observe config map dtabs stored in a Kubernetes environment. The endpoint can be reached using `http://<linkerd_ip>:<admin_port>/<router_label>/interpreter_state/io.l5d.k8s.configmap.json`

Example of a config map dtabs watch state
```json
{
   "state":{
      "running":true,
      "lastStartedAt":"2018-07-30 16:57:59 +0000",
      "lastUpdatedAt":"2018-07-30 16:58:21 +0000",
      "value":"/srv=>/#/io.l5d.k8s;/svc=>/$/io.buoyant.http.domainToPathPfx/srv"
   },
   "watch":{
      "request":"GET /api/v1/watch/namespaces/default/configmaps/dtabs",
      "lastRequestAt":"2018-07-30 16:58:21 +0000",
      "response":{
         "data":{
            "my-dtabs":"# version NzE1Ng==\n/srv  => /#/io.l5d.k8s ;\n/svc  => /$/io.buoyant.http.domainToPathPfx/srv\n"
         },
         "kind":"ConfigMap",
         "metadata":{
            "name":"dtabs",
            "namespace":"default",
            "selfLink":"/api/v1/namespaces/default/configmaps/dtabs",
            "uid":"4895d3fc-91ea-11e8-ad90-080027fcfc8a",
            "resourceVersion":"421",
            "creationTimestamp":"2018-07-27T22:13:26Z"
         },
         "apiVersion":"v1"
      },
      "lastResponseAt":"2018-07-30 16:58:21 +0000",
      "lastStreamStartAt":"2018-07-30 16:58:21 +0000",
      "lastStreamData":{
         "type":"ADDED",
         "object":{
            "data":{
               "my-dtabs":"# version NzE1Ng==\n/srv  => /#/io.l5d.k8s ;\n/svc  => /$/io.buoyant.http.domainToPathPfx/srv\n"
            },
            "kind":"ConfigMap",
            "metadata":{
               "name":"dtabs",
               "namespace":"default",
               "selfLink":"/api/v1/namespaces/default/configmaps/dtabs",
               "uid":"4895d3fc-91ea-11e8-ad90-080027fcfc8a",
               "resourceVersion":"421",
               "creationTimestamp":"2018-07-27T22:13:26Z"
            },
            "apiVersion":"v1"
         }
      },
      "lastStreamDataAt":"2018-07-30 16:58:21 +0000",
      "streaming":true
   }
}
```

Tests were done using minikube with a config map and a local Linkerd instance. 

fixes #1917

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>