### PR TITLE
Exclude Marathon tasks in health-check grace period (#2098)

### DIFF
--- a/marathon/src/main/scala/io/buoyant/marathon/v2/Api.scala
+++ b/marathon/src/main/scala/io/buoyant/marathon/v2/Api.scala
@@ -44,6 +44,8 @@ object Api {
     state: Option[String]
   )
 
+  final case class HealthCheck()
+
   final case class TaskIpAddress(
     ipAddress: Option[String]
   )
@@ -64,6 +66,7 @@ object Api {
   final case class App(
     id: Option[String],
     ipAddress: Option[AppIpAddress],
+    healthChecks: Option[Seq[HealthCheck]],
     tasks: Option[Seq[Task]]
   )
 
@@ -73,6 +76,11 @@ object Api {
 
   final case class AppRsp(
     app: Option[App] = None
+  )
+
+  final case class TaskWithHealthCheckInfo(
+    task: Task,
+    numberOfHealthChecks: Int
   )
 
   object discoveryPort {
@@ -92,9 +100,9 @@ object Api {
   }
 
   object healthyHostPort {
-    def unapply(task: Task): Option[(String, Int)] = {
-      if (isHealthy(task)) {
-        hostPort.unapply(task)
+    def unapply(extendedTask: TaskWithHealthCheckInfo): Option[(String, Int)] = {
+      if (isHealthy(extendedTask)) {
+        hostPort.unapply(extendedTask.task)
       } else {
         None
       }
@@ -108,13 +116,21 @@ object Api {
   }
 
   object healthyIpAddress {
-    def unapply(task: Task): Option[String] = {
-      if (isHealthy(task)) {
-        ipAddress.unapply(task)
+    def unapply(extendedTask: TaskWithHealthCheckInfo): Option[String] = {
+      if (isHealthy(extendedTask)) {
+        ipAddress.unapply(extendedTask.task)
       } else {
         None
       }
     }
+  }
+
+  object healthCheckCount {
+    def unapply(healthChecks: Option[Seq[HealthCheck]]): Option[Int] =
+      healthChecks match {
+        case Some(healthCheckSeq) => Some(healthCheckSeq.size)
+        case None => Some(0)
+      }
   }
 
   def apply(client: Client, uriPrefix: String, useHealthCheck: Boolean): Api =
@@ -146,33 +162,40 @@ object Api {
   private[this] def toAppIds(appsRsp: AppsRsp): Api.AppIds = {
     appsRsp.apps match {
       case Some(apps) =>
-        apps.collect { case App(Some(id), _, _) => Path.read(id.toLowerCase) }.toSet
+        apps.collect { case App(Some(id), _, _, _) => Path.read(id.toLowerCase) }.toSet
       case None => Set.empty
     }
   }
 
   private[v2] def toAddresses(appRsp: AppRsp, useHealthCheck: Boolean): Set[Address] =
     appRsp.app match {
-      case Some(App(_, discoveryPort(port), Some(tasks))) =>
-        tasks.collect {
-          case ipAddress(host) if !useHealthCheck => Address(host, port)
-          case healthyIpAddress(host) => Address(host, port)
-        }.toSet
-      case Some(App(_, _, Some(tasks))) =>
-        tasks.collect {
-          case hostPort(host, port) if !useHealthCheck => Address(host, port)
-          case healthyHostPort(host, port) => Address(host, port)
-        }.toSet
+      case Some(App(_, discoveryPort(port), healthCheckCount(count), Some(tasks))) =>
+        if (!useHealthCheck)
+          tasks.collect { case ipAddress(host) => Address(host, port) }.toSet
+        else
+          tasks.map(TaskWithHealthCheckInfo(_, count)).collect {
+            case healthyIpAddress(host) => Address(host, port)
+          }.toSet
+      case Some(App(_, _, healthCheckCount(count), Some(tasks))) =>
+        if (!useHealthCheck)
+          tasks.collect { case hostPort(host, port) => Address(host, port) }.toSet
+        else
+          tasks.map(TaskWithHealthCheckInfo(_, count)).collect {
+            case healthyHostPort(host, port) => Address(host, port)
+          }.toSet
       case _ => Set.empty
     }
 
-  private[this] def isHealthy(task: Task): Boolean =
-    task match {
-      case Task(_, _, _, _, Some(healthCheckResults), Some(state)) =>
+  private[this] def isHealthy(extendedTask: TaskWithHealthCheckInfo): Boolean = {
+    extendedTask.task match {
+      case Task(_, _, _, _, Some(healthCheckResults), Some(state)) if extendedTask.numberOfHealthChecks > 0 =>
         state == taskRunning &&
-          healthCheckResults.forall(_ == HealthCheckResult(Some(true)))
+          healthCheckResults.count(_ == HealthCheckResult(Some(true))) >= extendedTask.numberOfHealthChecks
+      case Task(_, _, _, _, _, Some(state)) =>
+        state == taskRunning && extendedTask.numberOfHealthChecks == 0
       case _ => false
     }
+  }
 }
 
 private class AppIdApi(client: Api.Client, apiPrefix: String, useHealthCheck: Boolean)

--- a/marathon/src/test/scala/io/buoyant/marathon/v2/ApiTest.scala
+++ b/marathon/src/test/scala/io/buoyant/marathon/v2/ApiTest.scala
@@ -33,6 +33,30 @@ class ApiTest extends FunSuite with Awaits with Exceptions {
       "app": {
         "id": "/foo",
         "cmd": "foo cmd",
+        "healthChecks": [
+          {
+            "gracePeriodSeconds": 30,
+            "intervalSeconds": 5,
+            "maxConsecutiveFailures": 10,
+            "path": "/health",
+            "portIndex": 0,
+            "protocol": "MESOS_HTTP",
+            "ipProtocol": "IPv4",
+            "timeoutSeconds": 10,
+            "delaySeconds": 15
+          },
+          {
+            "gracePeriodSeconds": 15,
+            "intervalSeconds": 10,
+            "maxConsecutiveFailures": 10,
+            "path": "/health2",
+            "portIndex": 0,
+            "protocol": "MESOS_HTTP",
+            "ipProtocol": "IPv4",
+            "timeoutSeconds": 15,
+            "delaySeconds": 15
+          }
+        ],
         "tasks": [
           {
             "id": "booksId",
@@ -75,6 +99,24 @@ class ApiTest extends FunSuite with Awaits with Exceptions {
               }
             ],
             "state": "TASK_KILLING"
+          },
+          {
+            "id": "booksId4",
+            "host": "13.14.15.16",
+            "ports": [7009, 7010, 7011],
+            "healthCheckResults": [],
+            "state": "TASK_RUNNING"
+          },
+          {
+            "id": "booksId5",
+            "host": "17.18.19.20",
+            "ports": [7012, 7013, 7014],
+            "healthCheckResults": [
+              {
+                "alive": true
+              }
+            ],
+            "state": "TASK_RUNNING"
           }
         ]
       }
@@ -86,6 +128,30 @@ class ApiTest extends FunSuite with Awaits with Exceptions {
       "app": {
         "id": "/foo",
         "cmd": "foo cmd",
+        "healthChecks": [
+          {
+            "gracePeriodSeconds": 30,
+            "intervalSeconds": 5,
+            "maxConsecutiveFailures": 10,
+            "path": "/health",
+            "portIndex": 0,
+            "protocol": "MESOS_HTTP",
+            "ipProtocol": "IPv4",
+            "timeoutSeconds": 10,
+            "delaySeconds": 15
+          },
+          {
+            "gracePeriodSeconds": 15,
+            "intervalSeconds": 10,
+            "maxConsecutiveFailures": 10,
+            "path": "/health2",
+            "portIndex": 0,
+            "protocol": "MESOS_HTTP",
+            "ipProtocol": "IPv4",
+            "timeoutSeconds": 15,
+            "delaySeconds": 15
+          }
+        ],
         "tasks": [
           {
             "id": "booksId",
@@ -146,8 +212,175 @@ class ApiTest extends FunSuite with Awaits with Exceptions {
               }
             ],
             "state": "TASK_KILLING"
+          },
+          {
+            "id": "booksId4",
+            "host": "13.14.15.16",
+            "ports": [],
+            "ipAddresses": [
+              {
+                "ipAddress": "250.1.62.3",
+                "protocol": "IPv4"
+              }
+            ],
+            "healthCheckResults": [],
+            "state": "TASK_RUNNING"
+          },
+          {
+            "id": "booksId5",
+            "host": "16.17.18.19",
+            "ports": [],
+            "ipAddresses": [
+              {
+                "ipAddress": "250.1.62.4",
+                "protocol": "IPv4"
+              }
+            ],
+            "healthCheckResults": [
+              {
+                "alive": true
+              }
+            ],
+            "state": "TASK_RUNNING"
           }
+        ],
+        "ipAddress": {
+          "discovery": {
+            "ports": [
+              {
+                "labels": {},
+                "name": "http",
+                "number": 8080,
+                "protocol": "tcp"
+              }
+            ]
+          }
+        }
+      }
+    }
+  """)
 
+  val appBufNoHealthCheck = Buf.Utf8("""
+    {
+      "app": {
+        "id": "/foo",
+        "cmd": "foo cmd",
+        "tasks": [
+          {
+            "id": "booksId",
+            "host": "1.2.3.4",
+            "ports": [7000, 7001, 7002],
+            "healthCheckResults": [],
+            "state": "TASK_RUNNING"
+          },
+          {
+            "id": "booksId2",
+            "host": "5.6.7.8",
+            "ports": [7003, 7004, 7005],
+            "healthCheckResults": [],
+            "state": "TASK_KILLING"
+          }
+        ]
+      }
+    }
+  """)
+
+  val ipAppBufNoHealthCheck = Buf.Utf8("""
+    {
+      "app": {
+        "id": "/foo",
+        "cmd": "foo cmd",
+        "tasks": [
+          {
+            "id": "booksId",
+            "host": "1.2.3.4",
+            "ports": [],
+            "ipAddresses": [
+              {
+                "ipAddress": "250.1.62.0",
+                "protocol": "IPv4"
+              }
+            ],
+            "healthCheckResults": [],
+            "state": "TASK_RUNNING"
+          },
+          {
+            "id": "booksId2",
+            "host": "5.6.7.8",
+            "ports": [7003, 7004, 7005],
+            "healthCheckResults": [],
+            "state": "TASK_KILLING"
+          }
+        ],
+        "ipAddress": {
+          "discovery": {
+            "ports": [
+              {
+                "labels": {},
+                "name": "http",
+                "number": 8080,
+                "protocol": "tcp"
+              }
+            ]
+          }
+        }
+      }
+    }
+ """)
+
+  val appBufEmptyHealthCheckList = Buf.Utf8("""
+    {
+      "app": {
+        "id": "/foo",
+        "cmd": "foo cmd",
+        "healthChecks": [],
+        "tasks": [
+          {
+            "id": "booksId",
+            "host": "1.2.3.4",
+            "ports": [7000, 7001, 7002],
+            "healthCheckResults": [],
+            "state": "TASK_RUNNING"
+          },
+          {
+            "id": "booksId2",
+            "host": "5.6.7.8",
+            "ports": [7003, 7004, 7005],
+            "healthCheckResults": [],
+            "state": "TASK_KILLING"
+          }
+        ]
+      }
+    }
+ """)
+
+  val ipAppBufEmptyHealthCheckList = Buf.Utf8("""
+    {
+      "app": {
+        "id": "/foo",
+        "cmd": "foo cmd",
+        "healthChecks": [],
+        "tasks": [
+          {
+            "id": "booksId",
+            "host": "1.2.3.4",
+            "ports": [],
+            "ipAddresses": [
+              {
+                "ipAddress": "250.1.62.0",
+                "protocol": "IPv4"
+              }
+            ],
+            "healthCheckResults": [],
+            "state": "TASK_RUNNING"
+          },
+          {
+            "id": "booksId2",
+            "host": "5.6.7.8",
+            "ports": [7003, 7004, 7005],
+            "healthCheckResults": [],
+            "state": "TASK_KILLING"
+          }
         ],
         "ipAddress": {
           "discovery": {
@@ -202,7 +435,9 @@ class ApiTest extends FunSuite with Awaits with Exceptions {
     assert(response == Set(
       Address("1.2.3.4", 7000),
       Address("5.6.7.8", 7003),
-      Address("9.10.11.12", 7006)
+      Address("9.10.11.12", 7006),
+      Address("13.14.15.16", 7009),
+      Address("17.18.19.20", 7012)
     ))
   }
 
@@ -213,7 +448,9 @@ class ApiTest extends FunSuite with Awaits with Exceptions {
     assert(response == Set(
       Address("250.1.62.0", 8080),
       Address("250.1.62.1", 8080),
-      Address("250.1.62.2", 8080)
+      Address("250.1.62.2", 8080),
+      Address("250.1.62.3", 8080),
+      Address("250.1.62.4", 8080)
     ))
   }
 
@@ -224,7 +461,7 @@ class ApiTest extends FunSuite with Awaits with Exceptions {
     assert(response.size == 0)
   }
 
-  test("getAddrs endpoint returns a seq of healthly addresses when useHealthCheck is enabled") {
+  test("getAddrs endpoint returns a seq of healthy addresses when useHealthCheck is enabled") {
     val service = stubService(appBuf)
 
     val response = await(Api(service, "prefix", true).getAddrs(Path.Utf8("foo")))
@@ -233,8 +470,44 @@ class ApiTest extends FunSuite with Awaits with Exceptions {
     ))
   }
 
-  test("getAddrs endpoint returns a seq of healthly addresses when useHealthCheck is enabled for Ip-Per-Task") {
+  test("getAddrs endpoint returns a seq of healthy addresses when useHealthCheck is enabled for Ip-Per-Task") {
     val service = stubService(ipAppBuf)
+
+    val response = await(Api(service, "prefix", true).getAddrs(Path.Utf8("foo")))
+    assert(response == Set(
+      Address("250.1.62.0", 8080)
+    ))
+  }
+
+  test("getAddrs endpoint returns a seq of healthy addresses when useHealthCheck is enabled and no health checks are defined") {
+    val service = stubService(appBufNoHealthCheck)
+
+    val response = await(Api(service, "prefix", true).getAddrs(Path.Utf8("foo")))
+    assert(response == Set(
+      Address("1.2.3.4", 7000)
+    ))
+  }
+
+  test("getAddrs endpoint returns a seq of healthy addresses when useHealthCheck is enabled and health check list is empty") {
+    val service = stubService(appBufEmptyHealthCheckList)
+
+    val response = await(Api(service, "prefix", true).getAddrs(Path.Utf8("foo")))
+    assert(response == Set(
+      Address("1.2.3.4", 7000)
+    ))
+  }
+
+  test("getAddrs endpoint returns a seq of healthy addresses when useHealthCheck is enabled for Ip-Per-Task and no health checks are defined") {
+    val service = stubService(ipAppBufNoHealthCheck)
+
+    val response = await(Api(service, "prefix", true).getAddrs(Path.Utf8("foo")))
+    assert(response == Set(
+      Address("250.1.62.0", 8080)
+    ))
+  }
+
+  test("getAddrs endpoint returns a seq of healthy addresses when useHealthCheck is enabled for Ip-Per-Task and health check list is empty") {
+    val service = stubService(ipAppBufEmptyHealthCheckList)
 
     val response = await(Api(service, "prefix", true).getAddrs(Path.Utf8("foo")))
     assert(response == Set(


### PR DESCRIPTION
This fixes #2098. The Marathon namer has a `useHealthCheck` option that allows for excluding tasks that Marathon claims to be unhealthy. However, if a Marathon app has a health-check grace period defined, a freshly started task will show up as running, but without any health-related status.
In this case the Marathon API returns a `TASK_RUNNING` status, but there aren't any `healthCheckResults` present in the response. Obviously, Linkerd should not route any request to such task and should wait until it shows up as healthy.

My change adds a check if a Marathon app has any health checks defined (a non-empty `healthChecks` attribute of the `app` record), and, if so, expect the same number of `healthCheckResults` to be positive before routing any request to such task.

I have added unit tests that include the `healthChecks` attribute in the Marathon API response and verify that the Marathon namer behavior is as expected.

Signed-off-by: Tomasz Rogozik <trogozik@applause.com>