### PR TITLE
Correct documentation about rewrite plugin.

### DIFF
--- a/linkerd/docs/namer.md
+++ b/linkerd/docs/namer.md
@@ -812,10 +812,8 @@ dtab: |
 
 A namer that completely rewrites a path.  This is useful for doing arbitrary
 reordering of the path segments that is not possible using standard prefix
-replacement.  While this is a general purpose tool for reordering path
-segments, it cannot be used to modify or split individual segments (for
-modification or splitting of individual segments, see the rewriting namers
-section below).
+replacement. In addition to reordering path segments, this tool can be used
+to modify or split individual segments using regex capture groups.
 
 If the name matches the pattern in the config, it will be replaced by the
 name in the config.  Additionally, any variables in the pattern will capture


### PR DESCRIPTION
Documentation about the `io.l5d.rewrite` plugin is a little out of date w.r.t. to the current functionality.
This PR adds a new description that specifies that path segments can now be split.

fixes #2100 

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>