### PR TITLE
Update Istio features with a deprecation notice.

### DIFF
--- a/interpreter/istio/src/main/scala/io/buoyant/interpreter/k8s/istio/IstioInterpreterInitializer.scala
+++ b/interpreter/istio/src/main/scala/io/buoyant/interpreter/k8s/istio/IstioInterpreterInitializer.scala
@@ -33,8 +33,7 @@ case class IstioInterpreterConfig(
   @JsonIgnore
   override val experimentalRequired = true
 
-  @JsonIgnore
-  val _ = Logger.get(this.getClass.getName).warning("Istio K8S Interpreter has been deprecated since version 1.4.7")
+  Logger.get(this.getClass.getName).warning("Istio K8S Interpreter has been deprecated since version 1.4.7")
 
   @JsonIgnore
   val prefix: Path = Path.read("/io.l5d.k8s.istio")

--- a/interpreter/istio/src/main/scala/io/buoyant/interpreter/k8s/istio/IstioInterpreterInitializer.scala
+++ b/interpreter/istio/src/main/scala/io/buoyant/interpreter/k8s/istio/IstioInterpreterInitializer.scala
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import com.twitter.finagle.naming.NameInterpreter
 import com.twitter.finagle.tracing.NullTracer
 import com.twitter.finagle.{Http, Path, Stack, param}
+import com.twitter.logging.Logger
 import io.buoyant.config.types.Port
 import io.buoyant.k8s.{SetHostFilter, SingleNsNamer}
 import io.buoyant.k8s.v1.Api
@@ -31,6 +32,9 @@ case class IstioInterpreterConfig(
 
   @JsonIgnore
   override val experimentalRequired = true
+
+  @JsonIgnore
+  val _ = Logger.get(this.getClass.getName).warning("Istio K8S Interpreter has been deprecated since version 1.4.7")
 
   @JsonIgnore
   val prefix: Path = Path.read("/io.l5d.k8s.istio")

--- a/linkerd/docs/namer.md
+++ b/linkerd/docs/namer.md
@@ -499,7 +499,7 @@ port-name | yes | The port name.
 svc-name | yes | The name of the service.
 label-value | yes if `labelSelector` is defined | The label value used to filter services.
 
-### Istio Configuration
+### Istio Configuration (Deprecated)
 
 > Configure an Istio namer
 
@@ -528,7 +528,7 @@ experimental | _required_ | Because this namer is still considered experimental,
 host | `istio-manager.default.svc.cluster.local` | The host of the Istio-Manager.
 port | `8080` | The port of the Istio-Manager.
 
-### Istio Path Parameters
+### Istio Path Parameters (Deprecated)
 
 > Dtab Path Format
 

--- a/linkerd/docs/protocol-h2.md
+++ b/linkerd/docs/protocol-h2.md
@@ -295,7 +295,7 @@ namespace | N/A | The Kubernetes namespace.
 port | N/A | The port name.
 svc | N/A | The name of the service.
 
-### HTTP/2 Istio Identifier
+### HTTP/2 Istio Identifier (Deprecated)
 
 kind: `io.l5d.k8s.istio`
 
@@ -358,7 +358,7 @@ Key | Default Value | Description
 --- | ------------- | -----------
 kind | _required_ | Only [`io.l5d.k8s.istio`](#istio-request-authorizer) is currently supported.
 
-### HTTP/2 Istio Request Authorizer
+### HTTP/2 Istio Request Authorizer (Deprecated)
 
 kind: `io.l5d.k8s.istio`.
 

--- a/linkerd/docs/protocol-http.md
+++ b/linkerd/docs/protocol-http.md
@@ -395,7 +395,7 @@ svc | N/A | The name of the service.
 
 
 <a href="istio-identifier"></a>
-### Istio Identifier
+### Istio Identifier (Deprecated)
 
 kind: `io.l5d.k8s.istio`
 
@@ -494,7 +494,7 @@ Key | Default Value | Description
 kind | _required_ | Only [`io.l5d.k8s.istio`](#istio-request-authorizer) is currently supported.
 
 <a name="istio-request-authorizer"></a>
-### Istio Request Authorizer
+### Istio Request Authorizer (Deprecated)
 
 kind: `io.l5d.k8s.istio`.
 

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/istio/IstioIdentifier.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/istio/IstioIdentifier.scala
@@ -40,8 +40,7 @@ case class IstioIdentifierConfig(
 ) extends H2IdentifierConfig {
   import IstioServices._
 
-  @JsonIgnore
-  val _ = Logger.get(this.getClass.getName).warning("Istio HTTP/2 Identifier has been deprecated since version 1.4.7")
+  Logger.get(this.getClass.getName).warning("Istio HTTP/2 Identifier has been deprecated since version 1.4.7")
 
   @JsonIgnore
   override def newIdentifier(params: Stack.Params) = {

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/istio/IstioIdentifier.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/istio/IstioIdentifier.scala
@@ -3,6 +3,7 @@ package io.buoyant.linkerd.protocol.h2.istio
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.twitter.finagle.buoyant.h2._
 import com.twitter.finagle.{Dtab, Path, Stack}
+import com.twitter.logging.Logger
 import com.twitter.util.Future
 import io.buoyant.config.types.Port
 import io.buoyant.k8s.istio._
@@ -38,6 +39,9 @@ case class IstioIdentifierConfig(
   mixerPort: Option[Port]
 ) extends H2IdentifierConfig {
   import IstioServices._
+
+  @JsonIgnore
+  val _ = Logger.get(this.getClass.getName).warning("Istio HTTP/2 Identifier has been deprecated since version 1.4.7")
 
   @JsonIgnore
   override def newIdentifier(params: Stack.Params) = {

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/istio/IstioIngressIdentifier.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/istio/IstioIngressIdentifier.scala
@@ -50,8 +50,7 @@ case class IstioIngressIdentifierConfig(
 ) extends H2IdentifierConfig with ClientConfig {
   import IstioServices._
 
-  @JsonIgnore
-  val _ = Logger.get(this.getClass.getName).warning("Istio HTTP/2 Ingress Identifier has been deprecated since version 1.4.7")
+  Logger.get(this.getClass.getName).warning("Istio HTTP/2 Ingress Identifier has been deprecated since version 1.4.7")
 
   def mkK8sApiClient() = mkClient(Params.empty).configured(Label("ingress-identifier"))
 

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/istio/IstioIngressIdentifier.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/istio/IstioIngressIdentifier.scala
@@ -5,6 +5,7 @@ import com.twitter.finagle.Stack.Params
 import com.twitter.finagle._
 import com.twitter.finagle.buoyant.h2.Request
 import com.twitter.finagle.param.Label
+import com.twitter.logging.Logger
 import com.twitter.util.Future
 import io.buoyant.config.types.Port
 import io.buoyant.k8s.istio._
@@ -48,6 +49,9 @@ case class IstioIngressIdentifierConfig(
   mixerPort: Option[Port]
 ) extends H2IdentifierConfig with ClientConfig {
   import IstioServices._
+
+  @JsonIgnore
+  val _ = Logger.get(this.getClass.getName).warning("Istio HTTP/2 Ingress Identifier has been deprecated since version 1.4.7")
 
   def mkK8sApiClient() = mkClient(Params.empty).configured(Label("ingress-identifier"))
 

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/istio/IstioRequestAuthorizer.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/istio/IstioRequestAuthorizer.scala
@@ -26,8 +26,7 @@ case class IstioRequestAuthorizerConfig(
 ) extends H2RequestAuthorizerConfig {
   import IstioServices._
 
-  @JsonIgnore
-  val _ = Logger.get(this.getClass.getName).warning("Istio HTTP/2 Request Authorizer has been deprecated since version 1.4.7")
+  Logger.get(this.getClass.getName).warning("Istio HTTP/2 Request Authorizer has been deprecated since version 1.4.7")
 
   @JsonIgnore
   override def role = Stack.Role("IstioRequestAuthorizer")

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/istio/IstioRequestAuthorizer.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/istio/IstioRequestAuthorizer.scala
@@ -3,6 +3,7 @@ package io.buoyant.linkerd.protocol.h2.istio
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.twitter.finagle.{Filter, Stack}
 import com.twitter.finagle.buoyant.h2.{Request, Response, Status, Stream => H2Stream}
+import com.twitter.logging.Logger
 import com.twitter.util.{Duration, Try}
 import io.buoyant.config.types.Port
 import io.buoyant.k8s.istio.mixer.MixerClient
@@ -24,6 +25,9 @@ case class IstioRequestAuthorizerConfig(
   mixerPort: Option[Port] = Some(Port(DefaultMixerPort))
 ) extends H2RequestAuthorizerConfig {
   import IstioServices._
+
+  @JsonIgnore
+  val _ = Logger.get(this.getClass.getName).warning("Istio HTTP/2 Request Authorizer has been deprecated since version 1.4.7")
 
   @JsonIgnore
   override def role = Stack.Role("IstioRequestAuthorizer")

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/istio/IstioIdentifier.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/istio/IstioIdentifier.scala
@@ -1,7 +1,9 @@
 package io.buoyant.linkerd.protocol.http.istio
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.twitter.finagle.http.Request
 import com.twitter.finagle.{Dtab, Path, Stack}
+import com.twitter.logging.Logger
 import com.twitter.util.Future
 import io.buoyant.config.types.Port
 import io.buoyant.k8s.istio._
@@ -40,6 +42,9 @@ case class IstioIdentifierConfig(
   mixerPort: Option[Port]
 ) extends HttpIdentifierConfig {
   import IstioServices._
+
+  @JsonIgnore
+  val _ = Logger.get(this.getClass.getName).warning("Istio HTTP Identifier has been deprecated since version 1.4.7")
 
   override def newIdentifier(
     prefix: Path,

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/istio/IstioIdentifier.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/istio/IstioIdentifier.scala
@@ -43,8 +43,7 @@ case class IstioIdentifierConfig(
 ) extends HttpIdentifierConfig {
   import IstioServices._
 
-  @JsonIgnore
-  val _ = Logger.get(this.getClass.getName).warning("Istio HTTP Identifier has been deprecated since version 1.4.7")
+  Logger.get(this.getClass.getName).warning("Istio HTTP Identifier has been deprecated since version 1.4.7")
 
   override def newIdentifier(
     prefix: Path,

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/istio/IstioIngressIdentifier.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/istio/IstioIngressIdentifier.scala
@@ -50,8 +50,7 @@ case class IstioIngressIdentifierConfig(
 ) extends HttpIdentifierConfig with ClientConfig {
   import IstioServices._
 
-  @JsonIgnore
-  val _ = Logger.get(this.getClass.getName).warning("Istio HTTP Ingress Identifier has been deprecated since version 1.4.7")
+  Logger.get(this.getClass.getName).warning("Istio HTTP Ingress Identifier has been deprecated since version 1.4.7")
 
   protected def mkK8sApiClient() = mkClient(Params.empty).configured(Label("ingress-identifier"))
 

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/istio/IstioIngressIdentifier.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/istio/IstioIngressIdentifier.scala
@@ -5,6 +5,7 @@ import com.twitter.finagle.Stack.Params
 import com.twitter.finagle._
 import com.twitter.finagle.http.Request
 import com.twitter.finagle.param.Label
+import com.twitter.logging.Logger
 import com.twitter.util.Future
 import io.buoyant.config.types.Port
 import io.buoyant.k8s.{ClientConfig, IngressCache}
@@ -48,6 +49,9 @@ case class IstioIngressIdentifierConfig(
   mixerPort: Option[Port]
 ) extends HttpIdentifierConfig with ClientConfig {
   import IstioServices._
+
+  @JsonIgnore
+  val _ = Logger.get(this.getClass.getName).warning("Istio HTTP Ingress Identifier has been deprecated since version 1.4.7")
 
   protected def mkK8sApiClient() = mkClient(Params.empty).configured(Label("ingress-identifier"))
 

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/istio/IstioRequestAuthorizer.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/istio/IstioRequestAuthorizer.scala
@@ -3,6 +3,7 @@ package io.buoyant.linkerd.protocol.http.istio
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.twitter.finagle.{Filter, Stack}
 import com.twitter.finagle.http.{Request, Response, Status, Version}
+import com.twitter.logging.Logger
 import com.twitter.util._
 import io.buoyant.config.types.Port
 import io.buoyant.k8s.istio.mixer.MixerClient
@@ -23,6 +24,9 @@ case class IstioRequestAuthorizerInitializerConfig(
   mixerPort: Option[Port] = Some(Port(DefaultMixerPort))
 ) extends HttpRequestAuthorizerConfig {
   import IstioServices._
+
+  @JsonIgnore
+  val _ = Logger.get(this.getClass.getName).warning("Istio HTTP Request Authorizer has been deprecated since version 1.4.7")
 
   @JsonIgnore
   override def role = Stack.Role("IstioRequestAuthorizer")

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/istio/IstioRequestAuthorizer.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/istio/IstioRequestAuthorizer.scala
@@ -25,8 +25,7 @@ case class IstioRequestAuthorizerInitializerConfig(
 ) extends HttpRequestAuthorizerConfig {
   import IstioServices._
 
-  @JsonIgnore
-  val _ = Logger.get(this.getClass.getName).warning("Istio HTTP Request Authorizer has been deprecated since version 1.4.7")
+  Logger.get(this.getClass.getName).warning("Istio HTTP Request Authorizer has been deprecated since version 1.4.7")
 
   @JsonIgnore
   override def role = Stack.Role("IstioRequestAuthorizer")


### PR DESCRIPTION
The Istio integration started off as an experiment to provide support for running Linkerd together with Istio's control plane. However, Linkerd's Istio integration has not seen any significant use as discussed in #2092.

This PR adds deprecation notices to docs as well as adds a warning when any of the Istio configurations are loaded at startup.

fixes #2092

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>