### PR TITLE
Switch to AsyncAppender for logging

### DIFF
--- a/linkerd/main/src/main/resources/log4j.properties
+++ b/linkerd/main/src/main/resources/log4j.properties
@@ -1,5 +1,6 @@
 log4j.rootLogger=WARN, stderr
-log4j.appender.stderr=org.apache.log4j.ConsoleAppender
-log4j.appender.stderr.Target=System.err
+log4j.appender.stderr=org.apache.log4j.AsyncAppender
 log4j.appender.stderr.layout=org.apache.log4j.PatternLayout
 log4j.appender.stderr.layout.ConversionPattern=%p %d{MMdd HH:mm:ss.SSS z} %t: %m%n
+log4j.appender.async=org.apache.log4j.AsyncAppender
+log4j.appender.async.appenders=console

--- a/namerd/main/src/main/resources/log4j.properties
+++ b/namerd/main/src/main/resources/log4j.properties
@@ -1,5 +1,6 @@
 log4j.rootLogger=WARN, stderr
-log4j.appender.stderr=org.apache.log4j.ConsoleAppender
-log4j.appender.stderr.Target=System.err
+log4j.appender.stderr=org.apache.log4j.AsyncAppender
 log4j.appender.stderr.layout=org.apache.log4j.PatternLayout
 log4j.appender.stderr.layout.ConversionPattern=%p %d{MMdd HH:mm:ss.SSS z} %t: %m%n
+log4j.appender.async=org.apache.log4j.AsyncAppender
+log4j.appender.async.appenders=console


### PR DESCRIPTION
Switch to AsyncAppender for logging that internally uses circular buffer and background thread to write