### PR TITLE
Fix for Namerd SRV record pollution issue => #2095 

### DIFF
--- a/namer/dnssrv/src/integration/scala/io/buoyant/namer/dnssrv/DnsSrvNamerIntegrationTest.scala
+++ b/namer/dnssrv/src/integration/scala/io/buoyant/namer/dnssrv/DnsSrvNamerIntegrationTest.scala
@@ -13,10 +13,9 @@ class DnsSrvNamerIntegrationTest extends FunSuite with Awaits with Matchers {
   test("can resolve some public SRV record") {
     val namer = new DnsSrvNamer(
       Path.empty,
-      new DNS.ExtendedResolver,
+      () => new DNS.ExtendedResolver,
       Duration.Zero,
-      new NullStatsReceiver,
-      FuturePool.unboundedPool
+      new NullStatsReceiver
     )(DefaultTimer)
     await(namer.lookup(Path.read("/_http._tcp.mxtoolbox.com")).toFuture) match {
       case NameTree.Leaf(Name.Bound(varAddr)) => varAddr.sample() match {


### PR DESCRIPTION
As described in #2095, we observed SRV record namer suffer pollution for a certain period of run time - after debugging through, we observed for some reasons the cache in Lookup object is polluted - which means some DNS enters into bad state and can never be recovered.

My attempt is to ensure the proper isolation for each resolver and Lookup object and expose more internal metrics and log for the namer.

It has been running in production 3 weeks and everything seems fine. 


Sample metrics

```
  "namer/#/io.l5d.dnssrv/#/io.l5d.dnssrv/lookup_dns/failed/host not found/1.staging.offerup.services/total" : 1,
  "namer/#/io.l5d.dnssrv/#/io.l5d.dnssrv/lookup_dns/failed/host not found/2.staging.offerup.services/total" : 1,
  "namer/#/io.l5d.dnssrv/#/io.l5d.dnssrv/lookup_dns/failed/host not found/3.staging.offerup.services/total" : 1,
  "namer/#/io.l5d.dnssrv/#/io.l5d.dnssrv/lookup_dns/failed/host not found/a.staging.offerup.services/total" : 1,
  "namer/#/io.l5d.dnssrv/#/io.l5d.dnssrv/lookup_dns/failed/host not found/b.staging.offerup.services/total" : 1,
  "namer/#/io.l5d.dnssrv/#/io.l5d.dnssrv/lookup_dns/failed/host not found/c.staging.offerup.services/total" : 1,
  "namer/#/io.l5d.dnssrv/#/io.l5d.dnssrv/lookup_dns/failed/host not found/e.staging.offerup.services/total" : 1,
  "namer/#/io.l5d.dnssrv/#/io.l5d.dnssrv/lookup_dns/failed/type not found/chat.integration.offerup.services/total" : 1779,
  "namer/#/io.l5d.dnssrv/#/io.l5d.dnssrv/lookup_dns/failed/type not found/webapp.integration.offerup.services/total" : 12,
  "namer/#/io.l5d.dnssrv/#/io.l5d.dnssrv/lookup_dns/iteration/1.staging.offerup.services" : 1.0,
  "namer/#/io.l5d.dnssrv/#/io.l5d.dnssrv/lookup_dns/iteration/2.staging.offerup.services" : 1.0,
  "namer/#/io.l5d.dnssrv/#/io.l5d.dnssrv/lookup_dns/iteration/3.staging.offerup.services" : 1.0,
  "namer/#/io.l5d.dnssrv/#/io.l5d.dnssrv/lookup_dns/iteration/a.staging.offerup.services" : 1.0,
  "namer/#/io.l5d.dnssrv/#/io.l5d.dnssrv/lookup_dns/iteration/auth.integration.offerup.services" : 1832.0,
  "namer/#/io.l5d.dnssrv/#/io.l5d.dnssrv/lookup_dns/iteration/autoregistration.Integration.offerup.services" : 420.0,
  "namer/#/io.l5d.dnssrv/#/io.l5d.dnssrv/lookup_dns/iteration/autoregistration.integration.offerup.services" : 485.0,
  "namer/#/io.l5d.dnssrv/#/io.l5d.dnssrv/lookup_dns/iteration/autos.integration.offerup.services" : 649.0,
  "namer/#/io.l5d.dnssrv/#/io.l5d.dnssrv/lookup_dns/iteration/b.staging.offerup.services" : 1.0,
  "namer/#/io.l5d.dnssrv/#/io.l5d.dnssrv/lookup_dns/iteration/boards.integration.offerup.services" : 1169.0,
  "namer/#/io.l5d.dnssrv/#/io.l5d.dnssrv/lookup_dns/iteration/bulkrequests.integration.offerup.services" : 1846.0,
  "namer/#/io.l5d.dnssrv/#/io.l5d.dnssrv/lookup_dns/iteration/c.staging.offerup.services" : 1.0,
  "namer/#/io.l5d.dnssrv/#/io.l5d.dnssrv/lookup_dns/iteration/chat.integration.offerup.services" : 1779.0,
  "namer/#/io.l5d.dnssrv/#/io.l5d.dnssrv/lookup_dns/iteration/clicktocall.integration.offerup.services" : 319.0,
  "namer/#/io.l5d.dnssrv/#/io.l5d.dnssrv/lookup_dns/iteration/dumbo.integration.offerup.services" : 1828.0,
  "namer/#/io.l5d.dnssrv/#/io.l5d.dnssrv/lookup_dns/iteration/e.staging.offerup.services" : 1.0,
  "namer/#/io.l5d.dnssrv/#/io.l5d.dnssrv/lookup_dns/iteration/externalads.integration.offerup.services" : 1787.0,
  "namer/#/io.l5d.dnssrv/#/io.l5d.dnssrv/lookup_dns/iteration/itempromo.integration.offerup.services" : 441.0,
  "namer/#/io.l5d.dnssrv/#/io.l5d.dnssrv/lookup_dns/iteration/itemview.integration.offerup.services" : 441.0,
  "namer/#/io.l5d.dnssrv/#/io.l5d.dnssrv/lookup_dns/iteration/mlmodels.integration.offerup.services" : 986.0,
  "namer/#/io.l5d.dnssrv/#/io.l5d.dnssrv/lookup_dns/iteration/notifications.integration.offerup.services" : 1169.0,
  "namer/#/io.l5d.dnssrv/#/io.l5d.dnssrv/lookup_dns/iteration/payments.integration.offerup.services" : 1826.0,
  "namer/#/io.l5d.dnssrv/#/io.l5d.dnssrv/lookup_dns/iteration/postflow.integration.offerup.services" : 1464.0,
  "namer/#/io.l5d.dnssrv/#/io.l5d.dnssrv/lookup_dns/iteration/scout.integration.offerup.services" : 1855.0,
  "namer/#/io.l5d.dnssrv/#/io.l5d.dnssrv/lookup_dns/iteration/search.integration.offerup.services" : 1855.0,
  "namer/#/io.l5d.dnssrv/#/io.l5d.dnssrv/lookup_dns/iteration/shipping.integration.offerup.services" : 1169.0,
  "namer/#/io.l5d.dnssrv/#/io.l5d.dnssrv/lookup_dns/iteration/web.integration.offerup.services" : 1855.0,
  "namer/#/io.l5d.dnssrv/#/io.l5d.dnssrv/lookup_dns/iteration/webapp.integration.offerup.services" : 1855.0,
  "namer/#/io.l5d.dnssrv/#/io.l5d.dnssrv/lookup_dns/success/auth.integration.offerup.services/total" : 1832,
  "namer/#/io.l5d.dnssrv/#/io.l5d.dnssrv/lookup_dns/success/autoregistration.Integration.offerup.services/total" : 420,
  "namer/#/io.l5d.dnssrv/#/io.l5d.dnssrv/lookup_dns/success/autoregistration.integration.offerup.services/total" : 485,
  "namer/#/io.l5d.dnssrv/#/io.l5d.dnssrv/lookup_dns/success/autos.integration.offerup.services/total" : 649,
  "namer/#/io.l5d.dnssrv/#/io.l5d.dnssrv/lookup_dns/success/boards.integration.offerup.services/total" : 1169,
  "namer/#/io.l5d.dnssrv/#/io.l5d.dnssrv/lookup_dns/success/bulkrequests.integration.offerup.services/total" : 1846,
  "namer/#/io.l5d.dnssrv/#/io.l5d.dnssrv/lookup_dns/success/clicktocall.integration.offerup.services/total" : 319,
  "namer/#/io.l5d.dnssrv/#/io.l5d.dnssrv/lookup_dns/success/dumbo.integration.offerup.services/total" : 1828,
  "namer/#/io.l5d.dnssrv/#/io.l5d.dnssrv/lookup_dns/success/externalads.integration.offerup.services/total" : 1787,
  "namer/#/io.l5d.dnssrv/#/io.l5d.dnssrv/lookup_dns/success/itempromo.integration.offerup.services/total" : 441,
  "namer/#/io.l5d.dnssrv/#/io.l5d.dnssrv/lookup_dns/success/itemview.integration.offerup.services/total" : 441,
  "namer/#/io.l5d.dnssrv/#/io.l5d.dnssrv/lookup_dns/success/mlmodels.integration.offerup.services/total" : 986,
  "namer/#/io.l5d.dnssrv/#/io.l5d.dnssrv/lookup_dns/success/notifications.integration.offerup.services/total" : 1169,
  "namer/#/io.l5d.dnssrv/#/io.l5d.dnssrv/lookup_dns/success/payments.integration.offerup.services/total" : 1826,
  "namer/#/io.l5d.dnssrv/#/io.l5d.dnssrv/lookup_dns/success/postflow.integration.offerup.services/total" : 1464,
  "namer/#/io.l5d.dnssrv/#/io.l5d.dnssrv/lookup_dns/success/scout.integration.offerup.services/total" : 1855,
  "namer/#/io.l5d.dnssrv/#/io.l5d.dnssrv/lookup_dns/success/search.integration.offerup.services/total" : 1855,
  "namer/#/io.l5d.dnssrv/#/io.l5d.dnssrv/lookup_dns/success/shipping.integration.offerup.services/total" : 1169,
  "namer/#/io.l5d.dnssrv/#/io.l5d.dnssrv/lookup_dns/success/web.integration.offerup.services/total" : 1855,
  "namer/#/io.l5d.dnssrv/#/io.l5d.dnssrv/lookup_dns/success/webapp.integration.offerup.services/total" : 1843,
```