### PR TITLE
Add GC logging by default

### DIFF
--- a/project/Base.scala
+++ b/project/Base.scala
@@ -170,6 +170,7 @@ class Base extends Build {
       val home = s"/${organization.value}/${name.value}/${version.value}"
       val exec = s"$home/${configuration.value}-exec"
       from(dockerJavaImage.value)
+      run("[ -d /var/log/linkerd ]", "||", "mkdir", "-p", "/var/log/linkerd")
       run("mkdir", "-p", home)
       workDir(home)
       env(envPrefix+"HOME", home)

--- a/project/Base.scala
+++ b/project/Base.scala
@@ -170,7 +170,6 @@ class Base extends Build {
       val home = s"/${organization.value}/${name.value}/${version.value}"
       val exec = s"$home/${configuration.value}-exec"
       from(dockerJavaImage.value)
-      run("[ -d /var/log/linkerd ]", "||", "mkdir", "-p", "/var/log/linkerd")
       run("mkdir", "-p", home)
       workDir(home)
       env(envPrefix+"HOME", home)

--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -373,10 +373,16 @@ object LinkerdBuild extends Base {
          |
          |# Configure GC logging directory
          |if [ -z "$GC_LOG" ]; then
-         |  GC_LOG="/var/log/linkerd"
+         |  GC_LOG="/var/log/namerd"
          |fi
          |
          |[ -d "$GC_LOG" ] || mkdir -p "$GC_LOG"
+         |
+         |if [ ! \( -w "$GC_LOG" \) ]; then
+         |  echo "GC_LOG must be set to a directory that user [$USER] has write permissions on.\
+         |  Unable to use [$GC_LOG] for GC logging."
+         |fi
+         |
          |""" +
       execScriptJvmOptions +
       """|exec "${JAVA_HOME:-/usr}/bin/java" -XX:+PrintCommandLineFlags \
@@ -442,10 +448,16 @@ object LinkerdBuild extends Base {
          |
          |# Configure GC logging directory
          |if [ -z "$GC_LOG" ]; then
-         |  GC_LOG="/var/log/linkerd"
+         |  GC_LOG="/var/log/namerd"
          |fi
          |
          |[ -d "$GC_LOG" ] || mkdir -p "$GC_LOG"
+         |
+         |if [ ! \( -w "$GC_LOG" \) ]; then
+         |  echo "GC_LOG must be set to a directory that user [$USER] has write permissions on.\
+         |  Unable to use [$GC_LOG] for GC logging."
+         |fi
+         |
          |""" +
       execScriptJvmOptions +
       """|if read -t 0; then
@@ -661,6 +673,12 @@ object LinkerdBuild extends Base {
          |fi
          |
          |[ -d "$GC_LOG" ] || mkdir -p "$GC_LOG"
+         |
+         |if [ ! \( -w "$GC_LOG" \) ]; then
+         |  echo "GC_LOG must be set to a directory that user [$USER] has write permissions on.\
+         |  Unable to use [$GC_LOG] for GC logging."
+         |fi
+         |
          |""" +
       execScriptJvmOptions +
       """|exec "${JAVA_HOME:-/usr}/bin/java" -XX:+PrintCommandLineFlags \

--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -367,7 +367,7 @@ object LinkerdBuild extends Base {
          |  GC_LOG="/var/log/namerd"
          |fi
          |
-         |mkdir -p "$GC_LOG" && touch "$GC_LOG/gc.log"
+         |mkdir -p "$GC_LOG" && [ -w "$GC_LOG" ]
          |
          |if [ $? -ne 0 ]; then
          |  echo "GC_LOG must be set to a directory that user [$USER] has write permissions on.\
@@ -454,7 +454,7 @@ object LinkerdBuild extends Base {
          |  GC_LOG="/var/log/namerd"
          |fi
          |
-         |mkdir -p "$GC_LOG" && touch "$GC_LOG/gc.log"
+         |mkdir -p "$GC_LOG" && [ -w "$GC_LOG" ]
          |
          |if [ $? -ne 0 ]; then
          |  echo "GC_LOG must be set to a directory that user [$USER] has write permissions on.\
@@ -687,7 +687,7 @@ object LinkerdBuild extends Base {
          |  GC_LOG="/var/log/linkerd"
          |fi
          |
-         |mkdir -p "$GC_LOG" && touch "$GC_LOG/gc.log"
+         |mkdir -p "$GC_LOG" && [ -w "$GC_LOG" ]
          |
          |if [ $? -ne 0 ]; then
          |  echo "GC_LOG must be set to a directory that user [$USER] has write permissions on.\

--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -367,11 +367,12 @@ object LinkerdBuild extends Base {
          |  GC_LOG="/var/log/namerd"
          |fi
          |
-         |if [ ! \( -w "$GC_LOG" \) ]; then
+         |mkdir -p "$GC_LOG" && touch "$GC_LOG/gc.log"
+         |
+         |if [ $? -ne 0 ]; then
          |  echo "GC_LOG must be set to a directory that user [$USER] has write permissions on.\
          |  Unable to use [$GC_LOG] for GC logging."
          |else
-         |  [ -d "$GC_LOG" ] || mkdir -p "$GC_LOG"
          |  GC_LOG_OPTION="
          |   -XX:+PrintGCDetails
          |   -XX:+PrintGCDateStamps
@@ -453,11 +454,12 @@ object LinkerdBuild extends Base {
          |  GC_LOG="/var/log/namerd"
          |fi
          |
-         |if [ ! \( -w "$GC_LOG" \) ]; then
+         |mkdir -p "$GC_LOG" && touch "$GC_LOG/gc.log"
+         |
+         |if [ $? -ne 0 ]; then
          |  echo "GC_LOG must be set to a directory that user [$USER] has write permissions on.\
          |  Unable to use [$GC_LOG] for GC logging."
          |else
-         |  [ -d "$GC_LOG" ] || mkdir -p "$GC_LOG"
          |  GC_LOG_OPTION="
          |   -XX:+PrintGCDetails
          |   -XX:+PrintGCDateStamps
@@ -685,11 +687,12 @@ object LinkerdBuild extends Base {
          |  GC_LOG="/var/log/linkerd"
          |fi
          |
-         |if [ ! \( -w "$GC_LOG" \) ]; then
+         |mkdir -p "$GC_LOG" && touch "$GC_LOG/gc.log"
+         |
+         |if [ $? -ne 0 ]; then
          |  echo "GC_LOG must be set to a directory that user [$USER] has write permissions on.\
          |  Unable to use [$GC_LOG] for GC logging."
          |else
-         |  [ -d "$GC_LOG" ] || mkdir -p "$GC_LOG"
          |  GC_LOG_OPTION="
          |   -XX:+PrintGCDetails
          |   -XX:+PrintGCDateStamps
@@ -698,9 +701,6 @@ object LinkerdBuild extends Base {
          |   -XX:+PrintGCApplicationStoppedTime
          |   -XX:+PrintPromotionFailure
          |   -Xloggc:${GC_LOG}/gc.log
-         |   -XX:+UseGCLogFileRotation
-         |   -XX:NumberOfGCLogFiles=10
-         |   -XX:GCLogFileSize=10M
          |   -XX:+UseGCLogFileRotation
          |   -XX:NumberOfGCLogFiles=10
          |   -XX:GCLogFileSize=10M"

--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -257,16 +257,7 @@ object LinkerdBuild extends Base {
        |   -Dio.netty.allocator.numHeapArenas=${FINAGLE_WORKERS:-8}      \
        |   -Dio.netty.allocator.numDirectArenas=${FINAGLE_WORKERS:-8}    \
        |   -Dcom.twitter.finagle.netty4.numWorkers=${FINAGLE_WORKERS:-8} \
-       |   -XX:+PrintGCDetails                                           \
-       |   -XX:+PrintGCDateStamps                                        \
-       |   -XX:+PrintHeapAtGC                                            \
-       |   -XX:+PrintTenuringDistribution                                \
-       |   -XX:+PrintGCApplicationStoppedTime                            \
-       |   -XX:+PrintPromotionFailure                                    \
-       |   -Xloggc:${GC_LOG}/gc.log                                      \
-       |   -XX:+UseGCLogFileRotation                                     \
-       |   -XX:NumberOfGCLogFiles=10                                     \
-       |   -XX:GCLogFileSize=10M                                         \
+       |   ${GC_LOG_OPTION:-}                                            \
        |   ${LOCAL_JVM_OPTIONS:-}                                        "
        |""".stripMargin
 
@@ -376,11 +367,22 @@ object LinkerdBuild extends Base {
          |  GC_LOG="/var/log/namerd"
          |fi
          |
-         |[ -d "$GC_LOG" ] || mkdir -p "$GC_LOG"
-         |
          |if [ ! \( -w "$GC_LOG" \) ]; then
          |  echo "GC_LOG must be set to a directory that user [$USER] has write permissions on.\
          |  Unable to use [$GC_LOG] for GC logging."
+         |else
+         |  [ -d "$GC_LOG" ] || mkdir -p "$GC_LOG"
+         |  GC_LOG_OPTION="
+         |   -XX:+PrintGCDetails
+         |   -XX:+PrintGCDateStamps
+         |   -XX:+PrintHeapAtGC
+         |   -XX:+PrintTenuringDistribution
+         |   -XX:+PrintGCApplicationStoppedTime
+         |   -XX:+PrintPromotionFailure
+         |   -Xloggc:${GC_LOG}/gc.log
+         |   -XX:+UseGCLogFileRotation
+         |   -XX:NumberOfGCLogFiles=10
+         |   -XX:GCLogFileSize=10M"
          |fi
          |
          |""" +
@@ -451,11 +453,22 @@ object LinkerdBuild extends Base {
          |  GC_LOG="/var/log/namerd"
          |fi
          |
-         |[ -d "$GC_LOG" ] || mkdir -p "$GC_LOG"
-         |
          |if [ ! \( -w "$GC_LOG" \) ]; then
          |  echo "GC_LOG must be set to a directory that user [$USER] has write permissions on.\
          |  Unable to use [$GC_LOG] for GC logging."
+         |else
+         |  [ -d "$GC_LOG" ] || mkdir -p "$GC_LOG"
+         |  GC_LOG_OPTION="
+         |   -XX:+PrintGCDetails
+         |   -XX:+PrintGCDateStamps
+         |   -XX:+PrintHeapAtGC
+         |   -XX:+PrintTenuringDistribution
+         |   -XX:+PrintGCApplicationStoppedTime
+         |   -XX:+PrintPromotionFailure
+         |   -Xloggc:${GC_LOG}/gc.log
+         |   -XX:+UseGCLogFileRotation
+         |   -XX:NumberOfGCLogFiles=10
+         |   -XX:GCLogFileSize=10M"
          |fi
          |
          |""" +
@@ -672,11 +685,25 @@ object LinkerdBuild extends Base {
          |  GC_LOG="/var/log/linkerd"
          |fi
          |
-         |[ -d "$GC_LOG" ] || mkdir -p "$GC_LOG"
-         |
          |if [ ! \( -w "$GC_LOG" \) ]; then
          |  echo "GC_LOG must be set to a directory that user [$USER] has write permissions on.\
          |  Unable to use [$GC_LOG] for GC logging."
+         |else
+         |  [ -d "$GC_LOG" ] || mkdir -p "$GC_LOG"
+         |  GC_LOG_OPTION="
+         |   -XX:+PrintGCDetails
+         |   -XX:+PrintGCDateStamps
+         |   -XX:+PrintHeapAtGC
+         |   -XX:+PrintTenuringDistribution
+         |   -XX:+PrintGCApplicationStoppedTime
+         |   -XX:+PrintPromotionFailure
+         |   -Xloggc:${GC_LOG}/gc.log
+         |   -XX:+UseGCLogFileRotation
+         |   -XX:NumberOfGCLogFiles=10
+         |   -XX:GCLogFileSize=10M
+         |   -XX:+UseGCLogFileRotation
+         |   -XX:NumberOfGCLogFiles=10
+         |   -XX:GCLogFileSize=10M"
          |fi
          |
          |""" +

--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -263,7 +263,7 @@ object LinkerdBuild extends Base {
        |   -XX:+PrintTenuringDistribution                                \
        |   -XX:+PrintGCApplicationStoppedTime                            \
        |   -XX:+PrintPromotionFailure                                    \
-       |   -Xloggc:/var/log/linkerd/gc.log                               \
+       |   -Xloggc:${GC_LOG}/gc.log                                      \
        |   -XX:+UseGCLogFileRotation                                     \
        |   -XX:NumberOfGCLogFiles=10                                     \
        |   -XX:GCLogFileSize=10M                                         \
@@ -370,6 +370,13 @@ object LinkerdBuild extends Base {
          |  done
          |fi
          |export MALLOC_ARENA_MAX=2
+         |
+         |# Configure GC logging directory
+         |if [ -z "$GC_LOG" ]; then
+         |  GC_LOG="/var/log/linkerd"
+         |fi
+         |
+         |[ -d "$GC_LOG" ] || mkdir -p "$GC_LOG"
          |""" +
       execScriptJvmOptions +
       """|exec "${JAVA_HOME:-/usr}/bin/java" -XX:+PrintCommandLineFlags \
@@ -432,6 +439,13 @@ object LinkerdBuild extends Base {
          |  done
          |fi
          |export MALLOC_ARENA_MAX=2
+         |
+         |# Configure GC logging directory
+         |if [ -z "$GC_LOG" ]; then
+         |  GC_LOG="/var/log/linkerd"
+         |fi
+         |
+         |[ -d "$GC_LOG" ] || mkdir -p "$GC_LOG"
          |""" +
       execScriptJvmOptions +
       """|if read -t 0; then
@@ -640,6 +654,13 @@ object LinkerdBuild extends Base {
          |  done
          |fi
          |export MALLOC_ARENA_MAX=2
+         |
+         |# Configure GC logging directory
+         |if [ -z "$GC_LOG" ]; then
+         |  GC_LOG="/var/log/linkerd"
+         |fi
+         |
+         |[ -d "$GC_LOG" ] || mkdir -p "$GC_LOG"
          |""" +
       execScriptJvmOptions +
       """|exec "${JAVA_HOME:-/usr}/bin/java" -XX:+PrintCommandLineFlags \

--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -257,6 +257,16 @@ object LinkerdBuild extends Base {
        |   -Dio.netty.allocator.numHeapArenas=${FINAGLE_WORKERS:-8}      \
        |   -Dio.netty.allocator.numDirectArenas=${FINAGLE_WORKERS:-8}    \
        |   -Dcom.twitter.finagle.netty4.numWorkers=${FINAGLE_WORKERS:-8} \
+       |   -XX:+PrintGCDetails                                           \
+       |   -XX:+PrintGCDateStamps                                        \
+       |   -XX:+PrintHeapAtGC                                            \
+       |   -XX:+PrintTenuringDistribution                                \
+       |   -XX:+PrintGCApplicationStoppedTime                            \
+       |   -XX:+PrintPromotionFailure                                    \
+       |   -Xloggc:/var/log/linkerd/gc.log                               \
+       |   -XX:+UseGCLogFileRotation                                     \
+       |   -XX:NumberOfGCLogFiles=10                                     \
+       |   -XX:GCLogFileSize=10M                                         \
        |   ${LOCAL_JVM_OPTIONS:-}                                        "
        |""".stripMargin
 


### PR DESCRIPTION
GC logging is necessary for debugging JVM issues in Linkerd. This PR adds flags to the Linkerd exec script to enable GC logging. It also adds a line in the exec script that creates a directory `var/log/linkerd` for `gc.log` files if it doesn't exist. it also allows for the GC log directory to be configurable using the environment variable `GC_LOG`

fixes #2110

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>