### PR TITLE
Configure adding clientId to TTwitter requests

### DIFF
--- a/linkerd/docs/protocol-thrift.md
+++ b/linkerd/docs/protocol-thrift.md
@@ -53,3 +53,4 @@ Key | Default Value | Description
 --- | ------------- | -----------
 thriftFramed | `true` | If `true`, a framed thrift transport is used for outgoing requests; otherwise, a buffered transport is used. Typically this setting matches the router's servers' `thriftFramed` param.
 attemptTTwitterUpgrade | `false` | Controls whether thrift protocol upgrade should be attempted.
+clientId | no clientId | If set, the given clientId is added to upgraded outgoing protocol requests when one is not given in the incoming client request.

--- a/linkerd/protocol/thrift/src/main/scala/io/buoyant/linkerd/protocol/ThriftInitializer.scala
+++ b/linkerd/protocol/thrift/src/main/scala/io/buoyant/linkerd/protocol/ThriftInitializer.scala
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.{JsonIgnore, JsonProperty, JsonSubTypes,
 import com.twitter.finagle.Stack
 import com.twitter.finagle.Stack.Params
 import com.twitter.finagle.Thrift.param
+import com.twitter.finagle.thrift.ClientId
 import com.twitter.finagle.buoyant.{ParamsMaybeWith, PathMatcher}
 import com.twitter.finagle.buoyant.linkerd.{ThriftClientPrep, ThriftServerPrep, ThriftTraceInitializer}
 import io.buoyant.config.types.ThriftProtocol
@@ -96,9 +97,11 @@ trait ThriftClientConfig extends ClientConfig {
 
   var thriftFramed: Option[Boolean] = None
   var attemptTTwitterUpgrade: Option[Boolean] = None
+  var clientId: Option[String] = None
 
   @JsonIgnore
   override def params(vars: Map[String, String]) = super.params(vars)
     .maybeWith(thriftFramed.map(param.Framed(_))) +
-    param.AttemptTTwitterUpgrade(attemptTTwitterUpgrade.getOrElse(false))
+    param.AttemptTTwitterUpgrade(attemptTTwitterUpgrade.getOrElse(false)) +
+    param.ClientId(clientId.map(new ClientId(_)))
 }

--- a/linkerd/protocol/thrift/src/test/scala/io/buoyant/linkerd/protocol/ThriftInitializerTest.scala
+++ b/linkerd/protocol/thrift/src/test/scala/io/buoyant/linkerd/protocol/ThriftInitializerTest.scala
@@ -63,4 +63,33 @@ class ThriftInitializerTest extends FunSuite with Exceptions {
     val params = linker.routers.head.params[PerClientParams].paramsFor(Path.read("/foo"))
     assert(!params[param.AttemptTTwitterUpgrade].upgrade)
   }
+
+  test("clientId defaults None") {
+    val config = """
+                   |routers:
+                   |- protocol: thrift
+                   |  thriftProtocol: compact
+                   |  client:
+                   |    thriftFramed: true
+                 """.stripMargin
+
+    val linker = Linker.Initializers(Seq(ThriftInitializer)).load(config)
+    val params = linker.routers.head.params[PerClientParams].paramsFor(Path.read("/foo"))
+    assert(params[param.ClientId].clientId.isEmpty)
+  }
+
+  test("clientId can be customized") {
+    val config = """
+                   |routers:
+                   |- protocol: thrift
+                   |  thriftProtocol: compact
+                   |  client:
+                   |    thriftFramed: true
+                   |    clientId: fooClient
+                 """.stripMargin
+
+    val linker = Linker.Initializers(Seq(ThriftInitializer)).load(config)
+    val params = linker.routers.head.params[PerClientParams].paramsFor(Path.read("/foo"))
+    assert(params[param.ClientId].clientId.get.name == "fooClient")
+  }
 }


### PR DESCRIPTION
There are Thrift clients for many languages but few support TTwitter
upgrade. Some Thrift servers use the TTwitter clientId header to apply
rate-limiting quotas on clients. Thrift clients that cannot speak
TTwitter are unable to make requests against such servers.

Linkerd already supports upgrading the protocol to the server, even when
the client does not talk TTwitter. This PR adds a Thrift client
configuration option to set the clientId on outgoing TTwitter requests
when no clientId is set on the incoming request. This allows a
TTwitter-unaware client to use a service that requires the clientId be
set by proxying the requests through an appropriately-configured
linkerd.

Signed-off-by: Cory Snider <cory.snider@fitbit.com>