### PR TITLE
[SPIKE] Expose stats scoped by the caller service

### DIFF
--- a/router/http/src/main/scala/io/buoyant/router/http/stats/ServiceToServiceStats.scala
+++ b/router/http/src/main/scala/io/buoyant/router/http/stats/ServiceToServiceStats.scala
@@ -1,0 +1,26 @@
+package io.buoyant.router.http.stats
+
+import com.twitter.finagle.http.Response
+import com.twitter.finagle.stats.{Counter, Stat, StatsReceiver}
+import com.twitter.util.Duration
+
+object ServiceToServiceStats {
+  def mk(statsReceiver: StatsReceiver, statusCode: Int): ServiceToServiceStats = {
+    val statusClass = s"${statusCode / 100}XX"
+    ServiceToServiceStats(
+      requestCount = statsReceiver.counter("requests"),
+      statusClassCount = statsReceiver.scope("status").counter(statusClass),
+      requestTime = statsReceiver.stat("request_latency_ms")
+    )
+  }
+}
+
+case class ServiceToServiceStats(requestCount: Counter, statusClassCount: Counter, requestTime: Stat) {
+  def count(response: Response, duration: Duration): Unit = {
+    requestCount.incr()
+    statusClassCount.incr()
+
+    val durationMs = duration.inMilliseconds
+    requestTime.add(durationMs.toFloat)
+  }
+}

--- a/router/http/src/main/scala/io/buoyant/router/http/stats/ServiceToServiceStatsFilter.scala
+++ b/router/http/src/main/scala/io/buoyant/router/http/stats/ServiceToServiceStatsFilter.scala
@@ -1,0 +1,35 @@
+package io.buoyant.router.http.stats
+
+import com.twitter.finagle.buoyant.Dst
+import com.twitter.finagle.http.Status.InternalServerError
+import com.twitter.finagle.http.{Method, Request, Response}
+import com.twitter.finagle.stats.StatsReceiver
+import com.twitter.finagle.{Service, SimpleFilter}
+import com.twitter.util._
+import io.buoyant.router.context.DstPathCtx
+
+class ServiceToServiceStatsFilter(statsReceiver: StatsReceiver) extends SimpleFilter[Request, Response] {
+  private val serviceToServiceStats = Memoize[(Src, Dst.Path, Method, Int), ServiceToServiceStats] {
+    case (src, dst, method, statusCode) =>
+      val scopedStatsReceiver =
+        statsReceiver.scope("route", src.name, dst.path.show, method.toString.toUpperCase)
+      ServiceToServiceStats.mk(scopedStatsReceiver, statusCode)
+  }
+
+  override def apply(request: Request, service: Service[Request, Response]): Future[Response] = {
+    val elapsed = Stopwatch.start()
+    service(request).respond {
+      case Return(response) => record(request, response, elapsed())
+      case Throw(e)         => record(request, Response(InternalServerError), elapsed())
+    }
+  }
+
+  private def record(request: Request, response: Response, duration: Duration) = {
+    val svcToSvcStats = for {
+      src <- Src.HeaderSrcIdentifier(request)
+      dst <- DstPathCtx.current
+    } yield serviceToServiceStats((src, dst, request.method, response.statusCode))
+
+    svcToSvcStats.foreach(_.count(response, duration))
+  }
+}

--- a/router/http/src/main/scala/io/buoyant/router/http/stats/Src.scala
+++ b/router/http/src/main/scala/io/buoyant/router/http/stats/Src.scala
@@ -1,0 +1,13 @@
+package io.buoyant.router.http.stats
+
+import com.twitter.finagle.http.Request
+
+final case class Src(name: String)
+object Src {
+  type SrcIdentifier = Request => Option[Src]
+
+  val SrcServiceHeader = "l5d-src-service"
+  val HeaderSrcIdentifier = (req: Request) => {
+    req.headerMap.get(SrcServiceHeader).map(Src(_))
+  }
+}

--- a/router/http/src/test/scala/io/buoyant/router/http/stats/ServiceToServiceStatsFilterTest.scala
+++ b/router/http/src/test/scala/io/buoyant/router/http/stats/ServiceToServiceStatsFilterTest.scala
@@ -1,0 +1,70 @@
+package io.buoyant.router.http.stats
+
+import com.twitter.finagle.buoyant.Dst
+import com.twitter.finagle.context.Contexts
+import com.twitter.finagle.http.{Method, Request, Response, Status}
+import com.twitter.finagle.stats.{InMemoryStatsReceiver, StatsReceiver}
+import com.twitter.finagle.{Filter, Path, Service}
+import com.twitter.util.{Future, Local}
+import io.buoyant.router.context.DstPathCtx
+import io.buoyant.router.http.stats.Src.SrcServiceHeader
+import io.buoyant.test.Awaits
+import org.scalatest.{fixture, Outcome}
+
+class ServiceToServiceStatsFilterTest extends fixture.FunSuite with Awaits {
+
+  case class F(svc: Service[Request, Response], stats: InMemoryStatsReceiver)
+
+  type FixtureParam = Service[Request, Response] => F
+
+  def setContext(f: Request => Path) =
+    Filter.mk[Request, Response, Request, Response] { (req, service) =>
+      val save = Local.save()
+      try Contexts.local.let(DstPathCtx, Dst.Path(f(req))) {
+        service(req)
+      } finally Local.restore(save)
+    }
+
+  def withFixture(test: OneArgTest): Outcome = {
+    val stats     = new InMemoryStatsReceiver
+    val filter    = new ServiceToServiceStatsFilter(stats)
+    val ctxFilter = setContext((req: Request) => Path.Utf8("dst-service"))
+
+    def service(backend: Service[Request, Response]) =
+      ctxFilter.andThen(filter).andThen(backend)
+    val save = Local.save()
+    try {
+      test(be => F(service(be), stats))
+    } finally Local.restore(save)
+  }
+
+  def mkService(sr: StatsReceiver) = {
+    val filter = new ServiceToServiceStatsFilter(sr)
+    filter.andThen(Service.const[Response](Future.value(Response.apply(Status.Ok))))
+  }
+
+  val scope = Seq("route", "src-service", "/dst-service", "GET")
+
+  test("reports service-to-service latency stats") { f =>
+    val origin = Service.const[Response](Future.value(Response(Status.Ok)))
+    val proxy  = f(origin)
+    val req    = Request(Method.Get, "/")
+    req.headerMap.add(SrcServiceHeader, "src-service")
+    Future.collect((1 to 10).map(_ => proxy.svc(req)))
+
+    assert(proxy.stats.counters.get(scope :+ "requests") == (Some(10)))
+    assert(proxy.stats.stats.get(scope :+ "request_latency_ms").map(_.size) == (Some(10)))
+  }
+
+  test("reports service-to-service errors stats") { f =>
+    val origin = Service.const[Response](Future.exception(new Exception("oops")))
+    val proxy  = f(origin)
+    val req    = Request(Method.Get, "/")
+    req.headerMap.add(SrcServiceHeader, "src-service")
+    Future.collect((1 to 10).map(_ => proxy.svc(req)))
+
+    assert(proxy.stats.counters.get(scope :+ "requests") == (Some(10)))
+    assert(proxy.stats.counters.get(scope :+ "status" :+ "5XX") == (Some(10)))
+
+  }
+}


### PR DESCRIPTION
Signed-off-by: fantayeneh <fantayeneh@gmail.com>

This PR not completed by far is to start the discussion on how we can expose
stats scoped by the caller service, which will help us to use linkerd as the source of truth for all service to service call metrics. 


The idea is stolen from Matt Klein talk on Envoy. 
<img width="1617" alt="svc2svc" src="https://user-images.githubusercontent.com/404798/46258167-c4895e00-c4bd-11e8-83e2-a19c1a3b02a0.png">

Let me know if you're interested in this, or if there is a better way of achieving the same result.

Things to think about are 
- strategy to define who the caller is (maybe tracing headers can be used for this)
- how to protect linkerd from the explosion of this stats

Fanta