### PR TITLE
Add support for socket options for Linkerd and Namerd server endpoints

### DIFF
--- a/admin/src/main/scala/io/buoyant/admin/AdminConfig.scala
+++ b/admin/src/main/scala/io/buoyant/admin/AdminConfig.scala
@@ -1,6 +1,6 @@
 package io.buoyant.admin
 
-import com.twitter.finagle.buoyant.TlsServerConfig
+import com.twitter.finagle.buoyant.{SocketOptionsConfig, TlsServerConfig}
 import com.twitter.finagle.stats.StatsReceiver
 import com.twitter.logging.Logger
 import java.net.{InetAddress, InetSocketAddress}
@@ -9,6 +9,7 @@ import io.buoyant.config.types.Port
 case class AdminConfig(
   ip: Option[InetAddress] = None,
   port: Option[Port] = None,
+  socketOptions: Option[SocketOptionsConfig] = None,
   shutdownGraceMs: Option[Int] = None,
   security: Option[AdminSecurityConfig] = None,
   tls: Option[TlsServerConfig] = None,
@@ -20,7 +21,7 @@ case class AdminConfig(
     val adminIp = ip.getOrElse(defaultAddr.getAddress)
     val adminPort = port.map(_.port).getOrElse(defaultAddr.getPort)
     val addr = new InetSocketAddress(adminIp, adminPort)
-    new Admin(addr, tls, workerThreads.getOrElse(2), stats, security)
+    new Admin(addr, tls, workerThreads.getOrElse(2), stats, security, socketOptions)
   }
 }
 

--- a/finagle/buoyant/src/main/scala/com/twitter/finagle/buoyant/SocketOptionsConfig.scala
+++ b/finagle/buoyant/src/main/scala/com/twitter/finagle/buoyant/SocketOptionsConfig.scala
@@ -4,11 +4,11 @@ import com.twitter.finagle.Stack
 import com.twitter.finagle.transport.Transport
 
 case class SocketOptionsConfig(
-  disableTcpNoDelay: Boolean = true,
-  reuseAddrEnabled: Boolean = true,
-  reusePortEnabled: Boolean = false
+  noDelay: Boolean = true,
+  reuseAddr: Boolean = true,
+  reusePort: Boolean = false
 ) {
   def params = Stack.Params.empty +
-    Transport.Options(disableTcpNoDelay, reuseAddrEnabled, reusePortEnabled)
+    Transport.Options(noDelay, reuseAddr, reusePort)
 
 }

--- a/finagle/buoyant/src/main/scala/com/twitter/finagle/buoyant/SocketOptionsConfig.scala
+++ b/finagle/buoyant/src/main/scala/com/twitter/finagle/buoyant/SocketOptionsConfig.scala
@@ -1,0 +1,14 @@
+package com.twitter.finagle.buoyant
+
+import com.twitter.finagle.Stack
+import com.twitter.finagle.transport.Transport
+
+case class SocketOptionsConfig(
+  disableTcpNoDelay: Boolean = true,
+  reuseAddrEnabled: Boolean = true,
+  reusePortEnabled: Boolean = false
+) {
+  def params = Stack.Params.empty +
+    Transport.Options(disableTcpNoDelay, reuseAddrEnabled, reusePortEnabled)
+
+}

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/Server.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/Server.scala
@@ -3,13 +3,13 @@ package io.buoyant.linkerd
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.twitter.concurrent.AsyncSemaphore
 import com.twitter.conversions.time._
-import com.twitter.finagle.buoyant.{TlsServerConfig, ParamsMaybeWith}
+import com.twitter.finagle.buoyant.{ParamsMaybeWith, SocketOptionsConfig, TlsServerConfig}
 import com.twitter.finagle.filter.RequestSemaphoreFilter
 import com.twitter.finagle.netty4.ssl.server.Netty4ServerEngineFactory
 import com.twitter.finagle.service.TimeoutFilter
 import com.twitter.finagle.ssl.server.SslServerEngineFactory
 import com.twitter.finagle.{ListeningServer, Path, Stack}
-import com.twitter.finagle.buoyant.ParamsMaybeWith
+import com.twitter.finagle.transport.Transport
 import io.buoyant.config.types.Port
 import java.net.{InetAddress, InetSocketAddress}
 
@@ -77,6 +77,7 @@ object Server {
 class ServerConfig { config =>
 
   var port: Option[Port] = None
+  var socketOptions: Option[SocketOptionsConfig] = None
   var ip: Option[InetAddress] = None
   var tls: Option[TlsServerConfig] = None
   var label: Option[String] = None
@@ -91,6 +92,7 @@ class ServerConfig { config =>
 
   @JsonIgnore
   protected def serverParams: Stack.Params = Stack.Params.empty
+    .maybeWith(socketOptions.map(_.params))
     .maybeWith(tls.map(_.params(alpnProtocols, sslServerEngine)))
     .maybeWith(clearContext.map(ClearContext.Enabled(_)))
     .maybeWith(timeoutMs.map(timeout => TimeoutFilter.Param(timeout.millis))) +

--- a/linkerd/docs/config.md
+++ b/linkerd/docs/config.md
@@ -83,6 +83,7 @@ Key | Default Value | Description
 --- | ------------- | -----------
 ip | loopback address | IP for the admin interface. A value like 0.0.0.0 configures admin to listen on all local IPv4 interfaces.
 port | `9990` | Port for the admin interface.
+socketOptions | none | Socket options to set for the admin interface.
 httpIdentifierPort | none | Port for the http identifier debug endpoint.
 shutdownGraceMs | 10000 | maximum grace period before the Linkerd process exits
 tls | no tls | The admin interface will serve over TLS if this parameter is provided. See [TLS](#server-tls).
@@ -270,3 +271,15 @@ Key | Default Value | Description
 --- | ------------- | -----------
 orgId | empty by default | Optional string of your choosing that identifies your organization
 enabled | true | If set to true, data is sent to Buoyant once per hour
+
+### Socket Options
+
+Linkerd supports configuring socket level options for any given interface.
+i.e. the admin and router interfaces. These configurations are only available 
+on Linux 3.9 distributions and newer.
+
+Key | Default Value | Description
+--- | ------------- | -----------
+noDelay | true | If set to true, enables the use of `TCP_NODELAY` on a socket interface
+reuseAddr | true | If set to true, enables the `SO_REUSEADDR` option
+reusePort | false | If set to true, enables the `SO_REUSEPORT` option, which can be used to bind another Linkerd process to the same interface port.

--- a/linkerd/docs/routers.md
+++ b/linkerd/docs/routers.md
@@ -86,6 +86,7 @@ Key | Default Value | Description
 --- | ------------- | -----------
 port | protocol dependent | The TCP port number. Protocols may provide default values. If no default is provided, the port parameter is required.
 ip | loopback address | The local IP address. A value like 0.0.0.0 configures the server to listen on all local IPv4 interfaces.
+socketOptions | none | Socket options to set for the router interface. See [Socket Options](#socket-options)
 tls | no tls | The server will serve over TLS if this parameter is provided. see [TLS](#server-tls).
 maxConcurrentRequests | unlimited | The maximum number of concurrent requests the server will accept.
 announce | an empty list | A list of concrete names to announce using the router's [announcers](#announcers).

--- a/namerd/core/src/main/scala/io/buoyant/namerd/InterfaceConfig.scala
+++ b/namerd/core/src/main/scala/io/buoyant/namerd/InterfaceConfig.scala
@@ -5,8 +5,8 @@ import com.twitter.finagle.Stack
 import com.twitter.finagle.stats.StatsReceiver
 import com.twitter.finagle.{Namer, Path}
 import io.buoyant.config.types.Port
-import io.buoyant.config.{PolymorphicConfig, ConfigInitializer}
-import com.twitter.finagle.buoyant.TlsServerConfig
+import io.buoyant.config.{ConfigInitializer, PolymorphicConfig}
+import com.twitter.finagle.buoyant.{SocketOptionsConfig, TlsServerConfig}
 import com.twitter.finagle.netty4.ssl.server.Netty4ServerEngineFactory
 import java.net.{InetAddress, InetSocketAddress}
 
@@ -16,6 +16,7 @@ import java.net.{InetAddress, InetSocketAddress}
 abstract class InterfaceConfig extends PolymorphicConfig {
   var ip: Option[InetAddress] = None
   var port: Option[Port] = None
+  var socketOptions: Option[SocketOptionsConfig] = None
   var tls: Option[TlsServerConfig] = None
 
   @JsonIgnore
@@ -26,6 +27,9 @@ abstract class InterfaceConfig extends PolymorphicConfig {
 
   @JsonIgnore
   def tlsParams = tls.map(_.params(None, Netty4ServerEngineFactory())).getOrElse(Stack.Params.empty)
+
+  @JsonIgnore
+  def socketOptParams = socketOptions.map(_.params).getOrElse(Stack.Params.empty)
 
   @JsonIgnore
   protected def defaultAddr: InetSocketAddress

--- a/namerd/docs/config.md
+++ b/namerd/docs/config.md
@@ -55,6 +55,7 @@ Key | Default Value | Description
 --- | ------------- | -----------
 ip | loopback address | IP for the admin interface. A value like 0.0.0.0 configures admin to listen on all local IPv4 interfaces.
 port | `9990` | Port for the admin interface.
+socketOptions | none | Socket options to set for the admin interface. See [Socket Options](https://linkerd.io/config/head/linkerd/index.html#socket-options)
 shutdownGraceMs | 10000 | maximum grace period before the Namerd process exits
 tls | no tls | The admin interface will serve over TLS if this parameter is provided. see [TLS](#server-tls).
 workerThreads | 2 | The number of worker threads used to serve the admin interface.

--- a/namerd/docs/interface.md
+++ b/namerd/docs/interface.md
@@ -15,9 +15,10 @@ may also have kind-specific parameters.
 
 Key | Default Value | Description
 --- | ------------- | -----------
-kind | _required_ | Either [`io.l5d.thriftNameInterpreter`](#thrift-name-interpreter), [`io.l5d.mesh`](#grpc-mesh-interface), or [`io.l5d.httpController`](#http-controller).
+kind | _required_ | Either [`io.l5d.thriftNameInterpreter`](#thrift-name-interpreter), [`io.l5d.mesh`](#grpc-mesh-interface),[`io.l5d.destination`](#linkerd2-destination-interface) or [`io.l5d.httpController`](#http-controller).
 ip | interface dependent | The local IP address on which to serve the namer interface.
 port | interface dependent | The port number on which to serve the namer interface.
+socketOptions | none | Socket options for a configured interface. See [Socket Options](https://linkerd.io/config/head/linkerd/index.html#socket-options)
 tls | no tls | The namer interface will serve over TLS if this parameter is provided. See [Server TLS](https://linkerd.io/config/head/linkerd#server-tls).
 
 ## Thrift Name Interpreter
@@ -32,6 +33,7 @@ Key | Default Value | Description
 --- | ------------- | -----------
 ip | loopback address | The local IP address on which to serve the namer interface. A value like 0.0.0.0 configures Namerd to listen on all local IPv4 interfaces.
 port | `4100` | The port number on which to serve the namer interface.
+socketOptions | none | Socket options for the thrift name interpreter interface. See [Socket Options](https://linkerd.io/config/head/linkerd/index.html#socket-options)
 cache | see [cache](#cache) | Binding and address cache size configuration.
 tls | no tls | The namer interface will serve over TLS if this parameter is provided. See [Server TLS](https://linkerd.io/config/head/linkerd#server-tls).
 
@@ -58,6 +60,7 @@ Key | Default Value | Description
 --- | ------------- | -----------
 ip | loopback address | The local IP address on which to serve the namer interface. A value like 0.0.0.0 configures Namerd to listen on all local IPv4 interfaces.
 port | `4321` | The port number on which to serve the namer interface.
+socketOptions | none | Socket options for the mesh interface. See [Socket Options](https://linkerd.io/config/head/linkerd/index.html#socket-options)
 tls | no tls | The namer interface will serve over TLS if this parameter is provided. See [Server TLS](https://linkerd.io/config/head/linkerd#server-tls). The server TLS key file must be in PKCS#8 format.
 
 ## Linkerd2 Destination Interface
@@ -71,6 +74,7 @@ Key | Default Value | Description
 --- | ------------- | -----------
 ip | loopback address | The local IP address on which to serve the destination interface. A value like 0.0.0.0 configures Namerd to listen on all local IPv4 interfaces.
 port | `8086` | The port number on which to serve the destination interface.
+socketOptions | none | Socket options to set for the l5d2 destination interface. See [Socket Options](https://linkerd.io/config/head/linkerd/index.html#socket-options)
 prefix | /svc | The prefix to use when delegating Linkerd2 request paths to Namerd
 namespace | default | The namespace with which Namerd should use to retrieve a dtab
 
@@ -89,6 +93,7 @@ Key | Default Value | Description
 --- | ------------- | -----------
 ip | loopback address | The local IP address on which to serve the namer interface. A value like 0.0.0.0 configures Namerd to listen on all local IPv4 interfaces.
 port | `4180` | The port number on which to serve the namer interface.
+socketOptions | none | Socket options to set for the http controller interface. See [Socket Options](https://linkerd.io/config/head/linkerd/index.html#socket-options)
 tls | no tls | The namer interface will serve over TLS if this parameter is provided. See [Server TLS](https://linkerd.io/config/head/linkerd#server-tls).
 
 ### GET /api/1/dtabs

--- a/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/HttpControlServiceConfig.scala
+++ b/namerd/iface/control-http/src/main/scala/io/buoyant/namerd/iface/HttpControlServiceConfig.scala
@@ -22,8 +22,8 @@ class HttpControlServiceConfig extends InterpreterInterfaceConfig {
       tlsParams +
         param.Stats(stats.scope(HttpControlServiceConfig.kind)) +
         param.Label(HttpControlServiceConfig.kind) +
-        Http.Netty4Impl
-
+        Http.Netty4Impl ++
+        socketOptParams
     HttpControlServable(addr, iface, params)
   }
 

--- a/namerd/iface/control-http/src/test/scala/io/buoyant/namerd/iface/HttpControlServiceConfigTest.scala
+++ b/namerd/iface/control-http/src/test/scala/io/buoyant/namerd/iface/HttpControlServiceConfigTest.scala
@@ -1,5 +1,6 @@
 package io.buoyant.namerd.iface
 
+import com.twitter.finagle.buoyant.SocketOptionsConfig
 import io.buoyant.config.Parser
 import org.scalatest.FunSuite
 
@@ -47,5 +48,24 @@ class HttpControlServiceConfigTest extends FunSuite {
     assert(tls.caCertPath == Some("cacert.pem"))
     assert(tls.ciphers == Some(List("foo", "bar")))
     assert(tls.requireClientAuth == Some(true))
+  }
+
+  test("socket options"){
+    val expectedOpts = SocketOptionsConfig(reusePortEnabled = true)
+    val yaml = """
+      |kind: io.l5d.httpController
+      |socketOptions:
+      |  disableTcpNoDelay: true
+      |  reuseAddrEnabled: true
+      |  reusePortEnabled: true
+    """.stripMargin
+
+    val config = Parser
+      .objectMapper(yaml,
+        Iterable(Seq(new HttpControlServiceInitializer))
+      ).readValue[HttpControlServiceConfig](yaml)
+
+    val sockOpts = config.socketOptions.get
+    assert(sockOpts == expectedOpts)
   }
 }

--- a/namerd/iface/control-http/src/test/scala/io/buoyant/namerd/iface/HttpControlServiceConfigTest.scala
+++ b/namerd/iface/control-http/src/test/scala/io/buoyant/namerd/iface/HttpControlServiceConfigTest.scala
@@ -51,13 +51,13 @@ class HttpControlServiceConfigTest extends FunSuite {
   }
 
   test("socket options"){
-    val expectedOpts = SocketOptionsConfig(reusePortEnabled = true)
+    val expectedOpts = SocketOptionsConfig(reusePort = true)
     val yaml = """
       |kind: io.l5d.httpController
       |socketOptions:
-      |  disableTcpNoDelay: true
-      |  reuseAddrEnabled: true
-      |  reusePortEnabled: true
+      |  noDelay: true
+      |  reuseAddr: true
+      |  reusePort: true
     """.stripMargin
 
     val config = Parser

--- a/namerd/iface/destination/src/main/scala/io/buoyant/namerd/iface/DestinationIfaceInitializer.scala
+++ b/namerd/iface/destination/src/main/scala/io/buoyant/namerd/iface/DestinationIfaceInitializer.scala
@@ -39,7 +39,9 @@ class DestinationIfaceConfig(
       log.info(s"DestinationIfaceInitializer using dtab in $ns with prefix $pfx")
       val destination = new DestinationService(pfx, delegate(ns))
       val dispatcher = ServerDispatcher(Destination.Server(destination))
-      H2.server.withTracer(NullTracer).serve(addr, dispatcher)
+      H2.server
+        .configuredParams(socketOptParams)
+        .withTracer(NullTracer).serve(addr, dispatcher)
     }
   }
 }

--- a/namerd/iface/destination/src/test/scala/io/buoyant/namerd/iface/DestinationIfaceInitializerTest.scala
+++ b/namerd/iface/destination/src/test/scala/io/buoyant/namerd/iface/DestinationIfaceInitializerTest.scala
@@ -1,5 +1,6 @@
 package io.buoyant.namerd.iface
 
+import com.twitter.finagle.buoyant.SocketOptionsConfig
 import io.buoyant.config.Parser
 import io.buoyant.test.FunSuite
 
@@ -13,5 +14,25 @@ class DestinationIfaceInitializerTest extends FunSuite{
     val config = Parser.objectMapper(yaml, Iterable(Seq(new DestinationIfaceInitializer)))
       .readValue[DestinationIfaceConfig](yaml)
     assert(config.addr.getHostString == "localhost")
+  }
+
+  test("read socket options"){
+    val expectedOpts = SocketOptionsConfig(reusePortEnabled = true)
+    val yaml = s"""
+       |kind: io.l5d.destination
+       |ip: 0.0.0.0
+       |port: 8085
+       |socketOptions:
+       |  disableTcpNoDelay: true
+       |  reuseAddrEnabled: true
+       |  reusePortEnabled: true
+     """.stripMargin
+
+    val config = Parser.objectMapper(yaml, Iterable(Seq(new DestinationIfaceInitializer)))
+      .readValue[DestinationIfaceConfig](yaml)
+    config.socketOptions match {
+      case None => fail(s"socket options is None. Expected $expectedOpts")
+      case Some(opts) => assert(opts == expectedOpts)
+    }
   }
 }

--- a/namerd/iface/destination/src/test/scala/io/buoyant/namerd/iface/DestinationIfaceInitializerTest.scala
+++ b/namerd/iface/destination/src/test/scala/io/buoyant/namerd/iface/DestinationIfaceInitializerTest.scala
@@ -17,15 +17,15 @@ class DestinationIfaceInitializerTest extends FunSuite{
   }
 
   test("read socket options"){
-    val expectedOpts = SocketOptionsConfig(reusePortEnabled = true)
+    val expectedOpts = SocketOptionsConfig(reusePort = true)
     val yaml = s"""
        |kind: io.l5d.destination
        |ip: 0.0.0.0
        |port: 8085
        |socketOptions:
-       |  disableTcpNoDelay: true
-       |  reuseAddrEnabled: true
-       |  reusePortEnabled: true
+       |  noDelay: true
+       |  reuseAddr: true
+       |  reusePort: true
      """.stripMargin
 
     val config = Parser.objectMapper(yaml, Iterable(Seq(new DestinationIfaceInitializer)))

--- a/namerd/iface/interpreter-thrift/src/main/scala/io/buoyant/namerd/iface/ThriftInterpreterInterfaceConfig.scala
+++ b/namerd/iface/interpreter-thrift/src/main/scala/io/buoyant/namerd/iface/ThriftInterpreterInterfaceConfig.scala
@@ -35,7 +35,8 @@ case class ThriftInterpreterInterfaceConfig(
     )
     val params =
       tlsParams +
-        param.Stats(stats1)
+        param.Stats(stats1) ++
+        socketOptParams
     ThriftServable(addr, iface, params)
   }
 }

--- a/namerd/iface/interpreter-thrift/src/test/scala/io/buoyant/namerd/iface/ThriftInterpreterInterfaceConfigTest.scala
+++ b/namerd/iface/interpreter-thrift/src/test/scala/io/buoyant/namerd/iface/ThriftInterpreterInterfaceConfigTest.scala
@@ -1,5 +1,6 @@
 package io.buoyant.namerd.iface
 
+import com.twitter.finagle.buoyant.SocketOptionsConfig
 import io.buoyant.config.Parser
 import org.scalatest.FunSuite
 
@@ -55,5 +56,27 @@ class ThriftInterpreterInterfaceConfigTest extends FunSuite {
     assert(tls.caCertPath == Some("cacert.pem"))
     assert(tls.ciphers == Some(List("foo", "bar")))
     assert(tls.requireClientAuth == Some(true))
+  }
+
+  test("socket options"){
+    test("read socket options"){
+      val expectedOpts = SocketOptionsConfig(reusePortEnabled = true)
+      val yaml = s"""
+        |kind: io.l5d.thriftNameInterpreter
+        |ip: 0.0.0.0
+        |port: 8085
+        |socketOptions:
+        |  disableTcpNoDelay: true
+        |  reuseAddrEnabled: true
+        |  reusePortEnabled: true
+     """.stripMargin
+
+      val config = Parser.objectMapper(yaml, Iterable(Seq(new ThriftInterpreterInterfaceInitializer)))
+        .readValue[ThriftInterpreterInterfaceConfig](yaml)
+      config.socketOptions match {
+        case None => fail(s"socket options is None. Expected $expectedOpts")
+        case Some(opts) => assert(opts == expectedOpts)
+      }
+    }
   }
 }

--- a/namerd/iface/interpreter-thrift/src/test/scala/io/buoyant/namerd/iface/ThriftInterpreterInterfaceConfigTest.scala
+++ b/namerd/iface/interpreter-thrift/src/test/scala/io/buoyant/namerd/iface/ThriftInterpreterInterfaceConfigTest.scala
@@ -8,13 +8,13 @@ class ThriftInterpreterInterfaceConfigTest extends FunSuite {
 
   test("cache capacity") {
     val yaml = """
-      |kind: io.l5d.thriftNameInterpreter
-      |cache:
-      |  bindingCacheActive: 5000
-      |  bindingCacheInactive: 1000
-      |  bindingCacheInactiveTTLSecs: 3600
-      |  addrCacheActive: 6000
-    """.stripMargin
+                 |kind: io.l5d.thriftNameInterpreter
+                 |cache:
+                 |  bindingCacheActive: 5000
+                 |  bindingCacheInactive: 1000
+                 |  bindingCacheInactiveTTLSecs: 3600
+                 |  addrCacheActive: 6000
+               """.stripMargin
 
     val config = Parser
       .objectMapper(
@@ -28,21 +28,24 @@ class ThriftInterpreterInterfaceConfigTest extends FunSuite {
     assert(capacity.bindingCacheInactiveTTLSecs == 3600)
     assert(capacity.addrCacheActive == 6000)
     assert(capacity.addrCacheInactive == ThriftNamerInterface.Capacity.default.addrCacheInactive)
-    assert(capacity.addrCacheInactiveTTLSecs == ThriftNamerInterface.Capacity.default.addrCacheInactiveTTLSecs)
+    assert(
+      capacity.addrCacheInactiveTTLSecs == ThriftNamerInterface.Capacity.default
+        .addrCacheInactiveTTLSecs
+    )
   }
 
   test("tls") {
     val yaml = """
-      |kind: io.l5d.thriftNameInterpreter
-      |tls:
-      |  certPath: cert.pem
-      |  keyPath: key.pem
-      |  caCertPath: cacert.pem
-      |  ciphers:
-      |  - "foo"
-      |  - "bar"
-      |  requireClientAuth: true
-    """.stripMargin
+                 |kind: io.l5d.thriftNameInterpreter
+                 |tls:
+                 |  certPath: cert.pem
+                 |  keyPath: key.pem
+                 |  caCertPath: cacert.pem
+                 |  ciphers:
+                 |  - "foo"
+                 |  - "bar"
+                 |  requireClientAuth: true
+               """.stripMargin
 
     val config = Parser
       .objectMapper(
@@ -58,10 +61,9 @@ class ThriftInterpreterInterfaceConfigTest extends FunSuite {
     assert(tls.requireClientAuth == Some(true))
   }
 
-  test("socket options"){
-    test("read socket options"){
-      val expectedOpts = SocketOptionsConfig(reusePortEnabled = true)
-      val yaml = s"""
+  test("read socket options") {
+    val expectedOpts = SocketOptionsConfig(reusePortEnabled = true)
+    val yaml = s"""
         |kind: io.l5d.thriftNameInterpreter
         |ip: 0.0.0.0
         |port: 8085
@@ -71,12 +73,11 @@ class ThriftInterpreterInterfaceConfigTest extends FunSuite {
         |  reusePortEnabled: true
      """.stripMargin
 
-      val config = Parser.objectMapper(yaml, Iterable(Seq(new ThriftInterpreterInterfaceInitializer)))
-        .readValue[ThriftInterpreterInterfaceConfig](yaml)
-      config.socketOptions match {
-        case None => fail(s"socket options is None. Expected $expectedOpts")
-        case Some(opts) => assert(opts == expectedOpts)
-      }
+    val config = Parser.objectMapper(yaml, Iterable(Seq(new ThriftInterpreterInterfaceInitializer)))
+      .readValue[ThriftInterpreterInterfaceConfig](yaml)
+    config.socketOptions match {
+      case None => fail(s"socket options is None. Expected $expectedOpts")
+      case Some(opts) => assert(opts == expectedOpts)
     }
   }
 }

--- a/namerd/iface/interpreter-thrift/src/test/scala/io/buoyant/namerd/iface/ThriftInterpreterInterfaceConfigTest.scala
+++ b/namerd/iface/interpreter-thrift/src/test/scala/io/buoyant/namerd/iface/ThriftInterpreterInterfaceConfigTest.scala
@@ -62,15 +62,15 @@ class ThriftInterpreterInterfaceConfigTest extends FunSuite {
   }
 
   test("read socket options") {
-    val expectedOpts = SocketOptionsConfig(reusePortEnabled = true)
+    val expectedOpts = SocketOptionsConfig(reusePort = true)
     val yaml = s"""
         |kind: io.l5d.thriftNameInterpreter
         |ip: 0.0.0.0
         |port: 8085
         |socketOptions:
-        |  disableTcpNoDelay: true
-        |  reuseAddrEnabled: true
-        |  reusePortEnabled: true
+        |  noDelay: true
+        |  reuseAddr: true
+        |  reusePort: true
      """.stripMargin
 
     val config = Parser.objectMapper(yaml, Iterable(Seq(new ThriftInterpreterInterfaceInitializer)))

--- a/namerd/iface/mesh/src/main/scala/io/buoyant/namerd/iface/MeshIfaceInitializer.scala
+++ b/namerd/iface/mesh/src/main/scala/io/buoyant/namerd/iface/MeshIfaceInitializer.scala
@@ -45,7 +45,11 @@ class MeshIfaceConfig extends InterfaceConfig {
         ServerDispatcher(codec, interpreter, delegator, resolver)
       }
 
-      H2.server.withTracer(NullTracer).configuredParams(tlsParams).withStatsReceiver(stats1)
+      H2.server
+        .withTracer(NullTracer)
+        .configuredParams(tlsParams)
+        .configuredParams(socketOptParams)
+        .withStatsReceiver(stats1)
         .serve(addr, dispatcher)
     }
   }


### PR DESCRIPTION
A recent update to Finagle allows `ListeningServer` sockets to enable `SO_REUSEPORT`. This feature allows two or more Linkerd or Namerd instance to bind to the same port enabling zero downtime configuration changes.

This PR adds  `SO_REUSEPORT` to Linkerd routers, Linkerd admin servers and all Namerd control plane interfaces. Note that this feature is only available to certain Linux distributions. There also may need to be additional work to understand how this feature can be used when Linkerd is deployed in a daemonset environment. 

fixes #1449

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>