### PR TITLE
Add request timeout to consul client to avoid stale service discovery updates

### DIFF
--- a/namer/consul/src/main/scala/io/buoyant/namer/consul/SvcAddr.scala
+++ b/namer/consul/src/main/scala/io/buoyant/namer/consul/SvcAddr.scala
@@ -81,7 +81,7 @@ private[consul] object SvcAddr {
             stopped = true
             Future.Unit
           case Throw(e: IndividualRequestTimeoutException) =>
-            // update state with last known state if we receive a API request timeout
+            // catch request timeout exceptions for Consul API. Use last known good state.
             stats.errors.incr()
             log.log(
               failureLogLevel,

--- a/namer/consul/src/main/scala/io/buoyant/namer/consul/SvcAddr.scala
+++ b/namer/consul/src/main/scala/io/buoyant/namer/consul/SvcAddr.scala
@@ -85,11 +85,10 @@ private[consul] object SvcAddr {
             stats.errors.incr()
             log.log(
               failureLogLevel,
-              "consul datacenter '%s' service '%s' observation error %s." +
+              "consul datacenter '%s' service '%s' lookup request timed out %s." +
                 " Last known state is %s",
               datacenter, key.name, e, currentValueToLog
             )
-            state.update(currentValueToLog)
             val backoff #:: nextBackoffs = backoffs
             // subsequent errors are logged as DEBUG
             Future.sleep(backoff).before(loop(None, nextBackoffs, Level.DEBUG, currentValueToLog))

--- a/namer/consul/src/test/scala/io/buoyant/namer/consul/SvcAddrTest.scala
+++ b/namer/consul/src/test/scala/io/buoyant/namer/consul/SvcAddrTest.scala
@@ -214,11 +214,11 @@ class SvcAddrTest extends FunSuite with Matchers with Awaits {
         case _ => fail("received unexpected Addr on timed out service discovery request")
       }
 
-      // Advance timer to go past backoff sleep future in SvcAddr
-      tc.advance(5.minutes)
+      // Advance timer to trigger Future.sleep(backoff) in SvcAddr
+      tc.advance(1.minutes)
       timer.tick()
 
-      tc.advance(2.minutes)
+      tc.advance(1.minutes)
       timer.tick()
 
       eventually {


### PR DESCRIPTION
There have been issues where Namerd with a consul namer fails to update its watch state in situations were a long-polling request to consul never returns with service discovery info.

This PR adds a request timeout configuration for the client that issues these requests. The timeout is set to 10 minutes, which is double the timeout that consul already provides for [blocking queries](https://www.consul.io/api/index.html#blocking-queries). When Linkerd's consul client reaches the 10 minute timeout, the client throws an `IndividualRequestTimeoutException` which triggers a new request to be issued in [SvcAddr](https://github.com/linkerd/linkerd/blob/master/namer/consul/src/main/scala/io/buoyant/namer/consul/SvcAddr.scala#L84) to the consul agent.

Tests were performed manually with a Test server that responded to any consul client request after 10 minutes. 

fixes #2131 

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>