### PR TITLE
Don't hang the demux loop when encountering frames on a closed stream

### DIFF
--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/Stream.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/Stream.scala
@@ -153,7 +153,12 @@ object Stream {
     override def onCancel: Future[Reset] = cancelP
 
     private[this] val endOnReleaseIfEnd: Try[Frame] => Unit = {
-      case Return(f) => if (f.isEnd) endP.become(f.onRelease)
+      case Return(f) =>
+        if (f.isEnd) {
+          f.onRelease.respond { k =>
+            endP.updateIfEmpty(k); ()
+          }
+        }; ()
       case Throw(e) => endP.updateIfEmpty(Throw(e)); ()
     }
 


### PR DESCRIPTION
Fixes #2128 

Receiving frames on a closed stream hangs the demux loop and causes Linkerd to stop receiving any new frames on that connection.

Continue the demux loop after receiving a frame on a closed stream.

Signed-off-by: Alex Leong <alex@buoyant.io>