### PR TITLE
Increase circleci resource class to large

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ jobs:
           CI_TERRIBLENESS: 30.seconds
     # Run two containers, $CIRCLE_NODE_TOTAL = 2, $CIRCLE_NODE_INDEX = [0|1]
     parallelism: 2
+    resource_class: large
     working_directory: ~/linkerd
     # All run steps execute in both containers unless otherwise specified.
     # Deploy steps execute on container 0.

--- a/linkerd/examples/src/test/scala/io/buoyant/linkerd/examples/ExamplesTest.scala
+++ b/linkerd/examples/src/test/scala/io/buoyant/linkerd/examples/ExamplesTest.scala
@@ -18,7 +18,7 @@ class ExamplesTest extends FunSuite {
   for (file <- files) {
     // Example tests are running out of memory in CI and so have been temporarily been disabled to
     // unblock CI.  This needs to be investigated and fixed.
-    ignore(file.getName) {
+    test(file.getName) {
       val source = Source.fromFile(file)
       try {
         val lines = source.getLines().toSeq


### PR DESCRIPTION
This should hopefully prevent Linkerd tests from getting terminated for using to memory.

Signed-off-by: Alex Leong <alex@buoyant.io>