### PR TITLE
set maxConcurrentStreamsPerConnection default 1000

### DIFF
--- a/linkerd/docs/protocol-h2.md
+++ b/linkerd/docs/protocol-h2.md
@@ -84,7 +84,7 @@ Key | Default Value | Description
 windowUpdateRatio | `0.99` | A number between 0 and 1, exclusive, indicating the ratio at which window updates should be sent. With a value of 0.75, updates will be sent when the available window size is 75% of its capacity.
 headerTableBytes | none | Configures `SETTINGS_HEADER_TABLE_SIZE` on new streams.
 initialStreamWindowBytes | 64KB | Configures `SETTINGS_INITIAL_WINDOW_SIZE` on streams.
-maxConcurrentStreamsPerConnection | unlimited | Configures `SETTINGS_MAX_CONCURRENT_STREAMS` on new streams.
+maxConcurrentStreamsPerConnection | 1000 | Configures `SETTINGS_MAX_CONCURRENT_STREAMS` on new streams.
 maxFrameBytes | 16KB | Configures `SETTINGS_MAX_FRAME_SIZE` on new streams.
 maxHeaderListByts | none | Configures `SETTINGS_MAX_HEADER_LIST_SIZE` on new streams.
 
@@ -411,8 +411,8 @@ The trace information in the header are serialized by Finagles `TraceId.serializ
 
 kind: `io.l5d.zipkin`.
 
-A trace propagator that writes Zipkin B3 trace headers to outgoing requests. Processes B3 Headers 
-received from upstream as well. 
+A trace propagator that writes Zipkin B3 trace headers to outgoing requests. Processes B3 Headers
+received from upstream as well.
 
 Header | Content
 ------ | -------

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/H2Config.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/H2Config.scala
@@ -255,7 +255,7 @@ case class RetryBufferSize(
 
 class H2ServerConfig extends ServerConfig with H2EndpointConfig {
 
-  var maxConcurrentStreamsPerConnection: Option[Int] = None
+  var maxConcurrentStreamsPerConnection: Option[Long] = None
   var addForwardedHeader: Option[AddForwardedHeaderConfig] = None
 
   @JsonIgnore
@@ -265,8 +265,8 @@ class H2ServerConfig extends ServerConfig with H2EndpointConfig {
   @JsonIgnore
   override val sslServerEngine = Netty4ServerEngineFactory()
 
-  override def withEndpointParams(params: Stack.Params): Stack.Params = super.withEndpointParams(params)
-    .maybeWith(maxConcurrentStreamsPerConnection.map(c => Settings.MaxConcurrentStreams(Some(c.toLong))))
+  override def withEndpointParams(params: Stack.Params): Stack.Params = (super.withEndpointParams(params)
+    + Settings.MaxConcurrentStreams(maxConcurrentStreamsPerConnection.orElse(Some(1000L))))
 
   @JsonIgnore
   override def serverParams = withEndpointParams(super.serverParams

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/H2Config.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/H2Config.scala
@@ -255,7 +255,7 @@ case class RetryBufferSize(
 
 class H2ServerConfig extends ServerConfig with H2EndpointConfig {
 
-  var maxConcurrentStreamsPerConnection: Option[Long] = None
+  var maxConcurrentStreamsPerConnection: Option[Int] = None
   var addForwardedHeader: Option[AddForwardedHeaderConfig] = None
 
   @JsonIgnore
@@ -266,7 +266,7 @@ class H2ServerConfig extends ServerConfig with H2EndpointConfig {
   override val sslServerEngine = Netty4ServerEngineFactory()
 
   override def withEndpointParams(params: Stack.Params): Stack.Params = (super.withEndpointParams(params)
-    + Settings.MaxConcurrentStreams(maxConcurrentStreamsPerConnection.orElse(Some(1000L))))
+    + Settings.MaxConcurrentStreams(maxConcurrentStreamsPerConnection.orElse(Some(1000)).map(_.toLong)))
 
   @JsonIgnore
   override def serverParams = withEndpointParams(super.serverParams


### PR DESCRIPTION
`maxConcurrentStreamsPerConnection`'s default value was unlimited,
meaning Linkerd could run out of memory if a client created enough
streams, particularly if the client is leaking streams but not properly
closing them.

Change default `maxConcurrentStreamsPerConnection` value to 1000,
disallow unlimited via a Linkerd config file.

Related to #2132 and https://github.com/grpc/grpc-go/pull/2354

Signed-off-by: Andrew Seigner <siggy@buoyant.io>