### PR TITLE
Log ingress matches at debug

### DIFF
--- a/k8s/src/main/scala/io/buoyant/k8s/IngressCache.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/IngressCache.scala
@@ -15,7 +15,7 @@ case class IngressSpec(
   def getMatchingPath(hostHeader: Option[String], requestPath: String): Option[IngressPath] = {
     val matchingPath = rules.find(_.matches(hostHeader, requestPath))
     matchingPath match {
-      case Some(path) => log.info("ingress %s.%s: found rule matching %s %s: %s", name.getOrElse("unknown"), namespace.getOrElse("default"), hostHeader.getOrElse(""), requestPath, path)
+      case Some(path) => log.debug("ingress %s.%s: found rule matching %s %s: %s", name.getOrElse("unknown"), namespace.getOrElse("default"), hostHeader.getOrElse(""), requestPath, path)
       case None => log.debug("ingress %s.%s: no rules found matching %s %s", name.getOrElse("unknown"), namespace.getOrElse("default"), hostHeader.getOrElse(""), requestPath)
     }
     matchingPath


### PR DESCRIPTION
This log line causes something like the following to be logged for every incoming HTTP request at ingress:

```
I 1010 21:21:31.948 UTC THREAD44 TraceId:f03960bfa2cf4f3c: ingress webtiles.live: found rule matching tiles3.REDACTED /v1/REDACTED: IngressPath(Some(tiles3.REDACTED),None,live,webtiles,5555)                         
```

I think it's more appropriate at debug than info.