### PR TITLE
removes all load balancers from the balancer registry

### DIFF
--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/LoadBalancerConfig.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/LoadBalancerConfig.scala
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.twitter.conversions.time._
 import com.twitter.finagle.Stack
 import com.twitter.finagle.loadbalancer.LoadBalancerFactory.EnableProbation
+import com.twitter.finagle.loadbalancer.buoyant.DeregisterLoadBalancerFactory
 import com.twitter.finagle.loadbalancer.{Balancers, LoadBalancerFactory}
 import io.buoyant.config.PolymorphicConfig
 
@@ -22,7 +23,8 @@ abstract class LoadBalancerConfig extends PolymorphicConfig {
   val enableProbation: Option[Boolean] = None
 
   @JsonIgnore
-  def clientParams = Stack.Params.empty + LoadBalancerFactory.Param(factory) +
+  def clientParams = Stack.Params.empty +
+    LoadBalancerFactory.Param(new DeregisterLoadBalancerFactory(factory)) +
     LoadBalancerFactory.EnableProbation(enableProbation.getOrElse(false))
 }
 

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/ClientTest.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/ClientTest.scala
@@ -2,6 +2,8 @@ package io.buoyant.linkerd
 
 import com.twitter.finagle.Path
 import com.twitter.finagle.liveness.{FailureAccrualFactory, FailureAccrualPolicy}
+import com.twitter.finagle.loadbalancer.LoadBalancerFactory._
+import com.twitter.finagle.loadbalancer.buoyant.DeregisterLoadBalancerFactory
 import com.twitter.finagle.loadbalancer.{FlagBalancerFactory, LoadBalancerFactory}
 import com.twitter.finagle.ssl.client.SslClientConfiguration
 import com.twitter.finagle.transport.Transport
@@ -20,11 +22,19 @@ class ClientTest extends FunSuite {
                           |  kind: ewma""".stripMargin)
 
     val fooParams = client.clientParams.paramsFor(Path.read("/foo"))
-    val LoadBalancerFactory.Param(fooBalancer) = fooParams[LoadBalancerFactory.Param]
-    assert(fooBalancer.toString == "P2CPeakEwma")
+    val Param(fooBalancer) = fooParams[LoadBalancerFactory.Param]
+    val fooBal = fooBalancer match {
+      case DeregisterLoadBalancerFactory(lbf) => lbf
+      case _ => fail("Unexpected load balancer configured")
+    }
+    assert(fooBal.toString == "P2CPeakEwma")
     val barParams = client.clientParams.paramsFor(Path.read("/bar"))
-    val LoadBalancerFactory.Param(barBalancer) = barParams[LoadBalancerFactory.Param]
-    assert(barBalancer.toString == "P2CPeakEwma")
+    val Param(barBalancer) = barParams[LoadBalancerFactory.Param]
+    val barBal = barBalancer match {
+      case DeregisterLoadBalancerFactory(lbf) => lbf
+      case _ => fail("Unexpected load balancer configured")
+    }
+    assert(barBal.toString == "P2CPeakEwma")
   }
 
   test("per client config") {
@@ -38,17 +48,31 @@ class ClientTest extends FunSuite {
                           |    kind: aperture""".stripMargin)
 
     val fooParams = client.clientParams.paramsFor(Path.read("/#/io.l5d.fs/foo"))
-    val LoadBalancerFactory.Param(fooBalancer) = fooParams[LoadBalancerFactory.Param]
-    assert(fooBalancer.toString == "P2CPeakEwma")
+    val Param(fooBalancer) = fooParams[LoadBalancerFactory.Param]
+    val fooBal = fooBalancer match {
+      case DeregisterLoadBalancerFactory(lbf) => lbf
+      case _ => fail("Unexpected load balancer configured")
+    }
+    assert(fooBal.toString == "P2CPeakEwma")
 
     val barParams = client.clientParams.paramsFor(Path.read("/#/io.l5d.fs/bar"))
-    val LoadBalancerFactory.Param(barBalancer) = barParams[LoadBalancerFactory.Param]
-    assert(barBalancer.toString == "ApertureLeastLoaded")
+    val Param(barBalancer) = barParams[LoadBalancerFactory.Param]
+    val barBal = barBalancer match {
+      case DeregisterLoadBalancerFactory(lbf) => lbf
+      case _ => fail("Unexpected load balancer configured")
+    }
+    assert(barBal.toString == "ApertureLeastLoaded")
 
     // bas, not configured, gets default values
     val basParams = client.clientParams.paramsFor(Path.read("/#/io.l5d.fs/bas"))
-    val LoadBalancerFactory.Param(basBalancer) = basParams[LoadBalancerFactory.Param]
-    assert(basBalancer == FlagBalancerFactory)
+    val Param(basBalancer) = basParams[LoadBalancerFactory.Param]
+    println(basBalancer)
+    val basBal = basBalancer match {
+      case DeregisterLoadBalancerFactory(lbf) => lbf
+      case flb: LoadBalancerFactory => flb
+      case _ => fail("Unexpected load balancer configured")
+    }
+    assert(basBal == FlagBalancerFactory)
   }
 
   test("later client configs override earlier ones") {
@@ -62,12 +86,20 @@ class ClientTest extends FunSuite {
                           |    kind: aperture""".stripMargin)
 
     val fooParams = client.clientParams.paramsFor(Path.read("/#/io.l5d.fs/foo"))
-    val LoadBalancerFactory.Param(fooBalancer) = fooParams[LoadBalancerFactory.Param]
-    assert(fooBalancer.toString == "P2CPeakEwma")
+    val Param(fooBalancer) = fooParams[LoadBalancerFactory.Param]
+    val fooBal = fooBalancer match {
+      case DeregisterLoadBalancerFactory(lbf) => lbf
+      case _ => fail("Unexpected load balancer configured")
+    }
+    assert(fooBal.toString == "P2CPeakEwma")
 
     val barParams = client.clientParams.paramsFor(Path.read("/#/io.l5d.fs/bar"))
-    val LoadBalancerFactory.Param(barBalancer) = barParams[LoadBalancerFactory.Param]
-    assert(barBalancer.toString == "ApertureLeastLoaded")
+    val Param(barBalancer) = barParams[LoadBalancerFactory.Param]
+    val barBal = barBalancer match {
+      case DeregisterLoadBalancerFactory(lbf) => lbf
+      case _ => fail("Unexpected load balancer configured")
+    }
+    assert(barBal.toString == "ApertureLeastLoaded")
   }
 
   test("variable capture from prefix") {

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/ClientTest.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/ClientTest.scala
@@ -66,7 +66,6 @@ class ClientTest extends FunSuite {
     // bas, not configured, gets default values
     val basParams = client.clientParams.paramsFor(Path.read("/#/io.l5d.fs/bas"))
     val Param(basBalancer) = basParams[LoadBalancerFactory.Param]
-    println(basBalancer)
     val basBal = basBalancer match {
       case DeregisterLoadBalancerFactory(lbf) => lbf
       case flb: LoadBalancerFactory => flb

--- a/router/core/src/main/scala/com/twitter/finagle/loadbalancer/buoyant/DeregisterLoadBalancerFactory.scala
+++ b/router/core/src/main/scala/com/twitter/finagle/loadbalancer/buoyant/DeregisterLoadBalancerFactory.scala
@@ -1,0 +1,38 @@
+package com.twitter.finagle.loadbalancer
+package buoyant
+
+import com.twitter.finagle.{NoBrokersAvailableException, ServiceFactory, ServiceFactoryProxy, Stack}
+import com.twitter.util.Activity
+
+/**
+ * Wraps a load balancer factory implementation and unregisters it from the
+ * Finagle global balancer registry.effectively disabling the use of the global registry.
+ * This class was added to workaround a Finagle bug where the Balancer Registry leaked load balancer
+ * instances. TODO: once https://github.com/twitter/finagle/issues/735 is fixed, we can get rid of
+ * this workaround.
+ *
+ * @param lbf the actual Load Balancer instance that is wrapped by DeregisterLoadBalancerFactory
+ */
+class DeregisterLoadBalancerFactory(lbf: LoadBalancerFactory) extends LoadBalancerFactory {
+  private val globalBalancerRegistry = BalancerRegistry.get
+
+  override def newBalancer[Req, Rep](
+    endpoints: Activity[IndexedSeq[EndpointFactory[Req, Rep]]],
+    emptyException: NoBrokersAvailableException,
+    params: Stack.Params
+  ): ServiceFactory[Req, Rep] = {
+    val underlying = lbf.newBalancer(endpoints, emptyException, params)
+
+    // A balancer is wrapped in a ServiceFactoryProxy so we need to unwrap it so that we
+    // can actually remove it from the registry.
+    underlying match {
+      case svcFacProxy: ServiceFactoryProxy[Req, Rep] =>
+        svcFacProxy.self match {
+          case bal: Balancer[Req, Rep] => globalBalancerRegistry.unregister(bal)
+          case _ => () // There are other types of balancers that aren't registerd i.e. heap. Do nothing
+        }
+      case _ => ()
+    }
+    underlying
+  }
+}

--- a/router/core/src/main/scala/com/twitter/finagle/loadbalancer/buoyant/DeregisterLoadBalancerFactory.scala
+++ b/router/core/src/main/scala/com/twitter/finagle/loadbalancer/buoyant/DeregisterLoadBalancerFactory.scala
@@ -6,14 +6,14 @@ import com.twitter.util.Activity
 
 /**
  * Wraps a load balancer factory implementation and unregisters it from the
- * Finagle global balancer registry.effectively disabling the use of the global registry.
+ * Finagle global balancer registry effectively disabling the use of the global registry.
  * This class was added to workaround a Finagle bug where the Balancer Registry leaked load balancer
  * instances. TODO: once https://github.com/twitter/finagle/issues/735 is fixed, we can get rid of
  * this workaround.
  *
  * @param lbf the actual Load Balancer instance that is wrapped by DeregisterLoadBalancerFactory
  */
-class DeregisterLoadBalancerFactory(lbf: LoadBalancerFactory) extends LoadBalancerFactory {
+case class DeregisterLoadBalancerFactory(lbf: LoadBalancerFactory) extends LoadBalancerFactory {
   private val globalBalancerRegistry = BalancerRegistry.get
 
   override def newBalancer[Req, Rep](

--- a/router/core/src/main/scala/io/buoyant/router/Router.scala
+++ b/router/core/src/main/scala/io/buoyant/router/Router.scala
@@ -373,12 +373,12 @@ object StackRouter {
     stk.result
   }
 
-  val defaultParams: Stack.Params = {
+  val defaultParams: Stack.Params =
     StackClient.defaultParams +
-      LoadBalancerFactory.Param(new DeregisterLoadBalancerFactory(Balancers.p2c())) +
+      LoadBalancerFactory.Param(DeregisterLoadBalancerFactory(Balancers.p2c())) +
       FailFastFactory.FailFast(false) +
       param.Stats(DefaultStatsReceiver.scope("rt"))
-  }
+
   /**
    * Analagous to c.t.f.FactoryToService.module, but is applied
    * unconditionally.

--- a/router/core/src/main/scala/io/buoyant/router/Router.scala
+++ b/router/core/src/main/scala/io/buoyant/router/Router.scala
@@ -4,6 +4,8 @@ import com.twitter.finagle._
 import com.twitter.finagle.buoyant._
 import com.twitter.finagle.client._
 import com.twitter.finagle.liveness.{FailureAccrualFactory => FFailureAccrualFactory}
+import com.twitter.finagle.loadbalancer.{Balancers, LoadBalancerFactory}
+import com.twitter.finagle.loadbalancer.buoyant._
 import com.twitter.finagle.naming.buoyant.{DstBindingFactory, RichConnectionFailedModule, RichConnectionFailedPathModule}
 import com.twitter.finagle.server.StackServer
 import com.twitter.finagle.service.{FailFastFactory, Retries, StatsFilter}
@@ -371,11 +373,12 @@ object StackRouter {
     stk.result
   }
 
-  val defaultParams: Stack.Params =
+  val defaultParams: Stack.Params = {
     StackClient.defaultParams +
+      LoadBalancerFactory.Param(new DeregisterLoadBalancerFactory(Balancers.p2c())) +
       FailFastFactory.FailFast(false) +
       param.Stats(DefaultStatsReceiver.scope("rt"))
-
+  }
   /**
    * Analagous to c.t.f.FactoryToService.module, but is applied
    * unconditionally.


### PR DESCRIPTION
Linkerd runs into an issue where it runs out of memory when it receives empty address sets after a while from any configured namer. This is due to Finagle's Balancer registry not managing balancer state correctly and inadvertently store balancer instances in its `BalancerRegistry`  that are never removed.

This PR is set up to effectively "disable" the `BalancerRegistry` module by immediately removing `Balancer` instances when they are created. Once the [issue](https://github.com/twitter/finagle/issues/735) is fixed we can remove this workaround.

Tests were performed with a locally running Linkerd instance backed by a fs namer. Removing and readding an ip address in the `cat` file caused the bug to appear. After this fix, the size of the `BalancerRegistery` does not grow. Tests were also done with all the various load balancer configurations with Linkerd.

fixes #2152

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>