### PR TITLE
Add Prometheus exception counters

### DIFF
--- a/telemetry/prometheus/src/main/scala/io/buoyant/telemetry/prometheus/PrometheusTelemeter.scala
+++ b/telemetry/prometheus/src/main/scala/io/buoyant/telemetry/prometheus/PrometheusTelemeter.scala
@@ -81,8 +81,16 @@ class PrometheusTelemeter(metrics: MetricsTree, private[prometheus] val handlerP
         (Seq("rt", "client"), labels0 :+ ("client" -> escapeLabelVal(id)))
       case Seq("rt", "client", "service", path) if !labelExists(labels0, "service") =>
         (Seq("rt", "client", "service"), labels0 :+ ("service" -> escapeLabelVal(path)))
+      case Seq("rt", "client", "failures", path) if !labelExists(labels0, "exception") =>
+        (Seq("rt", "client", "failures"), labels0 :+ ("exception" -> escapeLabelVal(path)))
+      case Seq("rt", "client", "exn", path) if !labelExists(labels0, "exception") =>
+        (Seq("rt", "client", "exn"), labels0 :+ ("exception" -> escapeLabelVal(path)))
       case Seq("rt", "server", srv) if !labelExists(labels0, "server") =>
         (Seq("rt", "server"), labels0 :+ ("server" -> escapeLabelVal(srv)))
+      case Seq("rt", "server", "failures", path) if !labelExists(labels0, "exception") =>
+        (Seq("rt", "server", "failures"), labels0 :+ ("exception" -> escapeLabelVal(path)))
+      case Seq("rt", "server", "exn", path) if !labelExists(labels0, "exception") =>
+        (Seq("rt", "server", "exn"), labels0 :+ ("exception" -> escapeLabelVal(path)))
       case _ => (prefix0, labels0)
     }
 

--- a/telemetry/prometheus/src/main/scala/io/buoyant/telemetry/prometheus/PrometheusTelemeter.scala
+++ b/telemetry/prometheus/src/main/scala/io/buoyant/telemetry/prometheus/PrometheusTelemeter.scala
@@ -75,22 +75,21 @@ class PrometheusTelemeter(metrics: MetricsTree, private[prometheus] val handlerP
     val (prefix1, labels1) = prefix0 match {
       case Seq("rt", router) if !labelExists(labels0, "rt") =>
         (Seq("rt"), labels0 :+ ("rt" -> escapeLabelVal(router)))
-      case Seq("rt", "service", path) if !labelExists(labels0, "service") =>
-        (Seq("rt", "service"), labels0 :+ ("service" -> escapeLabelVal(path)))
-      case Seq("rt", "client", id) if !labelExists(labels0, "client") =>
-        (Seq("rt", "client"), labels0 :+ ("client" -> escapeLabelVal(id)))
+
+      // Add label for peer { "service", "client", "server" }
+      case Seq("rt", peer, identifier) if !labelExists(labels0, peer) =>
+        (Seq("rt", peer), labels0 :+ (peer -> escapeLabelVal(identifier)))
+
+      // Handle client service case
       case Seq("rt", "client", "service", path) if !labelExists(labels0, "service") =>
         (Seq("rt", "client", "service"), labels0 :+ ("service" -> escapeLabelVal(path)))
-      case Seq("rt", "client", "failures", path) if !labelExists(labels0, "exception") =>
-        (Seq("rt", "client", "failures"), labels0 :+ ("exception" -> escapeLabelVal(path)))
-      case Seq("rt", "client", "exn", path) if !labelExists(labels0, "exception") =>
-        (Seq("rt", "client", "exn"), labels0 :+ ("exception" -> escapeLabelVal(path)))
-      case Seq("rt", "server", srv) if !labelExists(labels0, "server") =>
-        (Seq("rt", "server"), labels0 :+ ("server" -> escapeLabelVal(srv)))
-      case Seq("rt", "server", "failures", path) if !labelExists(labels0, "exception") =>
-        (Seq("rt", "server", "failures"), labels0 :+ ("exception" -> escapeLabelVal(path)))
-      case Seq("rt", "server", "exn", path) if !labelExists(labels0, "exception") =>
-        (Seq("rt", "server", "exn"), labels0 :+ ("exception" -> escapeLabelVal(path)))
+
+      // Add label for exception { "failures", "exn" }
+      case Seq("rt", peer, "failures", path) if !labelExists(labels0, "exception") =>
+        (Seq("rt", peer, "failures"), labels0 :+ ("exception" -> escapeLabelVal(path)))
+      case Seq("rt", peer, "exn", path) if !labelExists(labels0, "exception") =>
+        (Seq("rt", peer, "exceptions"), labels0 :+ ("exception" -> escapeLabelVal(path)))
+
       case _ => (prefix0, labels0)
     }
 

--- a/telemetry/prometheus/src/main/scala/io/buoyant/telemetry/prometheus/PrometheusTelemeter.scala
+++ b/telemetry/prometheus/src/main/scala/io/buoyant/telemetry/prometheus/PrometheusTelemeter.scala
@@ -76,19 +76,19 @@ class PrometheusTelemeter(metrics: MetricsTree, private[prometheus] val handlerP
       case Seq("rt", router) if !labelExists(labels0, "rt") =>
         (Seq("rt"), labels0 :+ ("rt" -> escapeLabelVal(router)))
 
-      // Add label for peer { "service", "client", "server" }
-      case Seq("rt", peer, identifier) if !labelExists(labels0, peer) =>
-        (Seq("rt", peer), labels0 :+ (peer -> escapeLabelVal(identifier)))
+      // Add label for stack { "service", "client", "server" }
+      case Seq("rt", stack, identifier) if !labelExists(labels0, stack) =>
+        (Seq("rt", stack), labels0 :+ (stack -> escapeLabelVal(identifier)))
 
       // Handle client service case
       case Seq("rt", "client", "service", path) if !labelExists(labels0, "service") =>
         (Seq("rt", "client", "service"), labels0 :+ ("service" -> escapeLabelVal(path)))
 
       // Add label for exception { "failures", "exn" }
-      case Seq("rt", peer, "failures", path) if !labelExists(labels0, "exception") =>
-        (Seq("rt", peer, "failures"), labels0 :+ ("exception" -> escapeLabelVal(path)))
-      case Seq("rt", peer, "exn", path) if !labelExists(labels0, "exception") =>
-        (Seq("rt", peer, "exceptions"), labels0 :+ ("exception" -> escapeLabelVal(path)))
+      case Seq("rt", stack, "failures", path) if !labelExists(labels0, "exception") =>
+        (Seq("rt", stack, "failures"), labels0 :+ ("exception" -> escapeLabelVal(path)))
+      case Seq("rt", stack, "exn", path) if !labelExists(labels0, "exception") =>
+        (Seq("rt", stack, "exceptions"), labels0 :+ ("exception" -> escapeLabelVal(path)))
 
       case _ => (prefix0, labels0)
     }

--- a/telemetry/prometheus/src/test/scala/io/buoyant/telemetry/prometheus/PrometheusTelemeterTest.scala
+++ b/telemetry/prometheus/src/test/scala/io/buoyant/telemetry/prometheus/PrometheusTelemeterTest.scala
@@ -145,45 +145,67 @@ class PrometheusTelemeterTest extends FunSuite {
     assert(rsp == "linkerd_rt:server:requests{rt=\"incoming\", server=\"127.0.0.1/4141\"} 1\n")
   }
 
+  test("exception stats are labelled for service") {
+    val (stats, handler) = statsAndHandler
+    // Replicate stack trace for some failure bar:baz
+    stats.scope("rt", "incoming", "service", "/#/foo", "failures").counter("bar").incr()
+    stats.scope("rt", "incoming", "service", "/#/foo", "failures").counter("bar:baz").incr()
+
+    // Replicate stack trace for some failure bar:qux
+    stats.scope("rt", "incoming", "service", "/#/foo", "failures").counter("bar").incr()
+    stats.scope("rt", "incoming", "service", "/#/foo", "failures").counter("bar:qux").incr()
+
+    // Replicate stack trace for some some exception thud
+    stats.scope("rt", "incoming", "service", "/#/foo", "exn").counter("thud").incr()
+
+    val rsp = await(handler(Request(prometheusPath))).contentString
+    assert(rsp == """linkerd_rt:service:failures{rt="incoming", service="/#/foo", exception="bar"} 2
+                    |linkerd_rt:service:failures{rt="incoming", service="/#/foo", exception="bar:qux"} 1
+                    |linkerd_rt:service:failures{rt="incoming", service="/#/foo", exception="bar:baz"} 1
+                    |linkerd_rt:service:exceptions{rt="incoming", service="/#/foo", exception="thud"} 1
+                    |""".stripMargin)
+  }
+
   test("exception stats are labelled for client") {
     val (stats, handler) = statsAndHandler
-    // Replicate stack trace for some exception foo:bar:baz
+    // Replicate stack trace for some failure bar:baz
     stats.scope("rt", "incoming", "client", "/#/foo", "failures").counter("bar").incr()
     stats.scope("rt", "incoming", "client", "/#/foo", "failures").counter("bar:baz").incr()
-    stats.scope("rt", "incoming", "client", "/#/foo", "failures").counter("bar:baz:qux").incr()
 
-    // Replicate stack trace for some exception foo:bar:qux
+    // Replicate stack trace for some failure bar:qux
     stats.scope("rt", "incoming", "client", "/#/foo", "failures").counter("bar").incr()
-    stats.scope("rt", "incoming", "client", "/#/foo", "failures").counter("bar:baz").incr()
-    stats.scope("rt", "incoming", "client", "/#/foo", "failures").counter("bar:baz:thud").incr()
+    stats.scope("rt", "incoming", "client", "/#/foo", "failures").counter("bar:qux").incr()
 
+    // Replicate stack trace for some some exception thud
+    stats.scope("rt", "incoming", "client", "/#/foo", "exn").counter("thud").incr()
 
     val rsp = await(handler(Request(prometheusPath))).contentString
     assert(rsp == """linkerd_rt:client:failures{rt="incoming", client="/#/foo", exception="bar"} 2
-                    |linkerd_rt:client:failures{rt="incoming", client="/#/foo", exception="bar:baz:qux"} 1
-                    |linkerd_rt:client:failures{rt="incoming", client="/#/foo", exception="bar:baz:thud"} 1
-                    |linkerd_rt:client:failures{rt="incoming", client="/#/foo", exception="bar:baz"} 2
+                    |linkerd_rt:client:failures{rt="incoming", client="/#/foo", exception="bar:qux"} 1
+                    |linkerd_rt:client:failures{rt="incoming", client="/#/foo", exception="bar:baz"} 1
+                    |linkerd_rt:client:exceptions{rt="incoming", client="/#/foo", exception="thud"} 1
                     |""".stripMargin)
   }
 
   test("exception stats are labelled for server") {
     val (stats, handler) = statsAndHandler
-    // Replicate stack trace for some exception foo:bar:baz
+    // Replicate stack trace for some failure foo:bar
     stats.scope("rt", "incoming", "server", "127.0.0.1/4141", "failures").counter("foo").incr()
     stats.scope("rt", "incoming", "server", "127.0.0.1/4141", "failures").counter("foo:bar").incr()
-    stats.scope("rt", "incoming", "server", "127.0.0.1/4141", "failures").counter("foo:bar:baz").incr()
 
-    // Replicate stack trace for some exception foo:bar:qux
+    // Replicate stack trace for some failure foo:baz
     stats.scope("rt", "incoming", "server", "127.0.0.1/4141", "failures").counter("foo").incr()
-    stats.scope("rt", "incoming", "server", "127.0.0.1/4141", "failures").counter("foo:bar").incr()
-    stats.scope("rt", "incoming", "server", "127.0.0.1/4141", "failures").counter("foo:bar:qux").incr()
+    stats.scope("rt", "incoming", "server", "127.0.0.1/4141", "failures").counter("foo:baz").incr()
+
+    // Replicate stack trace for some some exception qux
+    stats.scope("rt", "incoming", "server", "127.0.0.1/4141", "exn").counter("qux").incr()
 
 
     val rsp = await(handler(Request(prometheusPath))).contentString
-    assert(rsp == """linkerd_rt:server:failures{rt="incoming", server="127.0.0.1/4141", exception="foo:bar"} 2
-                    |linkerd_rt:server:failures{rt="incoming", server="127.0.0.1/4141", exception="foo:bar:baz"} 1
+    assert(rsp == """linkerd_rt:server:failures{rt="incoming", server="127.0.0.1/4141", exception="foo:bar"} 1
                     |linkerd_rt:server:failures{rt="incoming", server="127.0.0.1/4141", exception="foo"} 2
-                    |linkerd_rt:server:failures{rt="incoming", server="127.0.0.1/4141", exception="foo:bar:qux"} 1
+                    |linkerd_rt:server:failures{rt="incoming", server="127.0.0.1/4141", exception="foo:baz"} 1
+                    |linkerd_rt:server:exceptions{rt="incoming", server="127.0.0.1/4141", exception="qux"} 1
                     |""".stripMargin)
   }
 }

--- a/telemetry/prometheus/src/test/scala/io/buoyant/telemetry/prometheus/PrometheusTelemeterTest.scala
+++ b/telemetry/prometheus/src/test/scala/io/buoyant/telemetry/prometheus/PrometheusTelemeterTest.scala
@@ -153,7 +153,7 @@ class PrometheusTelemeterTest extends FunSuite {
 
     // Replicate stack trace for some failure bar:qux
     stats.scope("rt", "incoming", "service", "/#/foo", "failures").counter("bar").incr()
-    stats.scope("rt", "incoming", "service", "/#/foo", "failures").counter("bar:qux").incr()
+    stats.scope("rt", "incoming", "service", "/#/foo", "failures").counter("bar", "qux").incr()
 
     // Replicate stack trace for some some exception thud
     stats.scope("rt", "incoming", "service", "/#/foo", "exn").counter("thud").incr()
@@ -174,7 +174,7 @@ class PrometheusTelemeterTest extends FunSuite {
 
     // Replicate stack trace for some failure bar:qux
     stats.scope("rt", "incoming", "client", "/#/foo", "failures").counter("bar").incr()
-    stats.scope("rt", "incoming", "client", "/#/foo", "failures").counter("bar:qux").incr()
+    stats.scope("rt", "incoming", "client", "/#/foo", "failures").counter("bar", "qux").incr()
 
     // Replicate stack trace for some some exception thud
     stats.scope("rt", "incoming", "client", "/#/foo", "exn").counter("thud").incr()
@@ -195,7 +195,7 @@ class PrometheusTelemeterTest extends FunSuite {
 
     // Replicate stack trace for some failure foo:baz
     stats.scope("rt", "incoming", "server", "127.0.0.1/4141", "failures").counter("foo").incr()
-    stats.scope("rt", "incoming", "server", "127.0.0.1/4141", "failures").counter("foo:baz").incr()
+    stats.scope("rt", "incoming", "server", "127.0.0.1/4141", "failures").counter("foo", "baz").incr()
 
     // Replicate stack trace for some some exception qux
     stats.scope("rt", "incoming", "server", "127.0.0.1/4141", "exn").counter("qux").incr()

--- a/telemetry/prometheus/src/test/scala/io/buoyant/telemetry/prometheus/PrometheusTelemeterTest.scala
+++ b/telemetry/prometheus/src/test/scala/io/buoyant/telemetry/prometheus/PrometheusTelemeterTest.scala
@@ -4,6 +4,7 @@ import com.twitter.finagle.http.Request
 import com.twitter.finagle.stats.buoyant.Metric
 import io.buoyant.telemetry.{MetricsTree, MetricsTreeStatsReceiver}
 import io.buoyant.test.FunSuite
+import jdk.nashorn.internal.ir.RuntimeNode
 
 class PrometheusTelemeterTest extends FunSuite {
 
@@ -143,5 +144,26 @@ class PrometheusTelemeterTest extends FunSuite {
     counter.incr()
     val rsp = await(handler(Request(prometheusPath))).contentString
     assert(rsp == "linkerd_rt:server:requests{rt=\"incoming\", server=\"127.0.0.1/4141\"} 1\n")
+  }
+
+  test("exception stats are labelled") {
+    val (stats, handler) = statsAndHandler
+    // Replicate stack trace for some exception foo:bar:baz
+    stats.scope("rt", "incoming", "client", "127.0.0.1/4141", "failures").counter("foo").incr()
+    stats.scope("rt", "incoming", "client", "127.0.0.1/4141", "failures").counter("foo:bar").incr()
+    stats.scope("rt", "incoming", "client", "127.0.0.1/4141", "failures").counter("foo:bar:baz").incr()
+
+    // Replicate stack trace for some exception foo:bar:qux
+    stats.scope("rt", "incoming", "client", "127.0.0.1/4141", "failures").counter("foo").incr()
+    stats.scope("rt", "incoming", "client", "127.0.0.1/4141", "failures").counter("foo:bar").incr()
+    stats.scope("rt", "incoming", "client", "127.0.0.1/4141", "failures").counter("foo:bar:qux").incr()
+
+
+    val rsp = await(handler(Request(prometheusPath))).contentString
+    assert(rsp == """linkerd_rt:client:failures{rt="incoming", client="127.0.0.1/4141", exception="foo:bar"} 2
+                    |linkerd_rt:client:failures{rt="incoming", client="127.0.0.1/4141", exception="foo:bar:baz"} 1
+                    |linkerd_rt:client:failures{rt="incoming", client="127.0.0.1/4141", exception="foo"} 2
+                    |linkerd_rt:client:failures{rt="incoming", client="127.0.0.1/4141", exception="foo:bar:qux"} 1
+                    |""".stripMargin)
   }
 }


### PR DESCRIPTION
### Problem
Prometheus metric names for exception counters have the exception in the name (e.g., rt:server:exn:io_netty_handler_codec_DecoderException). This makes it difficult to aggregate or display by exception because it requires you to know in advance all of the possible exceptions.

### Solution
Consolidate all exceptions into a single counter and put the exception name in a label (e.g. rt:server:exn{exception="io_netty_handler_codec_DecoderException"}). That way, the exception names could be grouped or regex matched and you can select all of them using the same time series.

### Validation
Two tests were added for client and server side.

Fixes #2118 