### PR TITLE
stabilizeExistence's inner var should watch the underlying var

### DIFF
--- a/finagle/buoyant/src/main/scala/com/twitter/finagle/buoyant/ExistentialStability.scala
+++ b/finagle/buoyant/src/main/scala/com/twitter/finagle/buoyant/ExistentialStability.scala
@@ -11,7 +11,7 @@ object ExistentialStability {
 
   type VarUp[T] = Var[T] with Updatable[T]
 
-  implicit class ExistentialVar[T <: AnyRef](val unstable: Var[Option[T]])
+  implicit class ExistentialVar[T](val unstable: Var[Option[T]])
     extends AnyVal {
     /**
      * We can stabilize this by changing the type to Var[Option[Var[T]]].

--- a/finagle/buoyant/src/main/scala/com/twitter/finagle/buoyant/ExistentialStability.scala
+++ b/finagle/buoyant/src/main/scala/com/twitter/finagle/buoyant/ExistentialStability.scala
@@ -79,10 +79,6 @@ object ExistentialStability {
       // This keeps track of the state of the outer Var.
       // We need to track these three states because we only want to update the outer Var when we
       // transition between states.
-      sealed trait State
-      object DoesExist extends State
-      object DoesNotExist extends State
-      object NotOk extends State
       var exists: State = NotOk
 
       val mu = new {}
@@ -126,3 +122,8 @@ object ExistentialStability {
     }
   }
 }
+
+sealed trait State
+object DoesExist extends State
+object DoesNotExist extends State
+object NotOk extends State

--- a/finagle/buoyant/src/main/scala/com/twitter/finagle/buoyant/ExistentialStability.scala
+++ b/finagle/buoyant/src/main/scala/com/twitter/finagle/buoyant/ExistentialStability.scala
@@ -31,34 +31,30 @@ object ExistentialStability {
         }
       }
 
-      // Initial value for outer Var.
-      val init = unstable.sample().map { t =>
-        if (inner == null) {
-          inner = makeInner(t)
-        }
-        inner
-      }
-
-      @volatile var exists = init.isDefined
+      var exists = false
       val mu = new {}
 
-      Var.async[Option[Var[T]]](init) { update =>
+      Var.async[Option[Var[T]]](None) { update =>
         unstable.changes.respond { state =>
           mu.synchronized {
             state match {
-              case Some(_) if exists =>
-              // Do nothing.
-              case Some(t) if !exists =>
+              case Some(t) if inner == null =>
+                // T created.
+                inner = makeInner(t)
                 exists = true
-                if (inner == null) {
-                  inner = makeInner(t)
-                }
                 update() = Some(inner)
-              case None if !exists =>
-              // Do nothing.
+              case Some(_) if !exists =>
+                // T re-created.
+                update() = Some(inner)
+              case Some(_) if exists =>
+              // T modified.
+              // Existence has not changed so the outer Var should not be updated.
               case None if exists =>
+                // T deleted.
                 exists = false
                 update() = None
+              case None if !exists =>
+              // Spurious update in None state.  We can just ignore it.
             }
           }
         }
@@ -73,6 +69,13 @@ object ExistentialStability {
       // The inner Var is null until the first time unstable becomes a Some.
       @volatile var inner: Var[T] = null
 
+      def makeInner(init: T) = Var.async(init) { update =>
+        unstable.states.respond {
+          case Activity.Ok(Some(tt)) => update() = tt
+          case _ =>
+        }
+      }
+
       // This keeps track of the state of the outer Var:
       // None means the state was not Activity.Ok
       // Some(false) means the state was Activity.Ok(Some)
@@ -80,35 +83,37 @@ object ExistentialStability {
       //
       // We need to track these three states because we only want to update the outer Var when we
       // transition between states.
-      @volatile var exists: Option[Boolean] = None
+      var exists: Option[Boolean] = None
       val mu = new {}
 
       val outer = Var.async[Activity.State[Option[Var[T]]]](Activity.Pending) { update =>
         unstable.states.respond { state =>
           mu.synchronized {
             state match {
-              case Activity.Ok(Some(_)) if exists == Some(true) =>
-              // Do nothing.
-              case Activity.Ok(Some(t)) if exists != Some(true) =>
+              case Activity.Ok(Some(t)) if inner == null =>
+                // T created.
+                inner = makeInner(t)
                 exists = Some(true)
-                if (inner == null) {
-                  inner = Var.async(t) { update =>
-                    unstable.states.respond {
-                      case Activity.Ok(Some(tt)) => update() = tt
-                      case _ =>
-                    }
-                  }
-                }
                 update() = Activity.Ok(Some(inner))
-              case Activity.Ok(None) if exists == Some(false) =>
-              // Do nothing.
+              case Activity.Ok(Some(_)) if exists != Some(true) =>
+                // T re-created.
+                exists = Some(true)
+                update() = Activity.Ok(Some(inner))
+              case Activity.Ok(Some(_)) if exists == Some(true) =>
+              // T modified.
+              // Existence has not changed so the outer Var should not be updated.
               case Activity.Ok(None) if exists != Some(false) =>
+                // T deleted.
                 exists = Some(false)
                 update() = Activity.Ok(None)
+              case Activity.Ok(None) if exists == Some(false) =>
+              // Spurious update in None state.  We can just ignore it.
               case Activity.Pending =>
+                // Pending.
                 exists = None
                 update() = Activity.Pending
               case Activity.Failed(e) =>
+                // Failed.
                 exists = None
                 update() = Activity.Failed(e)
             }

--- a/finagle/buoyant/src/test/scala/com/twitter/finagle/buoyant/ExistentialStabilityTest.scala
+++ b/finagle/buoyant/src/test/scala/com/twitter/finagle/buoyant/ExistentialStabilityTest.scala
@@ -1,0 +1,59 @@
+package com.twitter.finagle.buoyant
+
+import com.twitter.util.{Activity, Var}
+import io.buoyant.test.FunSuite
+import com.twitter.finagle.buoyant.ExistentialStability._
+import org.scalatest.concurrent.Eventually
+
+class ExistentialStabilityTest extends FunSuite with Eventually {
+
+  def waitFor[T, U](v: Var[T])(pred: PartialFunction[T, U]): U = {
+    @volatile var value: Option[U] = None
+    val obs = v.changes.respond { t =>
+      if (pred.isDefinedAt(t)) value = Some(pred(t))
+    }
+    eventually {
+      assert(value.isDefined)
+    }
+    obs.close()
+    value.get
+  }
+
+  def assertBecomes[T](v: Var[T], expected: T): Unit = {
+    waitFor(v) {
+      case t if t == expected => ()
+    }
+  }
+
+  test("inner var can be independently observed") {
+    val unstable = Var[Option[Int]](Some(1))
+    val stable = unstable.stabilizeExistence
+
+    val inner = waitFor(stable) {
+      case Some(in) => in
+    }
+
+    assertBecomes(inner, 1)
+
+    unstable() = Some(2)
+
+    assertBecomes(inner, 2)
+  }
+
+  test("inner activity can be independently observed") {
+    val underlying = Var[Activity.State[Option[Int]]](Activity.Ok(Some(1)))
+    val unstable = Activity(underlying)
+    val stable = unstable.stabilizeExistence
+
+    val inner = waitFor(stable.run) {
+      case Activity.Ok(Some(in)) => in
+    }
+
+    assertBecomes(inner, 1)
+
+    underlying() = Activity.Ok(Some(2))
+
+    assertBecomes(inner, 2)
+  }
+
+}


### PR DESCRIPTION
Fixes #2079 

The `stabilizeExistence` method returns a type that consists of an outer `Var[Activity.State[Option[Var[T]]]]` which contains an inner `Var[T]`.  The outer `Var.async` which is driven by updates from the underlying unstable Activity.  This mostly behaves as intended with changes to the underlying unstable Activity causing updates to the outer and inner Vars as appropriate.  However, the inner Var is not an `Var.async` and is only updated so long as the outer Var is observed.  This means that if the inner Var is observed and the outer Var is not, changes will not propagate from the underlying unstable Activity to the inner Var.

This can cause a load balancer to get get stuck with an address set which never updates, even when new data comes in from service discovery.  Consider this scenario:

A first call to the Kubernetes namer is made and the namer calls `stabilizeExistence` on the underlying endpoints Activity.  The Activity (which is essentially the outer Var) is observed and the inner `Name.Bound` (which contains the inner Var) is cached as part of a client stack and also observed.  Then the observation on the outer Var is closed.  The inner Var is still observed but will not receive any updates from the endpoints Activity that backs it.  Since the client stack keeps this Var[Addr] cached, it will hold on to this stale Var for the lifetime of the client stack.

We solve this by making both the inner and outer Vars to be `Var.async` with each of them observing the underlying Activity.  This way, each Var will get updates if and only if that Var is observed.

Signed-off-by: Alex Leong <alex@buoyant.io>