### PR TITLE
Fix incorrect match introduced by #2163

### DIFF
--- a/telemetry/prometheus/src/main/scala/io/buoyant/telemetry/prometheus/PrometheusTelemeter.scala
+++ b/telemetry/prometheus/src/main/scala/io/buoyant/telemetry/prometheus/PrometheusTelemeter.scala
@@ -93,9 +93,9 @@ class PrometheusTelemeter(metrics: MetricsTree, private[prometheus] val handlerP
         (Seq("rt", "client", "service"), labels0 :+ ("service" -> escapeLabelVal(path)))
 
       // Add label for exception { "failures", "exn" }
-      case Seq("rt", stack, "failures", exception) =>
+      case Seq("rt", stack, "failures", exception) if Seq("service", "client", "server").contains(stack) =>
         (Seq("rt", stack, "failures"), addException(labels0, exception))
-      case Seq("rt", stack, "exn", exception) =>
+      case Seq("rt", stack, "exn", exception) if Seq("service", "client", "server").contains(stack) =>
         (Seq("rt", stack, "exceptions"), addException(labels0, exception))
 
       case _ => (prefix0, labels0)

--- a/telemetry/prometheus/src/main/scala/io/buoyant/telemetry/prometheus/PrometheusTelemeter.scala
+++ b/telemetry/prometheus/src/main/scala/io/buoyant/telemetry/prometheus/PrometheusTelemeter.scala
@@ -84,7 +84,8 @@ class PrometheusTelemeter(metrics: MetricsTree, private[prometheus] val handlerP
         (Seq("rt"), labels0 :+ ("rt" -> escapeLabelVal(router)))
 
       // Add label for stack { "service", "client", "server" }
-      case Seq("rt", stack, identifier) if !labelExists(labels0, stack) =>
+      case Seq("rt", stack, identifier) if Seq("service", "client", "server").contains(stack)
+        && !labelExists(labels0, stack) =>
         (Seq("rt", stack), labels0 :+ (stack -> escapeLabelVal(identifier)))
 
       // Handle client service case


### PR DESCRIPTION
# Problem
The `match` introduced in #2163 preemptively matches on all `stack` variables. This introduced incorrect parsing many Prometheus endpoints that matches the specific pattern.

E.g.
```
rt:interpreter_io_buoyant_namerd_iface_NamerdInterpreterConfig:sent_bytes{rt="outgoing", interpreter_io_buoyant_namerd_iface_NamerdInterpreterConfig="sent_bytes"} 541315
```
was being incorrectly formatted.

This PR corrects the `stack` matching to return the above to the correct format of
```
rt:interpreter_io_buoyant_namerd_iface_NamerdInterpreterConfig:sent_bytes{rt="outgoing"} 541315
```

# Solution
We now selectively match only on `stack` patterns that are _service_, _client_, or _server_.

# Validation
Running the Release Candidate locally verified that Prometheus once again parses the endpoints properly.

Re-fixes #2118 
#fixes #2174 

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>