### PR TITLE
Fix ClassCastException for socket option config

### DIFF
--- a/finagle/buoyant/src/main/scala/com/twitter/finagle/buoyant/SocketOptionsConfig.scala
+++ b/finagle/buoyant/src/main/scala/com/twitter/finagle/buoyant/SocketOptionsConfig.scala
@@ -1,5 +1,6 @@
 package com.twitter.finagle.buoyant
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.twitter.finagle.Stack
 import com.twitter.finagle.transport.Transport
 import com.twitter.util.Duration
@@ -8,8 +9,8 @@ case class SocketOptionsConfig(
   noDelay: Boolean = true,
   reuseAddr: Boolean = true,
   reusePort: Boolean = false,
-  writeTimeoutMs: Option[Long] = None,
-  readTimeoutMs: Option[Long] = None,
+  @JsonDeserialize(contentAs = classOf[java.lang.Long]) writeTimeoutMs: Option[Long] = None,
+  @JsonDeserialize(contentAs = classOf[java.lang.Long]) readTimeoutMs: Option[Long] = None,
   keepAlive: Option[Boolean] = None
 ) {
   def params: Stack.Params = {

--- a/linkerd/examples/socket-options.yaml
+++ b/linkerd/examples/socket-options.yaml
@@ -1,16 +1,16 @@
 namers:
-  - kind: io.l5d.fs
-    rootDir: linkerd/examples/io.l5d.fs
+- kind: io.l5d.fs
+  rootDir: linkerd/examples/io.l5d.fs
 routers:
-  - protocol: http
-    dtab: |
-      /svc => /#/io.l5d.fs ;
-    servers:
-      - port: 4140
-        socketOptions:
-          noDelay: true
-          reuseAddr: true
-          reusePort: true
-          readTimeoutMs: 61000
-          writeTimeoutMs: 61000
-          keepAlive: true
+- protocol: http
+  dtab: |
+    /svc => /#/io.l5d.fs ;
+  servers:
+  - port: 4140
+    socketOptions:
+      noDelay: true
+      reuseAddr: true
+      reusePort: true
+      readTimeoutMs: 61000
+      writeTimeoutMs: 61000
+      keepAlive: true

--- a/linkerd/examples/socket-options.yaml
+++ b/linkerd/examples/socket-options.yaml
@@ -1,0 +1,16 @@
+namers:
+  - kind: io.l5d.fs
+    rootDir: linkerd/examples/io.l5d.fs
+routers:
+  - protocol: http
+    dtab: |
+      /svc => /#/io.l5d.fs ;
+    servers:
+      - port: 4140
+        socketOptions:
+          noDelay: true
+          reuseAddr: true
+          reusePort: true
+          readTimeoutMs: 61000
+          writeTimeoutMs: 61000
+          keepAlive: true


### PR DESCRIPTION
When adding config values for `readTimeoutMs` and `writeTimeoutMs` in the socket option config section, Linkerd is unable to start because the Jackson parser is unable to determine the numeric type for those config values. 

This PR adds a `@JsonDeserialize` that specifies the actual numeric type for the socket option config values.

fixes #2182 

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>