### PR TITLE
Update linkerd/namerd scripts to check Java version

### DIFF
--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -360,30 +360,38 @@ object LinkerdBuild extends Base {
          |    jars="$jars:$jar"
          |  done
          |fi
+         |
          |export MALLOC_ARENA_MAX=2
          |
-         |# Configure GC logging directory
-         |if [ -z "$GC_LOG" ]; then
-         |  GC_LOG="/var/log/namerd"
-         |fi
+         |version=$("${JAVA_HOME:-usr}"/bin/java -version 2>&1 | awk -F '"' '/version/ {print $2}')
          |
-         |mkdir -p "$GC_LOG" && [ -w "$GC_LOG" ]
-         |
-         |if [ $? -ne 0 ]; then
-         |  echo "GC_LOG must be set to a directory that user [$USER] has write permissions on.\
-         |  Unable to use [$GC_LOG] for GC logging."
+         |if [[ $version = "9."* ]]; then
+         |  echo "GC logging feature not available for Linkerd with Java SE 9. Consider setting\
+         | JAVA_HOME environment variable to an upgraded SE, or upgrading to JAVA SE 10".
          |else
-         |  GC_LOG_OPTION="
-         |   -XX:+PrintGCDetails
-         |   -XX:+PrintGCDateStamps
-         |   -XX:+PrintHeapAtGC
-         |   -XX:+PrintTenuringDistribution
-         |   -XX:+PrintGCApplicationStoppedTime
-         |   -XX:+PrintPromotionFailure
-         |   -Xloggc:${GC_LOG}/gc.log
-         |   -XX:+UseGCLogFileRotation
-         |   -XX:NumberOfGCLogFiles=10
-         |   -XX:GCLogFileSize=10M"
+         |  # Configure GC logging directory
+         |  if [ -z "$GC_LOG" ]; then
+         |    GC_LOG="/var/log/linkerd"
+         |  fi
+         |
+         |  mkdir -p "$GC_LOG" && [ -w "$GC_LOG" ]
+         |
+         |  if [ $? -ne 0 ]; then
+         |    echo "GC_LOG must be set to a directory that user [$USER] has write permissions on.\
+         |    Unable to use [$GC_LOG] for GC logging."
+         |  else
+         |    GC_LOG_OPTION="
+         |     -XX:+PrintGCDetails
+         |     -XX:+PrintGCDateStamps
+         |     -XX:+PrintHeapAtGC
+         |     -XX:+PrintTenuringDistribution
+         |     -XX:+PrintGCApplicationStoppedTime
+         |     -XX:+PrintPromotionFailure
+         |     -Xloggc:${GC_LOG}/gc.log
+         |     -XX:+UseGCLogFileRotation
+         |     -XX:NumberOfGCLogFiles=10
+         |     -XX:GCLogFileSize=10M"
+         |  fi
          |fi
          |
          |""" +
@@ -447,30 +455,38 @@ object LinkerdBuild extends Base {
          |    jars="$jars:$jar"
          |  done
          |fi
+         |
          |export MALLOC_ARENA_MAX=2
          |
-         |# Configure GC logging directory
-         |if [ -z "$GC_LOG" ]; then
-         |  GC_LOG="/var/log/namerd"
-         |fi
+         |version=$("${JAVA_HOME:-usr}"/bin/java -version 2>&1 | awk -F '"' '/version/ {print $2}')
          |
-         |mkdir -p "$GC_LOG" && [ -w "$GC_LOG" ]
-         |
-         |if [ $? -ne 0 ]; then
-         |  echo "GC_LOG must be set to a directory that user [$USER] has write permissions on.\
-         |  Unable to use [$GC_LOG] for GC logging."
+         |if [[ $version = "9."* ]]; then
+         |  echo "GC logging feature not available for Linkerd with Java SE 9. Consider setting\
+         | JAVA_HOME environment variable to an upgraded SE, or upgrading to JAVA SE 10".
          |else
-         |  GC_LOG_OPTION="
-         |   -XX:+PrintGCDetails
-         |   -XX:+PrintGCDateStamps
-         |   -XX:+PrintHeapAtGC
-         |   -XX:+PrintTenuringDistribution
-         |   -XX:+PrintGCApplicationStoppedTime
-         |   -XX:+PrintPromotionFailure
-         |   -Xloggc:${GC_LOG}/gc.log
-         |   -XX:+UseGCLogFileRotation
-         |   -XX:NumberOfGCLogFiles=10
-         |   -XX:GCLogFileSize=10M"
+         |  # Configure GC logging directory
+         |  if [ -z "$GC_LOG" ]; then
+         |    GC_LOG="/var/log/linkerd"
+         |  fi
+         |
+         |  mkdir -p "$GC_LOG" && [ -w "$GC_LOG" ]
+         |
+         |  if [ $? -ne 0 ]; then
+         |    echo "GC_LOG must be set to a directory that user [$USER] has write permissions on.\
+         |    Unable to use [$GC_LOG] for GC logging."
+         |  else
+         |    GC_LOG_OPTION="
+         |     -XX:+PrintGCDetails
+         |     -XX:+PrintGCDateStamps
+         |     -XX:+PrintHeapAtGC
+         |     -XX:+PrintTenuringDistribution
+         |     -XX:+PrintGCApplicationStoppedTime
+         |     -XX:+PrintPromotionFailure
+         |     -Xloggc:${GC_LOG}/gc.log
+         |     -XX:+UseGCLogFileRotation
+         |     -XX:NumberOfGCLogFiles=10
+         |     -XX:GCLogFileSize=10M"
+         |  fi
          |fi
          |
          |""" +
@@ -684,30 +700,38 @@ object LinkerdBuild extends Base {
          |    jars="$jars:$jar"
          |  done
          |fi
+         |
          |export MALLOC_ARENA_MAX=2
          |
-         |# Configure GC logging directory
-         |if [ -z "$GC_LOG" ]; then
-         |  GC_LOG="/var/log/linkerd"
-         |fi
+         |version=$("${JAVA_HOME:-usr}"/bin/java -version 2>&1 | awk -F '"' '/version/ {print $2}')
          |
-         |mkdir -p "$GC_LOG" && [ -w "$GC_LOG" ]
-         |
-         |if [ $? -ne 0 ]; then
-         |  echo "GC_LOG must be set to a directory that user [$USER] has write permissions on.\
-         |  Unable to use [$GC_LOG] for GC logging."
+         |if [[ $version = "9."* ]]; then
+         |  echo "GC logging feature not available for Linkerd with Java SE 9. Consider setting\
+         | JAVA_HOME environment variable to an upgraded SE, or upgrading to JAVA SE 10".
          |else
-         |  GC_LOG_OPTION="
-         |   -XX:+PrintGCDetails
-         |   -XX:+PrintGCDateStamps
-         |   -XX:+PrintHeapAtGC
-         |   -XX:+PrintTenuringDistribution
-         |   -XX:+PrintGCApplicationStoppedTime
-         |   -XX:+PrintPromotionFailure
-         |   -Xloggc:${GC_LOG}/gc.log
-         |   -XX:+UseGCLogFileRotation
-         |   -XX:NumberOfGCLogFiles=10
-         |   -XX:GCLogFileSize=10M"
+         |  # Configure GC logging directory
+         |  if [ -z "$GC_LOG" ]; then
+         |    GC_LOG="/var/log/linkerd"
+         |  fi
+         |
+         |  mkdir -p "$GC_LOG" && [ -w "$GC_LOG" ]
+         |
+         |  if [ $? -ne 0 ]; then
+         |    echo "GC_LOG must be set to a directory that user [$USER] has write permissions on.\
+         |    Unable to use [$GC_LOG] for GC logging."
+         |  else
+         |    GC_LOG_OPTION="
+         |     -XX:+PrintGCDetails
+         |     -XX:+PrintGCDateStamps
+         |     -XX:+PrintHeapAtGC
+         |     -XX:+PrintTenuringDistribution
+         |     -XX:+PrintGCApplicationStoppedTime
+         |     -XX:+PrintPromotionFailure
+         |     -Xloggc:${GC_LOG}/gc.log
+         |     -XX:+UseGCLogFileRotation
+         |     -XX:NumberOfGCLogFiles=10
+         |     -XX:GCLogFileSize=10M"
+         |  fi
          |fi
          |
          |""" +

--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -365,34 +365,37 @@ object LinkerdBuild extends Base {
          |
          |version=$("${JAVA_HOME:-usr}"/bin/java -version 2>&1 | awk -F '"' '/version/ {print $2}')
          |
-         |if [[ $version = "9."* ]]; then
-         |  echo "GC logging feature not available for Linkerd with Java SE 9. Consider setting\
-         | JAVA_HOME environment variable to an upgraded SE, or upgrading to JAVA SE 10".
-         |else
-         |  # Configure GC logging directory
-         |  if [ -z "$GC_LOG" ]; then
-         |    GC_LOG="/var/log/linkerd"
-         |  fi
-         |
-         |  mkdir -p "$GC_LOG" && [ -w "$GC_LOG" ]
-         |
-         |  if [ $? -ne 0 ]; then
-         |    echo "GC_LOG must be set to a directory that user [$USER] has write permissions on.\
-         |    Unable to use [$GC_LOG] for GC logging."
-         |  else
-         |    GC_LOG_OPTION="
-         |     -XX:+PrintGCDetails
-         |     -XX:+PrintGCDateStamps
-         |     -XX:+PrintHeapAtGC
-         |     -XX:+PrintTenuringDistribution
-         |     -XX:+PrintGCApplicationStoppedTime
-         |     -XX:+PrintPromotionFailure
-         |     -Xloggc:${GC_LOG}/gc.log
-         |     -XX:+UseGCLogFileRotation
-         |     -XX:NumberOfGCLogFiles=10
-         |     -XX:GCLogFileSize=10M"
-         |  fi
-         |fi
+         |case "$version" in
+         |  9.*)
+         |    echo "GC logging feature not available for Linkerd with Java SE 9. Consider setting\
+         | JAVA_HOME environment variable to an upgraded SE, or upgrading to JAVA SE 10."
+         |    ;;
+         |  *)
+         |    # Configure GC logging directory
+         |    if [ -z "$GC_LOG" ]; then
+         |      GC_LOG="/var/log/linkerd"
+         |    fi
+         |  
+         |    mkdir -p "$GC_LOG" && [ -w "$GC_LOG" ]
+         |  
+         |    if [ $? -ne 0 ]; then
+         |      echo "GC_LOG must be set to a directory that user [$USER] has write permissions on.\
+         |      Unable to use [$GC_LOG] for GC logging."
+         |    else
+         |      GC_LOG_OPTION="
+         |       -XX:+PrintGCDetails
+         |       -XX:+PrintGCDateStamps
+         |       -XX:+PrintHeapAtGC
+         |       -XX:+PrintTenuringDistribution
+         |       -XX:+PrintGCApplicationStoppedTime
+         |       -XX:+PrintPromotionFailure
+         |       -Xloggc:${GC_LOG}/gc.log
+         |       -XX:+UseGCLogFileRotation
+         |       -XX:NumberOfGCLogFiles=10
+         |       -XX:GCLogFileSize=10M"
+         |    fi
+         |    ;;
+         |esac
          |
          |""" +
       execScriptJvmOptions +
@@ -460,34 +463,37 @@ object LinkerdBuild extends Base {
          |
          |version=$("${JAVA_HOME:-usr}"/bin/java -version 2>&1 | awk -F '"' '/version/ {print $2}')
          |
-         |if [[ $version = "9."* ]]; then
-         |  echo "GC logging feature not available for Linkerd with Java SE 9. Consider setting\
-         | JAVA_HOME environment variable to an upgraded SE, or upgrading to JAVA SE 10".
-         |else
-         |  # Configure GC logging directory
-         |  if [ -z "$GC_LOG" ]; then
-         |    GC_LOG="/var/log/linkerd"
-         |  fi
-         |
-         |  mkdir -p "$GC_LOG" && [ -w "$GC_LOG" ]
-         |
-         |  if [ $? -ne 0 ]; then
-         |    echo "GC_LOG must be set to a directory that user [$USER] has write permissions on.\
-         |    Unable to use [$GC_LOG] for GC logging."
-         |  else
-         |    GC_LOG_OPTION="
-         |     -XX:+PrintGCDetails
-         |     -XX:+PrintGCDateStamps
-         |     -XX:+PrintHeapAtGC
-         |     -XX:+PrintTenuringDistribution
-         |     -XX:+PrintGCApplicationStoppedTime
-         |     -XX:+PrintPromotionFailure
-         |     -Xloggc:${GC_LOG}/gc.log
-         |     -XX:+UseGCLogFileRotation
-         |     -XX:NumberOfGCLogFiles=10
-         |     -XX:GCLogFileSize=10M"
-         |  fi
-         |fi
+         |case "$version" in
+         |  9.*)
+         |    echo "GC logging feature not available for Linkerd with Java SE 9. Consider setting\
+         | JAVA_HOME environment variable to an upgraded SE, or upgrading to JAVA SE 10."
+         |    ;;
+         |  *)
+         |    # Configure GC logging directory
+         |    if [ -z "$GC_LOG" ]; then
+         |      GC_LOG="/var/log/linkerd"
+         |    fi
+         |  
+         |    mkdir -p "$GC_LOG" && [ -w "$GC_LOG" ]
+         |  
+         |    if [ $? -ne 0 ]; then
+         |      echo "GC_LOG must be set to a directory that user [$USER] has write permissions on.\
+         |      Unable to use [$GC_LOG] for GC logging."
+         |    else
+         |      GC_LOG_OPTION="
+         |       -XX:+PrintGCDetails
+         |       -XX:+PrintGCDateStamps
+         |       -XX:+PrintHeapAtGC
+         |       -XX:+PrintTenuringDistribution
+         |       -XX:+PrintGCApplicationStoppedTime
+         |       -XX:+PrintPromotionFailure
+         |       -Xloggc:${GC_LOG}/gc.log
+         |       -XX:+UseGCLogFileRotation
+         |       -XX:NumberOfGCLogFiles=10
+         |       -XX:GCLogFileSize=10M"
+         |    fi
+         |    ;;
+         |esac
          |
          |""" +
       execScriptJvmOptions +
@@ -705,34 +711,37 @@ object LinkerdBuild extends Base {
          |
          |version=$("${JAVA_HOME:-usr}"/bin/java -version 2>&1 | awk -F '"' '/version/ {print $2}')
          |
-         |if [[ $version = "9."* ]]; then
-         |  echo "GC logging feature not available for Linkerd with Java SE 9. Consider setting\
-         | JAVA_HOME environment variable to an upgraded SE, or upgrading to JAVA SE 10".
-         |else
-         |  # Configure GC logging directory
-         |  if [ -z "$GC_LOG" ]; then
-         |    GC_LOG="/var/log/linkerd"
-         |  fi
-         |
-         |  mkdir -p "$GC_LOG" && [ -w "$GC_LOG" ]
-         |
-         |  if [ $? -ne 0 ]; then
-         |    echo "GC_LOG must be set to a directory that user [$USER] has write permissions on.\
-         |    Unable to use [$GC_LOG] for GC logging."
-         |  else
-         |    GC_LOG_OPTION="
-         |     -XX:+PrintGCDetails
-         |     -XX:+PrintGCDateStamps
-         |     -XX:+PrintHeapAtGC
-         |     -XX:+PrintTenuringDistribution
-         |     -XX:+PrintGCApplicationStoppedTime
-         |     -XX:+PrintPromotionFailure
-         |     -Xloggc:${GC_LOG}/gc.log
-         |     -XX:+UseGCLogFileRotation
-         |     -XX:NumberOfGCLogFiles=10
-         |     -XX:GCLogFileSize=10M"
-         |  fi
-         |fi
+         |case "$version" in
+         |  9.*)
+         |    echo "GC logging feature not available for Linkerd with Java SE 9. Consider setting\
+         | JAVA_HOME environment variable to an upgraded SE, or upgrading to JAVA SE 10."
+         |    ;;
+         |  *)
+         |    # Configure GC logging directory
+         |    if [ -z "$GC_LOG" ]; then
+         |      GC_LOG="/var/log/linkerd"
+         |    fi
+         |  
+         |    mkdir -p "$GC_LOG" && [ -w "$GC_LOG" ]
+         |  
+         |    if [ $? -ne 0 ]; then
+         |      echo "GC_LOG must be set to a directory that user [$USER] has write permissions on.\
+         |      Unable to use [$GC_LOG] for GC logging."
+         |    else
+         |      GC_LOG_OPTION="
+         |       -XX:+PrintGCDetails
+         |       -XX:+PrintGCDateStamps
+         |       -XX:+PrintHeapAtGC
+         |       -XX:+PrintTenuringDistribution
+         |       -XX:+PrintGCApplicationStoppedTime
+         |       -XX:+PrintPromotionFailure
+         |       -Xloggc:${GC_LOG}/gc.log
+         |       -XX:+UseGCLogFileRotation
+         |       -XX:NumberOfGCLogFiles=10
+         |       -XX:GCLogFileSize=10M"
+         |    fi
+         |    ;;
+         |esac
          |
          |""" +
       execScriptJvmOptions +


### PR DESCRIPTION
# Problem
If we startup Linkerd with a `JAVA_HOME` targeting Java 9, we get this error:

```
sudo env JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk-9.0.4.jdk/Contents/Home linkerd/target/scala-2.12/linkerd-1.5.2-SNAPSHOT-exec linkerd/examples/fs.yaml
```

```
Java HotSpot(TM) 64-Bit Server VM warning: Option UseConcMarkSweepGC was deprecated in version 9.0 and will likely be removed in a future release.
Unrecognized VM option 'PrintGCDateStamps'
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```

# Solution
We check the Java version that will be used to startup Linkerd. If the Java version is 9.x, then we will display a warning that GC logging will not be used and skip setting `GC_LOG_OPTION`. This allows Linkerd to startup, but without GC logging. We suggest changing the Java version that `JAVA_HOME` points to, or upgrading to Java SE 10 (similar to [here](https://www.oracle.com/technetwork/java/javase/downloads/jdk9-downloads-3848520.html))

# Validation

```
sudo env JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk-9.0.4.jdk/Contents/Home linkerd/target/scala-2.12/linkerd-1.5.2-SNAPSHOT-exec linkerd/examples/fs.yaml
```

```
GC logging feature not available for Linkerd with Java SE 9. Consider setting JAVA_HOME environment variable to an upgraded SE, or upgrading to JAVA SE 10.
Java HotSpot(TM) 64-Bit Server VM warning: Option UseConcMarkSweepGC was deprecated in version 9.0 and will likely be removed in a future release.
[...]
I 1204 10:15:05.239 PST THREAD1: linkerd 1.5.2-SNAPSHOT (rev=67694a18ec328d3c3827ecc636468f991e497992) built at 20181204-101330
W 1204 10:15:05.503 PST THREAD1: failed to create Hotspot JVM interface, using NilJvm instead
I 1204 10:15:05.635 PST THREAD1: Finagle version 18.9.1 (rev=63182f815cb20549ced80c99465879609b05d94b) built at 20180926-144723
I 1204 10:15:07.802 PST THREAD1: Tracer: com.twitter.finagle.zipkin.thrift.ScribeZipkinTracer
I 1204 10:15:07.842 PST THREAD1: connecting to usageData proxy at Set(Inet(stats.buoyant.io/104.28.23.233:443,Map()))
I 1204 10:15:08.235 PST THREAD1: serving http admin on /127.0.0.1:9990
I 1204 10:15:08.257 PST THREAD1: serving http on localhost/127.0.0.1:4140
I 1204 10:15:08.305 PST THREAD1: initialized
```

Fixes #2165 