### PR TITLE
Use last known good state when consul responds with an 5xx error

### DIFF
--- a/namer/consul/src/main/scala/io/buoyant/namer/consul/SvcAddr.scala
+++ b/namer/consul/src/main/scala/io/buoyant/namer/consul/SvcAddr.scala
@@ -9,7 +9,6 @@ import io.buoyant.consul.v1
 import io.buoyant.consul.v1.UnexpectedResponse
 import io.buoyant.namer.{InstrumentedVar, Metadata}
 import java.net.{InetAddress, InetSocketAddress}
-import java.rmi.UnexpectedException
 import scala.util.control.NoStackTrace
 
 private[consul] case class SvcKey(name: String, tag: Option[String]) {
@@ -83,6 +82,9 @@ private[consul] object SvcAddr {
             )
             stopped = true
             Future.Unit
+            // this exception case checks if we queried for a service in a datacenter that
+            // doesn't exist. We capture this case so that we can return Addr.Neg to prevent
+            // service name resolution from timing out.
           case Throw(e: UnexpectedResponse) if e.rsp.contentString == DatacenterErrorMessage =>
             log.log(
               failureLogLevel,


### PR DESCRIPTION
After #1863, when the consul namer receives a 5xx response from consul, the namer evaluates to `Addr.Neg`. This behaviour is desired when a service resolution is performed with a non-existent DC. However, if consul sends a 5xx response that isn't caused by a request to a non-existent DC, we want to make sure that the last known good `Addr` is used instead. #1863 causes the namer to never use the last known good state and incorrectly resolves a logical name with `Addr.Neg`. This happens because it is difficult to reliably differentiate a 5xx response that requires an `Addr.Neg` or one that requires the use of the last known good state.

This PR adds a new check in `SvcAddr` that determines if an exception is one that is a result of resolving a service name to a non-existent DC. This new check is somewhat brittle since it reads the value of the response content string. This PR also changes the "catch-all" case that captures any exception from consul and lets `SvcAddr` use the previous resolution state.

A couple of unit tests have been changed to reflect this new behavior and I was able to test this out locally with reproduction steps similar to #2145 

fixes #2145

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>