### PR TITLE
Add new streamAfterContentLengthKB config field for HTTP/1

### DIFF
--- a/linkerd/docs/protocol-http.md
+++ b/linkerd/docs/protocol-http.md
@@ -36,6 +36,7 @@ httpAccessLogRollPolicy | never | When to roll the logfile. Possible values: Nev
 httpAccessLogAppend | true | Append to an existing logfile, or truncate it?
 httpAccessLogRotateCount | -1 | How many rotated logfiles to keep around, maximum. -1 means to keep them all.
 identifier | The `io.l5d.header.token` identifier | An identifier or list of identifiers.  See [Http-specific identifiers](#http-1-1-identifiers).
+streamAfterContentLengthKB | 5 | The threshold at which HTTP messages will be streamed if exceeded.
 maxHeadersKB | 8 | The maximum size of all headers in an HTTP message.
 maxInitialLineKB | 4 | The maximum size of an initial HTTP message line.
 maxRequestKB | 5120 | The maximum size of a non-chunked HTTP request payload.

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpConfig.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpConfig.scala
@@ -11,6 +11,7 @@ import com.twitter.finagle.buoyant.{ParamsMaybeWith, PathMatcher}
 import com.twitter.finagle.client.{AddrMetadataExtraction, StackClient}
 import com.twitter.finagle.filter.DtabStatsFilter
 import com.twitter.finagle.http.filter.{ClientDtabContextFilter, ServerDtabContextFilter, StatsFilter}
+import com.twitter.finagle.http.param.FixedLengthStreamedAfter
 import com.twitter.finagle.http.{Request, Response, param => hparam}
 import com.twitter.finagle.liveness.FailureAccrualFactory
 import com.twitter.finagle.service.Retries
@@ -210,6 +211,7 @@ case class HttpConfig(
   httpAccessLogAppend: Option[Boolean],
   httpAccessLogRotateCount: Option[Int],
   @JsonDeserialize(using = classOf[HttpIdentifierConfigDeserializer]) identifier: Option[Seq[HttpIdentifierConfig]],
+  streamAfterContentLengthKB: Option[Int],
   maxHeadersKB: Option[Int],
   maxInitialLineKB: Option[Int],
   maxRequestKB: Option[Int],
@@ -250,6 +252,7 @@ case class HttpConfig(
     .maybeWith(httpAccessLogAppend.map(AccessLogger.param.Append.apply))
     .maybeWith(httpAccessLogRotateCount.map(AccessLogger.param.RotateCount.apply))
     .maybeWith(maxHeadersKB.map(kb => hparam.MaxHeaderSize(kb.kilobytes)))
+    .maybeWith(streamAfterContentLengthKB.map(kb => hparam.FixedLengthStreamedAfter(kb.kilobytes)))
     .maybeWith(maxInitialLineKB.map(kb => hparam.MaxInitialLineSize(kb.kilobytes)))
     .maybeWith(maxRequestKB.map(kb => hparam.MaxRequestSize(kb.kilobytes)))
     .maybeWith(maxResponseKB.map(kb => hparam.MaxResponseSize(kb.kilobytes)))


### PR DESCRIPTION
When Linkerd receives a significantly large HTTP request with a set content-length, the underlying Finagle router service buffers the entire message into memory instead of streaming the HTTP message in smaller chunks. This can cause problems when a client is sending very large file uploads without using `Transfer-Encoding: Chunked`

This PR pulls in a new Finagle param [(#740)](https://github.com/twitter/finagle/pull/740) that forces a finagle server to receive large HTTP messages in smaller chunks when the HTTP messages content-length exceeds a certain content-length threshold. In addition, Linkerd exposes this Finagle param to allow for configurability.  I was able to test this out in a docker environment where I sent a significantly large file (140MB) to Linkerd. Previously Linkerd would load buffer the entire message into memory and was easily visible in the JVM memory usage. After the change, the same request was issued again and we no longer observe the spike in memory.

fixes #2188

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>