### PR TITLE
Fix silent failure when watchable object receives an HTTP 404 from k8s apiserver

### DIFF
--- a/k8s/src/main/scala/io/buoyant/k8s/Watchable.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/Watchable.scala
@@ -127,7 +127,6 @@ private[k8s] abstract class Watchable[O <: KubeObject: TypeReference, W <: Watch
       val retryingClient = infiniteRetryFilter andThen client
       watchState.foreach(_.recordApiCall(req))
       val initialState = Trace.letClear(retryingClient(req))
-
       close.set(Closable.make { _ =>
         log.trace("k8s watch cancelled")
         initialState.raise(Api.Closed)

--- a/namerd/storage/k8s/src/main/scala/io/buoyant/namerd/storage/K8sDtabStore.scala
+++ b/namerd/storage/k8s/src/main/scala/io/buoyant/namerd/storage/K8sDtabStore.scala
@@ -77,9 +77,15 @@ class K8sDtabStore(client: Http.Client, dst: String, namespace: String)
     watchApi.dtabs.activity(dtabListToNsMap, watchState = Some(watchState)) {
       (nsMap: NsMap, watchEvent) =>
         watchEvent match {
-          case DtabAdded(a) => nsMap + toDtabMap(a)
-          case DtabModified(m) => nsMap + toDtabMap(m)
-          case DtabDeleted(d) => nsMap - name(d)
+          case DtabAdded(a) =>
+            log.warning(s"k8s watch received DtabAdded: ${name(a)}")
+            nsMap + toDtabMap(a)
+          case DtabModified(m) =>
+            log.warning(s"k8s watch received DtabModified: ${name(m)}")
+            nsMap + toDtabMap(m)
+          case DtabDeleted(d) =>
+            log.warning(s"k8s watch received DtabDeleted: ${name(d)}")
+            nsMap - name(d)
           case DtabError(e) =>
             log.error("k8s watch error: %s", e)
             nsMap

--- a/namerd/storage/k8s/src/main/scala/io/buoyant/namerd/storage/K8sDtabStore.scala
+++ b/namerd/storage/k8s/src/main/scala/io/buoyant/namerd/storage/K8sDtabStore.scala
@@ -78,13 +78,13 @@ class K8sDtabStore(client: Http.Client, dst: String, namespace: String)
       (nsMap: NsMap, watchEvent) =>
         watchEvent match {
           case DtabAdded(a) =>
-            log.warning(s"k8s watch received DtabAdded: ${name(a)}")
+            log.debug(s"k8s watch received DtabAdded: ${name(a)}")
             nsMap + toDtabMap(a)
           case DtabModified(m) =>
-            log.warning(s"k8s watch received DtabModified: ${name(m)}")
+            log.debug(s"k8s watch received DtabModified: ${name(m)}")
             nsMap + toDtabMap(m)
           case DtabDeleted(d) =>
-            log.warning(s"k8s watch received DtabDeleted: ${name(d)}")
+            log.debug(s"k8s watch received DtabDeleted: ${name(d)}")
             nsMap - name(d)
           case DtabError(e) =>
             log.error("k8s watch error: %s", e)

--- a/namerd/storage/k8s/src/test/scala/io/buoyant/namerd/storage/K8sDtabStoreTest.scala
+++ b/namerd/storage/k8s/src/test/scala/io/buoyant/namerd/storage/K8sDtabStoreTest.scala
@@ -1,0 +1,111 @@
+package io.buoyant.namerd.storage
+
+import com.twitter.finagle.http.{Request, Response, Status}
+import com.twitter.finagle.{Dtab, Http, Service}
+import com.twitter.io.Buf
+import com.twitter.util.{Activity, Future}
+import io.buoyant.namerd.VersionedDtab
+import io.buoyant.test.FunSuite
+import java.net.InetSocketAddress
+import java.util.concurrent.atomic.AtomicInteger
+
+class K8sDtabStoreTest extends FunSuite {
+  val validAPIResponse = """
+                {
+   "apiVersion":"l5d.io/v1alpha1",
+   "items":[
+      {
+         "apiVersion":"l5d.io/v1alpha1",
+         "dentries":[
+            {
+               "dst":"/#/io.l5d.consul/dc1",
+               "prefix":"/svc"
+            },
+            {
+               "dst":"/$/inet/127.1/9991",
+               "prefix":"/svc/srv"
+            }
+         ],
+         "kind":"DTab",
+         "metadata":{
+            "annotations":null,
+            "clusterName":"",
+            "creationTimestamp":"2018-12-20T01:17:35Z",
+            "generateName":null,
+            "generation":1,
+            "labels":null,
+            "name":"secondary",
+            "namespace":"default",
+            "resourceVersion":"53333",
+            "selfLink":"/apis/l5d.io/v1alpha1/namespaces/default/dtabs/secondary",
+            "uid":"08784774-03f5-11e9-9f72-080027349b04"
+         }
+      }
+   ],
+   "kind":"DTabList",
+   "metadata":{
+      "continue":"",
+      "resourceVersion":"53337",
+      "selfLink":"/apis/l5d.io/v1alpha1/namespaces/default/dtabs"
+   }
+}
+             """
+
+
+  val initialEmptyResponse = """
+    {
+   "apiVersion":"l5d.io/v1alpha1",
+   "items":[],
+   "kind":"DTabList",
+   "metadata":{
+      "continue":"",
+      "resourceVersion":"44673",
+      "selfLink":"/apis/l5d.io/v1alpha1/namespaces/default/dtabs"
+   }
+}
+  """.stripMargin
+
+  val stepCount = new AtomicInteger()
+  val server = Http.server.serve(
+    ":*", Service.mk[Request, Response] { req =>
+      stepCount.getAndIncrement match {
+        case 0 =>
+          val rep = Response(req.version, Status.Ok)
+          rep.contentString = initialEmptyResponse
+          Future.value(rep)
+        case 1 =>
+          val rep = Response(req.version, Status.NotFound)
+          Future.value(rep)
+        case _ =>
+          val rep = Response(req.version, Status.Ok)
+          rep.contentString = validAPIResponse
+          Future.value(rep)
+      }
+    }
+  )
+
+
+  test("dtabstore should not stop watching dtab on 404 error") {
+    @volatile var states: Activity.State[Option[VersionedDtab]] = Activity.Pending
+    val store = new K8sDtabStore(
+      Http.client,
+      s"localhost:${server.boundAddress.asInstanceOf[InetSocketAddress].getPort}",
+      "default"
+    )
+
+    val act = store.observe("secondary")
+    act.run.changes.respond(states = _)
+
+    eventually {
+      val expected = Activity.Ok(
+        Some(
+          VersionedDtab(
+            Dtab.read("/svc=>/#/io.l5d.consul/dc1;/svc/srv=>/$/inet/127.1/9991"),
+            Buf.Utf8("53333")
+          )
+        )
+      )
+      assert(states == expected)
+    }
+  }
+}


### PR DESCRIPTION
The implemented `restartWatches` method  in `NsListResource` and `NsObjectResource` currently have a bug where HTTP 404 responses from a k8s apiserver could cause the method to fail silently. This has the effect of stopping watch streams whenever HTTP 404 response is encountered causing  k8s API resources to be removed from Linkerd and Namerd's watch context. 

This PR fixes the issue by pattern matching the response to a `get` request in the `restartWatches` method since it returns an `Option[O]` where O is the type of a k8s resource object. In the case where we receive a `None` the method needs to return a default empty value in order for the underlying `Watchable` object to restart the watch successfully.

fixes #2167

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>