### PR TITLE
Add user defined gRPC success status codes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,16 @@
-target/
 dist/
 logs/
 project/boot/
 project/plugins/project/
 project/plugins/src_managed/
+target/
+
+ensime-langserver.log
 http.pid
 npm-debug.log
+pc.stdout.log
+
+.ensime*
 .sbt-launch.jar
 .protoc
 .idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,11 @@
+target/
 dist/
 logs/
 project/boot/
 project/plugins/project/
 project/plugins/src_managed/
-target/
-
-ensime-langserver.log
 http.pid
 npm-debug.log
-pc.stdout.log
-
-.ensime*
 .sbt-launch.jar
 .protoc
 .idea

--- a/linkerd/docs/response_classifier.md
+++ b/linkerd/docs/response_classifier.md
@@ -92,9 +92,15 @@ status codes that should not count towards the total failure count for a
 router.
 
 ```yaml
-nonAccruableStatusCodes:
-- 3
-- 5
+routers:
+- protocol: h2
+  experimental: true
+  service:
+    responseClassifier:
+      kind: io.l5d.h2.grpc.default
+      nonAccruableStatusCodes:
+      - 3
+      - 5
 ```
 
 Status code 3 (`InvalidArgument`) and 5 (`NotFound`) will not be counted

--- a/linkerd/docs/response_classifier.md
+++ b/linkerd/docs/response_classifier.md
@@ -85,11 +85,15 @@ additional response classifiers are available to categorize responses based on
 [gRPC status codes](https://github.com/grpc/grpc/blob/master/doc/statuscodes.md)
 in the stream's trailers frame.
 
-By default, status code 0 (`OK`) is always considered successful, while all
-other gRPC status codes are considered failures. There exists an optional
-parameter `nonAccruableStatusCodes` that accepts a user-defined list of error
-status codes that should not count towards the total failure count for a
-router.
+By default, status code 0 (`OK`) is always classified as `Success`, while all
+other gRPC status codes are classified as `Failure`. There exists an optional
+parameter `successStatusCodes` that accepts a user-defined list of gRPC
+status codes that should always be classified as `Success`.
+
+<aside class="notice">
+When defining `successStatusCodes`, it is up to the user to explicity classify
+status code 0 (`OK`) as `Success`.
+</aside>
 
 ```yaml
 routers:
@@ -98,13 +102,14 @@ routers:
   service:
     responseClassifier:
       kind: io.l5d.h2.grpc.default
-      nonAccruableStatusCodes:
+      successStatusCodes:
+      - 0
       - 3
       - 5
 ```
 
-Status code 3 (`InvalidArgument`) and 5 (`NotFound`) will not be counted
-towards the total failure count for this router.
+Status code 0 (`Ok`), 3 (`InvalidArgument`), and 5 (`NotFound`) will be
+classified as `Success`.
 
 <aside class="notice">
 Since H2 routing is experimental, all gRPC response classifiers are also marked as experimental and require `experimental: true` in the router configuration.

--- a/linkerd/docs/response_classifier.md
+++ b/linkerd/docs/response_classifier.md
@@ -80,7 +80,25 @@ All responses are considered to be successful, regardless of status code.
 
 # gRPC Response Classifiers
 
-For HTTP/2 routers that handle gRPC traffic, four additional response classifiers are available to categorize responses based on [gRPC status codes](https://github.com/grpc/grpc/blob/master/doc/statuscodes.md) in the stream's trailers frame. Status code 0 (`OK`) is always considered successful, while all other gRPC status codes are considered failures.
+For HTTP/2 routers that handle gRPC traffic, one optional parameter and four
+additional response classifiers are available to categorize responses based on
+[gRPC status codes](https://github.com/grpc/grpc/blob/master/doc/statuscodes.md)
+in the stream's trailers frame.
+
+By default, status code 0 (`OK`) is always considered successful, while all
+other gRPC status codes are considered failures. There exists an optional
+parameter `nonAccruableStatusCodes` that accepts a user-defined list of error
+status codes that should not count towards the total failure count for a
+router.
+
+```yaml
+nonAccruableStatusCodes:
+- 3
+- 5
+```
+
+Status code 3 (`InvalidArgument`) and 5 (`NotFound`) will not be counted
+towards the total failure count for this router.
 
 <aside class="notice">
 Since H2 routing is experimental, all gRPC response classifiers are also marked as experimental and require `experimental: true` in the router configuration.

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/grpc/GrpcClassifierConfig.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/grpc/GrpcClassifierConfig.scala
@@ -5,11 +5,11 @@ import io.buoyant.linkerd.ResponseClassifierInitializer
 import io.buoyant.linkerd.protocol.h2._
 
 abstract class GrpcClassifierConfig extends H2ClassifierConfig {
-  var nonAccrualCodes: Option[Set[Int]] = None
+  var nonAccruableStatusCodes: Option[Set[Int]] = None
 }
 
 class NeverRetryableConfig extends GrpcClassifierConfig {
-  override def mk: H2Classifier = new GrpcClassifiers.NeverRetryable(nonAccrualCodes.getOrElse(Set.empty))
+  override def mk: H2Classifier = new GrpcClassifiers.NeverRetryable(nonAccruableStatusCodes.getOrElse(Set.empty))
 }
 
 class NeverRetryableInitializer extends ResponseClassifierInitializer {
@@ -20,7 +20,7 @@ class NeverRetryableInitializer extends ResponseClassifierInitializer {
 object NeverRetryableInitializer extends NeverRetryableInitializer
 
 class AlwaysRetryableConfig extends GrpcClassifierConfig {
-  override def mk: H2Classifier = new GrpcClassifiers.AlwaysRetryable(nonAccrualCodes.getOrElse(Set.empty))
+  override def mk: H2Classifier = new GrpcClassifiers.AlwaysRetryable(nonAccruableStatusCodes.getOrElse(Set.empty))
 }
 
 class AlwaysRetryableInitializer extends ResponseClassifierInitializer {
@@ -31,7 +31,7 @@ class AlwaysRetryableInitializer extends ResponseClassifierInitializer {
 object AlwaysRetryableInitializer extends AlwaysRetryableInitializer
 
 class DefaultConfig extends GrpcClassifierConfig {
-  override def mk: H2Classifier = new GrpcClassifiers.Default(nonAccrualCodes.getOrElse(Set.empty))
+  override def mk: H2Classifier = new GrpcClassifiers.Default(nonAccruableStatusCodes.getOrElse(Set.empty))
 }
 
 class DefaultInitializer extends ResponseClassifierInitializer {
@@ -42,7 +42,7 @@ class DefaultInitializer extends ResponseClassifierInitializer {
 object DefaultInitializer extends DefaultInitializer
 
 class CompliantConfig extends GrpcClassifierConfig {
-  override def mk: H2Classifier = new GrpcClassifiers.Compliant(nonAccrualCodes.getOrElse(Set.empty))
+  override def mk: H2Classifier = new GrpcClassifiers.Compliant(nonAccruableStatusCodes.getOrElse(Set.empty))
 }
 
 class CompliantInitializer extends ResponseClassifierInitializer {
@@ -54,7 +54,7 @@ object CompliantInitializer extends CompliantInitializer
 
 // TODO: support parsing the status codes by name rather than by number?
 class RetryableStatusCodesConfig(val retryableStatusCodes: Set[Int]) extends GrpcClassifierConfig {
-  override def mk: H2Classifier = new GrpcClassifiers.RetryableStatusCodes(retryableStatusCodes, nonAccrualCodes.getOrElse(Set.empty))
+  override def mk: H2Classifier = new GrpcClassifiers.RetryableStatusCodes(retryableStatusCodes, nonAccruableStatusCodes.getOrElse(Set.empty))
 }
 
 class RetryableStatusCodesInitializer extends ResponseClassifierInitializer {

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/grpc/GrpcClassifierConfig.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/grpc/GrpcClassifierConfig.scala
@@ -4,8 +4,12 @@ import com.twitter.finagle.buoyant.h2.service.H2Classifier
 import io.buoyant.linkerd.ResponseClassifierInitializer
 import io.buoyant.linkerd.protocol.h2._
 
-class NeverRetryableConfig extends H2ClassifierConfig {
-  override def mk: H2Classifier = GrpcClassifiers.NeverRetryable
+abstract class GrpcClassifierConfig extends H2ClassifierConfig {
+  var nonAccrualCodes: Option[Set[Int]] = None
+}
+
+class NeverRetryableConfig extends GrpcClassifierConfig {
+  override def mk: H2Classifier = new GrpcClassifiers.NeverRetryable(nonAccrualCodes.getOrElse(Set.empty))
 }
 
 class NeverRetryableInitializer extends ResponseClassifierInitializer {
@@ -15,8 +19,8 @@ class NeverRetryableInitializer extends ResponseClassifierInitializer {
 
 object NeverRetryableInitializer extends NeverRetryableInitializer
 
-class AlwaysRetryableConfig extends H2ClassifierConfig {
-  override def mk: H2Classifier = GrpcClassifiers.AlwaysRetryable
+class AlwaysRetryableConfig extends GrpcClassifierConfig {
+  override def mk: H2Classifier = new GrpcClassifiers.AlwaysRetryable(nonAccrualCodes.getOrElse(Set.empty))
 }
 
 class AlwaysRetryableInitializer extends ResponseClassifierInitializer {
@@ -26,8 +30,8 @@ class AlwaysRetryableInitializer extends ResponseClassifierInitializer {
 
 object AlwaysRetryableInitializer extends AlwaysRetryableInitializer
 
-class DefaultConfig extends H2ClassifierConfig {
-  override def mk: H2Classifier = GrpcClassifiers.Default
+class DefaultConfig extends GrpcClassifierConfig {
+  override def mk: H2Classifier = new GrpcClassifiers.Default(nonAccrualCodes.getOrElse(Set.empty))
 }
 
 class DefaultInitializer extends ResponseClassifierInitializer {
@@ -37,8 +41,8 @@ class DefaultInitializer extends ResponseClassifierInitializer {
 
 object DefaultInitializer extends DefaultInitializer
 
-class CompliantConfig extends H2ClassifierConfig {
-  override def mk: H2Classifier = GrpcClassifiers.Compliant
+class CompliantConfig extends GrpcClassifierConfig {
+  override def mk: H2Classifier = new GrpcClassifiers.Compliant(nonAccrualCodes.getOrElse(Set.empty))
 }
 
 class CompliantInitializer extends ResponseClassifierInitializer {
@@ -49,8 +53,8 @@ class CompliantInitializer extends ResponseClassifierInitializer {
 object CompliantInitializer extends CompliantInitializer
 
 // TODO: support parsing the status codes by name rather than by number?
-class RetryableStatusCodesConfig(val retryableStatusCodes: Set[Int]) extends H2ClassifierConfig {
-  override def mk: H2Classifier = new GrpcClassifiers.RetryableStatusCodes(retryableStatusCodes)
+class RetryableStatusCodesConfig(val retryableStatusCodes: Set[Int]) extends GrpcClassifierConfig {
+  override def mk: H2Classifier = new GrpcClassifiers.RetryableStatusCodes(retryableStatusCodes, nonAccrualCodes.getOrElse(Set.empty))
 }
 
 class RetryableStatusCodesInitializer extends ResponseClassifierInitializer {

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/grpc/GrpcClassifierConfig.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/grpc/GrpcClassifierConfig.scala
@@ -3,13 +3,16 @@ package io.buoyant.linkerd.protocol.h2.grpc
 import com.twitter.finagle.buoyant.h2.service.H2Classifier
 import io.buoyant.linkerd.ResponseClassifierInitializer
 import io.buoyant.linkerd.protocol.h2._
+import io.buoyant.grpc.runtime.GrpcStatus
+import io.buoyant.grpc.runtime.GrpcStatus.Ok
 
 abstract class GrpcClassifierConfig extends H2ClassifierConfig {
-  var nonAccruableStatusCodes: Option[Set[Int]] = None
+  var successStatusCodes: Option[Set[Int]] = None
+  def _successStatusCodes = successStatusCodes.getOrElse(Set(0))
 }
 
 class NeverRetryableConfig extends GrpcClassifierConfig {
-  override def mk: H2Classifier = new GrpcClassifiers.NeverRetryable(nonAccruableStatusCodes.getOrElse(Set.empty))
+  override def mk: H2Classifier = new GrpcClassifiers.NeverRetryable(_successStatusCodes)
 }
 
 class NeverRetryableInitializer extends ResponseClassifierInitializer {
@@ -20,7 +23,7 @@ class NeverRetryableInitializer extends ResponseClassifierInitializer {
 object NeverRetryableInitializer extends NeverRetryableInitializer
 
 class AlwaysRetryableConfig extends GrpcClassifierConfig {
-  override def mk: H2Classifier = new GrpcClassifiers.AlwaysRetryable(nonAccruableStatusCodes.getOrElse(Set.empty))
+  override def mk: H2Classifier = new GrpcClassifiers.AlwaysRetryable(_successStatusCodes)
 }
 
 class AlwaysRetryableInitializer extends ResponseClassifierInitializer {
@@ -31,7 +34,7 @@ class AlwaysRetryableInitializer extends ResponseClassifierInitializer {
 object AlwaysRetryableInitializer extends AlwaysRetryableInitializer
 
 class DefaultConfig extends GrpcClassifierConfig {
-  override def mk: H2Classifier = new GrpcClassifiers.Default(nonAccruableStatusCodes.getOrElse(Set.empty))
+  override def mk: H2Classifier = new GrpcClassifiers.Default(_successStatusCodes)
 }
 
 class DefaultInitializer extends ResponseClassifierInitializer {
@@ -42,7 +45,7 @@ class DefaultInitializer extends ResponseClassifierInitializer {
 object DefaultInitializer extends DefaultInitializer
 
 class CompliantConfig extends GrpcClassifierConfig {
-  override def mk: H2Classifier = new GrpcClassifiers.Compliant(nonAccruableStatusCodes.getOrElse(Set.empty))
+  override def mk: H2Classifier = new GrpcClassifiers.Compliant(_successStatusCodes)
 }
 
 class CompliantInitializer extends ResponseClassifierInitializer {
@@ -54,7 +57,7 @@ object CompliantInitializer extends CompliantInitializer
 
 // TODO: support parsing the status codes by name rather than by number?
 class RetryableStatusCodesConfig(val retryableStatusCodes: Set[Int]) extends GrpcClassifierConfig {
-  override def mk: H2Classifier = new GrpcClassifiers.RetryableStatusCodes(retryableStatusCodes, nonAccruableStatusCodes.getOrElse(Set.empty))
+  override def mk: H2Classifier = new GrpcClassifiers.RetryableStatusCodes(retryableStatusCodes, _successStatusCodes)
 }
 
 class RetryableStatusCodesInitializer extends ResponseClassifierInitializer {

--- a/linkerd/protocol/h2/src/test/scala/io/buoyant/linkerd/protocol/h2/CompliantGrpcClassifierTest.scala
+++ b/linkerd/protocol/h2/src/test/scala/io/buoyant/linkerd/protocol/h2/CompliantGrpcClassifierTest.scala
@@ -24,13 +24,14 @@ class CompliantGrpcClassifierTest extends FunSuite with GeneratorDrivenPropertyC
         Request(Headers.empty, FStream.empty()),
         Return(Response(status.toTrailers, FStream.empty()))
       )
-      assert(Compliant.responseClassifier.isDefinedAt(reqrep))
+      val compliant = new Compliant
+      assert(compliant.responseClassifier.isDefinedAt(reqrep))
       if (status.code != 0) {
-        assert(Compliant.responseClassifier(reqrep) == ResponseClass.NonRetryableFailure)
+        assert(compliant.responseClassifier(reqrep) == ResponseClass.NonRetryableFailure)
       } else if (status.code == 14) {
-        assert(Compliant.responseClassifier(reqrep) == ResponseClass.RetryableFailure)
+        assert(compliant.responseClassifier(reqrep) == ResponseClass.RetryableFailure)
       } else {
-        assert(Compliant.responseClassifier(reqrep) == ResponseClass.Success)
+        assert(compliant.responseClassifier(reqrep) == ResponseClass.Success)
       }
     }
   }
@@ -40,8 +41,9 @@ class CompliantGrpcClassifierTest extends FunSuite with GeneratorDrivenPropertyC
       Request(Headers.empty, FStream.empty()),
       Throw(Reset.Refused)
     )
-    assert(Compliant.responseClassifier.isDefinedAt(reqrep))
-    assert(Compliant.responseClassifier(reqrep) == ResponseClass.RetryableFailure)
+    val compliant = new Compliant
+    assert(compliant.responseClassifier.isDefinedAt(reqrep))
+    assert(compliant.responseClassifier(reqrep) == ResponseClass.RetryableFailure)
   }
 
   test("Compliant classifies Reset:Other as non-retryable") {
@@ -49,8 +51,9 @@ class CompliantGrpcClassifierTest extends FunSuite with GeneratorDrivenPropertyC
       Request(Headers.empty, FStream.empty()),
       Throw(Reset.EnhanceYourCalm)
     )
-    assert(Compliant.responseClassifier.isDefinedAt(reqrep))
-    assert(Compliant.responseClassifier(reqrep) == ResponseClass.NonRetryableFailure)
+    val compliant = new Compliant
+    assert(compliant.responseClassifier.isDefinedAt(reqrep))
+    assert(compliant.responseClassifier(reqrep) == ResponseClass.NonRetryableFailure)
   }
 
   test("Compliant classifies retryable http responses") {
@@ -60,8 +63,9 @@ class CompliantGrpcClassifierTest extends FunSuite with GeneratorDrivenPropertyC
         Request(Headers.empty, FStream.empty()),
         Return(Response(status, FStream.empty()))
       )
-      assert(Compliant.responseClassifier.isDefinedAt(reqrep))
-      assert(Compliant.responseClassifier(reqrep) == ResponseClass.RetryableFailure)
+      val compliant = new Compliant
+      assert(compliant.responseClassifier.isDefinedAt(reqrep))
+      assert(compliant.responseClassifier(reqrep) == ResponseClass.RetryableFailure)
     })
   }
 
@@ -71,8 +75,9 @@ class CompliantGrpcClassifierTest extends FunSuite with GeneratorDrivenPropertyC
         Request(Headers.empty, FStream.empty()),
         Return(Response(status, FStream.empty()))
       )
-      assert(Compliant.responseClassifier.isDefinedAt(reqrep))
-      assert(Compliant.responseClassifier(reqrep) == ResponseClass.NonRetryableFailure)
+      val compliant = new Compliant
+      assert(compliant.responseClassifier.isDefinedAt(reqrep))
+      assert(compliant.responseClassifier(reqrep) == ResponseClass.NonRetryableFailure)
     })
   }
 
@@ -87,13 +92,14 @@ class CompliantGrpcClassifierTest extends FunSuite with GeneratorDrivenPropertyC
           Some(Return(trailers))
         ))
       )
-      assert(Compliant.streamClassifier.isDefinedAt(reqrep))
+      val compliant = new Compliant
+      assert(compliant.streamClassifier.isDefinedAt(reqrep))
       if (status.code != 0) {
-        assert(Compliant.streamClassifier(reqrep) == ResponseClass.NonRetryableFailure)
+        assert(compliant.streamClassifier(reqrep) == ResponseClass.NonRetryableFailure)
       } else if (status.code == 14) {
-        assert(Compliant.streamClassifier(reqrep) == ResponseClass.RetryableFailure)
+        assert(compliant.streamClassifier(reqrep) == ResponseClass.RetryableFailure)
       } else {
-        assert(Compliant.streamClassifier(reqrep) == ResponseClass.Success)
+        assert(compliant.streamClassifier(reqrep) == ResponseClass.Success)
       }
     }
   }
@@ -106,8 +112,9 @@ class CompliantGrpcClassifierTest extends FunSuite with GeneratorDrivenPropertyC
         Some(Throw(Reset.Refused))
       ))
     )
-    assert(Compliant.streamClassifier.isDefinedAt(reqrep))
-    assert(Compliant.streamClassifier(reqrep) == ResponseClass.RetryableFailure)
+    val compliant = new Compliant
+    assert(compliant.streamClassifier.isDefinedAt(reqrep))
+    assert(compliant.streamClassifier(reqrep) == ResponseClass.RetryableFailure)
   }
 
   test("Compliant classifies Reset:Other stream as non-retryable") {
@@ -118,8 +125,9 @@ class CompliantGrpcClassifierTest extends FunSuite with GeneratorDrivenPropertyC
         Some(Throw(Reset.EnhanceYourCalm))
       ))
     )
-    assert(Compliant.streamClassifier.isDefinedAt(reqrep))
-    assert(Compliant.streamClassifier(reqrep) == ResponseClass.NonRetryableFailure)
+    val compliant = new Compliant
+    assert(compliant.streamClassifier.isDefinedAt(reqrep))
+    assert(compliant.streamClassifier(reqrep) == ResponseClass.NonRetryableFailure)
   }
 
   test("Compliant classifies retryable stream http responses") {
@@ -132,8 +140,9 @@ class CompliantGrpcClassifierTest extends FunSuite with GeneratorDrivenPropertyC
           Some(Return(Trailers()))
         ))
       )
-      assert(Compliant.streamClassifier.isDefinedAt(reqrep))
-      assert(Compliant.streamClassifier(reqrep) == ResponseClass.RetryableFailure)
+      val compliant = new Compliant
+      assert(compliant.streamClassifier.isDefinedAt(reqrep))
+      assert(compliant.streamClassifier(reqrep) == ResponseClass.RetryableFailure)
     })
   }
 
@@ -146,8 +155,9 @@ class CompliantGrpcClassifierTest extends FunSuite with GeneratorDrivenPropertyC
           Some(Return(Trailers()))
         ))
       )
-      assert(Compliant.streamClassifier.isDefinedAt(reqrep))
-      assert(Compliant.streamClassifier(reqrep) == ResponseClass.NonRetryableFailure)
+      val compliant = new Compliant
+      assert(compliant.streamClassifier.isDefinedAt(reqrep))
+      assert(compliant.streamClassifier(reqrep) == ResponseClass.NonRetryableFailure)
     })
   }
 }

--- a/linkerd/protocol/h2/src/test/scala/io/buoyant/linkerd/protocol/h2/GrpcClassifierTest.scala
+++ b/linkerd/protocol/h2/src/test/scala/io/buoyant/linkerd/protocol/h2/GrpcClassifierTest.scala
@@ -82,8 +82,8 @@ class GrpcClassifierTest extends FunSuite with GeneratorDrivenPropertyChecks {
     }
   }
 
-  test("Non-accruable status codes classify specific codes as success") {
-    forAll("status", "non-accruable status codes") { (status: GrpcStatus, codes: Set[Int]) =>
+  test("Success status codes classify specific codes as success") {
+    forAll("status", "success status codes") { (status: GrpcStatus, codes: Set[Int]) =>
       val trailers = status.toTrailers
       val reqrep = H2ReqRepFrame(
         Request(Headers.empty, FStream.empty()),
@@ -94,9 +94,7 @@ class GrpcClassifierTest extends FunSuite with GeneratorDrivenPropertyChecks {
       )
       val classifier = new NeverRetryable(codes)
       assert(classifier.streamClassifier.isDefinedAt(reqrep))
-      if (status.code == 0) {
-        assert(classifier.streamClassifier(reqrep) == ResponseClass.Success)
-      } else if (codes.contains(status.code)) {
+      if (codes.contains(status.code)) {
         assert(classifier.streamClassifier(reqrep) == ResponseClass.Success)
       } else {
         assert(classifier.streamClassifier(reqrep) == ResponseClass.NonRetryableFailure)
@@ -124,7 +122,8 @@ class GrpcClassifierTest extends FunSuite with GeneratorDrivenPropertyChecks {
             |service:
             |  responseClassifier:
             |    kind: $kind
-            |    nonAccruableStatusCodes:
+            |    successStatusCodes:
+            |    - 0
             |    - 1
             |    - 2
             |    - 3
@@ -154,7 +153,8 @@ class GrpcClassifierTest extends FunSuite with GeneratorDrivenPropertyChecks {
           |    - 1
           |    - 2
           |    - 3
-          |    nonAccruableStatusCodes:
+          |    successStatusCodes:
+          |    - 0
           |    - 4
           |    - 5
           |servers:

--- a/linkerd/protocol/h2/src/test/scala/io/buoyant/linkerd/protocol/h2/GrpcClassifierTest.scala
+++ b/linkerd/protocol/h2/src/test/scala/io/buoyant/linkerd/protocol/h2/GrpcClassifierTest.scala
@@ -82,8 +82,8 @@ class GrpcClassifierTest extends FunSuite with GeneratorDrivenPropertyChecks {
     }
   }
 
-  test("TestCaseClass classifies specific codes as Success") {
-    forAll("status", "retryable statuses") { (status: GrpcStatus, codes: Set[Int]) =>
+  test("Non-accruable status codes classify specific codes as success") {
+    forAll("status", "non-accruable status codes") { (status: GrpcStatus, codes: Set[Int]) =>
       val trailers = status.toTrailers
       val reqrep = H2ReqRepFrame(
         Request(Headers.empty, FStream.empty()),
@@ -124,6 +124,10 @@ class GrpcClassifierTest extends FunSuite with GeneratorDrivenPropertyChecks {
             |service:
             |  responseClassifier:
             |    kind: $kind
+            |    nonAccruableStatusCodes:
+            |    - 1
+            |    - 2
+            |    - 3
             |servers:
             |- port: 0
             |""".stripMargin
@@ -150,6 +154,9 @@ class GrpcClassifierTest extends FunSuite with GeneratorDrivenPropertyChecks {
           |    - 1
           |    - 2
           |    - 3
+          |    nonAccruableStatusCodes:
+          |    - 4
+          |    - 5
           |servers:
           |- port: 0
           |""".stripMargin


### PR DESCRIPTION
# Problem

Linkerd does not allow a user to specify which gRPC status codes are not counted towards failure accrual.

# Solution

Linkerd should allow a user to custom configure which gRPC status codes will not count towards failure accrual. Similar to how Linkerd allows the specification of gRPC user defined `RetryableFailure` status codes, there should also be an ability to specify user defined status codes that do not count towards failure accrual.

In `responseClassifier` configuration, a user can now specify `nonAccruableStatusCodes` to enumerate which gRPC status codes (other than 0) should not count towards failure accrual.

# Validation

When running a simple [strest-grpc](https://github.com/BuoyantIO/strest-grpc) server and [h2 Linkerd example](https://github.com/linkerd/linkerd/blob/master/linkerd/examples/h2.yaml) like the following:
```
admin:
  ip: 0.0.0.0
  port: 9990

# HTTP/2 protocol.
namers:
- kind: io.l5d.fs
  rootDir: linkerd/examples/io.l5d.fs

routers:
- protocol: h2
  service:
    responseClassifier:
      kind: io.l5d.h2.grpc.default
  h2AccessLog: logs/access.log
...
```

send an H2 request and observe the response classification:
```
"rt/h2/client/#/io.l5d.fs/cat/service/svc/cat/failures": 1,
"rt/h2/client/#/io.l5d.fs/cat/service/svc/cat/failures/com.twitter.finagle.service.ResponseClassificationSyntheticException": 1,
"rt/h2/client/#/io.l5d.fs/cat/service/svc/cat/requests": 1,
```

Now running the same setup, add the following to the `responseClassifier`:
```
admin:
  ip: 0.0.0.0
  port: 9990

# HTTP/2 protocol.
namers:
- kind: io.l5d.fs
  rootDir: linkerd/examples/io.l5d.fs

routers:
- protocol: h2
  service:
    responseClassifier:
      kind: io.l5d.h2.grpc.default
+     nonAccruableStatusCodes:
+     - 8
  h2AccessLog: logs/access.log
...
```

Send the same H2 request and observe the response classification:
```
"rt/h2/client/#/io.l5d.fs/cat/service/svc/cat/failures": 0,
"rt/h2/client/#/io.l5d.fs/cat/service/svc/cat/requests": 1,
```

Fixes #2183 
