### PR TITLE
1.6.0 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@
 Linkerd 1.6.0 includes a Finagle upgrade that reduces direct memory allocation and adds support for
 more efficient HTTP/1.1 streaming for large HTTP requests. This release also improves Linkerd's 
 execution script to run with Java 9 and higher. Finally, this release adds a new gRPC 
-response-classifier that may be configured with gRPC status codes.
+response-classifier that may be configured with user defined gRPC status codes.
 
 Full release notes:
 
@@ -11,7 +11,7 @@ Full release notes:
 * **Breaking Change**
   * `requestAuthorizers` are now configured in the client section of a router configuration.
   * `maxChunkKB` has been removed and is no longer configurable for HTTP/1.1 routers. Rather than
-   enforcing a hard size limit,Linkerd now streams HTTP/1.1 chunked messages that exceed 
+   enforcing a hard size limit, Linkerd now streams HTTP/1.1 chunked messages that exceed 
   `streamAfterContentLengthKB`
   
 HTTP/1.1
@@ -20,7 +20,7 @@ HTTP/1.1
   not used.
 * Consul  
   * Fixes an issue where the last known good state of an `io.l5d.consul` namer would be cleared if 
-  an 5xx API response from Consul was received.
+  a 5xx API response was received from Consul.
 * gRPC
   * Adds support for all `io.l5d.h2.grpc.*` response classifiers to classify gRPC status codes as 
   `Success` based off of a user defined list within the response classification section of a config.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,31 @@
+## 1.5.3 2018-12-20
+
+Linkerd 1.5.3 includes a Finagle upgrade that fixes some memory related issues and adds support for 
+more efficient HTTP/1.1 routing for large HTTP requests. This release also improves 
+Linkerd's start up script to can run with newer versions of Java. Finally, this release adds a
+new feature for gRPC response classifiers that allow for added flexibility in classifying user 
+defined gRPC status codes.
+
+Full release notes:
+
+HTTP/1.1
+  * Adds a new config option `streamAfterContentLengthKB` that sets a threshold at which HTTP 
+  messages will be streamed by Netty if exceeded. This avoids having to allocate large HTTP messages
+  in memory when routing requests. e.g. file uploads.
+* Consul  
+  * Fixes an issue where the last known good state of an `io.l5d.consul` namer would be cleared if 
+  an 5xx API response from Consul was received.
+* gRPC
+  * Adds support for all `io.l5d.h2.grpc.*` response classifiers to classify gRPC status codes as 
+  `Success` based off of a user defined list within the response classification section of a config.
+* Fixes a startup issue where Linkerd would fail to load `readTimeoutMs` and `writeTimeoutMs`values
+  from socket option configs.  
+* Fixes Linkerd's executable script to work with Java version 9 and higher.
+* Upgrades Finagle to 18.12.0 which reduces the amount of direct memory Linkerd uses at startup time.
+* **Breaking Change**
+  * `requestAuthorizers` are now configured in the client section of a router configuration.
+  * `maxChunkKB` has been removed and is no longer configurable for HTTP/1.1 routers
+    
 ## 1.5.2 2018-11-19
 
 Linkerd 1.5.2 adds performance improvements to HTTP/2, dramatically improving throughput when

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,17 +1,23 @@
-## 1.5.3 2018-12-20
+## 1.6.0 2018-12-20
 
-Linkerd 1.5.3 includes a Finagle upgrade that fixes some memory related issues and adds support for 
-more efficient HTTP/1.1 routing for large HTTP requests. This release also improves 
-Linkerd's start up script to can run with newer versions of Java. Finally, this release adds a
-new feature for gRPC response classifiers that allow for added flexibility in classifying user 
-defined gRPC status codes.
+Linkerd 1.6.0 includes a Finagle upgrade that reduces direct memory allocation and adds support for
+more efficient HTTP/1.1 streaming for large HTTP requests. This release also improves Linkerd's 
+execution script to run with Java 9 and higher. Finally, this release adds a new gRPC 
+response-classifier that may be configured with gRPC status codes.
 
 Full release notes:
 
+
+* **Breaking Change**
+  * `requestAuthorizers` are now configured in the client section of a router configuration.
+  * `maxChunkKB` has been removed and is no longer configurable for HTTP/1.1 routers. Rather than
+   enforcing a hard size limit,Linkerd now streams HTTP/1.1 chunked messages that exceed 
+  `streamAfterContentLengthKB`
+  
 HTTP/1.1
-  * Adds a new config option `streamAfterContentLengthKB` that sets a threshold at which HTTP 
-  messages will be streamed by Netty if exceeded. This avoids having to allocate large HTTP messages
-  in memory when routing requests. e.g. file uploads.
+  * Adds a new config option `streamAfterContentLengthKB` that sets a threshold at which HTTP
+  messages will be streamed instead of being fully buffered in memory, even when chunked-encoding is
+  not used.
 * Consul  
   * Fixes an issue where the last known good state of an `io.l5d.consul` namer would be cleared if 
   an 5xx API response from Consul was received.
@@ -21,10 +27,8 @@ HTTP/1.1
 * Fixes a startup issue where Linkerd would fail to load `readTimeoutMs` and `writeTimeoutMs`values
   from socket option configs.  
 * Fixes Linkerd's executable script to work with Java version 9 and higher.
-* Upgrades Finagle to 18.12.0 which reduces the amount of direct memory Linkerd uses at startup time.
-* **Breaking Change**
-  * `requestAuthorizers` are now configured in the client section of a router configuration.
-  * `maxChunkKB` has been removed and is no longer configurable for HTTP/1.1 routers
+* Upgrades Finagle to 18.12.0 which reduces the amount of direct memory Linkerd allocates at startup
+ time.
     
 ## 1.5.2 2018-11-19
 

--- a/project/Base.scala
+++ b/project/Base.scala
@@ -32,7 +32,7 @@ object Base {
 class Base extends Build {
   import Base._
 
-  val headVersion = "1.5.2"
+  val headVersion = "1.5.3"
   val openJdkVersion = "8u151"
   val openJ9Version = "jdk8u162-b12_openj9-0.8.0"
 

--- a/project/Base.scala
+++ b/project/Base.scala
@@ -32,7 +32,7 @@ object Base {
 class Base extends Build {
   import Base._
 
-  val headVersion = "1.5.3"
+  val headVersion = "1.6.0"
   val openJdkVersion = "8u151"
   val openJ9Version = "jdk8u162-b12_openj9-0.8.0"
 


### PR DESCRIPTION
Linkerd 1.6.0 includes a Finagle upgrade that reduces direct memory allocation and adds support for more efficient HTTP/1.1 streaming for large HTTP requests. This release also improves Linkerd's execution script to run with Java 9 and higher. Finally, this release adds a new gRPC response-classifier that may be configured with user defined gRPC status codes.

Full release notes:

* **Breaking Change**
  * `requestAuthorizers` are now configured in the client section of a router configuration.
  * `maxChunkKB` has been removed and is no longer configurable for HTTP/1.1 routers. Rather than enforcing a hard size limit, Linkerd now streams HTTP/1.1 chunked messages that exceed `streamAfterContentLengthKB`
  
* HTTP/1.1
  * Adds a new config option `streamAfterContentLengthKB` that sets a threshold at which HTTP messages will be streamed instead of being fully buffered in memory, even when chunked-encoding is not used.
* Consul  
  * Fixes an issue where the last known good state of an `io.l5d.consul` namer would be cleared if a 5xx API response was received from Consul.
* gRPC
  * Adds support for all `io.l5d.h2.grpc.*` response classifiers to classify gRPC status codes as 
  `Success` based off of a user defined list within the response classification section of a config.
* Fixes a startup issue where Linkerd would fail to load `readTimeoutMs` and `writeTimeoutMs`values from socket option configs.  
* Fixes Linkerd's executable script to work with Java version 9 and higher.
* Upgrades Finagle to 18.12.0 which reduces the amount of direct memory Linkerd allocates at startup time.

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>