### PR TITLE
Retain last state on "No path to datacenter" error

### DIFF
--- a/namer/consul/src/main/scala/io/buoyant/namer/consul/SvcAddr.scala
+++ b/namer/consul/src/main/scala/io/buoyant/namer/consul/SvcAddr.scala
@@ -96,7 +96,7 @@ private[consul] object SvcAddr {
             state.update(Addr.Neg)
             val backoff #:: nextBackoffs = backoffs
             // subsequent errors are logged as DEBUG
-            Future.sleep(backoff).before(loop(None, nextBackoffs, Level.DEBUG, currentState))
+            Future.sleep(backoff).before(loop(None, nextBackoffs, Level.DEBUG, Addr.Neg))
           case Throw(e: IndividualRequestTimeoutException) =>
             // catch request timeout exceptions for Consul API. Use last known good state.
             stats.errors.incr()

--- a/namer/consul/src/main/scala/io/buoyant/namer/consul/SvcAddr.scala
+++ b/namer/consul/src/main/scala/io/buoyant/namer/consul/SvcAddr.scala
@@ -103,8 +103,8 @@ private[consul] object SvcAddr {
             // subsequent errors are logged as DEBUG
             Future.sleep(backoff).before(loop(None, nextBackoffs, Level.DEBUG, effectiveState))
           case Return(v1.Indexed(_, None)) =>
-            // TODO: this looks like dead code. If response is 200, it will contain index. Remove?
             // If consul doesn't return an index, we're in bad shape.
+            // TODO: do we want to revert to the last good state here, as well?
             state.update(Addr.Failed(NoIndexException))
             stats.errors.incr()
             log.error(

--- a/namer/consul/src/test/scala/io/buoyant/namer/consul/ConsulNamerTest.scala
+++ b/namer/consul/src/test/scala/io/buoyant/namer/consul/ConsulNamerTest.scala
@@ -581,7 +581,7 @@ class ConsulNamerTest extends FunSuite with Awaits {
     }
   }
 
-  test("Namer state returns Pending then Bound then Neg when a datacenter becomes available and then becomes unavailable") {
+  test("Namer state returns Pending then Bound then remains Bound when a datacenter becomes available and then becomes unavailable") {
     val datacenterWillBeUnavailable = new Promise[Unit]
     val datacenterIsAvailable = new Promise[Unit]
     @volatile var datacenterIsUp = false
@@ -642,7 +642,7 @@ class ConsulNamerTest extends FunSuite with Awaits {
     withClue("during datacenter crash") {
       datacenterWillBeUnavailable.setDone()
       eventually {
-        assert(state == Activity.Ok(NameTree.Neg))
+        assertOnAddrs(state) { (addrs, _) => assert(addrs.size == 2); () }
       }
     }
   }

--- a/namer/consul/src/test/scala/io/buoyant/namer/consul/ConsulNamerTest.scala
+++ b/namer/consul/src/test/scala/io/buoyant/namer/consul/ConsulNamerTest.scala
@@ -96,7 +96,7 @@ class ConsulNamerTest extends FunSuite with Awaits {
     }
   }
 
-  test("Namer stays pending if the consul api cannot be reached") {
+  test("Namer returns Neg if the consul api cannot be reached for a name that was never resolved") {
     class TestApi extends CatalogApi(null, "/v1") {
       override def serviceNodes(
         serviceName: String,
@@ -116,7 +116,7 @@ class ConsulNamerTest extends FunSuite with Awaits {
         state = _
       }
 
-      assert(state == Activity.Pending)
+      assert(state == Activity.Ok(NameTree.Neg))
       assert(
         stats.counters == Map(
           Seq("service", "updates") -> 0,
@@ -581,7 +581,7 @@ class ConsulNamerTest extends FunSuite with Awaits {
     }
   }
 
-  test("Namer state returns Pending then Bound then remains Bound when a datacenter becomes available and then becomes unavailable") {
+  test("Namer state returns Neg then Bound then remains Bound when a datacenter becomes available and then becomes unavailable") {
     val datacenterWillBeUnavailable = new Promise[Unit]
     val datacenterIsAvailable = new Promise[Unit]
     @volatile var datacenterIsUp = false
@@ -629,7 +629,7 @@ class ConsulNamerTest extends FunSuite with Awaits {
 
     withClue("before datacenter is available") {
       eventually {
-        assert(state == Activity.Pending)
+        assert(state == Activity.Ok(NameTree.Neg))
       }
 
       datacenterIsAvailable.setDone()

--- a/namer/consul/src/test/scala/io/buoyant/namer/consul/SvcAddrTest.scala
+++ b/namer/consul/src/test/scala/io/buoyant/namer/consul/SvcAddrTest.scala
@@ -1,7 +1,7 @@
 package io.buoyant.namer.consul
 
 import com.twitter.conversions.DurationOps._
-import com.twitter.finagle.http.Request
+import com.twitter.finagle.http.{Request, Response, Status, Version}
 import com.twitter.finagle.stats.NullStatsReceiver
 import com.twitter.finagle.util.DefaultTimer
 import com.twitter.finagle.{Addr, Address, Failure, IndividualRequestTimeoutException}
@@ -48,41 +48,142 @@ class SvcAddrTest extends FunSuite with Matchers with Awaits {
       ): ApiCall[IndexedServiceNodes] = ApiCall(emptyRequest, _ => stubFn(serviceName, datacenter, tag, blockingIndex, consistency, retry))
     }
 
-  test("should keep last known Addr.Bound value on error") {
-    // given
-    val invoked = Promise[Unit]()
-    val (serviceNode, serviceAddr) = service()
-    val response = Indexed[Seq[ServiceNode]](Seq(serviceNode), Some("1"))
-    val backoffs: Stream[Duration] = Stream.fill(10)(10.millis)
-    @volatile var changes: Addr = Addr.Pending
-    @volatile var requestCount = new AtomicInteger()
-    val api = apiStub { (_, _, _, _, _, _) =>
-      synchronized {
-        requestCount.getAndIncrement() match {
-          case 0 => Future.value(response)
-          case 1 => Future.exception(new Throwable("whatever is thrown we catch"))
-          case _ =>
-            invoked.setDone()
-            Future.never
-        }
+  /**
+   * Creates CatalogApi stub that serves responses in sequence.
+   * Returns CatalogApi and a Future that is satisfied after all responses are served.
+   */
+  def scriptedApiStub(scriptedResponses: Future[IndexedServiceNodes]*): (CatalogApi, Future[Unit]) = {
+    val servedAllResponses = Promise[Unit]()
+    var remaining = scriptedResponses.toSeq
+    apiStub { (_, _, _, _, _, _) =>
+      remaining match {
+        case head +: tail =>
+          remaining = tail
+          head
+        case _ =>
+          servedAllResponses.setDone()
+          Future.never
       }
-    }
+    } -> servedAllResponses
+  }
+
+  object singletonSet {
+    def unapply[T](arg: Set[T]): Option[T]= arg.headOption
+  }
+
+  test("should keep last known Addr.Bound value on generic error") {
+    // given
+    val (serviceNode, serviceAddr) = service()
+    val (api, servedAll) = scriptedApiStub(
+      Future.value(Indexed[Seq[ServiceNode]](Seq(serviceNode), Some("1"))),
+      Future.exception(new Throwable("whatever is thrown we catch"))
+    )
 
     // when
-    val addr: InstrumentedVar[Addr] = SvcAddr(api, backoffs, "dc1", SvcKey("svc", None), None, None, None, Map.empty, Stats(NullStatsReceiver), new PollState)
+    val svcAddrVar: InstrumentedVar[Addr] = SvcAddr(
+      api,
+      Stream.continually(1.millis),
+      "dc1",
+      SvcKey("svc", None),
+      None,
+      None,
+      None,
+      Map.empty,
+      Stats(NullStatsReceiver),
+      new PollState
+    )
+    // observe Var so it is not dormant
+    svcAddrVar.underlying.changes.respond(_ => ())
 
     // then
-    addr.underlying.changes.respond(changes = _)
-    await(invoked)
-    addr.running shouldBe true
-    addr.lastStartedAt shouldBe 'defined
-    addr.lastStoppedAt should not be 'defined
-    addr.lastUpdatedAt shouldBe 'defined
-    changes match {
-      case Addr.Bound(addrSet, _) =>
-        addrSet should have size 1
-        addrSet.head should matchPattern { case Address.Inet(addr, _) if addr == serviceAddr => }
-      case neg: Addr => neg should be(Addr.Neg)
+    await(servedAll)
+
+    svcAddrVar.running shouldBe true
+    svcAddrVar.lastStartedAt shouldBe 'defined
+    svcAddrVar.lastStoppedAt should not be 'defined
+    svcAddrVar.lastUpdatedAt shouldBe 'defined
+
+    svcAddrVar.underlying.sample() should matchPattern {
+      case Addr.Bound(singletonSet(Address.Inet(addr, _)), _) if addr == serviceAddr => ()
+    }
+  }
+
+  test("should keep last known Addr.Bound value on the 'No path to datacenter' error") {
+    // given
+    val (serviceNode, serviceAddr) = service()
+
+    val rsp = Response(Version.Http11, Status.InternalServerError)
+    rsp.contentString = "No path to datacenter"
+    val (api, servedAll) = scriptedApiStub(
+      Future.value(Indexed[Seq[ServiceNode]](Seq(serviceNode), Some("1"))),
+      Future.exception(UnexpectedResponse(rsp))
+    )
+
+    // when
+    val svcAddrVar: InstrumentedVar[Addr] = SvcAddr(
+      api,
+      Stream.continually(1.millis),
+      "dc1",
+      SvcKey("svc", None),
+      None,
+      None,
+      None,
+      Map.empty,
+      Stats(NullStatsReceiver),
+      new PollState
+    )
+    // observe Var so it is not dormant
+    svcAddrVar.underlying.changes.respond(_ => ())
+
+    // then
+    await(servedAll)
+
+    svcAddrVar.running shouldBe true
+    svcAddrVar.lastStartedAt shouldBe 'defined
+    svcAddrVar.lastStoppedAt should not be 'defined
+    svcAddrVar.lastUpdatedAt shouldBe 'defined
+
+    svcAddrVar.underlying.sample() should matchPattern {
+      case Addr.Bound(singletonSet(Address.Inet(addr, _)), _) if addr == serviceAddr => ()
+    }
+  }
+
+  test("should return Addr.Neg on the 'No path to datacenter' error if no previous state exist") {
+    // given
+    val (serviceNode, serviceAddr) = service()
+
+    val rsp = Response(Version.Http11, Status.InternalServerError)
+    rsp.contentString = "No path to datacenter"
+    val (api, servedAll) = scriptedApiStub(
+      Future.exception(UnexpectedResponse(rsp))
+    )
+
+    // when
+    val svcAddrVar: InstrumentedVar[Addr] = SvcAddr(
+      api,
+      Stream.continually(1.millis),
+      "dc1",
+      SvcKey("svc", None),
+      None,
+      None,
+      None,
+      Map.empty,
+      Stats(NullStatsReceiver),
+      new PollState
+    )
+    // observe Var so it is not dormant
+    svcAddrVar.underlying.changes.respond(_ => ())
+
+    // then
+    await(servedAll)
+
+    svcAddrVar.running shouldBe true
+    svcAddrVar.lastStartedAt shouldBe 'defined
+    svcAddrVar.lastStoppedAt should not be 'defined
+    svcAddrVar.lastUpdatedAt shouldBe 'defined
+
+    svcAddrVar.underlying.sample() should matchPattern {
+      case Addr.Neg =>
     }
   }
 


### PR DESCRIPTION
Consul responds with "No path to datacenter" when it is queried about DC
that does not exist (case 1) or DC that can't be contacted due to
network partition (case 2). Currently consul namer responds with
Addr.Neg on such response.
This makes sense in (case 1), because we want to fallback to
explore alternatives in dtab asap when we try to resolve new name.
However in (case 2) we want to retain previously known state (if it
exists), so namerd could survive intermittent consul failures caused by
network partition.

This commit adjusts consul namer so it only returns Addr.Neg if current
state is Addr.Pending. Otherwise, previous address is retained.

Fixes #2200

Signed-off-by: Dmytro Kostiuchenko <edio@archlinux.us>