### PR TITLE
Update curator dependency

### DIFF
--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -2,9 +2,9 @@ import sbt._
 
 object Deps {
 
-  val curatorFramework = "org.apache.curator" % "curator-framework" % "2.9.1"
-  val curatorClient = "org.apache.curator" % "curator-client" % "2.9.1"
-  val curatorDiscovery = "org.apache.curator" % "curator-x-discovery" % "2.9.1"
+  val curatorFramework = "org.apache.curator" % "curator-framework" % "4.1.0"
+  val curatorClient = "org.apache.curator" % "curator-client" % "4.1.0"
+  val curatorDiscovery = "org.apache.curator" % "curator-x-discovery" % "4.1.0"
 
   // process lifecycle
   val twitterServer =


### PR DESCRIPTION
# Problem
`org.apache.curator` version _4.1.0_ has a dependency on `com.google.guava`
version _16.0.1._. This version is evicted by the `org.apache.curator` version
_23.0._ dependency that Linkerd has. When the older version is evicted, there
are depreciated methods that are expected to be there by `org.apache.curator`.
When those methods are not there, a runtime error occurs!

# Solution
This can be reproduced with the following:

The following `repro.yaml` configuration:
```yaml
admin:
  port: 9990

namers:
- kind: io.l5d.curator
  experimental: true
  zkAddrs:
  - host: localhost
    port: 2800
  basePath: /curator

routers:
- protocol: http
  identifier:
    kind: io.l5d.static
    path: /test
  dtab: |
    /svc => /#/io.l5d.curator/test;
  httpAccessLog: logs/access.log
  label: http
  servers:
  - port: 4140
    ip: 0.0.0.0
```

1. A running Zookeeper instance on `localhost:2800`
2. `$ ./linkerd repro.yaml`
3. `$ curl localhost:4140`

# Validation
After updating the `org.apache.curator` dependency, the `curl` command will
properly timeout and Linkerd will report the following error:
```
E 0123 15:31:21.065 PST THREAD10 TraceId:a0d46cf41dcfb22c: service failure: com.twitter.finagle.naming.buoyant.DynBoundTimeoutException: Exceeded 10.seconds binding timeout while resolving name: /svc/test
```

Fixes #2199

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>