### PR TITLE
Fix NPE in Namerd when delegator service is used

### DIFF
--- a/namerd/iface/mesh/src/test/scala/io/buoyant/namerd/iface/mesh/DelegatorServiceTest.scala
+++ b/namerd/iface/mesh/src/test/scala/io/buoyant/namerd/iface/mesh/DelegatorServiceTest.scala
@@ -1,0 +1,16 @@
+package io.buoyant.namerd.iface.mesh
+
+import com.google.protobuf.CodedOutputStream
+import com.twitter.finagle._
+import io.buoyant.namer.DelegateTree
+import io.buoyant.test.FunSuite
+import io.linkerd.mesh.DelegateTreeRsp
+import java.io.ByteArrayOutputStream
+
+class DelegatorServiceTest extends FunSuite {
+  test("Delegator service responding with DelegateTree Exception shouldn't throw a null pointer exception"){
+    val out = CodedOutputStream.newInstance(new ByteArrayOutputStream())
+    DelegateTreeRsp.codec.encode(DelegatorService.toDelegateTreeRsp(DelegateTree.Exception(Path.read("/svc"), Dentry.nop, new Throwable)), out)
+    assert(out.getTotalBytesWritten > 0)
+  }
+}


### PR DESCRIPTION
In the `io.l5d.mesh` interface, If a call to get the delegate tree for a particular dtab and path fails in some way and an exception is thrown, Namerd will transform that exception into a gRPC mesh response with the exception message. In some cases, exceptions that are thrown do not have an underlying message, when that occurs, `io.l5d.mesh's` gRPC ends up trying to decode a null string which results in a NPE.

This PR adds a check to make sure that if an Exception message is null, we do not send a null string through the codec but rather provide a default message `BoundDelegateTree Exception: No underlying exception message`.

A new unit test was added to reproduce the issue that was reported.

fixes #2206 

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>