### PR TITLE
Upgrade OpenJ9 docker image to v0.11.0 (#2210)

### DIFF
--- a/project/Base.scala
+++ b/project/Base.scala
@@ -34,7 +34,7 @@ class Base extends Build {
 
   val headVersion = "1.6.0"
   val openJdkVersion = "8u151"
-  val openJ9Version = "jdk8u162-b12_openj9-0.8.0"
+  val openJ9Version = "jdk8u192-b12_openj9-0.11.0"
 
   object Git {
     def git(arg: String, args: String*) = Process("git" +: arg +: args)


### PR DESCRIPTION
This PR changes OpenJ9 base docker image version to 0.11.0 and resolves the problem described in issue #2210 

OpenJ9 v0.11.0 is container aware and will no longer cause memory spikes beyond heap size or container limits when JIT compilations occur at runtime.

There is no OpenJ9 v0.11.0 docker image available for openjdk8 `u162`, so it also switches to a `u192` build for OpenJ9

