### PR TITLE
add missing forward slash in Linkerd and Namerd exec scripts

### DIFF
--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -374,7 +374,7 @@ object LinkerdBuild extends Base {
          |  echo "GC_LOG must be set to a directory that user [$USER] has write permissions on.\
          | Unable to use [$GC_LOG] for GC logging."
          |else
-         |  version=$("${JAVA_HOME:-usr}"/bin/java -version 2>&1 | sed 's/.*version "\([0-9]*\)\..*/\1/; 1q')
+         |  version=$("${JAVA_HOME:-/usr}"/bin/java -version 2>&1 | sed 's/.*version "\([0-9]*\)\..*/\1/; 1q')
          |
          |  if [ "$version" -ge 9 ]; then
          |    GC_LOG_OPTION="-Xlog:gc*,gc+age=trace,gc+heap=debug,gc+promotion=trace,safepoint:file=${GC_LOG}/gc.log::filecount=10,filesize=10000:time"
@@ -469,7 +469,7 @@ object LinkerdBuild extends Base {
          |  echo "GC_LOG must be set to a directory that user [$USER] has write permissions on.\
          | Unable to use [$GC_LOG] for GC logging."
          |else
-         |  version=$("${JAVA_HOME:-usr}"/bin/java -version 2>&1 | sed 's/.*version "\([0-9]*\)\..*/\1/; 1q')
+         |  version=$("${JAVA_HOME:-/usr}"/bin/java -version 2>&1 | sed 's/.*version "\([0-9]*\)\..*/\1/; 1q')
          |
          |  if [ "$version" -ge 9 ]; then
          |    GC_LOG_OPTION="-Xlog:gc*,gc+age=trace,gc+heap=debug,gc+promotion=trace,safepoint:file=${GC_LOG}/gc.log::filecount=10,filesize=10000:time"
@@ -714,7 +714,7 @@ object LinkerdBuild extends Base {
          |  echo "GC_LOG must be set to a directory that user [$USER] has write permissions on.\
          | Unable to use [$GC_LOG] for GC logging."
          |else
-         |  version=$("${JAVA_HOME:-usr}"/bin/java -version 2>&1 | sed 's/.*version "\([0-9]*\)\..*/\1/; 1q')
+         |  version=$("${JAVA_HOME:-/usr}"/bin/java -version 2>&1 | sed 's/.*version "\([0-9]*\)\..*/\1/; 1q')
          |
          |  if [ "$version" -ge 9 ]; then
          |    GC_LOG_OPTION="-Xlog:gc*,gc+age=trace,gc+heap=debug,gc+promotion=trace,safepoint:file=${GC_LOG}/gc.log::filecount=10,filesize=10000:time"


### PR DESCRIPTION
This PR fixes an issue where part of the exec script for Linkerd and Namerd are unable to check the java version due to a missing forward slash.

Tests were conducted in docker where the JAVA_HOME variable was set to an empty string in the docker image. Then both Linkerd and Namerd were run separately to exercise the offending branch of the bash script. Before the fix, the message `line 24: usr/bin/java: No such file or directory: integer expression expected` appeared in the logs. After this PR, the message is no longer visible.

Fixes #2207 

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>