### PR TITLE
Add support for setting the backlog queue size under socketOptions

### DIFF
--- a/finagle/buoyant/src/main/scala/com/twitter/finagle/buoyant/SocketOptionsConfig.scala
+++ b/finagle/buoyant/src/main/scala/com/twitter/finagle/buoyant/SocketOptionsConfig.scala
@@ -3,6 +3,7 @@ package com.twitter.finagle.buoyant
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.twitter.finagle.Stack
 import com.twitter.finagle.transport.Transport
+import com.twitter.finagle.server.Listener
 import com.twitter.util.Duration
 
 case class SocketOptionsConfig(
@@ -11,7 +12,8 @@ case class SocketOptionsConfig(
   reusePort: Boolean = false,
   @JsonDeserialize(contentAs = classOf[java.lang.Long]) writeTimeoutMs: Option[Long] = None,
   @JsonDeserialize(contentAs = classOf[java.lang.Long]) readTimeoutMs: Option[Long] = None,
-  keepAlive: Option[Boolean] = None
+  keepAlive: Option[Boolean] = None,
+  backlog: Option[Int] = None
 ) {
   def params: Stack.Params = {
     val writeTimeout: Duration = writeTimeoutMs match {
@@ -26,7 +28,8 @@ case class SocketOptionsConfig(
 
     Stack.Params.empty +
       Transport.Options(noDelay, reuseAddr, reusePort) +
-      Transport.Liveness(writeTimeout, readTimeout, keepAlive)
+      Transport.Liveness(writeTimeout, readTimeout, keepAlive) +
+      Listener.Backlog(backlog)
   }
 
 }

--- a/linkerd/docs/config.md
+++ b/linkerd/docs/config.md
@@ -275,7 +275,7 @@ enabled | true | If set to true, data is sent to Buoyant once per hour
 ### Socket Options
 
 Linkerd supports configuring socket level options for any given interface.
-i.e. the admin and router interfaces. These configurations are only available 
+i.e. the admin and router interfaces. These configurations are only available
 on Linux 3.9 distributions and newer.
 
 Key | Default Value | Description
@@ -286,3 +286,4 @@ reusePort | false | If set to true, enables the `SO_REUSEPORT` option, which can
 readTimeoutMs | unbounded | Configures this client or server with given transport-level socket read timeout in milliseconds.
 writeTimeoutMs | unbounded | Configures this client or server with given transport-level socket write timeout in milliseconds.
 keepAlive | false | If set to true, enables the `SO_KEEPALIVE` option, which will enable keep alive on the socket.
+backlog | None | If set will adjust the backlog queue size of the socket, a default of None falls back to the OS defined value of SOMAXCONN

--- a/linkerd/examples/socket-options.yaml
+++ b/linkerd/examples/socket-options.yaml
@@ -14,3 +14,4 @@ routers:
       readTimeoutMs: 61000
       writeTimeoutMs: 61000
       keepAlive: true
+      backlog: 128

--- a/namerd/iface/control-http/src/test/scala/io/buoyant/namerd/iface/HttpControlServiceConfigTest.scala
+++ b/namerd/iface/control-http/src/test/scala/io/buoyant/namerd/iface/HttpControlServiceConfigTest.scala
@@ -51,7 +51,7 @@ class HttpControlServiceConfigTest extends FunSuite {
   }
 
   test("socket options"){
-    val expectedOpts = SocketOptionsConfig(reusePort = true, readTimeoutMs = Some(60000), writeTimeoutMs = Some(2000), keepAlive = Some(true))
+    val expectedOpts = SocketOptionsConfig(reusePort = true, readTimeoutMs = Some(60000), writeTimeoutMs = Some(2000), keepAlive = Some(true), backlog = Some(128))
     val yaml = """
       |kind: io.l5d.httpController
       |socketOptions:
@@ -61,6 +61,7 @@ class HttpControlServiceConfigTest extends FunSuite {
       |  readTimeoutMs: 60000
       |  writeTimeoutMs: 2000
       |  keepAlive: true
+      |  backlog: 128
     """.stripMargin
 
     val config = Parser


### PR DESCRIPTION
Fixes #2214

Signed-off-by: Chris Goffinet <chris@threecomma.io>