### PR TITLE
fix incorrect rendering of IP addresses in watch endpoints

### DIFF
--- a/interpreter/mesh/src/main/scala/io/buoyant/interpreter/mesh/BufSerializers.scala
+++ b/interpreter/mesh/src/main/scala/io/buoyant/interpreter/mesh/BufSerializers.scala
@@ -9,8 +9,9 @@ object BufSerializers {
   def path(path: Seq[Buf]): String = path.map(utf8).mkString("/", "/", "")
 
   def ipv4(addr: Buf): String = {
-    val bytes = Buf.ByteArray.coerce(addr)
-    s"${bytes.get(0)}.${bytes.get(1)}.${bytes.get(2)}.${bytes.get(3)}"
+    val bytes = Buf.ByteArray.Owned.extract(addr).map(_ & (-1 >>> 24))
+
+    s"${bytes(0)}.${bytes(1)}.${bytes(2)}.${bytes(3)}"
   }
 
 }

--- a/interpreter/mesh/src/test/scala/io/buoyant/interpreter/mesh/BufSerializersTest.scala
+++ b/interpreter/mesh/src/test/scala/io/buoyant/interpreter/mesh/BufSerializersTest.scala
@@ -1,0 +1,24 @@
+package io.buoyant.interpreter.mesh
+
+import com.twitter.io.Buf
+import io.buoyant.test.FunSuite
+
+class BufSerializersTest extends FunSuite {
+
+  test("Converts string ip byte array to string representation"){
+    val ipTable = Seq(
+      (Buf.ByteArray(Seq(10, 120, 1, 137).map(_.toByte):_*), "10.120.1.137"),
+      (Buf.ByteArray(Seq(127, 0, 0, 1).map(_.toByte):_*), "127.0.0.1"),
+      (Buf.ByteArray(Seq(255, 255, 255, 255).map(_.toByte):_*),"255.255.255.255"),
+      (Buf.ByteArray(Seq(1, 2, 3, 4).map(_.toByte):_*), "1.2.3.4"),
+      (Buf.ByteArray(Seq(192, 168, 203, 255).map(_.toByte):_*), "192.168.203.255"),
+      (Buf.ByteArray(Seq(0, 0, 0, 0).map(_.toByte):_*), "0.0.0.0")
+    )
+
+    for(ip <- ipTable){
+      assert(BufSerializers.ipv4(ip._1) == ip._2)
+    }
+  }
+
+
+}


### PR DESCRIPTION
This PR fixes an issue where IP addresses within the watch endpoint JSON would render IP addresses with negative numbers.

Fixes #2203 

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>