### PR TITLE
add support for HTTP/2 ping frame and add failure detector for mesh interpreter

### DIFF
--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/H2.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/H2.scala
@@ -60,7 +60,7 @@ object H2 extends Client[Request, Response] with Server[Request, Response] {
     protected def newDispatcher(trans: Http2FrameTransport {
       type Context <: self.Context
     }): Service[Request, Response] = {
-      new Netty4ClientDispatcher(trans, Some(detectorCfg), statsReceiver.scope("stream"))
+      new Netty4ClientDispatcher(trans, Some(detectorCfg), statsReceiver)
     }
   }
 
@@ -109,7 +109,7 @@ object H2 extends Client[Request, Response] with Server[Request, Response] {
       },
       service: Service[Request, Response]
     ): Closable = {
-      new Netty4ServerDispatcher(trans, None, service, statsReceiver.scope("stream"))
+      new Netty4ServerDispatcher(trans, None, service, statsReceiver)
     }
   }
 

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/H2.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/H2.scala
@@ -3,6 +3,7 @@ package com.twitter.finagle.buoyant
 import com.twitter.finagle.buoyant.h2._
 import com.twitter.finagle.buoyant.h2.netty4._
 import com.twitter.finagle.client.{StackClient, StdStackClient, Transporter}
+import com.twitter.finagle.liveness.FailureDetector
 import com.twitter.finagle.param.{WithDefaultLoadBalancer, WithSessionPool}
 import com.twitter.finagle.pool.SingletonPool
 import com.twitter.finagle.server.{Listener, StackServer, StdStackServer}
@@ -54,11 +55,13 @@ object H2 extends Client[Request, Response] with Server[Request, Response] {
     ): Client = copy(stack, params)
 
     private[this] lazy val param.Stats(statsReceiver) = params[param.Stats]
+    private[this] lazy val FailureDetector.Param(detectorCfg) = params[FailureDetector.Param]
 
     protected def newDispatcher(trans: Http2FrameTransport {
       type Context <: self.Context
-    }): Service[Request, Response] =
-      new Netty4ClientDispatcher(trans, statsReceiver.scope("stream"))
+    }): Service[Request, Response] = {
+      new Netty4ClientDispatcher(trans, Some(detectorCfg), statsReceiver.scope("stream"))
+    }
   }
 
   val client = Client()
@@ -106,7 +109,7 @@ object H2 extends Client[Request, Response] with Server[Request, Response] {
       },
       service: Service[Request, Response]
     ): Closable = {
-      new Netty4ServerDispatcher(trans, service, statsReceiver.scope("stream"))
+      new Netty4ServerDispatcher(trans, None, service, statsReceiver.scope("stream"))
     }
   }
 

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/H2Transport.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/H2Transport.scala
@@ -37,5 +37,7 @@ object H2Transport {
     def goAway(err: GoAway, deadline: Time): Future[Unit]
 
     final def goAway(err: GoAway): Future[Unit] = goAway(err, Time.Top)
+
+    def ping(): Future[Unit]
   }
 }

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/H2Transport.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/H2Transport.scala
@@ -38,6 +38,6 @@ object H2Transport {
 
     final def goAway(err: GoAway): Future[Unit] = goAway(err, Time.Top)
 
-    def ping(): Future[Unit]
+    def sendPing(): Future[Unit]
   }
 }

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/H2Transport.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/H2Transport.scala
@@ -38,6 +38,11 @@ object H2Transport {
 
     final def goAway(err: GoAway): Future[Unit] = goAway(err, Time.Top)
 
+    /**
+     * Writes a Non-ACK PING frame on the transport. This method does not send
+     * ACK PING frames on a stream. ACK PING frames are automatically
+     * sent by the underlying Netty H2 implementation.
+     */
     def sendPing(): Future[Unit]
   }
 }

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4ClientDispatcher.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4ClientDispatcher.scala
@@ -36,7 +36,7 @@ class Netty4ClientDispatcher(
   override protected[this] val prefix =
     s"C L:${transport.context.localAddress} R:${transport.context.remoteAddress}"
 
-  private[this] val streamStats = new Netty4StreamTransport.StatsReceiver(stats)
+  private[this] val streamStats = new Netty4StreamTransport.StatsReceiver(stats.scope("stream"))
 
   transport.onClose.onSuccess(onTransportClose)
 
@@ -67,7 +67,7 @@ class Netty4ClientDispatcher(
   }
 
   override def status: SvcStatus =
-    if (isClosed || failureDetector.status == SvcStatus.Closed) SvcStatus.Closed
+    if (isClosed) SvcStatus.Closed
     else SvcStatus.Open
 
   /**

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4ClientDispatcher.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4ClientDispatcher.scala
@@ -67,7 +67,7 @@ class Netty4ClientDispatcher(
   }
 
   override def status: SvcStatus =
-    if (isClosed) SvcStatus.Closed
+    if (isClosed || failureDetector.status == SvcStatus.Closed) SvcStatus.Closed
     else SvcStatus.Open
 
   /**

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4ClientDispatcher.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4ClientDispatcher.scala
@@ -2,6 +2,7 @@ package com.twitter.finagle.buoyant.h2
 package netty4
 
 import com.twitter.concurrent.AsyncMutex
+import com.twitter.finagle.liveness.FailureDetector
 import com.twitter.finagle.stats.StatsReceiver
 import com.twitter.finagle.{Service, Status => SvcStatus}
 import com.twitter.finagle.transport.Transport
@@ -25,6 +26,7 @@ object Netty4ClientDispatcher {
  */
 class Netty4ClientDispatcher(
   override protected[this] val transport: Transport[Http2Frame, Http2Frame],
+  override protected[this] val failureThreshold: Option[FailureDetector.Config],
   protected[this] val stats: StatsReceiver
 ) extends Service[Request, Response] with Netty4DispatcherBase[Request, Response] {
   import Netty4ClientDispatcher._

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4DispatcherBase.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4DispatcherBase.scala
@@ -180,7 +180,9 @@ trait Netty4DispatcherBase[SendMsg <: Message, RecvMsg <: Message] {
           // client sent a ping and got acknowledgement. Satisfy promise to let failure detector
           // know the connection is still alive.
           val prevPingPromise = pingPromise.getAndSet(null)
-          prevPingPromise.setDone()
+          if (prevPingPromise != null) {
+            prevPingPromise.setDone()
+          }
         }
         transport.read().transform(loop)
 

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4H2Writer.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4H2Writer.scala
@@ -49,7 +49,7 @@ private[netty4] trait Netty4H2Writer extends H2Transport.Writer {
     write(frame)
   }
 
-  override def ping(): Future[Unit] = {
+  override def sendPing(): Future[Unit] = {
     val frame = new DefaultHttp2PingFrame(0)
     write(frame)
   }

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4H2Writer.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4H2Writer.scala
@@ -49,6 +49,11 @@ private[netty4] trait Netty4H2Writer extends H2Transport.Writer {
     write(frame)
   }
 
+  override def ping(): Future[Unit] = {
+    val frame = new DefaultHttp2PingFrame(0)
+    write(frame)
+  }
+
   /*
    * Connection errors
    */

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4ServerDispatcher.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4ServerDispatcher.scala
@@ -40,7 +40,7 @@ class Netty4ServerDispatcher(
   override protected[this] val log = Netty4ServerDispatcher.log
   override protected[this] val prefix =
     s"S L:${transport.context.localAddress} R:${transport.context.remoteAddress}"
-  private[this] val streamStats = new Netty4StreamTransport.StatsReceiver(stats)
+  private[this] val streamStats = new Netty4StreamTransport.StatsReceiver(stats.scope("stream"))
 
   transport.onClose.onSuccess(onTransportClose)
 

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4ServerDispatcher.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4ServerDispatcher.scala
@@ -3,6 +3,7 @@ package netty4
 
 import com.twitter.finagle.{Failure, FailureFlags, Service}
 import com.twitter.finagle.context.{Contexts, RemoteInfo}
+import com.twitter.finagle.liveness.FailureDetector
 import com.twitter.finagle.stats.StatsReceiver
 import com.twitter.finagle.transport.Transport
 import com.twitter.logging.Logger
@@ -30,6 +31,7 @@ object Netty4ServerDispatcher {
  */
 class Netty4ServerDispatcher(
   override protected[this] val transport: Transport[Http2Frame, Http2Frame],
+  override protected[this] val failureThreshold: Option[FailureDetector.Config],
   service: Service[Request, Response],
   protected[this] val stats: StatsReceiver
 ) extends Netty4DispatcherBase[Response, Request] with Closable {

--- a/finagle/h2/src/main/scala/io/netty/handler/codec/http2/H2FrameCodec.scala
+++ b/finagle/h2/src/main/scala/io/netty/handler/codec/http2/H2FrameCodec.scala
@@ -299,18 +299,11 @@ object H2FrameCodec {
         0 // bytes are marked as consumed via WindowUpdateFrame writes
       }
 
-      override def onPingRead(
-        ctx: ChannelHandlerContext,
-        data: Long
-      ): Unit = {
-        val ping = new DefaultHttp2PingFrame(data)
-        ctx.fireChannelRead(ping); ()
-      }
-
       override def onPingAckRead(
         ctx: ChannelHandlerContext,
         data: Long
       ): Unit = {
+        // Propagate ping acks so that failure detector is informed of PING ACK Frames
         val pingAck = new DefaultHttp2PingFrame(data, true)
         ctx.fireChannelRead(pingAck); ()
       }

--- a/finagle/h2/src/main/scala/io/netty/handler/codec/http2/H2FrameCodec.scala
+++ b/finagle/h2/src/main/scala/io/netty/handler/codec/http2/H2FrameCodec.scala
@@ -298,6 +298,22 @@ object H2FrameCodec {
         ctx.fireChannelRead(data)
         0 // bytes are marked as consumed via WindowUpdateFrame writes
       }
+
+      override def onPingRead(
+        ctx: ChannelHandlerContext,
+        data: Long
+      ): Unit = {
+        val ping = new DefaultHttp2PingFrame(data)
+        ctx.fireChannelRead(ping); ()
+      }
+
+      override def onPingAckRead(
+        ctx: ChannelHandlerContext,
+        data: Long
+      ): Unit = {
+        val pingAck = new DefaultHttp2PingFrame(data, true)
+        ctx.fireChannelRead(pingAck); ()
+      }
     }
   }
 }

--- a/finagle/h2/src/test/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4ClientDispatcherTest.scala
+++ b/finagle/h2/src/test/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4ClientDispatcherTest.scala
@@ -38,7 +38,7 @@ class Netty4ClientDispatcherTest extends FunSuite {
     }
 
     val stats = new InMemoryStatsReceiver
-    val dispatcher = new Netty4ClientDispatcher(transport, stats)
+    val dispatcher = new Netty4ClientDispatcher(transport, None, stats)
     assert(dispatcher.status == SvcStatus.Open)
 
     var released = 0

--- a/finagle/h2/src/test/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4ServerDispatcherTest.scala
+++ b/finagle/h2/src/test/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4ServerDispatcherTest.scala
@@ -58,7 +58,7 @@ class Netty4ServerDispatcherTest extends FunSuite {
     }
 
     val stats = new InMemoryStatsReceiver
-    val dispatcher = new Netty4ServerDispatcher(transport, service, stats)
+    val dispatcher = new Netty4ServerDispatcher(transport, None, service, stats)
 
     assert(!bartmanCalled.get)
     assert(recvq.offer({

--- a/interpreter/mesh/src/test/scala/io/buoyant/interpreter/MeshInterpreterInitializerTest.scala
+++ b/interpreter/mesh/src/test/scala/io/buoyant/interpreter/MeshInterpreterInitializerTest.scala
@@ -9,7 +9,7 @@ import org.scalatest.FunSuite
 class MeshInterpreterInitializerTest extends FunSuite {
   test("sanity") {
     // ensure it doesn't totally blowup
-    val _ = MeshInterpreterConfig(Some(Path.read("/whats/in/a")), Some(Path.read("/default")), None, None)
+    val _ = MeshInterpreterConfig(Some(Path.read("/whats/in/a")), Some(Path.read("/default")), None, None, None)
       .newInterpreter(Stack.Params.empty)
   }
 

--- a/linkerd/docs/interpreter.md
+++ b/linkerd/docs/interpreter.md
@@ -111,6 +111,7 @@ dst | _required_ | A Finagle path locating the Namerd service.
 root | `/default` | A single-element Finagle path representing the Namerd namespace.
 retry | see [Namerd retry](#namerd-retry) | An object configuring retry backoffs for requests to Namerd.
 tls | no tls | Requests to Namerd will be made using TLS if this parameter is provided.  It must be a [client TLS](#client-tls) object.
+failureThreshold | no failureThreshold | Sets the [failure threshold](#failure-threshold) used by Linkerd's threshold failure detector to gauge a Namerd instance's health
 
 ## File-System
 


### PR DESCRIPTION
The current HTTP/2 implementation does not support ping frames between an H2 server and client. This makes it difficult to implement a failure detector in Linkerd or Namerd to ensure that connections are alive and in a good state.

To fix this issue, This PR, adds a "listener" to the existing implementation that notifies the transport when a PING frame is received on both the client and the server. This PR also implements a failure detector for HTTP/2 connections between Linkerd and Namerd which ensures that no stale connections between the two instance stay up longer than a given period of time.

I conducted two different tests.
- Linkerd <> HA Proxy <> Namerd
1. Start HA Proxy with a tcp timeout of 1000ms for the client and server facing interface of the proxy
2. Start up Linkerd and Namerd. Linkerd streams dtab updates through `io.l5d.mesh` through HA Proxy
3. Set up a failure threshold for Linkerd's `interpreter` with a `minPeriod` of 500ms and a closeTimeout` of 1000ms
4. Observe the connections between Linkerd and HA Proxy. They should never be closed by HA Proxy since we are sending Ping frames to Namerd. Before this PR. The connection would always be torn down by HA Proxy with this same configuration.

- Linkerd <> 2 x Namerd
1. Start two instances of Namerd 
2. Start Linkerd and point its `interpreter` to both Namerd. 
3. Send a request through Linkerd, this should make Linkerd stream dtabs from the first Namerd instance.
4. `SIGSTOP` the first Namerd process. This forces the HTTP/2 connection to trigger the failure detector which will close the connection. Linkerd will switch to using the second Namerd process for dtab resolution.
  

Fixes #2219 

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>