### PR TITLE
Namerd stops watching dtabs if it receives a 404 during watch restart

### DIFF
--- a/k8s/src/main/scala/io/buoyant/k8s/resources.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/resources.scala
@@ -152,15 +152,16 @@ private[k8s] class ListResource[O <: KubeObject: TypeReference, W <: Watch[O]: O
   override protected def restartWatches(
     labelSelector: Option[String],
     fieldSelector: Option[String]
-  ): Future[(Seq[W], Option[String])] =
+  ): Future[(Seq[W], Option[String])] = {
     get(
       labelSelector = labelSelector,
       fieldSelector = fieldSelector,
       retryIndefinitely = true
-    ).map { maybeList =>
-      val list = maybeList.get // list resources should always exist
-      (list.items.map(od.toWatch), list.metadata.flatMap(_.resourceVersion))
+    ).map {
+      case Some(list) => (list.items.map(od.toWatch), list.metadata.flatMap(_.resourceVersion))
+      case None => (Seq.empty, None)
     }
+  }
 }
 
 /**


### PR DESCRIPTION
This PR is almost the same as #2192 but adds a fix to the exact piece of code that introduces this bug.

The implemented `restartWatches`  currently has an issue where HTTP 404 responses from a k8s apiserver could cause the method to fail silently. This has the effect of stopping watch streams whenever HTTP 404 response is encountered.

This PR fixes the issue by pattern matching the response to a `get` request in the `restartWatches` method since it returns an `Option[O]` where O is the type of a k8s resource object. In the case where we receive a `None` the method needs to return a default empty value in order for the underlying `Watchable` object to restart the watch successfully.

Tests were done locally with Namerd and Kubernetes on Docker. Before this PR, if you:
1. Start Namerd configured with k8s dtab storage with `-log.level=DEBUG`.
2. Start Linkerd with a Namerd interpreter.
3. Send a request through Linkerd to get it to watch dtabs from Namerd.
4. Delete the custom resource definition for `dtabs.l5d.io`

The logs should show these logs lines and nothing else. This indicates that Namerd tries to restart the watch but fails to continue restarting.
```bash
W 0128 23:49:17.122 UTC THREAD45 TraceId:f4ee3042e6688020: k8s failed to watch resource /apis/l5d.io/v1alpha1/namespaces/ck-system/dtabs: 404 Not Found
D 0128 23:49:17.139 UTC THREAD11 TraceId:f4ee3042e6688020: k8s restarting watch on /apis/l5d.io/v1alpha1/watch/namespaces/ck-system/dtabs, resource version Some(1268327) was too old
```
After this PR, and following the steps above, you should see log lines that indicate that the watch is continually restarting. This shows that its retrying after each subsequent 404 we receive from k8s apiserver.

Fixes #2167 

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>