### PR TITLE
Replacing **HTTP** by **HTTPS** for securing kubernetes links

### DIFF
--- a/k8s/src/main/scala/io/buoyant/k8s/Api.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/Api.scala
@@ -95,7 +95,7 @@ trait ObjectDescriptor[O <: KubeObject, W <: Watch[O]] {
 
 /**
  * Describes an Object in the Kubernetes API (i.e.
- * http://kubernetes.io/docs/api-reference/v1/definitions/#_v1_endpoints)
+ * https://kubernetes.io/docs/api-reference/v1/definitions/#_v1_endpoints)
  */
 trait KubeObject extends KubeMetadata {
   def apiVersion: Option[String]
@@ -154,7 +154,7 @@ case class ObjectReference(
 
 /**
  * An event resulting from a "watch" on the Kubernetes API:
- * http://kubernetes.io/docs/api-reference/v1/definitions/#_json_watchevent
+ * https://kubernetes.io/docs/api-reference/v1/definitions/#_json_watchevent
  *
  * Note: Dealing with this class is a little clunky because we haven't been able to get Jackson to
  * handle the combination of generics and polymorphic inheritance correctly. Thus, you'll need to

--- a/linkerd/docs/transformer.md
+++ b/linkerd/docs/transformer.md
@@ -94,7 +94,7 @@ that are on the same /24 subnet as localhost.  Since each Kubernetes node is its
 This transformer does not have any configuration properties but it does require
 the `POD_IP` environment variable be set with the localhost IP address.  This is
 most easily done with the
-[Kubernetes downward API](http://kubernetes.io/docs/user-guide/downward-api/).
+[Kubernetes downward API](https://kubernetes.io/docs/user-guide/downward-api/).
 
 > In your container spec:
 


### PR DESCRIPTION
Currently, when we access **kubernetes.io** with **HTTP**, it is
redirected to **HTTPS** automatically. So this commit aims to
replace **http://kubernetes.io/** by **https://kubernetes.io/**
for security.

Co-Authored-By: Nguyen Phuong An <AnNP@vn.fujitsu.com>
Signed-off-by: Kim Bao Long <longkb@vn.fujitsu.com>