### PR TITLE
Add `socketOptions` to `ClientConfig`

### DIFF
--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/ClientConfig.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/ClientConfig.scala
@@ -3,7 +3,7 @@ package io.buoyant.linkerd
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.twitter.conversions.DurationOps._
 import com.twitter.finagle.Stack
-import com.twitter.finagle.buoyant.{ClientAuth, ParamsMaybeWith, PathMatcher, TlsClientConfig => FTlsClientConfig}
+import com.twitter.finagle.buoyant.{ClientAuth, ParamsMaybeWith, PathMatcher, SocketOptionsConfig, TlsClientConfig => FTlsClientConfig}
 import com.twitter.finagle.client.DefaultPool
 import com.twitter.finagle.service._
 import com.twitter.logging.Logger
@@ -25,6 +25,7 @@ trait ClientConfig {
   var requestAttemptTimeoutMs: Option[Int] = None
   var requeueBudget: Option[RetryBudgetConfig] = None
   var clientSession: Option[ClientSessionConfig] = None
+  var socketOptions: Option[SocketOptionsConfig] = None
 
   @JsonIgnore
   def params(vars: Map[String, String]): Stack.Params = Stack.Params.empty
@@ -36,6 +37,7 @@ trait ClientConfig {
     .maybeWith(requeueBudget)
     .maybeWith(failureAccrual.map(FailureAccrualConfig.param))
     .maybeWith(clientSession.map(_.param))
+    .maybeWith(socketOptions.map(_.params))
 }
 
 case class TlsClientConfig(
@@ -99,5 +101,4 @@ case class ClientSessionConfig(
     lifeTime = lifeTimeMs.map(_.millis).getOrElse(default.lifeTime),
     idleTime = idleTimeMs.map(_.millis).getOrElse(default.idleTime)
   )
-
 }

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/SocketOptionsTest.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/SocketOptionsTest.scala
@@ -1,0 +1,29 @@
+package io.buoyant.linkerd
+
+import com.twitter.finagle.Path
+import com.twitter.finagle.buoyant.SocketOptionsConfig
+import io.buoyant.linkerd.Linker.Initializers
+import io.buoyant.router.StackRouter.Client.PerClientParams
+import org.scalatest.FunSuite
+
+class SocketOptionsTest extends FunSuite {
+  test("socket options") {
+    val config =
+      """
+        |routers:
+        |- protocol: plain
+        |  client:
+        |    socketOptions:
+        |      noDelay: true
+        |      reuseAddr: true
+        |      reusePort: true
+        |  servers:
+        |  - {}
+      """.stripMargin
+    val linker = Linker.load(config, Initializers(protocol = Seq(TestProtocol.Plain)))
+    val params = linker.routers.head.params[PerClientParams].paramsFor(Path.read("/foo"))
+    val options = SocketOptionsConfig(reusePort = true).params
+
+    assert(params == options)
+  }
+}

--- a/linkerd/docs/routers.md
+++ b/linkerd/docs/routers.md
@@ -248,6 +248,10 @@ client:
   failureAccrual:
     kind: io.l5d.consecutiveFailures
     failures: 10
+  socketOptions:
+    reusePort: true
+    readTimeoutMs: 61000
+    writeTimeoutMs: 61000
 ```
 
 Key | Default Value | Description

--- a/linkerd/examples/client-options.yaml
+++ b/linkerd/examples/client-options.yaml
@@ -27,6 +27,7 @@ routers:
       loadBalancer:
         kind: aperture
       socketOptions:
+        keepAlive: true
         reusePort: true
         readTimeoutMs: 61000
         writeTimeoutMs: 61000

--- a/linkerd/examples/client-options.yaml
+++ b/linkerd/examples/client-options.yaml
@@ -26,6 +26,10 @@ routers:
       # this client only
       loadBalancer:
         kind: aperture
+      socketOptions:
+        reusePort: true
+        readTimeoutMs: 61000
+        writeTimeoutMs: 61000
     # Wildcards and variable capture can be used in prefixes
     - prefix: "/#/*/{service}"
       tls:

--- a/namerd/iface/mesh/src/main/scala/io/buoyant/namerd/iface/mesh/DelegatorService.scala
+++ b/namerd/iface/mesh/src/main/scala/io/buoyant/namerd/iface/mesh/DelegatorService.scala
@@ -137,7 +137,7 @@ object DelegatorService {
     case DelegateTree.Delegate(p, d, t) =>
       mkBoundDelegateTree(p, d, mesh.BoundDelegateTree.OneofNode.Delegate(toDelegateTree(t)))
     case DelegateTree.Exception(p, d, e) =>
-      val msg = if(e.getMessage == null) "No underlying exception message" else e.getMessage
+      val msg = if (e.getMessage == null) "No underlying exception message" else e.getMessage
       mkBoundDelegateTree(p, d, mesh.BoundDelegateTree.OneofNode.Exception(s"BoundDelegateTree Exception: $msg"))
     case DelegateTree.Transformation(p, desc, n, t) =>
       val leaf = mkBoundDelegateTreeLeaf(n)


### PR DESCRIPTION
# Problem

At the moment we've added support for setting custom socketOptions on the admin and routers, we should expand this for clients, so they can enable things like keepAlive

# Solution

Add `socketOptions` to `ClientConfig` so that a user can set the expected properties.

Closes #2218

Signed-off-by: Kevin Leimkuhler <kevinl@buoyant.io>
