### PR TITLE
Remove duplicated words in comments

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -172,7 +172,7 @@ Full release notes:
   * Fix a memory leak when there are a large number of reset streams
   * Allow HTTP/2 response classifiers to be loaded as plugins
 * Namerd
-  * Fix a memory leak in the the io.l5d.mesh interpreter when idle services are reaped
+  * Fix a memory leak in the io.l5d.mesh interpreter when idle services are reaped
 
 ## 1.4.4 2018-07-06
 

--- a/namerd/storage/consul/src/main/scala/io/buoyant/namerd/storage/consul/ConsulDtabStore.scala
+++ b/namerd/storage/consul/src/main/scala/io/buoyant/namerd/storage/consul/ConsulDtabStore.scala
@@ -190,8 +190,8 @@ class ConsulDtabStore(
                 val version = Buf.Utf8(result.index.get)
                 // the raw string, not yet parsed as a dtab.
                 val rawDtab = result.value
-                // attempt to parse the string as a dtab, and update the the
-                // Activity with  the new state - either Ok if the string was
+                // attempt to parse the string as a dtab, and update the
+                // Activity with the new state - either Ok if the string was
                 // parsed successfully, or Failed if an error occurred.
                 val nextState = Try {
                   Dtab.read(rawDtab)


### PR DESCRIPTION
Although it is spelling mistakes, it might make an affects
while reading.

Signed-off-by: Nguyen Hai Truong <truongnh@vn.fujitsu.com>