### PR TITLE
Update deprecated URL for ConfigMap in kubernetes.io

### DIFF
--- a/linkerd/docs/interpreter.md
+++ b/linkerd/docs/interpreter.md
@@ -131,7 +131,7 @@ kind: `io.l5d.k8s.configMap`
 
 The Kubernetes ConfigMap interpreter resolves names via the configured
 [`namers`](#namers), just like the default interpreter, but also uses
-a dtab read from a [ConfigMap](https://kubernetes.io/docs/tasks/configure-pod-container/configmap/#understanding-configmaps) using the Kubernetes API. The specified ConfigMap is watched for changes, as in the [file-system interpreter](#file-system).
+a dtab read from a [ConfigMap](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#understanding-configmaps-and-pods) using the Kubernetes API. The specified ConfigMap is watched for changes, as in the [file-system interpreter](#file-system).
 
 > Example configuration
 


### PR DESCRIPTION
Currently, the link to **ConfigMap** is out of date. This patch aims to update
this URL to the working one in **http://kubernetes.io** that user can access.

Co-Authored-By: Nguyen Phuong An <AnNP@vn.fujitsu.com>
Signed-off-by: Kim Bao Long <longkb@vn.fujitsu.com>