### PR TITLE
Update docs links from HTTP to HTTPS for security and consistency

### DIFF
--- a/linkerd/docs/namer.md
+++ b/linkerd/docs/namer.md
@@ -7,7 +7,7 @@ namers:
   rootDir: disco
 ```
 
-A namer binds a [concrete name to a physical address](http://twitter.github.io/finagle/guide/Names.html).
+A namer binds a [concrete name to a physical address](https://twitter.github.io/finagle/guide/Names.html).
 
 <aside class="notice">
 These parameters are available to the namer regardless of kind. Namers may also have kind-specific parameters.

--- a/linkerd/docs/protocol-mux.md
+++ b/linkerd/docs/protocol-mux.md
@@ -15,7 +15,7 @@ routers:
 protocol: `mux`
 
 Linkerd experimentally supports the [mux
-protocol](http://twitter.github.io/finagle/guide/Protocols.html#mux).
+protocol](https://twitter.github.io/finagle/guide/Protocols.html#mux).
 
 ## Mux Router Parameters
 

--- a/linkerd/docs/protocol-thrift.md
+++ b/linkerd/docs/protocol-thrift.md
@@ -20,7 +20,7 @@ routers:
 
 protocol: `thrift`
 
-If the [TTwitter thrift](http://twitter.github.io/finagle/guide/Protocols.html#thrift) protocol is
+If the [TTwitter thrift](https://twitter.github.io/finagle/guide/Protocols.html#thrift) protocol is
 used, the value from the `dest` request header will be used for routing:
 
 > Dtab Path Format For Thrift

--- a/linkerd/docs/protocol-thriftmux.md
+++ b/linkerd/docs/protocol-thriftmux.md
@@ -19,7 +19,7 @@ protocol: `thriftmux`
 Linkerd _experimentally_ supports the thriftmux protocol.
 
 Thriftmux protocol is capable of routing traffic to pure thrift service and
-will use [Thrift](http://twitter.github.io/finagle/guide/Protocols.html#thrift) protocol on the client.
+will use [Thrift](https://twitter.github.io/finagle/guide/Protocols.html#thrift) protocol on the client.
 
 Protocol configuration uses the same parameters as
 [Thrift protocol](https://linkerd.io/config/head/linkerd#thrift-protocol).

--- a/linkerd/docs/retries.md
+++ b/linkerd/docs/retries.md
@@ -91,7 +91,7 @@ ms | `0` | The number of milliseconds to wait before each retry.
 
 kind: `jittered`
 
-Uses a [decorrelated jitter](http://www.awsarchitectureblog.com/2015/03/backoff.html) backoff algorithm.
+Uses a [decorrelated jitter](https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/) backoff algorithm.
 
 Key | Default Value | Description
 --- | ------------- | -----------


### PR DESCRIPTION
This PR replaces old HTTP links in docs by new, correct HTTPS links for security and consistency.