### PR TITLE
Update all links to HTTPS for security and consistency

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -297,5 +297,5 @@ $ docker run -p 2181:2181 -p 4180:4180 -v /path/to/repo:/myapp -w /myapp buoyant
 
 [funsuite]: http://www.scalatest.org/getting_started_with_fun_suite
 [l5d-ci]: https://circleci.com/gh/linkerd/linkerd
-[sbt]: http://www.scala-sbt.org/
+[sbt]: https://www.scala-sbt.org/
 [scalatest]: http://www.scalatest.org/

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1031,7 +1031,7 @@ We’ve made some internal changes to keep up with the latest and greatest:
 * DTab explorer admin page now supports inspecting DTabs for all configured
   routers.
 * New `/routers.json` endpoint with runtime router state.
-* We now have a [slack channel](http://slack.linkerd.io)! Operators are
+* We now have a [slack channel](https://slack.linkerd.io)! Operators are
   standing by to field YOUR questions today.
 * Admin site redesign to match [linkerd.io](https://linkerd.io/), now with
   favicon!
@@ -1079,7 +1079,7 @@ This is a big release! Get ready.
   sufficient Java version (we require JDK 8) before attempting to start the
   router.
 * Upgrades to a newer version of the
-  [Finagle](http://twitter.github.io/finagle/) library.
+  [Finagle](https://twitter.github.io/finagle/) library.
 * More information added to HTTP tracing:
   * Host header
   * Transfer-Encoding header

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,4 +103,4 @@ changes should include before- and after- benchmark results.
 [issue]: https://github.com/linkerd/linkerd/issues/new
 [members]: https://github.com/orgs/linkerd/people
 [slack]: https://slack.linkerd.io/
-[ssg]: http://docs.scala-lang.org/style/scaladoc.html
+[ssg]: https://docs.scala-lang.org/style/scaladoc.html

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ specific language governing permissions and limitations under the License.
 [license-badge]: https://img.shields.io/github/license/linkerd/linkerd.svg
 [namerctl]: https://github.com/linkerd/namerctl
 [netty]: https://netty.io/
-[slack-badge]: http://slack.linkerd.io/badge.svg
+[slack-badge]: https://slack.linkerd.io/badge.svg
 [slack]: https://slack.linkerd.io
 [zipkin]: https://github.com/openzipkin/zipkin
 [releases]: https://github.com/linkerd/linkerd/releases

--- a/istio-proto/src/main/protobuf/google/rpc/error_details.proto
+++ b/istio-proto/src/main/protobuf/google/rpc/error_details.proto
@@ -162,7 +162,7 @@ message Help {
 // which can be attached to an RPC error.
 message LocalizedMessage {
   // The locale used following the specification defined at
-  // http://www.rfc-editor.org/rfc/bcp/bcp47.txt.
+  // https://www.rfc-editor.org/rfc/bcp/bcp47.txt.
   // Examples are: "en-US", "fr-CH", "es-MX"
   string locale = 1;
 

--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/HelpPageHandler.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/HelpPageHandler.scala
@@ -31,7 +31,7 @@ object HelpPageHandler {
           </p>
           <ul>
               <li>Ask questions about configuration or troubleshooting in the <a href="https://discourse.linkerd.io/">linkerd Discourse instance</a>.</li>
-              <li>Chat with us in <a href="http://slack.linkerd.io">the linkerd public Slack</a>.</li>
+              <li>Chat with us in <a href="https://slack.linkerd.io">the linkerd public Slack</a>.</li>
               <li>Email us at <a href="mailto:linkerd-users@googlegroups.com">linkerd-users@googlegroups.com</a>.</li>
           </ul>
           <p>You can also report bugs or file feature requests on the <a href="https://github.com/buoyantio/linkerd">linkerd Github repo</a>.</p>

--- a/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/ErrorResponderTest.scala
+++ b/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/ErrorResponderTest.scala
@@ -32,7 +32,7 @@ class ErrorResponderTest extends FunSuite with Awaits {
 
   val redirectService = mkService {
     val redirect = Response(Status.Found)
-    redirect.location = "http://linkerd.io"
+    redirect.location = "https://linkerd.io"
     Future.exception(HttpResponseException(redirect))
   }
 
@@ -63,7 +63,7 @@ class ErrorResponderTest extends FunSuite with Awaits {
   test("respects HttpResponseException") {
     val rsp = await(redirectService(Request()))
     assert(rsp.status == Status.Found)
-    assert(rsp.location == Some("http://linkerd.io"))
+    assert(rsp.location == Some("https://linkerd.io"))
   }
 
   test("returns ServiceUnavailable for request attempt timeouts") {

--- a/namer/core/src/main/scala/io/buoyant/namer/BackoffConfig.scala
+++ b/namer/core/src/main/scala/io/buoyant/namer/BackoffConfig.scala
@@ -20,7 +20,7 @@ case class ConstantBackoffConfig(ms: Int) extends BackoffConfig {
   def mk = Backoff.constant(ms.millis)
 }
 
-/** See http://www.awsarchitectureblog.com/2015/03/backoff.html */
+/** See https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/ */
 case class JitteredBackoffConfig(minMs: Option[Int], maxMs: Option[Int]) extends BackoffConfig {
   def mk = {
     val min = minMs match {

--- a/telemetry/statsd/src/main/scala/io/buoyant/telemetry/statsd/StatsDStatsReceiver.scala
+++ b/telemetry/statsd/src/main/scala/io/buoyant/telemetry/statsd/StatsDStatsReceiver.scala
@@ -11,7 +11,7 @@ private[telemetry] object StatsDStatsReceiver {
     name.mkString("/")
       .replaceAll("[^/A-Za-z0-9]", "_")
       .replace("//", "/")
-      .replace("/", ".") // http://graphite.readthedocs.io/en/latest/feeding-carbon.html#step-1-plan-a-naming-hierarchy
+      .replace("/", ".") // https://graphite.readthedocs.io/en/latest/feeding-carbon.html#step-1-plan-a-naming-hierarchy
   }
 }
 


### PR DESCRIPTION
This is the follow-up of #2239.
After checking docs and updating links from HTTP to HTTPS, I realized there are still many deprecated HTTP links in other places. So I decided to update all of them with this PR.