### PR TITLE
Docs: updated blog URL and added private key clarification

### DIFF
--- a/linkerd/docs/client_tls.md
+++ b/linkerd/docs/client_tls.md
@@ -28,6 +28,10 @@ requireClientAuth | false | If true, only accept requests with valid client cert
 caCertPath | none | File path to the CA cert to validate the client certificates.
 protocols | unspecified | The list of TLS protocols to enable (TLSv1.2)
 
+<aside class="notice">
+Linkerd needs the private key as .pem file in PKCS8 format. PKCS1 is not supported.  
+</aside>
+
 See [Transparent TLS with Linkerd](https://blog.linkerd.io/2016/03/24/transparent-tls-with-linkerd/) for more on how to generate certificate
 and key files.
 

--- a/linkerd/docs/client_tls.md
+++ b/linkerd/docs/client_tls.md
@@ -28,7 +28,7 @@ requireClientAuth | false | If true, only accept requests with valid client cert
 caCertPath | none | File path to the CA cert to validate the client certificates.
 protocols | unspecified | The list of TLS protocols to enable (TLSv1.2)
 
-See [Transparent TLS with Linkerd](https://blog.buoyant.io/2016/03/24/transparent-tls-with-linkerd/) for more on how to generate certificate
+See [Transparent TLS with Linkerd](https://blog.linkerd.io/2016/03/24/transparent-tls-with-linkerd/) for more on how to generate certificate
 and key files.
 
 ## Client TLS


### PR DESCRIPTION
Just something I just stumbled over: 
- The referenced blog article was moved. 
- There is no reference in which format the private key needs to be. Keys in PKCS1 format fail as follows: 
`W 0314 09:29:20.149 UTC THREAD24: PKCS8EncodedKeySpec (xxxx.net.pem) failed to load: PemFile (xxxx.net.pem) failed to load: Missing -----BEGIN PRIVATE KEY-----.
