### PR TITLE
Pass through stack params to dtab storage

### DIFF
--- a/namerd/storage/k8s/src/main/scala/io/buoyant/namerd/storage/K8sDtabStoreInitializer.scala
+++ b/namerd/storage/k8s/src/main/scala/io/buoyant/namerd/storage/K8sDtabStoreInitializer.scala
@@ -17,7 +17,7 @@ case class K8sConfig(
 
   @JsonIgnore
   override def mkDtabStore(params: Stack.Params): DtabStore = {
-    val client = mkClient()
+    val client = mkClient(params)
 
     new K8sDtabStore(client, dst, namespace.getOrElse(DefaultNamespace))
   }


### PR DESCRIPTION
We were not passing through `params` when making the dtab store client, so there was no stats receiver for the client metrics.

Closes #2248 

Signed-off-by: Kevin Leimkuhler <kevinl@buoyant.io>