### PR TITLE
adds support for dynamically modifying log levels in Namerd

### DIFF
--- a/admin/src/main/resources/io/buoyant/admin/js/main-namerd.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/main-namerd.js
@@ -23,7 +23,12 @@ require.config({
 require([
   'jQuery',
   'bootstrap',
-  'src/dashboard_delegate'
-], function ($, bootstrap, namerdDtabPlayground) {
-  new namerdDtabPlayground();
+  'src/dashboard_delegate',
+  'src/logging'
+], function ($, bootstrap, namerdDtabPlayground, loggingConfig) {
+  if(window.location.pathname.indexOf("/dtab") >= 0){
+    new namerdDtabPlayground();
+  } else if(window.location.pathname.endsWith("/logging")){
+    new loggingConfig();
+  }
 });

--- a/admin/src/main/resources/io/buoyant/admin/js/src/admin.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/admin.js
@@ -17,10 +17,13 @@ define([
       var routers = routersRsp.routers || [];
       addAllRoutersLabel(routers, removeRoutersAllOption);
 
-      // !routersRsp.storage is a hack to force the admin page to not append a ?router=all
-      // suffix to the page URL if we are viewing a Namerd admin page.
-      if(window.location.pathname === "/" && !matches && routers.length > 0 && !routersRsp.storage) {
-        selectRouter(routers[0].label || routers[0].protocol);
+        // selectRouter appends ?router=all to the address bar URL which causes an additional page
+        // reload. We need a way to prevent this when running Namerd since Namerd doesn't use
+        // routers. We use routersRps.storage as a way to differentiate between a Namerd admin page
+        // or a Linkerd admin page. If routersRsp.storage doesn't exist in the config.json, we know
+        // that we are viewing a Namerd admin page so don't call selectRouter.
+        if(window.location.pathname === "/" && !matches && routers.length > 0 && !routersRsp.storage) {
+          selectRouter(routers[0].label || routers[0].protocol);
       }
       return routersRsp;
     });

--- a/admin/src/main/resources/io/buoyant/admin/js/src/admin.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/admin.js
@@ -14,10 +14,12 @@ define([
     }
 
     return $.get("config.json").done(function(routersRsp) {
-      var routers = routersRsp.routers;
+      var routers = routersRsp.routers || [];
       addAllRoutersLabel(routers, removeRoutersAllOption);
 
-      if(window.location.pathname === "/" && !matches && routers.length > 0) {
+      // !routersRsp.storage is a hack to force the admin page to not append a ?router=all
+      // suffix to the page URL if we are viewing a Namerd admin page.
+      if(window.location.pathname === "/" && !matches && routers.length > 0 && !routersRsp.storage) {
         selectRouter(routers[0].label || routers[0].protocol);
       }
       return routersRsp;

--- a/admin/src/main/resources/io/buoyant/admin/js/src/admin.js
+++ b/admin/src/main/resources/io/buoyant/admin/js/src/admin.js
@@ -14,16 +14,11 @@ define([
     }
 
     return $.get("config.json").done(function(routersRsp) {
-      var routers = routersRsp.routers || [];
+      var routers = routersRsp.routers;
       addAllRoutersLabel(routers, removeRoutersAllOption);
 
-        // selectRouter appends ?router=all to the address bar URL which causes an additional page
-        // reload. We need a way to prevent this when running Namerd since Namerd doesn't use
-        // routers. We use routersRps.storage as a way to differentiate between a Namerd admin page
-        // or a Linkerd admin page. If routersRsp.storage doesn't exist in the config.json, we know
-        // that we are viewing a Namerd admin page so don't call selectRouter.
-        if(window.location.pathname === "/" && !matches && routers.length > 0 && !routersRsp.storage) {
-          selectRouter(routers[0].label || routers[0].protocol);
+      if(window.location.pathname === "/" && !matches && routers.length > 0) {
+        selectRouter(routers[0].label || routers[0].protocol);
       }
       return routersRsp;
     });

--- a/namerd/main/src/main/scala/io/buoyant/namerd/DtabHandler.scala
+++ b/namerd/main/src/main/scala/io/buoyant/namerd/DtabHandler.scala
@@ -31,7 +31,6 @@ class DtabHandler(
 
   def renderDtab(name: String, dtab: Dtab): Future[Response] = {
     val body = s"""
-          <div class="container-fluid">
             <div class="row">
               <div class="col-lg-6">
                 <h2 class="router-label-title">Namespace "$name"</h2>
@@ -39,20 +38,18 @@ class DtabHandler(
             </div>
             <div class="delegator">
             </div>
-          </div>
 
           <script id="data" type="application/json">{"namespace": "$name", "dtab": ${
       DelegateApiHandler
         .Codec.writeStr(dtab)
     }}</script>
-          <script data-main="../files/js/main-namerd" src="../files/js/lib/require.js"></script>
+          <script data-main="/files/js/main-namerd" src="/files/js/lib/require.js"></script>
       """
     render(body)
   }
 
   def renderError(e: Throwable): Future[Response] = {
     val body = s"""
-          <div class="container-fluid">
             <div class="row">
               <div class="col-lg-6">
                 <h2 class="router-label-title">Dtab Error</h2>
@@ -60,31 +57,14 @@ class DtabHandler(
                 <pre>$e</pre>
               </div>
             </div>
-          </div>
     """
     render(body)
   }
 
   def render(body: String): Future[Response] = {
-    val content = s"""
-      <!doctype html>
-      <html>
-        <head>
-          <title>namerd admin</title>
-          <link rel="shortcut icon" href="../files/images/favicon.png" />
-          <link type="text/css" href="../files/css/lib/bootstrap.min.css" rel="stylesheet"/>
-          <link type="text/css" href="../files/css/fonts.css" rel="stylesheet"/>
-          <link type="text/css" href="../files/css/dashboard.css" rel="stylesheet"/>
-          <link type="text/css" href="../files/css/delegator.css" rel="stylesheet"/>
-        </head>
-        <body>
-        $body
-        </body>
-      </html>
-    """
     val response = Response()
-    response.contentType = MediaType.Html + ";charset=UTF-8"
-    response.contentString = content
+    response.contentType = MediaType.Html
+    response.contentString = body
     Future.value(response)
   }
 }

--- a/namerd/main/src/main/scala/io/buoyant/namerd/DtabHandler.scala
+++ b/namerd/main/src/main/scala/io/buoyant/namerd/DtabHandler.scala
@@ -43,7 +43,7 @@ class DtabHandler(
       DelegateApiHandler
         .Codec.writeStr(dtab)
     }}</script>
-          <script data-main="/files/js/main-namerd" src="/files/js/lib/require.js"></script>
+          <script data-main="../files/js/main-namerd" src="../files/js/lib/require.js"></script>
       """
     render(body)
   }

--- a/namerd/main/src/main/scala/io/buoyant/namerd/DtabListHandler.scala
+++ b/namerd/main/src/main/scala/io/buoyant/namerd/DtabListHandler.scala
@@ -12,7 +12,7 @@ class DtabListHandler(
   override def apply(req: Request): Future[Response] =
     store.list().toFuture.map { list =>
       val response = Response()
-      response.contentType = MediaType.Html + ";charset=UTF-8"
+      response.contentType = MediaType.Html
       response.contentString = render(list.toSeq.sorted)
       response
     }
@@ -42,25 +42,11 @@ class DtabListHandler(
     }
 
     s"""
-      <!doctype html>
-      <html>
-        <head>
-          <title>namerd admin</title>
-          <link rel="shortcut icon" href="files/images/favicon.png" />
-          <link type="text/css" href="files/css/lib/bootstrap.min.css" rel="stylesheet"/>
-          <link type="text/css" href="files/css/fonts.css" rel="stylesheet"/>
-          <link type="text/css" href="files/css/dashboard.css" rel="stylesheet"/>
-        </head>
-        <body>
-          <div class="container-fluid">
-            <div class="row">
-              <div class="col-lg-6">
-                $content
-              </div>
-            </div>
-          </div>
-        </body>
-      </html>
+      <div class="row">
+        <div class="col-lg-6">
+          $content
+        </div>
+    </div>
     """
   }
 }

--- a/namerd/main/src/main/scala/io/buoyant/namerd/NamerdAdmin.scala
+++ b/namerd/main/src/main/scala/io/buoyant/namerd/NamerdAdmin.scala
@@ -1,10 +1,12 @@
 package io.buoyant.namerd
 
-import com.twitter.finagle.{Namer, Path}
+import com.twitter.finagle.http.{MediaType, Request, Response}
+import com.twitter.finagle.{Namer, Path, Service, SimpleFilter}
 import com.twitter.server.handler.ResourceHandler
-import io.buoyant.admin.Admin.Handler
+import com.twitter.util.Future
+import io.buoyant.admin.Admin.{Handler, NavItem}
 import io.buoyant.admin.names.DelegateApiHandler
-import io.buoyant.admin.{Admin, ConfigHandler, StaticFilter}
+import io.buoyant.admin._
 import io.buoyant.namer.ConfiguredNamersInterpreter
 
 object NamerdAdmin {
@@ -21,15 +23,116 @@ object NamerdAdmin {
     Handler("/config.json", new ConfigHandler(nc, NamerdConfig.LoadedInitializers.iter))
   )
 
-  def dtabs(dtabStore: DtabStore, namers: Map[Path, Namer]) = Seq(
-    Handler("/", new DtabListHandler(dtabStore)),
-    Handler("/dtab/delegator.json", new DelegateApiHandler(ns => ConfiguredNamersInterpreter(namers.toSeq))),
-    Handler("/dtab/", new DtabHandler(dtabStore))
-  )
+  def dtabs(dtabStore: DtabStore, namers: Map[Path, Namer], adminHandler: NamerdAdmin) = {
+    val adminFilter = new NamerdFilter(adminHandler)
+    Seq(
+      Handler("/", adminFilter.andThen(new DtabListHandler(dtabStore))),
+      Handler("/dtab/delegator.json", new DelegateApiHandler(ns => ConfiguredNamersInterpreter(namers.toSeq))),
+      Handler("/dtab/", adminFilter.andThen(new DtabHandler(dtabStore)))
+    )
+  }
 
-  def apply(nc: NamerdConfig, namerd: Namerd): Seq[Handler] =
+  def logging(adminHandler: NamerdAdmin): Seq[Handler] = {
+    val adminFilter = new NamerdFilter(adminHandler)
+    Seq(
+      Handler("/logging.json", new LoggingApiHandler()),
+      Handler("/logging", adminFilter.andThen(new LoggingHandler(adminHandler)))
+    )
+  }
+
+  def apply(nc: NamerdConfig, namerd: Namerd): Seq[Handler] = {
+    val handler = new NamerdAdmin(Seq(NavItem("dtabs", "dtabs"), NavItem("logging", "logging")))
+
     static ++ config(nc) ++
-      dtabs(namerd.dtabStore, namerd.namers) ++
+      dtabs(namerd.dtabStore, namerd.namers, handler) ++ logging(handler) ++
       Admin.extractHandlers(namerd.dtabStore +: (namerd.namers.values.toSeq ++ namerd.telemeters))
+  }
 
+}
+
+private class NamerdAdmin(navItems: Seq[NavItem]) extends HtmlView {
+  private[this] def navHtml(highlightedItem: String = "") = navItems.map { item =>
+    val activeClass = if (item.name == highlightedItem) "active" else ""
+    s"""<li class=$activeClass><a href="/${item.url}">${item.name}</a></li>"""
+  }.mkString("\n")
+
+  override def html(
+    content: String,
+    tailContent: String,
+    csses: Seq[String],
+    navHighlight: String,
+    showRouterDropdown: Boolean
+  ): String =
+    s"""
+<!doctype html>
+      <html>
+        <head>
+          <title>namerd admin</title>
+          <link type="text/css" href="/files/css/lib/bootstrap.min.css" rel="stylesheet"/>
+          <link type="text/css" href="/files/css/fonts.css" rel="stylesheet"/>
+          <link type="text/css" href="/files/css/dashboard.css" rel="stylesheet"/>
+          <link type="text/css" href="/files/css/logger.css" rel="stylesheet"/>
+          <link type="text/css" href="/files/css/delegator.css" rel="stylesheet"/>
+          <link rel="shortcut icon" href="/files/images/favicon.png" />
+        </head>
+        <body>
+          <nav class="navbar navbar-inverse">
+      <div class="navbar-container">
+        <div class="navbar-header">
+          <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false">
+            <span class="sr-only">Toggle navigation</span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+          </button>
+
+          <a class="navbar-brand" href="/">
+            <div>Namerd</div>
+          </a>
+        </div>
+        <div id="navbar" class="collapse navbar-collapse">
+          <ul class="nav navbar-nav">
+          ${navHtml(navHighlight)}
+          </ul>
+        </div>
+      </div>
+    </nav>
+
+          <div class="container-fluid">
+            $content
+          </div>
+          $tailContent
+
+          <script data-main="/files/js/main-linkerd" src="/files/js/lib/require.js"></script>
+
+        </body>
+      </html>
+     """
+
+  override def mkResponse(
+    content: String,
+    mediaType: String
+  ): Future[Response] = {
+    val response = Response()
+    response.contentType = mediaType + ";charset=UTF-8"
+    response.contentString = content
+    Future.value(response)
+  }
+}
+
+private class NamerdFilter(
+  adminHandler: NamerdAdmin, css: Seq[String] = Nil
+) extends SimpleFilter[Request, Response] {
+  override def apply(
+    request: Request,
+    service: Service[Request, Response]
+  ): Future[Response] = {
+    service(request).map { rsp =>
+      val itemToHighlight = request.path.replace("/", "")
+      if (rsp.contentType.contains(MediaType.Html))
+        rsp.contentString = adminHandler
+          .html(rsp.contentString, csses = css, navHighlight = itemToHighlight)
+      rsp
+    }
+  }
 }

--- a/namerd/main/src/main/scala/io/buoyant/namerd/NamerdAdmin.scala
+++ b/namerd/main/src/main/scala/io/buoyant/namerd/NamerdAdmin.scala
@@ -24,15 +24,15 @@ object NamerdAdmin {
   )
 
   def dtabs(dtabStore: DtabStore, namers: Map[Path, Namer], adminFilter: NamerdFilter) = Seq(
-      Handler("/", adminFilter.andThen(new DtabListHandler(dtabStore))),
-      Handler("/dtab/delegator.json", new DelegateApiHandler(_ => ConfiguredNamersInterpreter(namers.toSeq))),
-      Handler("/dtab/", adminFilter.andThen(new DtabHandler(dtabStore)))
-    )
+    Handler("/", adminFilter.andThen(new DtabListHandler(dtabStore))),
+    Handler("/dtab/delegator.json", new DelegateApiHandler(_ => ConfiguredNamersInterpreter(namers.toSeq))),
+    Handler("/dtab/", adminFilter.andThen(new DtabHandler(dtabStore)))
+  )
 
   def logging(adminHandler: NamerdAdmin, adminFilter: NamerdFilter): Seq[Handler] = Seq(
-      Handler("/logging.json", new LoggingApiHandler()),
-      Handler("/logging", adminFilter.andThen(new LoggingHandler(adminHandler)))
-    )
+    Handler("/logging.json", new LoggingApiHandler()),
+    Handler("/logging", adminFilter.andThen(new LoggingHandler(adminHandler)))
+  )
 
   def apply(nc: NamerdConfig, namerd: Namerd): Seq[Handler] = {
     val handler = new NamerdAdmin(Seq(NavItem("logging", "logging")))
@@ -60,18 +60,18 @@ private class NamerdAdmin(navItems: Seq[NavItem]) extends HtmlView {
   ): String =
     s"""
 <!doctype html>
-      <html>
-        <head>
-          <title>namerd admin</title>
-          <link type="text/css" href="/files/css/lib/bootstrap.min.css" rel="stylesheet"/>
-          <link type="text/css" href="/files/css/fonts.css" rel="stylesheet"/>
-          <link type="text/css" href="/files/css/dashboard.css" rel="stylesheet"/>
-          <link type="text/css" href="/files/css/logger.css" rel="stylesheet"/>
-          <link type="text/css" href="/files/css/delegator.css" rel="stylesheet"/>
-          <link rel="shortcut icon" href="/files/images/favicon.png" />
-        </head>
-        <body>
-          <nav class="navbar navbar-inverse">
+<html>
+  <head>
+    <title>namerd admin</title>
+    <link type="text/css" href="/files/css/lib/bootstrap.min.css" rel="stylesheet"/>
+    <link type="text/css" href="/files/css/fonts.css" rel="stylesheet"/>
+    <link type="text/css" href="/files/css/dashboard.css" rel="stylesheet"/>
+    <link type="text/css" href="/files/css/logger.css" rel="stylesheet"/>
+    <link type="text/css" href="/files/css/delegator.css" rel="stylesheet"/>
+    <link rel="shortcut icon" href="/files/images/favicon.png" />
+  </head>
+  <body>
+    <nav class="navbar navbar-inverse">
       <div class="navbar-container">
         <div class="navbar-header">
           <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false">
@@ -80,28 +80,24 @@ private class NamerdAdmin(navItems: Seq[NavItem]) extends HtmlView {
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </button>
-
           <a class="navbar-brand" href="/">
             <div>Namerd</div>
           </a>
         </div>
         <div id="navbar" class="collapse navbar-collapse">
           <ul class="nav navbar-nav">
-          ${navHtml(navHighlight)}
+            ${navHtml(navHighlight)}
           </ul>
         </div>
       </div>
     </nav>
-
-          <div class="container-fluid">
-            $content
-          </div>
-          $tailContent
-
-          <script data-main="/files/js/main-linkerd" src="/files/js/lib/require.js"></script>
-
-        </body>
-      </html>
+    <div class="container-fluid">
+      $content
+    </div>
+    $tailContent
+    <script data-main="/files/js/main-namerd" src="/files/js/lib/require.js"></script>
+  </body>
+</html>
      """
 
   override def mkResponse(


### PR DESCRIPTION
Namerd's dashboard currently does not have the ability to dynamically change log levels for modules running within the Namerd process. This makes it difficult to debug issues that may arise in Namerd since you are left to rely on the current log levels set at startup time.

This PR adds a new "Logging" page which allows you to change log levels dynamically. This PR also includes a nav bar for Namerd to assist in switching between the dtab playground and the new logging page.

Fixes #2254 

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>