### PR TITLE
Remove delegate tree from rich exceptions

### DIFF
--- a/linkerd/protocol/h2/src/test/scala/io/buoyant/linkerd/protocol/h2/ErrorReseterTest.scala
+++ b/linkerd/protocol/h2/src/test/scala/io/buoyant/linkerd/protocol/h2/ErrorReseterTest.scala
@@ -55,7 +55,7 @@ class ErrorReseterTest extends FunSuite with Awaits {
 
   test("response from exceptions should have l5d-err header"){
     val service = ErrorReseter.filter.andThen(Service.mk[Request, Response]{_ =>
-      Future.exception(new RichNoBrokersAvailableException(Dst.Path.empty,None, None))
+      Future.exception(new RichNoBrokersAvailableException(Dst.Path.empty,None))
     })
     val req = Request("http", Method.Get, "hihost", "/", Stream.empty())
     val resp = await(service(req))

--- a/router/core/src/main/scala/com/twitter/finagle/naming/buoyant/DstBindingFactory.scala
+++ b/router/core/src/main/scala/com/twitter/finagle/naming/buoyant/DstBindingFactory.scala
@@ -163,7 +163,7 @@ object DstBindingFactory {
           }
 
           private val handleNoBrokers: PartialFunction[Throwable, Future[Service[Req, Rsp]]] = {
-            case e: NoBrokersAvailableException => RichNoBrokersAvailableException(dst, namer)
+            case e: NoBrokersAvailableException => RichNoBrokersAvailableException(dst)
           }
 
         }

--- a/router/core/src/main/scala/com/twitter/finagle/naming/buoyant/RichConnectionFailedException.scala
+++ b/router/core/src/main/scala/com/twitter/finagle/naming/buoyant/RichConnectionFailedException.scala
@@ -1,10 +1,8 @@
 package com.twitter.finagle.naming.buoyant
 
 import com.twitter.finagle.buoyant.Dst
-import com.twitter.finagle.naming.NameInterpreter
 import com.twitter.finagle._
 import com.twitter.util.Future
-import io.buoyant.namer.{DelegateTree, Delegator}
 import java.net.SocketAddress
 import scala.util.control.NoStackTrace
 

--- a/router/core/src/main/scala/com/twitter/finagle/naming/buoyant/RichConnectionFailedModule.scala
+++ b/router/core/src/main/scala/com/twitter/finagle/naming/buoyant/RichConnectionFailedModule.scala
@@ -10,7 +10,7 @@ import com.twitter.util.Future
  * RichConnectionFailedExceptions, adding helpful information about the current routing context.
  * This module is typically used in the client stack.
  */
-class RichConnectionFailedModule[Request, Response] extends Stack.Module2[BindingFactory.Dest, DstBindingFactory.Namer, ServiceFactory[Request, Response]] {
+class RichConnectionFailedModule[Request, Response] extends Stack.Module1[BindingFactory.Dest, ServiceFactory[Request, Response]] {
 
   override def role: Stack.Role = Stack.Role("RichConnectionFailed")
 
@@ -18,7 +18,6 @@ class RichConnectionFailedModule[Request, Response] extends Stack.Module2[Bindin
 
   override def make(
     dest: BindingFactory.Dest,
-    interpreter: DstBindingFactory.Namer,
     next: ServiceFactory[Request, Response]
   ): ServiceFactory[Request, Response] = {
 
@@ -33,8 +32,7 @@ class RichConnectionFailedModule[Request, Response] extends Stack.Module2[Bindin
           case Failure(Some(e: ConnectionFailedException)) =>
             Future.exception(RichConnectionFailedException(
               bound,
-              e.remoteAddress,
-              interpreter.interpreter
+              e.remoteAddress
             ))
         }
       }

--- a/router/core/src/main/scala/com/twitter/finagle/naming/buoyant/RichNoBrokersAvailableException.scala
+++ b/router/core/src/main/scala/com/twitter/finagle/naming/buoyant/RichNoBrokersAvailableException.scala
@@ -2,9 +2,7 @@ package com.twitter.finagle.naming.buoyant
 
 import com.twitter.finagle._
 import com.twitter.finagle.buoyant.Dst
-import com.twitter.finagle.naming.NameInterpreter
 import com.twitter.util.Future
-import io.buoyant.namer.{DelegateTree, Delegator, RichActivity}
 
 class RichNoBrokersAvailableException(
   path: Dst.Path,


### PR DESCRIPTION
RichConnectionFailedException and RichNoBrokersException make a call to the `delegete` when they are populated to provide the delegate tree in the text of the exception.  In cases where there is a high rate of these exceptions being created (for example, when there are many requeues) this results in a high rate of calls to `delegate`.  If Namerd is used for delegation, this results in a high rate of requests to Namerd which can have Denial of Service effects.

We remove the delegation tree information from the rich exceptions.  This ensures that Namerd will not be impacted when there is a high rate of these exceptions.  The rich exceptions will still contain the service name and client name, so the delegation tree can still be retrieved manually from the dtab UI in the admin server if it is desired.

Signed-off-by: Alex Leong <alex@buoyant.io>