### PR TITLE
[DO NOT MERGE] 1.6.2.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+## 1.6.2.1 2019-03-28
+
+This bug fix release fixes an issue where Linkerd can send excessive load to Namerd in certain
+when Linkerd is unable to establish TCP connections to services.  To remedy this, detailed
+delegation information has been removed from error responses returned by Linkerd.  This detailed
+delegation information is still available by using the dtab page of the Linkerd admin server.
+ 
 ## 1.6.2 2019-03-08
 This Linkerd release includes bug fixes for Namerd's k8s watch API as well as memory management
 improvements in the `io.l5d.zk` storage plugin. This release features a new failure detector

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,10 @@
 ## 1.6.2.1 2019-03-28
 
 This bug fix release fixes an issue where Linkerd can send excessive load to Namerd in certain
-when Linkerd is unable to establish TCP connections to services.  To remedy this, detailed
-delegation information has been removed from error responses returned by Linkerd.  This detailed
-delegation information is still available by using the dtab page of the Linkerd admin server.
+situations when Linkerd is unable to establish TCP connections to services.  To remedy this,
+detailed delegation information has been removed from error responses returned by Linkerd.  This
+detailed delegation information is still available by using the dtab page of the Linkerd admin
+server.
  
 ## 1.6.2 2019-03-08
 This Linkerd release includes bug fixes for Namerd's k8s watch API as well as memory management

--- a/linkerd/protocol/h2/src/test/scala/io/buoyant/linkerd/protocol/h2/ErrorReseterTest.scala
+++ b/linkerd/protocol/h2/src/test/scala/io/buoyant/linkerd/protocol/h2/ErrorReseterTest.scala
@@ -55,7 +55,7 @@ class ErrorReseterTest extends FunSuite with Awaits {
 
   test("response from exceptions should have l5d-err header"){
     val service = ErrorReseter.filter.andThen(Service.mk[Request, Response]{_ =>
-      Future.exception(new RichNoBrokersAvailableException(Dst.Path.empty,None, None))
+      Future.exception(new RichNoBrokersAvailableException(Dst.Path.empty,None))
     })
     val req = Request("http", Method.Get, "hihost", "/", Stream.empty())
     val resp = await(service(req))

--- a/project/Base.scala
+++ b/project/Base.scala
@@ -32,7 +32,7 @@ object Base {
 class Base extends Build {
   import Base._
 
-  val headVersion = "1.6.2"
+  val headVersion = "1.6.2.1"
   val openJdkVersion = "8u151"
   val openJ9Version = "jdk8u192-b12_openj9-0.11.0"
 

--- a/router/core/src/main/scala/com/twitter/finagle/naming/buoyant/DstBindingFactory.scala
+++ b/router/core/src/main/scala/com/twitter/finagle/naming/buoyant/DstBindingFactory.scala
@@ -163,7 +163,7 @@ object DstBindingFactory {
           }
 
           private val handleNoBrokers: PartialFunction[Throwable, Future[Service[Req, Rsp]]] = {
-            case e: NoBrokersAvailableException => RichNoBrokersAvailableException(dst, namer)
+            case e: NoBrokersAvailableException => RichNoBrokersAvailableException(dst)
           }
 
         }

--- a/router/core/src/main/scala/com/twitter/finagle/naming/buoyant/RichConnectionFailedException.scala
+++ b/router/core/src/main/scala/com/twitter/finagle/naming/buoyant/RichConnectionFailedException.scala
@@ -1,10 +1,8 @@
 package com.twitter.finagle.naming.buoyant
 
 import com.twitter.finagle.buoyant.Dst
-import com.twitter.finagle.naming.NameInterpreter
 import com.twitter.finagle._
 import com.twitter.util.Future
-import io.buoyant.namer.{DelegateTree, Delegator}
 import java.net.SocketAddress
 import scala.util.control.NoStackTrace
 
@@ -17,8 +15,7 @@ import scala.util.control.NoStackTrace
  */
 case class RichConnectionFailedException(
   client: Option[Name.Bound],
-  remote: SocketAddress,
-  namer: NameInterpreter
+  remote: SocketAddress
 ) extends Exception(null, null)
   with NoStackTrace
   with SourcedException
@@ -28,8 +25,7 @@ case class RichConnectionFailedException(
     RichConnectionFailedExceptionWithPath(
       service,
       client,
-      remote,
-      namer
+      remote
     )
   }
 
@@ -47,8 +43,7 @@ class RichConnectionFailedExceptionWithPath(
   service: Dst.Path,
   client: String,
   addresses: Set[Address],
-  remote: String,
-  resolution: Seq[String]
+  remote: String
 ) extends Exception(null, null)
   with NoStackTrace
   with SourcedException
@@ -58,8 +53,6 @@ class RichConnectionFailedExceptionWithPath(
     case Address.Inet(isa, _) => isa.toString.stripPrefix("/")
   }.mkString("[", ", ", "]")
 
-  private[this] val resolutionList = resolution.mkString("\n")
-
   override lazy val exceptionMessage: String =
     s"""Unable to establish connection to $remote.
 
@@ -67,8 +60,6 @@ service name: ${service.path.show}
 client name: $client
 addresses: $addressList
 selected address: ${remote.toString.stripPrefix("/")}
-dtab resolution:
-$resolutionList
 """
 
   override def flags = FailureFlags.Retryable
@@ -82,8 +73,7 @@ object RichConnectionFailedExceptionWithPath {
   def apply(
     path: Dst.Path,
     client: Option[Name.Bound],
-    remote: SocketAddress,
-    namer: NameInterpreter
+    remote: SocketAddress
   ): Future[Nothing] = {
 
     val addresses = client match {
@@ -95,22 +85,6 @@ object RichConnectionFailedExceptionWithPath {
       case None => Future.value(Set.empty[Address])
     }
 
-    val resolution = (namer match {
-      case delegator: Delegator =>
-        delegator.delegate(path.dtab, path.path).map { tree =>
-          DelegateTree.find[Name.Bound](tree, client.contains)
-        }
-      case _ => Future.None
-    }).map {
-      case Some(nodes) => nodes.map {
-        case (path, "") =>
-          s"  ${path.show}"
-        case (path, dentry) =>
-          s"  ${path.show} ($dentry)"
-      }
-      case None => Nil
-    }
-
     val clnt = client match {
       case Some(b) =>
         b.id match {
@@ -120,15 +94,13 @@ object RichConnectionFailedExceptionWithPath {
       case None => "unknown"
     }
 
-    addresses.join(resolution).map {
-      case (addrs, res) =>
-        new RichConnectionFailedExceptionWithPath(
-          path,
-          clnt,
-          addrs,
-          remote.toString.stripPrefix("/"),
-          res
-        )
+    addresses.map { addrs =>
+      new RichConnectionFailedExceptionWithPath(
+        path,
+        clnt,
+        addrs,
+        remote.toString.stripPrefix("/")
+      )
     }.flatMap(Future.exception)
   }
 }

--- a/router/core/src/main/scala/com/twitter/finagle/naming/buoyant/RichConnectionFailedModule.scala
+++ b/router/core/src/main/scala/com/twitter/finagle/naming/buoyant/RichConnectionFailedModule.scala
@@ -10,7 +10,7 @@ import com.twitter.util.Future
  * RichConnectionFailedExceptions, adding helpful information about the current routing context.
  * This module is typically used in the client stack.
  */
-class RichConnectionFailedModule[Request, Response] extends Stack.Module2[BindingFactory.Dest, DstBindingFactory.Namer, ServiceFactory[Request, Response]] {
+class RichConnectionFailedModule[Request, Response] extends Stack.Module1[BindingFactory.Dest, ServiceFactory[Request, Response]] {
 
   override def role: Stack.Role = Stack.Role("RichConnectionFailed")
 
@@ -18,7 +18,6 @@ class RichConnectionFailedModule[Request, Response] extends Stack.Module2[Bindin
 
   override def make(
     dest: BindingFactory.Dest,
-    interpreter: DstBindingFactory.Namer,
     next: ServiceFactory[Request, Response]
   ): ServiceFactory[Request, Response] = {
 
@@ -33,8 +32,7 @@ class RichConnectionFailedModule[Request, Response] extends Stack.Module2[Bindin
           case Failure(Some(e: ConnectionFailedException)) =>
             Future.exception(RichConnectionFailedException(
               bound,
-              e.remoteAddress,
-              interpreter.interpreter
+              e.remoteAddress
             ))
         }
       }

--- a/router/core/src/main/scala/com/twitter/finagle/naming/buoyant/RichNoBrokersAvailableException.scala
+++ b/router/core/src/main/scala/com/twitter/finagle/naming/buoyant/RichNoBrokersAvailableException.scala
@@ -2,14 +2,11 @@ package com.twitter.finagle.naming.buoyant
 
 import com.twitter.finagle._
 import com.twitter.finagle.buoyant.Dst
-import com.twitter.finagle.naming.NameInterpreter
 import com.twitter.util.Future
-import io.buoyant.namer.{DelegateTree, Delegator, RichActivity}
 
 class RichNoBrokersAvailableException(
   path: Dst.Path,
-  dtab: Option[Dtab],
-  resolutions: Option[Seq[String]]
+  dtab: Option[Dtab]
 ) extends RequestException {
 
   private[this] def formatDtab(d: Dtab): String =
@@ -21,8 +18,6 @@ class RichNoBrokersAvailableException(
     s"""Unable to route request!
 
 service name: ${path.path.show}
-resolutions considered:
-${resolutions.getOrElse(Seq("unknown")).map("  " + _).mkString("\n")}
 dtab:
 ${formatDtab(dtab.getOrElse(Dtab.empty))}
 base dtab:
@@ -34,43 +29,6 @@ ${formatDtab(path.localDtab)}
 
 object RichNoBrokersAvailableException {
 
-  def apply(path: Dst.Path, namer: NameInterpreter): Future[Nothing] = {
-    namer match {
-      case delegator: Delegator =>
-
-        val dtab = delegator.dtab.toFuture
-        val res = delegator.delegate(path.dtab, path.path).flatMap(resolutions)
-
-        dtab.join(res).flatMap {
-          case (d, r) => Future.exception(new RichNoBrokersAvailableException(path, Some(d), Some(r)))
-        }
-      case _ => Future.exception(new RichNoBrokersAvailableException(path, None, None))
-    }
-  }
-
-  def resolutions(tree: DelegateTree[Name.Bound]): Future[Seq[String]] = {
-    tree match {
-      case DelegateTree.Leaf(path, _, Name.Bound(vaddr)) =>
-        vaddr.changes.toFuture().map {
-          case Addr.Bound(_, _) => Seq(s"${path.show} (bound)")
-          case Addr.Failed(e) => Seq(s"${path.show} (exception: ${e.getMessage}")
-          case Addr.Neg => Seq(s"${path.show} (neg)")
-          case Addr.Pending => Seq(s"${path.show} (pending)")
-        }
-      case DelegateTree.Exception(path, _, e) => Future.value(Seq(s"${path.show} (exception: ${e.getMessage}"))
-      case DelegateTree.Empty(path, _) => Future.value(Seq(s"${path.show} (empty)"))
-      case DelegateTree.Fail(path, _) => Future.value(Seq(s"${path.show} (fail)"))
-      case DelegateTree.Neg(path, _) => Future.value(Seq(s"${path.show} (neg)"))
-      case DelegateTree.Delegate(_, _, next) => resolutions(next)
-      case DelegateTree.Transformation(_, _, _, next) => resolutions(next)
-      case DelegateTree.Union(_, _, children@_*) =>
-        Future.collect {
-          children.map { child =>
-            resolutions(child.tree)
-          }
-        }.map(_.flatten)
-      case DelegateTree.Alt(_, _, children@_*) =>
-        Future.collect(children.map(resolutions)).map(_.flatten)
-    }
-  }
+  def apply(path: Dst.Path): Future[Nothing] =
+    Future.exception(new RichNoBrokersAvailableException(path, None))
 }


### PR DESCRIPTION
## 1.6.2.1 2019-03-28

This bug fix release fixes an issue where Linkerd can send excessive load to Namerd in certain
situations when Linkerd is unable to establish TCP connections to services.  To remedy this,
detailed delegation information has been removed from error responses returned by Linkerd.  This
detailed delegation information is still available by using the dtab page of the Linkerd admin
server.