### PR TITLE
Properly set default JVM GC strategy

### DIFF
--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -233,7 +233,7 @@ object LinkerdBuild extends Base {
 
   val ConfigFileRE = """^(.*)\.yaml$""".r
 
-  val defaultExecScript =
+  val baseExecScript =
     """|#!/bin/sh
        |
        |jars="$0"
@@ -402,7 +402,7 @@ object LinkerdBuild extends Base {
      * to the classpath if it exists.
      */
     val namerdExecScript = (
-      defaultExecScript +
+      baseExecScript +
       execScriptJvmOptions +
       """|exec "${JAVA_HOME:-/usr}/bin/java" -XX:+PrintCommandLineFlags \
          |     ${JVM_OPTIONS:-$DEFAULT_JVM_OPTIONS} $HSPREF_SETTING -cp $jars -server \
@@ -454,7 +454,7 @@ object LinkerdBuild extends Base {
      * 3) boots namerd
      */
     val dcosExecScript = (
-      defaultExecScript +
+      baseExecScript +
       execScriptJvmOptions +
       """|if read -t 0; then
          |  CONFIG_INPUT=`cat`
@@ -656,7 +656,7 @@ object LinkerdBuild extends Base {
      * to the classpath if it exists.
      */
     val linkerdExecScript = (
-      defaultExecScript +
+      baseExecScript +
       execScriptJvmOptions +
       """|exec "${JAVA_HOME:-/usr}/bin/java" -XX:+PrintCommandLineFlags \
          |     ${JVM_OPTIONS:-$DEFAULT_JVM_OPTIONS} $HSPREF_SETTING -cp $jars -server \

--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -258,7 +258,12 @@ object LinkerdBuild extends Base {
        |   -Dio.netty.allocator.numDirectArenas=${FINAGLE_WORKERS:-8}    \
        |   -Dcom.twitter.finagle.netty4.numWorkers=${FINAGLE_WORKERS:-8} \
        |   ${GC_LOG_OPTION:-}                                            \
-       |   ${LOCAL_JVM_OPTIONS:-}                                        "
+       |   ${LOCAL_JVM_OPTIONS:-}"
+       |
+       |if ! [ "$LOCAL_JAVA_VERSION" -ge 9 ]; then
+       |  DEFAULT_JVM_OPTIONS="$DEFAULT_JVM_OPTIONS -XX:+UseConcMarkSweepGC"
+       |fi
+       |
        |""".stripMargin
 
   object Namerd {
@@ -368,15 +373,16 @@ object LinkerdBuild extends Base {
          |  GC_LOG="/var/log/namerd"
          |fi
          |
+         |# Check Java version for use in GC_LOG_OPTION and DEFAULT_JVM_OPTIONS
+         |LOCAL_JAVA_VERSION=$("${JAVA_HOME:-/usr}"/bin/java -version 2>&1 | sed 's/.*version "\([0-9]*\)\..*/\1/; 1q')
+         |
          |mkdir -p "$GC_LOG" && [ -w "$GC_LOG" ]
          |
          |if [ $? -ne 0 ]; then
          |  echo "GC_LOG must be set to a directory that user [$USER] has write permissions on.\
          | Unable to use [$GC_LOG] for GC logging."
          |else
-         |  version=$("${JAVA_HOME:-/usr}"/bin/java -version 2>&1 | sed 's/.*version "\([0-9]*\)\..*/\1/; 1q')
-         |
-         |  if [ "$version" -ge 9 ]; then
+         |  if [ "$LOCAL_JAVA_VERSION" -ge 9 ]; then
          |    GC_LOG_OPTION="-Xlog:gc*,gc+age=trace,gc+heap=debug,gc+promotion=trace,safepoint:file=${GC_LOG}/gc.log::filecount=10,filesize=10000:time"
          |  else
          |    GC_LOG_OPTION="
@@ -390,7 +396,6 @@ object LinkerdBuild extends Base {
          |      -XX:+UseGCLogFileRotation
          |      -XX:NumberOfGCLogFiles=10
          |      -XX:GCLogFileSize=10M"
-         |    DEFAULT_JVM_OPTIONS="-XX:+UseConcMarkSweepGC"
          |  fi
          |fi
          |
@@ -463,15 +468,16 @@ object LinkerdBuild extends Base {
          |  GC_LOG="/var/log/namerd"
          |fi
          |
+         |# Check Java version for use in GC_LOG_OPTION and DEFAULT_JVM_OPTIONS
+         |LOCAL_JAVA_VERSION=$("${JAVA_HOME:-/usr}"/bin/java -version 2>&1 | sed 's/.*version "\([0-9]*\)\..*/\1/; 1q')
+         |
          |mkdir -p "$GC_LOG" && [ -w "$GC_LOG" ]
          |
          |if [ $? -ne 0 ]; then
          |  echo "GC_LOG must be set to a directory that user [$USER] has write permissions on.\
          | Unable to use [$GC_LOG] for GC logging."
          |else
-         |  version=$("${JAVA_HOME:-/usr}"/bin/java -version 2>&1 | sed 's/.*version "\([0-9]*\)\..*/\1/; 1q')
-         |
-         |  if [ "$version" -ge 9 ]; then
+         |  if [ "$LOCAL_JAVA_VERSION" -ge 9 ]; then
          |    GC_LOG_OPTION="-Xlog:gc*,gc+age=trace,gc+heap=debug,gc+promotion=trace,safepoint:file=${GC_LOG}/gc.log::filecount=10,filesize=10000:time"
          |  else
          |    GC_LOG_OPTION="
@@ -485,7 +491,6 @@ object LinkerdBuild extends Base {
          |      -XX:+UseGCLogFileRotation
          |      -XX:NumberOfGCLogFiles=10
          |      -XX:GCLogFileSize=10M"
-         |    DEFAULT_JVM_OPTIONS="-XX:+UseConcMarkSweepGC"
          |  fi
          |fi
          |
@@ -708,15 +713,16 @@ object LinkerdBuild extends Base {
          |  GC_LOG="/var/log/linkerd"
          |fi
          |
+         |# Check Java version for use in GC_LOG_OPTION and DEFAULT_JVM_OPTIONS
+         |LOCAL_JAVA_VERSION=$("${JAVA_HOME:-/usr}"/bin/java -version 2>&1 | sed 's/.*version "\([0-9]*\)\..*/\1/; 1q')
+         |
          |mkdir -p "$GC_LOG" && [ -w "$GC_LOG" ]
          |
          |if [ $? -ne 0 ]; then
          |  echo "GC_LOG must be set to a directory that user [$USER] has write permissions on.\
          | Unable to use [$GC_LOG] for GC logging."
          |else
-         |  version=$("${JAVA_HOME:-/usr}"/bin/java -version 2>&1 | sed 's/.*version "\([0-9]*\)\..*/\1/; 1q')
-         |
-         |  if [ "$version" -ge 9 ]; then
+         |  if [ "$LOCAL_JAVA_VERSION" -ge 9 ]; then
          |    GC_LOG_OPTION="-Xlog:gc*,gc+age=trace,gc+heap=debug,gc+promotion=trace,safepoint:file=${GC_LOG}/gc.log::filecount=10,filesize=10000:time"
          |  else
          |    GC_LOG_OPTION="
@@ -730,7 +736,6 @@ object LinkerdBuild extends Base {
          |      -XX:+UseGCLogFileRotation
          |      -XX:NumberOfGCLogFiles=10
          |      -XX:GCLogFileSize=10M"
-         |    DEFAULT_JVM_OPTIONS="-XX:+UseConcMarkSweepGC"
          |  fi
          |fi
          |

--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -237,13 +237,13 @@ object LinkerdBuild extends Base {
     """|#!/bin/sh
        |
        |jars="$0"
-       |HSPREF_SETTING=$([ ! -z "$ENABLE_HSPREF" ] && echo "" || echo "-XX:+PerfDisableSharedMem")
-       |if [ -n "$NAMERD_HOME" ] && [ -d $NAMERD_HOME/plugins ]; then
-       |  for jar in $NAMERD_HOME/plugins/*.jar ; do
+       |HSPREF_SETTING=$([ -n "$ENABLE_HSPREF" ] && echo "" || echo "-XX:+PerfDisableSharedMem")
+       |if [ -n "$NAMERD_HOME" ] && [ -d "$NAMERD_HOME"/plugins ]; then
+       |  for jar in "$NAMERD_HOME"/plugins/*.jar ; do
        |    jars="$jars:$jar"
        |  done
        |fi
-       |	
+       |
        |export MALLOC_ARENA_MAX=2
        |
        |# Configure GC logging directory
@@ -257,9 +257,9 @@ object LinkerdBuild extends Base {
     """|#!/bin/sh
        |
        |jars="$0"
-       |HSPREF_SETTING=$([ ! -z "$ENABLE_HSPREF" ] && echo "" || echo "-XX:+PerfDisableSharedMem")
-       |if [ -n "$L5D_HOME" ] && [ -d $L5D_HOME/plugins ]; then
-       |  for jar in $L5D_HOME/plugins/*.jar ; do
+       |HSPREF_SETTING=$([ -n "$ENABLE_HSPREF" ] && echo "" || echo "-XX:+PerfDisableSharedMem")
+       |if [ -n "$L5D_HOME" ] && [ -d "$L5D_HOME"/plugins ]; then
+       |  for jar in "$L5D_HOME"/plugins/*.jar ; do
        |    jars="$jars:$jar"
        |  done
        |fi
@@ -277,9 +277,7 @@ object LinkerdBuild extends Base {
     """|# Check Java version for use in GC_LOG_OPTION and DEFAULT_JVM_OPTIONS
        |LOCAL_JAVA_VERSION=$("${JAVA_HOME:-/usr}"/bin/java -version 2>&1 | sed 's/.*version "\([0-9]*\)\..*/\1/; 1q')
        |
-       |mkdir -p "$GC_LOG" && [ -w "$GC_LOG" ]
-       |
-       |if [ $? -ne 0 ]; then
+       |if mkdir -p "$GC_LOG" && [ ! -w "$GC_LOG" ]; then
        |  echo "GC_LOG must be set to a directory that user [$USER] has write permissions on.\
        | Unable to use [$GC_LOG] for GC logging."
        |else
@@ -330,9 +328,9 @@ object LinkerdBuild extends Base {
        |   -Dio.netty.allocator.numHeapArenas=${FINAGLE_WORKERS:-8}      \
        |   -Dio.netty.allocator.numDirectArenas=${FINAGLE_WORKERS:-8}    \
        |   -Dcom.twitter.finagle.netty4.numWorkers=${FINAGLE_WORKERS:-8} \
+       |   ${GC_OPTION:-}                                                \
        |   ${GC_LOG_OPTION:-}                                            \
-       |   ${LOCAL_JVM_OPTIONS:-}                                        \
-       |   ${GC_OPTION:-}"
+       |   ${LOCAL_JVM_OPTIONS:-}                                        "
        |""".stripMargin
 
   object Namerd {
@@ -428,8 +426,8 @@ object LinkerdBuild extends Base {
       baseNamerdExecScript +
       gcLogOptionScript +
       execScriptJvmOptions +
-      """|exec "${JAVA_HOME:-/usr}/bin/java" -XX:+PrintCommandLineFlags \
-         |     ${JVM_OPTIONS:-$DEFAULT_JVM_OPTIONS} $HSPREF_SETTING -cp $jars -server \
+      """|exec "${JAVA_HOME:-/usr}"/bin/java -XX:+PrintCommandLineFlags \
+         |     ${JVM_OPTIONS:-$DEFAULT_JVM_OPTIONS} "$HSPREF_SETTING" -cp "$jars" -server \
          |     io.buoyant.namerd.Main "$@"
          |"""
       ).stripMargin
@@ -481,18 +479,18 @@ object LinkerdBuild extends Base {
       baseNamerdExecScript +
       gcLogOptionScript +
       execScriptJvmOptions +
-      """|if read -t 0; then
-         |  CONFIG_INPUT=`cat`
+      """|if read -r 0; then
+         |  CONFIG_INPUT=$(cat)
          |fi
          |
-         |echo $CONFIG_INPUT | \
-         |${JAVA_HOME:-/usr}/bin/java -XX:+PrintCommandLineFlags \
-         |${JVM_OPTIONS:-$DEFAULT_JVM_OPTIONS} $HSPREF_SETTING -cp $jars -server \
+         |echo "$CONFIG_INPUT" | \
+         |"${JAVA_HOME:-/usr}"/bin/java -XX:+PrintCommandLineFlags \
+         |${JVM_OPTIONS:-$DEFAULT_JVM_OPTIONS} "$HSPREF_SETTING" -cp "$jars" -server \
          |io.buoyant.namerd.DcosBootstrap "$@"
          |
-         |echo $CONFIG_INPUT | \
-         |${JAVA_HOME:-/usr}/bin/java -XX:+PrintCommandLineFlags \
-         |${JVM_OPTIONS:-$DEFAULT_JVM_OPTIONS} -cp $jars -server \
+         |echo "$CONFIG_INPUT" | \
+         |"${JAVA_HOME:-/usr}"/bin/java -XX:+PrintCommandLineFlags \
+         |${JVM_OPTIONS:-$DEFAULT_JVM_OPTIONS} -cp "$jars" -server \
          |io.buoyant.namerd.Main "$@"
          |
          |exit
@@ -684,8 +682,8 @@ object LinkerdBuild extends Base {
       baseLinkerdExecScript +
       gcLogOptionScript +
       execScriptJvmOptions +
-      """|exec "${JAVA_HOME:-/usr}/bin/java" -XX:+PrintCommandLineFlags \
-         |     ${JVM_OPTIONS:-$DEFAULT_JVM_OPTIONS} $HSPREF_SETTING -cp $jars -server \
+      """|exec "${JAVA_HOME:-/usr}"/bin/java -XX:+PrintCommandLineFlags \
+         |     ${JVM_OPTIONS:-$DEFAULT_JVM_OPTIONS} "$HSPREF_SETTING" -cp "$jars" -server \
          |     io.buoyant.linkerd.Main "$@"
          |"""
       ).stripMargin


### PR DESCRIPTION
### Overview
This change properly defaults the GC strategy to CMS on Java versions less than 9.

`version` was renamed to `LOCAL_JAVA_VERSION` because it better conveys the meaning of "the Java version being used to execute this script".

`LOCAL_JAVA_VERSION` is set in each assembly-running script. It is then used by `execScriptJvmOptions`.

### Before:
```
env JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_202.jdk/Contents/Home/ linkerd/target/scala-2.12/linkerd-1.6.2-SNAPSHOT-exec linkerd/examples/fs.yaml
GC_LOG must be set to a directory that user [kleimkuhler] has write permissions on. Unable to use [/var/log/linkerd] for GC logging.
-XX:+AggressiveOpts -XX:+AlwaysPreTouch -XX:+CMSClassUnloadingEnabled -XX:CMSInitiatingOccupancyFraction=70 -XX:+CMSParallelRemarkEnabled -XX:+CMSScavengeBeforeRemark -XX:InitialHeapSize=33554432 -XX:MaxHeapSize=1073741824 -XX:+PerfDisableSharedMem -XX:+PrintCommandLineFlags -XX:+ScavengeBeforeFullGC -XX:-TieredCompilation -XX:+UseCMSInitiatingOccupancyOnly -XX:+UseCompressedClassPointers -XX:+UseCompressedOops -XX:+UseParallelGC -XX:+UseStringDeduplication
May 08, 2019 11:14:58 AM com.twitter.finagle.http.HttpMuxer$ $anonfun$new$1
```

### After:
```
env JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_202.jdk/Contents/Home/ linkerd/target/scala-2.12/linkerd-1.6.2-SNAPSHOT-exec linkerd/examples/fs.yaml
GC_LOG must be set to a directory that user [kleimkuhler] has write permissions on. Unable to use [/var/log/linkerd] for GC logging.
Here!
-XX:+AggressiveOpts -XX:+AlwaysPreTouch -XX:+CMSClassUnloadingEnabled -XX:CMSInitiatingOccupancyFraction=70 -XX:+CMSParallelRemarkEnabled -XX:+CMSScavengeBeforeRemark -XX:InitialHeapSize=33554432 -XX:MaxHeapSize=1073741824 -XX:MaxNewSize=348966912 -XX:MaxTenuringThreshold=6 -XX:OldPLABSize=16 -XX:+PerfDisableSharedMem -XX:+PrintCommandLineFlags -XX:+ScavengeBeforeFullGC -XX:-TieredCompilation -XX:+UseCMSInitiatingOccupancyOnly -XX:+UseCompressedClassPointers -XX:+UseCompressedOops -XX:+UseConcMarkSweepGC -XX:+UseParNewGC -XX:+UseStringDeduplication
May 08, 2019 12:43:36 PM com.twitter.finagle.http.HttpMuxer$ $anonfun$new$1
```

Fixes #2265

Signed-off-by: Kevin Leimkuhler <kevinl@buoyant.io>