### PR TITLE
Add additional logging to track mesh clients interacting with Namerd

### DIFF
--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/H2HeaderInjector.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/H2HeaderInjector.scala
@@ -1,0 +1,27 @@
+package com.twitter.finagle.buoyant.h2
+
+import com.twitter.finagle
+import com.twitter.finagle._
+import com.twitter.util.Future
+
+object H2HeaderInjector {
+  def module(headerMap: Map[String, String]): Stackable[ServiceFactory[Request, Response]] = {
+    new finagle.Stack.Module0[ServiceFactory[Request, Response]] {
+      override def make(next: ServiceFactory[Request, Response]): ServiceFactory[Request, Response] =
+        new HeaderInjector(headerMap).andThen(next)
+
+      override def role: Stack.Role = Stack.Role("H2HeaderInjector")
+      override def description: String = "Add arbitrary headers to H2 requests"
+    }
+  }
+}
+
+class HeaderInjector(injectHeaders: Map[String, String]) extends SimpleFilter[Request, Response] {
+  override def apply(request: Request, service: Service[Request, Response]): Future[Response] = {
+    val req = request.dup()
+    injectHeaders.foreach { kvPair =>
+      req.headers.add(kvPair._1, kvPair._2); ()
+    }
+    service(req)
+  }
+}

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4H2Writer.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4H2Writer.scala
@@ -90,7 +90,7 @@ private[netty4] object Netty4H2Writer {
       override protected[this] def write(frame: Http2Frame): Future[Unit] = {
         log.trace("[L:%s R:%s] write: %s", trans.context.localAddress, trans.context.remoteAddress, frame.name)
         val f = trans.write(frame).rescue(wrapWriteException)
-        f.respond(v => log.trace("[L:%s R:%s] wrote: %s: %s", trans.context.localAddress, trans.context.remoteAddress, frame.name, v))
+        f.respond(_ => log.trace("[L:%s R:%s] wrote: %s: %s", trans.context.localAddress, trans.context.remoteAddress, frame.name, frame))
         f
       }
 

--- a/interpreter/mesh/src/main/scala/io/buoyant/interpreter/MeshInterpreterInitializer.scala
+++ b/interpreter/mesh/src/main/scala/io/buoyant/interpreter/MeshInterpreterInitializer.scala
@@ -1,10 +1,7 @@
 package io.buoyant.interpreter
 
-import java.util.UUID.randomUUID
-
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.twitter.conversions.DurationOps._
-import com.twitter.finagle.Stack.Module
 import com.twitter.finagle._
 import com.twitter.finagle.buoyant.h2.H2HeaderInjector
 import com.twitter.finagle.buoyant.{H2, TlsClientConfig}
@@ -16,7 +13,7 @@ import com.twitter.finagle.util.DefaultTimer
 import com.twitter.logging.Logger
 import io.buoyant.interpreter.mesh.Client
 import io.buoyant.namer.{InterpreterConfig, InterpreterInitializer}
-
+import java.util.UUID.randomUUID
 import scala.util.control.NoStackTrace
 
 /**

--- a/interpreter/mesh/src/test/scala/io/buoyant/interpreter/mesh/ClientTest.scala
+++ b/interpreter/mesh/src/test/scala/io/buoyant/interpreter/mesh/ClientTest.scala
@@ -38,7 +38,7 @@ class ClientTest extends FunSuite {
           addrRsps
         }
       }
-      Client(Path.Utf8("foons"), interp, resolv, unusedDelegator, scala.Stream.empty, DefaultTimer)
+      Client("", Path.Utf8("foons"), interp, resolv, unusedDelegator, scala.Stream.empty, DefaultTimer)
     }
 
     val act = client.bind(Dtab.read("/stuff => /mas"), Path.read("/some/name"))

--- a/k8s/src/main/scala/io/buoyant/k8s/Watchable.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/Watchable.scala
@@ -185,7 +185,10 @@ private[k8s] abstract class Watchable[O <: KubeObject: TypeReference, W <: Watch
 
         case Some((event, ws)) =>
           import Ordering.Implicits._
-          watchState.foreach(_.recordStreamData(event))
+          watchState.foreach { state =>
+            state.recordStreamData(event)
+            log.trace("k8s event on '%s' received '%s", watchPath, event)
+          }
           // Register the update only if its resource version is larger than or equal to the largest version
           // seen so far.
           if (largestEvent.forall(_ <= event)) {


### PR DESCRIPTION
There have been reports of Linkerd mesh clients not receiving updates from a Namerd server. There currently are watch state endpoints in Linkerd that tell you the last known value received from Namerd. This information is helpful in figuring out when Linkerd gets into this state. However, this information does not reveal the sequence of events that led up to that state.

This PR adds logging in the mesh client that logs every state change the Linkerd process is notified of i.e. Address set changes observed by Namerd. Given that this PR increases the number of log lines that will be available for diagnosis, each mesh client will now contain a unique identifier that will be injected when a watch request is initiated between Linkerd and Namerd for better analysis. This will help identify which client gets into a bad state when crawling through logs and will help in situations were remote IPs (NATed IPs) do not easily identify a Linkerd client in the Namerd logs.

fixes #2245