### PR TITLE
Expose HTTP Message sizing configuration in the Consul namer

### DIFF
--- a/linkerd/docs/namer.md
+++ b/linkerd/docs/namer.md
@@ -212,6 +212,10 @@ consistencyMode | `default` | Select between [Consul API consistency modes](http
 failFast | `false` | If `false`, disable fail fast and failure accrual for Consul client. Keep it `false` when using a local agent but change it to `true` when talking directly to an HA Consul API.
 preferServiceAddress | `true` | If `true` use the service address if defined and default to the node address. If `false` always use the node address.
 weights | none | List of tag-weight configurations, for adjusting the weights of node addresses. When a node matches more than one tag, it gets the highest matching weight. In the absence of match or configuration, nodes get a default weight of `1.0`.
+maxHeadersKB | 8 | The maximum size of all headers in an HTTP message created by the Consul client.
+maxInitialLineKB | 4 | The maximum size of an initial HTTP message line created by the Consul client.
+maxRequestKB | 5120 | The maximum size of a non-chunked HTTP request payload sent by the Consul client.
+maxResponseKB | 5120 | The maximum size of a non-chunked HTTP response payload received by the Consul client.
 tls | no tls | Use TLS during connection with Consul. see [Consul Encryption](https://www.consul.io/docs/agent/encryption.html) and [TLS](#consul-tls).
 
 ### Consul Path Parameters

--- a/namer/consul/src/main/scala/io/buoyant/namer/consul/ConsulInitializer.scala
+++ b/namer/consul/src/main/scala/io/buoyant/namer/consul/ConsulInitializer.scala
@@ -85,6 +85,7 @@ case class ConsulConfig(
 
     val service = Http.client
       .withParams(Http.client.params ++ tlsParams ++ params)
+      .withStreaming(true)
       .withLabel("client")
       .interceptInterrupts
       .failFast(failFast)

--- a/namer/consul/src/test/scala/io/buoyant/namer/consul/ConsulTest.scala
+++ b/namer/consul/src/test/scala/io/buoyant/namer/consul/ConsulTest.scala
@@ -13,7 +13,7 @@ class ConsulTest extends FunSuite {
 
   test("sanity") {
     // ensure it doesn't totally blowup
-    val _ = ConsulConfig(None, None, None, None, None, None, None, None, None, None).newNamer(Stack.Params.empty)
+    val _ = ConsulConfig(None, None, None, None, None, None, None, None, None, None, None, None, None, None, None).newNamer(Stack.Params.empty)
   }
 
   test("service registration") {
@@ -40,6 +40,10 @@ class ConsulTest extends FunSuite {
                     |token: some-token
                     |includeTag: true
                     |useHealthCheck: true
+                    |maxHeadersKB: 4
+                    |maxInitialLineKB: 8
+                    |maxRequestKB: 5192
+                    |maxResponseKB: 5192
                     |healthStatuses:
                     | - warning
                     |setHost: true
@@ -70,6 +74,10 @@ class ConsulTest extends FunSuite {
     assert(consul.consistencyMode == Some(ConsistencyMode.Stale))
     assert(consul.failFast == Some(true))
     assert(consul.preferServiceAddress == Some(false))
+    assert(consul.maxHeadersKB == Some(4))
+    assert(consul.maxInitialLineKB == Some(8))
+    assert(consul.maxRequestKB == Some(5192))
+    assert(consul.maxResponseKB == Some(5192))
     assert(consul.weights == Some(Seq(TagWeight("primary", 100.0))))
     val clientAuth = ClientAuth("/certificates/cert.pem", None, "/certificates/key.pem")
     val tlsConfig = TlsClientConfig(None, Some(false), Some("consul.io"), None, Some("/certificates/cacerts-bundle.pem"), Some(clientAuth))


### PR DESCRIPTION
When Consul sends back discovery information in an HTTP request that exceeds 5MB, the Consul namer will throw a `TooLongMessageException`. This is because Finagle has a default limit on an HTTP message (5MB). This limit can be configured and the settings to configure an HTTP message are already exposed on Linkerd's HTTP router protocol

This PR mimics the router protocol's config to expose these settings for the Consul Namer's client.

To reproduce the issue:
- Create a Consul [service configuration](https://gist.github.com/dadjeibaah/692de3f11b84033ecfb559990cbf3f65) file that contains a large number of unique service addresses.
- Load the file in a local Consul agent and make sure that you place the service configuration file in the path specified in the `-config-dir` flag of the consul command
```bash
consul agent -dev -advertise 127.0.0.1 -config-dir /etc/consul.d 
```
- Run Namerd and point this config file by default points to a locally running consul agent.
```yaml
namers:
- kind: io.l5d.consul
  useHealthCheck: true
admin:
  port: 9991
storage:
  kind: io.l5d.inMemory
  namespaces:
    default: |
      /svc => /#/io.l5d.consul/dc1;
interfaces:
- kind: io.l5d.thriftNameInterpreter
- kind: io.l5d.httpController
- kind: io.l5d.mesh
```
- In Namerd's dtab playground, resolve the name `/svc/cat`. Before this PR you would see Namerd 
throw the `TooLongMessageException`.

After this PR run the same test mentioned above but this time with this config for Namerd.
```yaml
namers:
- kind: io.l5d.consul
  useHealthCheck: true
  maxResponseKB: 1000000  # Sets the max response the namer can receive to approx. 1GB
admin:
  port: 9991
storage:
  kind: io.l5d.inMemory
  namespaces:
    default: |
      /svc => /#/io.l5d.consul/dc1;
interfaces:
- kind: io.l5d.thriftNameInterpreter
- kind: io.l5d.httpController
- kind: io.l5d.mesh
```
The exception no longer appears in Namerd's logs.

Fixes #2286 
