### PR TITLE
a possible fix for #2201

### DIFF
--- a/linkerd/docs/protocol-http.md
+++ b/linkerd/docs/protocol-http.md
@@ -15,6 +15,7 @@ routers:
   maxInitialLineKB: 4
   maxRequestKB: 5120
   maxResponseKB: 5120
+  maxErrResponseKB: 5120
   servers:
   - port: 5000
     addForwardedHeader:
@@ -41,6 +42,7 @@ maxHeadersKB | 8 | The maximum size of all headers in an HTTP message.
 maxInitialLineKB | 4 | The maximum size of an initial HTTP message line.
 maxRequestKB | 5120 | The maximum size of a non-chunked HTTP request payload.
 maxResponseKB | 5120 | The maximum size of a non-chunked HTTP response payload.
+maxErrResponseKB | 5120 | The maximum size of a HTTP error response payload.
 compressionLevel | `-1`, automatically compresses textual content types with compression level 6 | The compression level to use (on 0-9).
 streamingEnabled | `true` | Streaming allows Linkerd to work with HTTP messages that have large (or infinite) content bodies using chunked encoding.  Disabling this is highly discouraged.
 tracePropagator | `io.l5d.default` | A trace propagator.  See [Http-specific trace propagator](#http-1-1-trace-propagators).

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpConfig.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpConfig.scala
@@ -66,6 +66,7 @@ class HttpInitializer extends ProtocolInitializer.Simple {
       .configured(router.params[hparam.MaxInitialLineSize])
       .configured(router.params[hparam.MaxRequestSize])
       .configured(router.params[hparam.MaxResponseSize])
+      .configured(router.params[Headers.param.MaxErrResponseSize])
       .configured(router.params[hparam.Streaming])
       .configured(router.params[hparam.CompressionLevel])
       .configured(router.params[HttpTracePropagatorConfig.Param])
@@ -216,6 +217,7 @@ case class HttpConfig(
   maxInitialLineKB: Option[Int],
   maxRequestKB: Option[Int],
   maxResponseKB: Option[Int],
+  maxErrResponseKB: Option[Int],
   streamingEnabled: Option[Boolean],
   compressionLevel: Option[Int],
   tracePropagator: Option[HttpTracePropagatorConfig]
@@ -256,6 +258,7 @@ case class HttpConfig(
     .maybeWith(maxInitialLineKB.map(kb => hparam.MaxInitialLineSize(kb.kilobytes)))
     .maybeWith(maxRequestKB.map(kb => hparam.MaxRequestSize(kb.kilobytes)))
     .maybeWith(maxResponseKB.map(kb => hparam.MaxResponseSize(kb.kilobytes)))
+    .maybeWith(maxErrResponseKB.map(kb => Headers.param.MaxErrResponseSize.apply(kb.kilobytes)))
     .maybeWith(streamingEnabled.map(hparam.Streaming(_)))
     .maybeWith(compressionLevel.map(hparam.CompressionLevel(_)))
     .maybeWith(combinedIdentifier(params))

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/ErrorResponder.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/ErrorResponder.scala
@@ -10,7 +10,7 @@ import io.buoyant.router.RoutingFactory
 import io.buoyant.router.RoutingFactory.ResponseException
 import scala.util.control.NonFatal
 
-class ErrorResponder(maxHeaderSize: Int)
+class ErrorResponder(maxHeaderSize: Int, maxErrResponseSize: Int)
   extends SimpleFilter[Request, Response] {
   private[this] val log = Logger.get("ErrorResponseFilter")
 
@@ -22,13 +22,13 @@ class ErrorResponder(maxHeaderSize: Int)
       e match {
         case RoutingFactory.UnknownDst(_, _) =>
           log.debug(e, "unknown dst")
-          Headers.Err.respond(e.getMessage, Status.BadRequest, maxHeaderSize)
+          Headers.Err.respond(e.getMessage, Status.BadRequest, maxHeaderSize, maxErrResponseSize)
         case ErrorResponder.HttpResponseException(rsp) =>
           rsp
         case e: RichNoBrokersAvailableException =>
-          Headers.Err.respond(e.exceptionMessage(), Status.BadGateway, maxHeaderSize)
+          Headers.Err.respond(e.exceptionMessage(), Status.BadGateway, maxHeaderSize, maxErrResponseSize)
         case e: RichConnectionFailedExceptionWithPath =>
-          Headers.Err.respond(e.exceptionMessage, Status.BadGateway, maxHeaderSize)
+          Headers.Err.respond(e.exceptionMessage, Status.BadGateway, maxHeaderSize, maxErrResponseSize)
         case _ =>
           val message = e.getMessage match {
             case null => e.getClass.getName
@@ -41,7 +41,7 @@ class ErrorResponder(maxHeaderSize: Int)
               log.error("service failure: %s", e)
               Status.BadGateway
           }
-          val rsp = Headers.Err.respond(message, status, maxHeaderSize)
+          val rsp = Headers.Err.respond(message, status, maxHeaderSize, maxErrResponseSize)
           if (RetryableWriteException.unapply(e).isDefined) {
             Headers.Retryable.set(rsp.headerMap, retryable = true)
           }
@@ -53,12 +53,14 @@ class ErrorResponder(maxHeaderSize: Int)
 object ErrorResponder {
   val role = Stack.Role("ErrorResponder")
   val module: Stackable[ServiceFactory[Request, Response]] =
-    new Stack.Module1[param.MaxHeaderSize, ServiceFactory[Request, Response]] {
+    new Stack.Module2[param.MaxHeaderSize, Headers.param.MaxErrResponseSize, ServiceFactory[Request, Response]] {
       val role = ErrorResponder.role
       val description = "Crafts HTTP responses for routing errors"
-      def filter(maxHeaderSize: Int) = new ErrorResponder(maxHeaderSize)
-      def make(maxHeaderSize: param.MaxHeaderSize, factory: ServiceFactory[Request, Response]) =
-        filter(maxHeaderSize.size.bytes.toInt).andThen(factory)
+      def filter(maxHeaderSize: Int, maxErrResponseSize: Int) =
+        new ErrorResponder(maxHeaderSize, maxErrResponseSize)
+      def make(maxHeaderSize: param.MaxHeaderSize, maxErrResponseSize: Headers.param.MaxErrResponseSize,
+        factory: ServiceFactory[Request, Response]) =
+        filter(maxHeaderSize.size.bytes.toInt, maxErrResponseSize.size.bytes.toInt).andThen(factory)
     }
 
   case class HttpResponseException(rsp: Response) extends ResponseException {


### PR DESCRIPTION
Here https://api.linkerd.io/1.6.1/linkerd/index.html#http-1-1-protocol, I've found two http config options here which can be used to truncate large headers or response bodies as requested for #2201:
maxHeadersKB | 8 | The maximum size of all headers in an HTTP message.
maxResponseKB | 5120 | The maximum size of a non-chunked HTTP response payload.

maxHeadersKB was already implemented and supported for l5d-err headers, I've done some tests with large dtabs and the l5d-err headers are truncated to the size specified by maxHeadersKB.

maxResponseKB was only parsed by HttpConfig.scala but was not implemented/supported by the rest of the Linderd code. This pull request adds support for maxResponseKB limit when constructing responses containing l5d-err header, what it does it just truncates the error response body to the limit specified by the maxResponseKB. The option name is somehow misleading, as one might expected the truncation to be done for the http response packet size instead of the http response body size, more precisely for error response body size. 

With this fix someone setting the config maxResponseKB / hparam.MaxResponseSize to a value lower than the 5120 default, will obtain truncation of the err response body size.

IMO A better approach would be to have two new config options specific to err headers and err response bodies, called maxErrHeadersKB and maxErrResponseKB. In this way users would benefit by the standard limits for headers and reponses and also have a much finer control over err headers and err responses.
