### PR TITLE
Enable streaming in Consul HTTP client

### DIFF
--- a/consul/src/main/scala/io/buoyant/consul/v1/package.scala
+++ b/consul/src/main/scala/io/buoyant/consul/v1/package.scala
@@ -1,6 +1,8 @@
 package io.buoyant.consul
 
-import com.twitter.finagle.{SimpleFilter, Service, http}
+import com.twitter.finagle.http.{Chunk, HeaderMap}
+import com.twitter.finagle.{Service, SimpleFilter, http}
+import com.twitter.io.{Buf, Reader}
 import com.twitter.util.Future
 
 package object v1 {
@@ -30,6 +32,22 @@ package object v1 {
           case _ => Future.exception(UnexpectedResponse(response))
         }
       }
+    }
+  }
+
+  implicit class RichChunkReader(val r: Reader[Chunk]) extends AnyVal {
+    def accumulate: Future[(Buf, Option[HeaderMap])] = {
+      def loop(acc: Buf, trailers: Option[HeaderMap]): Future[(Buf, Option[HeaderMap])] =
+        r.read().flatMap {
+          case Some(chunk) =>
+            if (chunk.isLast && chunk.trailers.nonEmpty)
+              loop(acc.concat(chunk.content), Some(chunk.trailers))
+            else
+              loop(acc.concat(chunk.content), None)
+          case None =>
+            Future.value(acc -> trailers)
+        }
+      loop(Buf.Empty, None)
     }
   }
 

--- a/consul/src/main/scala/io/buoyant/consul/v1/package.scala
+++ b/consul/src/main/scala/io/buoyant/consul/v1/package.scala
@@ -1,8 +1,6 @@
 package io.buoyant.consul
 
-import com.twitter.finagle.http.{Chunk, HeaderMap}
 import com.twitter.finagle.{Service, SimpleFilter, http}
-import com.twitter.io.{Buf, Reader}
 import com.twitter.util.Future
 
 package object v1 {
@@ -34,21 +32,4 @@ package object v1 {
       }
     }
   }
-
-  implicit class RichChunkReader(val r: Reader[Chunk]) extends AnyVal {
-    def accumulate: Future[(Buf, Option[HeaderMap])] = {
-      def loop(acc: Buf, trailers: Option[HeaderMap]): Future[(Buf, Option[HeaderMap])] =
-        r.read().flatMap {
-          case Some(chunk) =>
-            if (chunk.isLast && chunk.trailers.nonEmpty)
-              loop(acc.concat(chunk.content), Some(chunk.trailers))
-            else
-              loop(acc.concat(chunk.content), None)
-          case None =>
-            Future.value(acc -> trailers)
-        }
-      loop(Buf.Empty, None)
-    }
-  }
-
 }

--- a/consul/src/test/scala/io/buoyant/consul/v1/BaseApiTest.scala
+++ b/consul/src/test/scala/io/buoyant/consul/v1/BaseApiTest.scala
@@ -1,0 +1,70 @@
+package io.buoyant.consul.v1
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
+import com.twitter.finagle.{Service, http}
+import com.twitter.finagle.http.{Request, Response, Status, Version}
+import com.twitter.finagle.service.Backoff
+import com.twitter.finagle.stats.{DefaultStatsReceiver, StatsReceiver}
+import com.twitter.io.{Buf, Reader}
+import com.twitter.util.{Duration, Future}
+import io.buoyant.test.Awaits
+import org.scalatest.FunSuite
+import com.twitter.conversions.DurationOps._
+
+
+class BaseApiTest extends FunSuite with Awaits {
+  import BaseApiTest._
+
+  test("works with chunked response") {
+    val service = stubService(chunked = true)
+    val result = await(StubApi(service).result())
+    assert(result == ChunkedStubData)
+  }
+
+  test("works with non-chunked response") {
+    val service = stubService(chunked = false)
+    val result = await(StubApi(service).result())
+    assert(result == NonChunkedStubData)
+  }
+
+}
+
+object BaseApiTest {
+
+  private val mapper = new ObjectMapper with ScalaObjectMapper
+  mapper.registerModule(DefaultScalaModule)
+
+  final case class StubData(dataType: String)
+
+  val ChunkedStubData = StubData("chunked")
+  val NonChunkedStubData = StubData("non-chunked")
+  val ChunkSize = 1
+
+  def stubService(chunked: Boolean) = Service.mk[Request, Response] { _ =>
+    val rsp =
+      if (chunked)
+        Response(Version.Http11, Status.Ok, Reader.fromBuf(Buf.Utf8(mapper.writeValueAsString(ChunkedStubData)), ChunkSize))
+      else Response()
+    rsp.setContentTypeJson()
+    if (!chunked)
+      rsp.content = Buf.Utf8(mapper.writeValueAsString(NonChunkedStubData))
+    rsp.headerMap.set("X-Consul-Index", "4")
+    Future.value(rsp)
+  }
+
+  final case class StubApi(client: Client) extends BaseApi {
+    override val uriPrefix: String = s"/$versionString"
+    override val backoffs: Stream[Duration] = Backoff.exponentialJittered(1.milliseconds, 5.seconds)
+
+    override def stats: StatsReceiver = DefaultStatsReceiver
+
+    def result(retry: Boolean = false): Future[StubData] = {
+      val req = mkreq(http.Method.Get, s"$uriPrefix/test", None)
+      executeJson[StubData](req, retry).map(_.value)
+    }
+
+  }
+
+}

--- a/linkerd/docs/namer.md
+++ b/linkerd/docs/namer.md
@@ -212,10 +212,7 @@ consistencyMode | `default` | Select between [Consul API consistency modes](http
 failFast | `false` | If `false`, disable fail fast and failure accrual for Consul client. Keep it `false` when using a local agent but change it to `true` when talking directly to an HA Consul API.
 preferServiceAddress | `true` | If `true` use the service address if defined and default to the node address. If `false` always use the node address.
 weights | none | List of tag-weight configurations, for adjusting the weights of node addresses. When a node matches more than one tag, it gets the highest matching weight. In the absence of match or configuration, nodes get a default weight of `1.0`.
-maxHeadersKB | 8 | The maximum size of all headers in an HTTP message created by the Consul client.
-maxInitialLineKB | 4 | The maximum size of an initial HTTP message line created by the Consul client.
-maxRequestKB | 5120 | The maximum size of a non-chunked HTTP request payload sent by the Consul client.
-maxResponseKB | 5120 | The maximum size of a non-chunked HTTP response payload received by the Consul client.
+fixedLengthStreamedAfterKB | 5120 | The maximum HTTP message size that can be buffered by the Consul client. After this size threshold is crossed, the message is streamed.
 tls | no tls | Use TLS during connection with Consul. see [Consul Encryption](https://www.consul.io/docs/agent/encryption.html) and [TLS](#consul-tls).
 
 ### Consul Path Parameters

--- a/namer/consul/src/test/scala/io/buoyant/namer/consul/ConsulTest.scala
+++ b/namer/consul/src/test/scala/io/buoyant/namer/consul/ConsulTest.scala
@@ -13,7 +13,7 @@ class ConsulTest extends FunSuite {
 
   test("sanity") {
     // ensure it doesn't totally blowup
-    val _ = ConsulConfig(None, None, None, None, None, None, None, None, None, None, None, None, None, None, None).newNamer(Stack.Params.empty)
+    val _ = ConsulConfig(None, None, None, None, None, None, None, None, None, None, None, None, None).newNamer(Stack.Params.empty)
   }
 
   test("service registration") {
@@ -40,10 +40,7 @@ class ConsulTest extends FunSuite {
                     |token: some-token
                     |includeTag: true
                     |useHealthCheck: true
-                    |maxHeadersKB: 4
-                    |maxInitialLineKB: 8
-                    |maxRequestKB: 5192
-                    |maxResponseKB: 5192
+                    |fixedLengthStreamedAfterKB: 5192
                     |healthStatuses:
                     | - warning
                     |setHost: true
@@ -74,10 +71,7 @@ class ConsulTest extends FunSuite {
     assert(consul.consistencyMode == Some(ConsistencyMode.Stale))
     assert(consul.failFast == Some(true))
     assert(consul.preferServiceAddress == Some(false))
-    assert(consul.maxHeadersKB == Some(4))
-    assert(consul.maxInitialLineKB == Some(8))
-    assert(consul.maxRequestKB == Some(5192))
-    assert(consul.maxResponseKB == Some(5192))
+    assert(consul.fixedLengthStreamedAfterKB == Some(5192))
     assert(consul.weights == Some(Seq(TagWeight("primary", 100.0))))
     val clientAuth = ClientAuth("/certificates/cert.pem", None, "/certificates/key.pem")
     val tlsConfig = TlsClientConfig(None, Some(false), Some("consul.io"), None, Some("/certificates/cacerts-bundle.pem"), Some(clientAuth))


### PR DESCRIPTION
This work is continuation of #2287. In essence the change enables `streaming` for the consul http client and as a result of that makes handling large consul responses easier (i.e. not limited by max size config). The PR exposes the `fixedLengthStreamedAfterKB` which as described in the docs

> configures `fixedLengthStreamedAfter` limit, which effectively turns on streaming (think `withStreaming(true)`). The `fixedLengthStreamedAfter`, however, disables streaming for sufficiently small messages of known fixed length.

In order to reproduce the initial issue and validate the solution you can use the method described by @dadjeibaah in #2287. Note that if you want to see the initial issue you need to first run against [this](https://github.com/linkerd/linkerd/commit/753fc177f969f136cd40ddaf8ae0128a49c12f6e) version of the code.  After this PR is applied you can run the example again and convince yourself that exception is not thrown despite the fact that the message size configuration is not tweaked.

Fixes #2288 

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>