### PR TITLE
Return node and service metadata from consul in namerd response

### DIFF
--- a/consul/src/main/scala/io/buoyant/consul/v1/ConsulApi.scala
+++ b/consul/src/main/scala/io/buoyant/consul/v1/ConsulApi.scala
@@ -159,7 +159,7 @@ class HealthApi(
 case class Node(
   Node: Option[String],
   Address: Option[String],
-  Meta: Option[MetaData]
+  Meta: Option[Metadata]
 )
 
 case class Service_(
@@ -168,7 +168,7 @@ case class Service_(
   Address: Option[String],
   Tags: Option[Seq[String]],
   Port: Option[Int],
-  Meta: Option[MetaData]
+  Meta: Option[Metadata]
 )
 
 case class ServiceHealth(
@@ -190,6 +190,6 @@ case class ServiceNode(
   ServiceAddress: Option[String],
   ServicePort: Option[Int],
   Status: Option[HealthStatus.Value],
-  ServiceMeta: Option[MetaData],
-  NodeMeta: Option[MetaData]
+  ServiceMeta: Option[Metadata],
+  NodeMeta: Option[Metadata]
 )

--- a/consul/src/main/scala/io/buoyant/consul/v1/ConsulApi.scala
+++ b/consul/src/main/scala/io/buoyant/consul/v1/ConsulApi.scala
@@ -141,7 +141,9 @@ class HealthApi(
           service.flatMap(_.Tags),
           service.flatMap(_.Address),
           service.flatMap(_.Port),
-          checks.reduceOption(HealthStatus.worstCase)
+          checks.reduceOption(HealthStatus.worstCase),
+          service.flatMap(_.Meta),
+          node.flatMap(_.Meta)
         )
       }
       val nodes = if (statuses == Set(HealthStatus.Passing)) {
@@ -156,7 +158,8 @@ class HealthApi(
 
 case class Node(
   Node: Option[String],
-  Address: Option[String]
+  Address: Option[String],
+  Meta: Option[MetaData]
 )
 
 case class Service_(
@@ -164,7 +167,8 @@ case class Service_(
   Service: Option[String],
   Address: Option[String],
   Tags: Option[Seq[String]],
-  Port: Option[Int]
+  Port: Option[Int],
+  Meta: Option[MetaData]
 )
 
 case class ServiceHealth(
@@ -185,5 +189,7 @@ case class ServiceNode(
   ServiceTags: Option[Seq[String]],
   ServiceAddress: Option[String],
   ServicePort: Option[Int],
-  Status: Option[HealthStatus.Value]
+  Status: Option[HealthStatus.Value],
+  ServiceMeta: Option[MetaData],
+  NodeMeta: Option[MetaData]
 )

--- a/consul/src/main/scala/io/buoyant/consul/v1/package.scala
+++ b/consul/src/main/scala/io/buoyant/consul/v1/package.scala
@@ -8,7 +8,7 @@ package object v1 {
   type Client = Service[http.Request, http.Response]
   type IndexedServiceNodes = Indexed[Seq[ServiceNode]]
   type IndexedServiceMap = Indexed[Map[String, Seq[String]]]
-  type MetaData = Map[String, Any]
+  type Metadata = Map[String, String]
 
   trait ConsulApiError extends Throwable {
     def rsp: http.Response

--- a/consul/src/main/scala/io/buoyant/consul/v1/package.scala
+++ b/consul/src/main/scala/io/buoyant/consul/v1/package.scala
@@ -8,6 +8,7 @@ package object v1 {
   type Client = Service[http.Request, http.Response]
   type IndexedServiceNodes = Indexed[Seq[ServiceNode]]
   type IndexedServiceMap = Indexed[Map[String, Seq[String]]]
+  type MetaData = Map[String, Any]
 
   trait ConsulApiError extends Throwable {
     def rsp: http.Response

--- a/consul/src/test/scala/io/buoyant/consul/v1/CatalogApiTest.scala
+++ b/consul/src/test/scala/io/buoyant/consul/v1/CatalogApiTest.scala
@@ -9,7 +9,7 @@ import org.scalatest.FunSuite
 
 class CatalogApiTest extends FunSuite with Awaits with Exceptions {
   val datacentersBuf = Buf.Utf8("""["dc1", "dc2"]""")
-  val nodesBuf = Buf.Utf8("""[{"Node":"Sarahs-MBP-2","Address":"192.168.1.37","ServiceID":"hosted_web","ServiceName":"hosted_web","ServiceTags":["master"],"ServiceAddress":"","ServicePort":8084}]""")
+  val nodesBuf = Buf.Utf8("""[{"Node":"Sarahs-MBP-2","Address":"192.168.1.37","ServiceID":"hosted_web","ServiceName":"hosted_web","ServiceTags":["master"],"ServiceAddress":"","ServicePort":8084, "ServiceMeta":{"serv_meta":"some_serv_meta"}, "NodeMeta":{"node_meta":"some_node_meta"}}]""")
   val mapBuf = Buf.Utf8("""{"consul":[],"hosted_web":["master"],"redis":[]}""")
   var lastUri = ""
 
@@ -37,6 +37,8 @@ class CatalogApiTest extends FunSuite with Awaits with Exceptions {
     assert(response.size == 1)
     assert(response.head.ServiceName == Some("hosted_web"))
     assert(response.head.Node == Some("Sarahs-MBP-2"))
+    assert(response.head.ServiceMeta == Some(Map("serv_meta" -> "some_serv_meta")))
+    assert(response.head.NodeMeta == Some(Map("node_meta" -> "some_node_meta")))
     assert(response.head.ServiceAddress == Some(""))
     assert(response.head.ServicePort == Some(8084))
   }

--- a/consul/src/test/scala/io/buoyant/consul/v1/HealthApiTest.scala
+++ b/consul/src/test/scala/io/buoyant/consul/v1/HealthApiTest.scala
@@ -8,12 +8,12 @@ import io.buoyant.test.Awaits
 import org.scalatest.FunSuite
 
 class HealthApiTest extends FunSuite with Awaits {
-  val nodesBuf = Buf.Utf8("""[{"Node":{"Node":"Sarahs-MBP-2","Address":"192.168.1.37"}, "Service": {"Service":"hosted_web","Tags":["master"],"Port":8084, "Address":""}}]""")
+  val nodesBuf = Buf.Utf8("""[{"Node":{"Node":"Sarahs-MBP-2","Address":"192.168.1.37", "Meta": {"node_meta":"some_node_meta"}}, "Service": {"Service":"hosted_web","Tags":["master"],"Port":8084, "Address":"", "Meta": {"serv_meta":"some_serv_meta"}}}]""")
   val nodesWithChecksBuf = Buf.Utf8("""[
-    {"Node":{"Node":"node-passing"}, "Service": {"Service":"hosted_web"}, "Checks": [{"Status":"passing"}]},
-    {"Node":{"Node":"node-warning"}, "Service": {"Service":"hosted_web"}, "Checks": [{"Status":"warning"}]},
-    {"Node":{"Node":"node-critical"}, "Service": {"Service":"hosted_web"}, "Checks": [{"Status":"critical"}]},
-    {"Node":{"Node":"node-maintenance"}, "Service": {"Service":"hosted_web"}, "Checks": [{"Status":"maintenance"}]}
+    {"Node":{"Node":"node-passing", "Meta": {"node_meta":"some_node_meta"}}, "Service": {"Service":"hosted_web", "Meta": {"serv_meta":"some_serv_meta"}}, "Checks": [{"Status":"passing"}]},
+    {"Node":{"Node":"node-warning", "Meta": {"node_meta":"some_node_meta"}}, "Service": {"Service":"hosted_web", "Meta": {"serv_meta":"some_serv_meta"}}, "Checks": [{"Status":"warning"}]},
+    {"Node":{"Node":"node-critical", "Meta": {"node_meta":"some_node_meta"}}, "Service": {"Service":"hosted_web", "Meta": {"serv_meta":"some_serv_meta"}}, "Checks": [{"Status":"critical"}]},
+    {"Node":{"Node":"node-maintenance", "Meta": {"node_meta":"some_node_meta"}}, "Service": {"Service":"hosted_web", "Meta": {"serv_meta":"some_serv_meta"}}, "Checks": [{"Status":"maintenance"}]}
   ]""")
   var lastUri = ""
 
@@ -34,6 +34,8 @@ class HealthApiTest extends FunSuite with Awaits {
     assert(response.head.ServiceName == Some("hosted_web"))
     assert(response.head.Node == Some("Sarahs-MBP-2"))
     assert(response.head.ServiceAddress == Some(""))
+    assert(response.head.ServiceMeta == Some(Map("serv_meta" -> "some_serv_meta")))
+    assert(response.head.NodeMeta == Some(Map("node_meta" -> "some_node_meta")))
     assert(response.head.ServicePort == Some(8084))
   }
 

--- a/interpreter/mesh/src/main/scala/io/buoyant/interpreter/mesh/EndpointSerializer.scala
+++ b/interpreter/mesh/src/main/scala/io/buoyant/interpreter/mesh/EndpointSerializer.scala
@@ -16,7 +16,8 @@ class EndpointSerializer extends ConfigSerializer[mesh.Endpoint] {
     gen.writeStartObject()
     for (iaf <- value.inetAf) gen.writeObjectField("inetAf", iaf)
     for (addr <- value.address) gen.writeStringField("address", BufSerializers.ipv4(addr))
-    for (meta <- value.`meta`) gen.writeObjectField("meta", meta)
+    for (meta <- value.meta) gen.writeObjectField("meta", meta)
+    for (metadata <- value.metadata) gen.writeObjectField("metadata", metadata)
     for (port <- value.port) gen.writeStringField("port", port.toString)
     gen.writeEndObject()
   }

--- a/interpreter/mesh/src/main/scala/io/buoyant/interpreter/mesh/EndpointSerializer.scala
+++ b/interpreter/mesh/src/main/scala/io/buoyant/interpreter/mesh/EndpointSerializer.scala
@@ -16,7 +16,7 @@ class EndpointSerializer extends ConfigSerializer[mesh.Endpoint] {
     gen.writeStartObject()
     for (iaf <- value.inetAf) gen.writeObjectField("inetAf", iaf)
     for (addr <- value.address) gen.writeStringField("address", BufSerializers.ipv4(addr))
-    for (meta <- value.meta) gen.writeObjectField("meta", meta)
+    for (meta <- value.`meta`) gen.writeObjectField("meta", meta)
     for (port <- value.port) gen.writeStringField("port", port.toString)
     gen.writeEndObject()
   }

--- a/interpreter/mesh/src/test/scala/io/buoyant/interpreter/mesh/ClientTest.scala
+++ b/interpreter/mesh/src/test/scala/io/buoyant/interpreter/mesh/ClientTest.scala
@@ -107,7 +107,7 @@ class ClientTest extends FunSuite {
             assert(addrReq == mesh.ReplicasReq(Some(mesh.Path(Seq(Buf.Utf8("id2"))))))
 
             val ip0 = InetAddress.getByName("192.168.42.66")
-            val meta0: Map[String, Any] = Map("nodeName" -> "anode")
+            val meta0: Map[String, Any] = Map("nodeName" -> "anode", "node_metadata" -> Map("foo" -> "bar", "baz" -> 5))
 
             val ip1 = InetAddress.getByName("fe80::62f8:1dff:fed0:4452")
             val meta1 = Map.empty[String, Any]
@@ -117,13 +117,13 @@ class ClientTest extends FunSuite {
                 Some(mesh.Endpoint.AddressFamily.INET4),
                 Some(Buf.ByteArray.Owned(ip0.getAddress)),
                 Some(1234),
-                Some(mesh.Endpoint.Meta(nodeName = Some("anode")))
+                Map("nodeName" -> "anode", "node_metadata" -> "{\"foo\":\"bar\",\"baz\":5}")
               ),
               mesh.Endpoint(
                 Some(mesh.Endpoint.AddressFamily.INET6),
                 Some(Buf.ByteArray.Owned(ip1.getAddress)),
                 Some(5678),
-                Some(mesh.Endpoint.Meta())
+                Map.empty[String, String]
               )
             )
             val send2F = addrRsps.send(mesh.Replicas(Some(

--- a/interpreter/mesh/src/test/scala/io/buoyant/interpreter/mesh/ClientTest.scala
+++ b/interpreter/mesh/src/test/scala/io/buoyant/interpreter/mesh/ClientTest.scala
@@ -107,7 +107,7 @@ class ClientTest extends FunSuite {
             assert(addrReq == mesh.ReplicasReq(Some(mesh.Path(Seq(Buf.Utf8("id2"))))))
 
             val ip0 = InetAddress.getByName("192.168.42.66")
-            val meta0: Map[String, Any] = Map("nodeName" -> "anode", "node_metadata" -> Map("foo" -> "bar", "baz" -> 5))
+            val meta0: Map[String, Any] = Map("nodeName" -> "anode", "foo1" -> "bar1", "foo2" -> "bar2")
 
             val ip1 = InetAddress.getByName("fe80::62f8:1dff:fed0:4452")
             val meta1 = Map.empty[String, Any]
@@ -117,12 +117,17 @@ class ClientTest extends FunSuite {
                 Some(mesh.Endpoint.AddressFamily.INET4),
                 Some(Buf.ByteArray.Owned(ip0.getAddress)),
                 Some(1234),
-                Map("nodeName" -> "anode", "node_metadata" -> "{\"foo\":\"bar\",\"baz\":5}")
+                None,
+                Map("nodeName" -> "anode",
+                  "foo1" -> "bar1",
+                  "foo2" -> "bar2"
+                  )
               ),
               mesh.Endpoint(
                 Some(mesh.Endpoint.AddressFamily.INET6),
                 Some(Buf.ByteArray.Owned(ip1.getAddress)),
                 Some(5678),
+                None,
                 Map.empty[String, String]
               )
             )

--- a/linkerd/docs/namer.md
+++ b/linkerd/docs/namer.md
@@ -214,7 +214,7 @@ preferServiceAddress | `true` | If `true` use the service address if defined and
 weights | none | List of tag-weight configurations, for adjusting the weights of node addresses. When a node matches more than one tag, it gets the highest matching weight. In the absence of match or configuration, nodes get a default weight of `1.0`.
 fixedLengthStreamedAfterKB | 5120 | The maximum HTTP message size that can be buffered by the Consul client. After this size threshold is crossed, the message is streamed.
 tls | no tls | Use TLS during connection with Consul. see [Consul Encryption](https://www.consul.io/docs/agent/encryption.html) and [TLS](#consul-tls).
-transferMetaData | `false` | If `true` service and endpoint metadata from Consul will be carried over the HTTP interface of namerd
+transferMetadata | `false` | If `true` service and endpoint metadata from Consul will be carried over the HTTP interface of namerd
 
 ### Consul Path Parameters
 

--- a/linkerd/docs/namer.md
+++ b/linkerd/docs/namer.md
@@ -214,6 +214,7 @@ preferServiceAddress | `true` | If `true` use the service address if defined and
 weights | none | List of tag-weight configurations, for adjusting the weights of node addresses. When a node matches more than one tag, it gets the highest matching weight. In the absence of match or configuration, nodes get a default weight of `1.0`.
 fixedLengthStreamedAfterKB | 5120 | The maximum HTTP message size that can be buffered by the Consul client. After this size threshold is crossed, the message is streamed.
 tls | no tls | Use TLS during connection with Consul. see [Consul Encryption](https://www.consul.io/docs/agent/encryption.html) and [TLS](#consul-tls).
+transferMetaData | `false` | If `true` service and endpoint metadata from Consul will be carried over the HTTP interface of namerd
 
 ### Consul Path Parameters
 

--- a/mesh/core/src/main/protobuf/resolver.proto
+++ b/mesh/core/src/main/protobuf/resolver.proto
@@ -39,13 +39,7 @@ message Endpoint {
   int32 port = 3;
 
   /** Endpoint-specific diagonstic metadata */
-  message Meta {
-    /**
-     * In scheduled environments, a diagnostic name for the parent node.
-     */
-    string nodeName = 1;
-  }
-  Meta meta = 4;
+  map<string, string> meta = 4;
 }
 
 message Replicas {
@@ -60,6 +54,7 @@ message Replicas {
 
   message Bound {
     repeated Endpoint endpoints = 1;
+    map<string, string> meta = 2;
   }
 
   oneof result {

--- a/mesh/core/src/main/protobuf/resolver.proto
+++ b/mesh/core/src/main/protobuf/resolver.proto
@@ -39,7 +39,15 @@ message Endpoint {
   int32 port = 3;
 
   /** Endpoint-specific diagonstic metadata */
-  map<string, string> meta = 4;
+    message Meta {
+      /**
+       * In scheduled environments, a diagnostic name for the parent node.
+       */
+      string nodeName = 1;
+    }
+    Meta meta = 4;
+
+  map<string, string> metadata = 5;
 }
 
 message Replicas {
@@ -54,7 +62,7 @@ message Replicas {
 
   message Bound {
     repeated Endpoint endpoints = 1;
-    map<string, string> meta = 2;
+    map<string, string> metadata = 2;
   }
 
   oneof result {

--- a/namer/consul/src/main/scala/io/buoyant/namer/consul/ConsulInitializer.scala
+++ b/namer/consul/src/main/scala/io/buoyant/namer/consul/ConsulInitializer.scala
@@ -127,7 +127,7 @@ case class ConsulConfig(
           preferServiceAddress,
           tagWeights,
           stats,
-          transferMetaData
+          transferMetaData.getOrElse(false)
         )
       case _ =>
         ConsulNamer.untagged(
@@ -139,7 +139,7 @@ case class ConsulConfig(
           preferServiceAddress,
           tagWeights,
           stats,
-          transferMetaData
+          transferMetaData.getOrElse(false)
         )
     }
   }

--- a/namer/consul/src/main/scala/io/buoyant/namer/consul/ConsulInitializer.scala
+++ b/namer/consul/src/main/scala/io/buoyant/namer/consul/ConsulInitializer.scala
@@ -41,6 +41,7 @@ import io.buoyant.namer.{NamerConfig, NamerInitializer}
  *     clientAuth:
  *       certPath: /certificates/cert.pem
  *       keyPath: /certificates/key.pem
+ *    transferMetaData: true
  * </pre>
  */
 class ConsulInitializer extends NamerInitializer {
@@ -65,7 +66,8 @@ case class ConsulConfig(
   preferServiceAddress: Option[Boolean] = None,
   weights: Option[Seq[TagWeight]] = None,
   fixedLengthStreamedAfterKB: Option[Int],
-  tls: Option[TlsClientConfig] = None
+  tls: Option[TlsClientConfig] = None,
+  transferMetaData: Option[Boolean] = None
 ) extends NamerConfig {
 
   @JsonIgnore
@@ -87,7 +89,6 @@ case class ConsulConfig(
     val DefaultRequestTimeout = 10.minutes
     val tlsParams = tls.map(_.params).getOrElse(Stack.Params.empty)
     val DefaultStreamAfter = 5.megabytes
-
 
     val service = Http.client
       .withParams(Http.client.params ++ tlsParams ++ params)
@@ -118,11 +119,27 @@ case class ConsulConfig(
     includeTag match {
       case Some(true) =>
         ConsulNamer.tagged(
-          prefix, consul, agent, setHost.getOrElse(false), consistencyMode, preferServiceAddress, tagWeights, stats
+          prefix,
+          consul,
+          agent,
+          setHost.getOrElse(false),
+          consistencyMode,
+          preferServiceAddress,
+          tagWeights,
+          stats,
+          transferMetaData
         )
       case _ =>
         ConsulNamer.untagged(
-          prefix, consul, agent, setHost.getOrElse(false), consistencyMode, preferServiceAddress, tagWeights, stats
+          prefix,
+          consul,
+          agent,
+          setHost.getOrElse(false),
+          consistencyMode,
+          preferServiceAddress,
+          tagWeights,
+          stats,
+          transferMetaData
         )
     }
   }

--- a/namer/consul/src/main/scala/io/buoyant/namer/consul/ConsulInitializer.scala
+++ b/namer/consul/src/main/scala/io/buoyant/namer/consul/ConsulInitializer.scala
@@ -41,7 +41,7 @@ import io.buoyant.namer.{NamerConfig, NamerInitializer}
  *     clientAuth:
  *       certPath: /certificates/cert.pem
  *       keyPath: /certificates/key.pem
- *    transferMetaData: true
+ *    transferMetadata: true
  * </pre>
  */
 class ConsulInitializer extends NamerInitializer {
@@ -67,7 +67,7 @@ case class ConsulConfig(
   weights: Option[Seq[TagWeight]] = None,
   fixedLengthStreamedAfterKB: Option[Int],
   tls: Option[TlsClientConfig] = None,
-  transferMetaData: Option[Boolean] = None
+  transferMetadata: Option[Boolean] = None
 ) extends NamerConfig {
 
   @JsonIgnore
@@ -127,7 +127,7 @@ case class ConsulConfig(
           preferServiceAddress,
           tagWeights,
           stats,
-          transferMetaData.getOrElse(false)
+          transferMetadata.getOrElse(false)
         )
       case _ =>
         ConsulNamer.untagged(
@@ -139,7 +139,7 @@ case class ConsulConfig(
           preferServiceAddress,
           tagWeights,
           stats,
-          transferMetaData.getOrElse(false)
+          transferMetadata.getOrElse(false)
         )
     }
   }

--- a/namer/consul/src/main/scala/io/buoyant/namer/consul/ConsulNamer.scala
+++ b/namer/consul/src/main/scala/io/buoyant/namer/consul/ConsulNamer.scala
@@ -21,9 +21,9 @@ object ConsulNamer {
     preferServiceAddress: Option[Boolean] = None,
     weights: Map[String, Double] = Map.empty,
     stats: StatsReceiver = NullStatsReceiver,
-    transferMetaData: Boolean = false
+    transferMetadata: Boolean = false
   ): Namer = {
-    val lookup = new LookupCache(consulApi, agentApi, setHost, consistency, preferServiceAddress, weights, stats, transferMetaData)
+    val lookup = new LookupCache(consulApi, agentApi, setHost, consistency, preferServiceAddress, weights, stats, transferMetadata)
     new TaggedNamer(lookup, prefix)
   }
 
@@ -36,9 +36,9 @@ object ConsulNamer {
     preferServiceAddress: Option[Boolean] = None,
     weights: Map[String, Double] = Map.empty,
     stats: StatsReceiver = NullStatsReceiver,
-    transferMetaData: Boolean = false
+    transferMetadata: Boolean = false
   ): Namer = {
-    val lookup = new LookupCache(consulApi, agentApi, setHost, consistency, preferServiceAddress, weights, stats, transferMetaData)
+    val lookup = new LookupCache(consulApi, agentApi, setHost, consistency, preferServiceAddress, weights, stats, transferMetadata)
     new UntaggedNamer(lookup, prefix)
   }
 

--- a/namer/consul/src/main/scala/io/buoyant/namer/consul/ConsulNamer.scala
+++ b/namer/consul/src/main/scala/io/buoyant/namer/consul/ConsulNamer.scala
@@ -21,7 +21,7 @@ object ConsulNamer {
     preferServiceAddress: Option[Boolean] = None,
     weights: Map[String, Double] = Map.empty,
     stats: StatsReceiver = NullStatsReceiver,
-    transferMetaData: Option[Boolean] = None
+    transferMetaData: Boolean = false
   ): Namer = {
     val lookup = new LookupCache(consulApi, agentApi, setHost, consistency, preferServiceAddress, weights, stats, transferMetaData)
     new TaggedNamer(lookup, prefix)
@@ -36,7 +36,7 @@ object ConsulNamer {
     preferServiceAddress: Option[Boolean] = None,
     weights: Map[String, Double] = Map.empty,
     stats: StatsReceiver = NullStatsReceiver,
-    transferMetaData: Option[Boolean] = None
+    transferMetaData: Boolean = false
   ): Namer = {
     val lookup = new LookupCache(consulApi, agentApi, setHost, consistency, preferServiceAddress, weights, stats, transferMetaData)
     new UntaggedNamer(lookup, prefix)

--- a/namer/consul/src/main/scala/io/buoyant/namer/consul/ConsulNamer.scala
+++ b/namer/consul/src/main/scala/io/buoyant/namer/consul/ConsulNamer.scala
@@ -20,9 +20,10 @@ object ConsulNamer {
     consistency: Option[v1.ConsistencyMode] = None,
     preferServiceAddress: Option[Boolean] = None,
     weights: Map[String, Double] = Map.empty,
-    stats: StatsReceiver = NullStatsReceiver
+    stats: StatsReceiver = NullStatsReceiver,
+    transferMetaData: Option[Boolean] = None
   ): Namer = {
-    val lookup = new LookupCache(consulApi, agentApi, setHost, consistency, preferServiceAddress, weights, stats)
+    val lookup = new LookupCache(consulApi, agentApi, setHost, consistency, preferServiceAddress, weights, stats, transferMetaData)
     new TaggedNamer(lookup, prefix)
   }
 
@@ -34,9 +35,10 @@ object ConsulNamer {
     consistency: Option[v1.ConsistencyMode] = None,
     preferServiceAddress: Option[Boolean] = None,
     weights: Map[String, Double] = Map.empty,
-    stats: StatsReceiver = NullStatsReceiver
+    stats: StatsReceiver = NullStatsReceiver,
+    transferMetaData: Option[Boolean] = None
   ): Namer = {
-    val lookup = new LookupCache(consulApi, agentApi, setHost, consistency, preferServiceAddress, weights, stats)
+    val lookup = new LookupCache(consulApi, agentApi, setHost, consistency, preferServiceAddress, weights, stats, transferMetaData)
     new UntaggedNamer(lookup, prefix)
   }
 

--- a/namer/consul/src/main/scala/io/buoyant/namer/consul/LookupCache.scala
+++ b/namer/consul/src/main/scala/io/buoyant/namer/consul/LookupCache.scala
@@ -29,7 +29,7 @@ private[consul] class LookupCache(
   preferServiceAddress: Option[Boolean] = None,
   weights: Map[String, Double] = Map.empty,
   stats: StatsReceiver = NullStatsReceiver,
-  transferMetaData: Option[Boolean] = None
+  transferMetaData: Boolean = false
 ) {
 
   private[this] val localDcMoniker = ".local"

--- a/namer/consul/src/main/scala/io/buoyant/namer/consul/LookupCache.scala
+++ b/namer/consul/src/main/scala/io/buoyant/namer/consul/LookupCache.scala
@@ -28,7 +28,8 @@ private[consul] class LookupCache(
   consistency: Option[v1.ConsistencyMode] = None,
   preferServiceAddress: Option[Boolean] = None,
   weights: Map[String, Double] = Map.empty,
-  stats: StatsReceiver = NullStatsReceiver
+  stats: StatsReceiver = NullStatsReceiver,
+  transferMetaData: Option[Boolean] = None
 ) {
 
   private[this] val localDcMoniker = ".local"
@@ -58,7 +59,8 @@ private[consul] class LookupCache(
             preferServiceAddress = preferServiceAddress,
             weights,
             serviceStats,
-            pollState
+            pollState,
+            transferMetaData
           )
       }
 

--- a/namer/consul/src/main/scala/io/buoyant/namer/consul/LookupCache.scala
+++ b/namer/consul/src/main/scala/io/buoyant/namer/consul/LookupCache.scala
@@ -29,7 +29,7 @@ private[consul] class LookupCache(
   preferServiceAddress: Option[Boolean] = None,
   weights: Map[String, Double] = Map.empty,
   stats: StatsReceiver = NullStatsReceiver,
-  transferMetaData: Boolean = false
+  transferMetadata: Boolean = false
 ) {
 
   private[this] val localDcMoniker = ".local"
@@ -60,7 +60,7 @@ private[consul] class LookupCache(
             weights,
             serviceStats,
             pollState,
-            transferMetaData
+            transferMetadata
           )
       }
 

--- a/namer/consul/src/main/scala/io/buoyant/namer/consul/SvcAddr.scala
+++ b/namer/consul/src/main/scala/io/buoyant/namer/consul/SvcAddr.scala
@@ -21,8 +21,6 @@ private[consul] case class SvcKey(name: String, tag: Option[String]) {
 
 private[consul] object SvcAddr {
 
-  type MetaWithAddresses = (v1.MetaData, Set[Address])
-
   private[this] val ServiceRelease =
     new Exception("service observation released") with NoStackTrace
 
@@ -50,11 +48,11 @@ private[consul] object SvcAddr {
     tagWeights: Map[String, Double] = Map.empty,
     stats: Stats,
     stateWatch: v1.PollState[String, v1.IndexedServiceNodes],
-    transferMetaData: Option[Boolean] = None
+    transferMetaData: Boolean = false
   )(implicit timer: Timer = DefaultTimer): InstrumentedVar[Addr] = {
     val meta = mkMeta(key, datacenter, domain)
 
-    def getAddresses(index: Option[String]): Future[v1.Indexed[MetaWithAddresses]] = {
+    def getAddresses(index: Option[String]): Future[v1.Indexed[Addr.Bound]] = {
       val apiCall = consulApi.serviceNodes(
         key.name,
         datacenter = Some(datacenter),
@@ -65,12 +63,15 @@ private[consul] object SvcAddr {
       v1.InstrumentedApiCall.execute(apiCall, stateWatch)
         .map {
           case v1.Indexed(nodes, idx) => {
-            val meta: v1.MetaData = nodes.headOption.flatMap(_.ServiceMeta) -> transferMetaData match {
-              case (Some(serviceMeta), Some(true)) => serviceMeta
-              case _ => Map.empty[String, Any]
+            // we use the metadata from the first node, because all nodes from
+            // the same service are assumed to have identical metadata.
+            // For reference: https://www.consul.io/api/catalog.html
+            val meta: v1.Metadata = nodes.headOption.flatMap(_.ServiceMeta) -> transferMetaData match {
+              case (Some(serviceMeta), true) => serviceMeta
+              case _ => Map.empty[String, String]
             }
-            val addresses = nodesToAddresses(preferServiceAddress, tagWeights)(nodes)
-            v1.Indexed(meta -> addresses, idx)
+            val addresses = nodesToAddresses(preferServiceAddress, tagWeights, transferMetaData)(nodes)
+            v1.Indexed(Addr.Bound(addresses, meta), idx)
           }
         }
     }
@@ -126,11 +127,11 @@ private[consul] object SvcAddr {
             )
             Future.exception(NoIndexException)
 
-          case Return(v1.Indexed((srvMeta, addresses), xConsulIndex)) =>
+          case Return(v1.Indexed(Addr.Bound(addresses, srvMeta), xConsulIndex)) =>
             stats.updates.incr()
             val addr = addresses match {
               case addrs if addrs.isEmpty => Addr.Neg
-              case addrs => Addr.Bound(addrs, meta ++ Map(Metadata.serviceMeta -> srvMeta))
+              case addrs => Addr.Bound(addrs, meta ++ srvMeta)
             }
             state.update(addr)
 
@@ -164,7 +165,7 @@ private[consul] object SvcAddr {
   private[this] def nodesToAddresses(
     preferServiceAddress: Option[Boolean],
     tagWeights: Map[String, Double],
-    transferMetaData: Option[Boolean] = None
+    transferMetaData: Boolean
   ): Seq[ServiceNode] => Set[Address] = { nodes =>
     preferServiceAddress match {
       case Some(false) => nodes.flatMap(serviceNodeToNodeAddr(_, tagWeights, transferMetaData)).toSet
@@ -178,11 +179,13 @@ private[consul] object SvcAddr {
   private def serviceNodeToAddr(
     n: v1.ServiceNode,
     w: Map[String, Double],
-    transferMetaData: Option[Boolean]
+    transferMetaData: Boolean
   ): Traversable[Address] =
-    (n.Address, n.ServiceAddress, n.ServicePort) match {
-      case (_, Some(ip), Some(port)) if !ip.isEmpty => weightedAddress(ip, port, n, w, n.NodeMeta)
-      case (Some(ip), _, Some(port)) if !ip.isEmpty => weightedAddress(ip, port, n, w, n.NodeMeta)
+    (n.Address, n.ServiceAddress, n.ServicePort, transferMetaData) match {
+      case (_, Some(ip), Some(port), true) if !ip.isEmpty => weightedAddress(ip, port, n, w, n.NodeMeta)
+      case (_, Some(ip), Some(port), false) if !ip.isEmpty => weightedAddress(ip, port, n, w, None)
+      case (Some(ip), _, Some(port), true) if !ip.isEmpty => weightedAddress(ip, port, n, w, n.NodeMeta)
+      case (Some(ip), _, Some(port), false) if !ip.isEmpty => weightedAddress(ip, port, n, w, None)
       case _ => None
     }
 
@@ -192,11 +195,11 @@ private[consul] object SvcAddr {
   private def serviceNodeToNodeAddr(
     n: v1.ServiceNode,
     w: Map[String, Double],
-    transferMetaData: Option[Boolean] = None
+    transferMetaData: Boolean
   ): Traversable[Address] =
     (n.Address, n.ServicePort, transferMetaData) match {
-      case (Some(ip), Some(port), Some(true)) if !ip.isEmpty => weightedAddress(ip, port, n, w, n.NodeMeta)
-      case (Some(ip), Some(port), _) if !ip.isEmpty => weightedAddress(ip, port, n, w, None)
+      case (Some(ip), Some(port), true) if !ip.isEmpty => weightedAddress(ip, port, n, w, n.NodeMeta)
+      case (Some(ip), Some(port), false) if !ip.isEmpty => weightedAddress(ip, port, n, w, None)
       case _ => None
     }
 
@@ -208,17 +211,14 @@ private[consul] object SvcAddr {
     port: Int,
     n: v1.ServiceNode,
     w: Map[String, Double],
-    m: Option[v1.MetaData]
+    m: Option[v1.Metadata]
   ) = {
     val weight = n.ServiceTags.map(_.flatMap(w.get)) match {
       case None => 1.0
       case Some(Nil) => 1.0
       case Some(ws) => ws.max
     }
-    val meta = Addr.Metadata((Metadata.endpointWeight, weight)) ++ Map(
-      Metadata.nodeMeta -> m
-        .getOrElse(Map.empty)
-    )
+    val meta = Addr.Metadata((Metadata.endpointWeight, weight)) ++ m.getOrElse(Map.empty)
     Try(
       InetAddress.getAllByName(ip)
         .toTraversable

--- a/namer/consul/src/test/scala/io/buoyant/namer/consul/ConsulNamerTest.scala
+++ b/namer/consul/src/test/scala/io/buoyant/namer/consul/ConsulNamerTest.scala
@@ -449,7 +449,7 @@ class ConsulNamerTest extends FunSuite with Awaits {
   }
 
 
-  test("Namer returns Consul metadata when transferMetaData is set to true") {
+  test("Namer returns Consul metadata when transferMetadata is set to true") {
     class TestApi extends CatalogApi(null, "/v1") {
       override def serviceNodes(
         serviceName: String,
@@ -473,7 +473,7 @@ class ConsulNamerTest extends FunSuite with Awaits {
       new TestApi(),
       new TestAgentApi("consul.acme.co"),
       stats = stats,
-      transferMetaData = true
+      transferMetadata = true
     )
     @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
     namer.lookup(Path.read("/dc1/servicename/residual")).states respond {
@@ -488,7 +488,7 @@ class ConsulNamerTest extends FunSuite with Awaits {
     }
   }
 
-  test("Namer skips Consul metadata when transferMetaData is set to false") {
+  test("Namer skips Consul metadata when transferMetadata is set to false") {
     class TestApi extends CatalogApi(null, "/v1") {
       override def serviceNodes(
         serviceName: String,
@@ -512,7 +512,7 @@ class ConsulNamerTest extends FunSuite with Awaits {
       new TestApi(),
       new TestAgentApi("consul.acme.co"),
       stats = stats,
-      transferMetaData = false
+      transferMetadata = false
     )
     @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
     namer.lookup(Path.read("/dc1/servicename/residual")).states respond {
@@ -550,7 +550,7 @@ class ConsulNamerTest extends FunSuite with Awaits {
       new TestAgentApi("consul.acme.co"),
       setHost = true,
       stats = stats,
-      transferMetaData = true
+      transferMetadata = true
     )
     @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
     namer.lookup(Path.read("/dc1/servicename/residual")).states respond { state = _ }
@@ -605,7 +605,7 @@ class ConsulNamerTest extends FunSuite with Awaits {
       new TestAgentApi("consul.acme.co"),
       setHost = true,
       stats = stats,
-      transferMetaData = true
+      transferMetadata = true
     )
     @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
     namer.lookup(Path.read("/dc1/master/servicename/residual")).states respond { state = _ }
@@ -660,7 +660,7 @@ class ConsulNamerTest extends FunSuite with Awaits {
       new TestAgentApi("consul.acme.co"),
       setHost = true,
       stats = stats,
-      transferMetaData = true
+      transferMetadata = true
     )
     @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
     namer.lookup(Path.read("/dc1/servicename/residual")).states respond { state = _ }
@@ -884,7 +884,7 @@ class ConsulNamerTest extends FunSuite with Awaits {
       new TestAgentApi("consul.acme.co"),
       weights = Map("primary" -> 100),
       stats = stats,
-      transferMetaData = true
+      transferMetadata = true
     )
     @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
     namer.lookup(Path.read("/dc1/servicename/residual")).states respond { state = _ }

--- a/namer/consul/src/test/scala/io/buoyant/namer/consul/ConsulNamerTest.scala
+++ b/namer/consul/src/test/scala/io/buoyant/namer/consul/ConsulNamerTest.scala
@@ -473,7 +473,7 @@ class ConsulNamerTest extends FunSuite with Awaits {
       new TestApi(),
       new TestAgentApi("consul.acme.co"),
       stats = stats,
-      transferMetaData = Some(true)
+      transferMetaData = true
     )
     @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
     namer.lookup(Path.read("/dc1/servicename/residual")).states respond {
@@ -482,7 +482,7 @@ class ConsulNamerTest extends FunSuite with Awaits {
 
     assertOnAddrs(state) { (_, metadata) =>
       assert(
-        metadata == Addr.Metadata(Metadata.serviceMeta -> Map("srv_meta" -> "some_srv_meta"))
+        metadata == Addr.Metadata("srv_meta" -> "some_srv_meta")
       )
       ()
     }
@@ -512,7 +512,7 @@ class ConsulNamerTest extends FunSuite with Awaits {
       new TestApi(),
       new TestAgentApi("consul.acme.co"),
       stats = stats,
-      transferMetaData = Some(false)
+      transferMetaData = false
     )
     @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
     namer.lookup(Path.read("/dc1/servicename/residual")).states respond {
@@ -520,7 +520,7 @@ class ConsulNamerTest extends FunSuite with Awaits {
     }
 
     assertOnAddrs(state) { (_, metadata) =>
-      metadata == Addr.Metadata(Metadata.serviceMeta -> Map.empty)
+      metadata == Addr.Metadata.empty
       ()
     }
   }
@@ -550,7 +550,7 @@ class ConsulNamerTest extends FunSuite with Awaits {
       new TestAgentApi("consul.acme.co"),
       setHost = true,
       stats = stats,
-      transferMetaData = Some(true)
+      transferMetaData = true
     )
     @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
     namer.lookup(Path.read("/dc1/servicename/residual")).states respond { state = _ }
@@ -560,7 +560,7 @@ class ConsulNamerTest extends FunSuite with Awaits {
         metadata == Addr
           .Metadata(
             Metadata.authority -> "servicename.service.dc1.consul.acme.co",
-            Metadata.serviceMeta -> Map("srv_meta" -> "some_srv_meta")
+            "srv_meta" -> "some_srv_meta"
           )
       )
       ()
@@ -605,7 +605,7 @@ class ConsulNamerTest extends FunSuite with Awaits {
       new TestAgentApi("consul.acme.co"),
       setHost = true,
       stats = stats,
-      transferMetaData = Some(true)
+      transferMetaData = true
     )
     @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
     namer.lookup(Path.read("/dc1/master/servicename/residual")).states respond { state = _ }
@@ -614,7 +614,7 @@ class ConsulNamerTest extends FunSuite with Awaits {
       assert(
         metadata == Addr.Metadata(
           Metadata.authority -> "master.servicename.service.dc1.consul.acme.co",
-          Metadata.serviceMeta -> Map("srv_meta" -> "some_srv_meta")
+          "srv_meta" -> "some_srv_meta"
         )
       )
       ()
@@ -660,7 +660,7 @@ class ConsulNamerTest extends FunSuite with Awaits {
       new TestAgentApi("consul.acme.co"),
       setHost = true,
       stats = stats,
-      transferMetaData = Some(true)
+      transferMetaData = true
     )
     @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
     namer.lookup(Path.read("/dc1/servicename/residual")).states respond { state = _ }
@@ -670,7 +670,7 @@ class ConsulNamerTest extends FunSuite with Awaits {
       assert(
         metadata == Addr.Metadata(
           Metadata.authority -> "servicename.service.dc1.consul.acme.co",
-          Metadata.serviceMeta -> Map("srv_meta" -> "some_srv_meta")
+         "srv_meta" -> "some_srv_meta"
         )
       )
       ()
@@ -883,7 +883,8 @@ class ConsulNamerTest extends FunSuite with Awaits {
       new TestApi(),
       new TestAgentApi("consul.acme.co"),
       weights = Map("primary" -> 100),
-      stats = stats
+      stats = stats,
+      transferMetaData = true
     )
     @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
     namer.lookup(Path.read("/dc1/servicename/residual")).states respond { state = _ }
@@ -894,7 +895,7 @@ class ConsulNamerTest extends FunSuite with Awaits {
       assert(
         inet.metadata == Map(
           Metadata.endpointWeight -> 100,
-          Metadata.nodeMeta -> Map("nd_meta" -> "some_nd_meta")
+         "nd_meta" -> "some_nd_meta"
         )
       )
       ()

--- a/namer/consul/src/test/scala/io/buoyant/namer/consul/ConsulTest.scala
+++ b/namer/consul/src/test/scala/io/buoyant/namer/consul/ConsulTest.scala
@@ -13,7 +13,7 @@ class ConsulTest extends FunSuite {
 
   test("sanity") {
     // ensure it doesn't totally blowup
-    val _ = ConsulConfig(None, None, None, None, None, None, None, None, None, None, None, None, None).newNamer(Stack.Params.empty)
+    val _ = ConsulConfig(None, None, None, None, None, None, None, None, None, None, None, None, None, None).newNamer(Stack.Params.empty)
   }
 
   test("service registration") {
@@ -57,6 +57,7 @@ class ConsulTest extends FunSuite {
                     |  clientAuth:
                     |    certPath: /certificates/cert.pem
                     |    keyPath: /certificates/key.pem
+                    |transferMetaData: true
       """.stripMargin
 
     val mapper = Parser.objectMapper(yaml, Iterable(Seq(ConsulInitializer)))
@@ -77,5 +78,7 @@ class ConsulTest extends FunSuite {
     val tlsConfig = TlsClientConfig(None, Some(false), Some("consul.io"), None, Some("/certificates/cacerts-bundle.pem"), Some(clientAuth))
     assert(consul.tls == Some(tlsConfig))
     assert(!consul.disabled)
+    assert(consul.transferMetaData == Some(true))
+
   }
 }

--- a/namer/consul/src/test/scala/io/buoyant/namer/consul/ConsulTest.scala
+++ b/namer/consul/src/test/scala/io/buoyant/namer/consul/ConsulTest.scala
@@ -57,7 +57,7 @@ class ConsulTest extends FunSuite {
                     |  clientAuth:
                     |    certPath: /certificates/cert.pem
                     |    keyPath: /certificates/key.pem
-                    |transferMetaData: true
+                    |transferMetadata: true
       """.stripMargin
 
     val mapper = Parser.objectMapper(yaml, Iterable(Seq(ConsulInitializer)))
@@ -78,7 +78,7 @@ class ConsulTest extends FunSuite {
     val tlsConfig = TlsClientConfig(None, Some(false), Some("consul.io"), None, Some("/certificates/cacerts-bundle.pem"), Some(clientAuth))
     assert(consul.tls == Some(tlsConfig))
     assert(!consul.disabled)
-    assert(consul.transferMetaData == Some(true))
+    assert(consul.transferMetadata == Some(true))
 
   }
 }

--- a/namer/consul/src/test/scala/io/buoyant/namer/consul/SvcAddrTest.scala
+++ b/namer/consul/src/test/scala/io/buoyant/namer/consul/SvcAddrTest.scala
@@ -312,7 +312,8 @@ class SvcAddrTest extends FunSuite with Matchers with Awaits {
         None,
         Map.empty,
         Stats(NullStatsReceiver),
-        new PollState
+        new PollState,
+        transferMetaData = true
       )(timer)
 
       addr.underlying.changes.respond {
@@ -329,7 +330,7 @@ class SvcAddrTest extends FunSuite with Matchers with Awaits {
             Addr
               .Metadata(
                 Metadata.endpointWeight -> 1.0,
-                Metadata.nodeMeta -> Map("nd_meta" -> "some_nd_meta")
+               "nd_meta" -> "some_nd_meta"
               )
           )
         case _ => fail("received unexpected Addr on initial service discovery")
@@ -344,7 +345,7 @@ class SvcAddrTest extends FunSuite with Matchers with Awaits {
             Addr
               .Metadata(
                 Metadata.endpointWeight -> 1.0,
-                Metadata.nodeMeta -> Map("nd_meta" -> "some_nd_meta")
+                "nd_meta" -> "some_nd_meta"
               )
           )
         case _ => fail("received unexpected Addr on timed out service discovery request")
@@ -363,7 +364,7 @@ class SvcAddrTest extends FunSuite with Matchers with Awaits {
             .Inet(
               secondAddr, Addr.Metadata(
                 Metadata.endpointWeight -> 1.0,
-                Metadata.nodeMeta -> Map("nd_meta" -> "some_nd_meta")
+               "nd_meta" -> "some_nd_meta"
               )
             )
           case _ => fail("received unexpected Addr on timed out service discovery request")

--- a/namer/consul/src/test/scala/io/buoyant/namer/consul/SvcAddrTest.scala
+++ b/namer/consul/src/test/scala/io/buoyant/namer/consul/SvcAddrTest.scala
@@ -8,7 +8,7 @@ import com.twitter.finagle.{Addr, Address, Failure, IndividualRequestTimeoutExce
 import com.twitter.util._
 import io.buoyant.consul.v1._
 import io.buoyant.namer.consul.SvcAddr.Stats
-import io.buoyant.namer.InstrumentedVar
+import io.buoyant.namer.{InstrumentedVar, Metadata}
 import io.buoyant.test.Awaits
 import java.net.InetSocketAddress
 import java.util.concurrent.atomic.AtomicInteger
@@ -31,7 +31,9 @@ class SvcAddrTest extends FunSuite with Matchers with Awaits {
         Some(Seq.empty),
         Some(""),
         Some(port),
-        Some(HealthStatus.Passing)
+        Some(HealthStatus.Passing),
+        Some(Map("srv_meta" -> "some_srv_meta")),
+        Some(Map("nd_meta" -> "some_nd_meta"))
       ),
         new InetSocketAddress(host, port)
     )
@@ -322,7 +324,14 @@ class SvcAddrTest extends FunSuite with Matchers with Awaits {
       timer.tick()
       changes match {
         case Addr.Bound(addrs, _) => addrs.head shouldBe Address
-          .Inet(firstAddr, Addr.Metadata("endpoint_addr_weight" -> 1.0))
+          .Inet(
+            firstAddr,
+            Addr
+              .Metadata(
+                Metadata.endpointWeight -> 1.0,
+                Metadata.nodeMeta -> Map("nd_meta" -> "some_nd_meta")
+              )
+          )
         case _ => fail("received unexpected Addr on initial service discovery")
       }
 
@@ -330,7 +339,14 @@ class SvcAddrTest extends FunSuite with Matchers with Awaits {
       timer.tick()
       changes match {
         case Addr.Bound(addrs, _) => addrs.head shouldBe Address
-          .Inet(firstAddr, Addr.Metadata("endpoint_addr_weight" -> 1.0))
+          .Inet(
+            firstAddr,
+            Addr
+              .Metadata(
+                Metadata.endpointWeight -> 1.0,
+                Metadata.nodeMeta -> Map("nd_meta" -> "some_nd_meta")
+              )
+          )
         case _ => fail("received unexpected Addr on timed out service discovery request")
       }
 
@@ -344,7 +360,12 @@ class SvcAddrTest extends FunSuite with Matchers with Awaits {
       eventually {
         changes match {
           case Addr.Bound(addrs, _) => addrs.head shouldBe Address
-            .Inet(secondAddr, Addr.Metadata("endpoint_addr_weight" -> 1.0))
+            .Inet(
+              secondAddr, Addr.Metadata(
+                Metadata.endpointWeight -> 1.0,
+                Metadata.nodeMeta -> Map("nd_meta" -> "some_nd_meta")
+              )
+            )
           case _ => fail("received unexpected Addr on timed out service discovery request")
         }
       }

--- a/namer/consul/src/test/scala/io/buoyant/namer/consul/SvcAddrTest.scala
+++ b/namer/consul/src/test/scala/io/buoyant/namer/consul/SvcAddrTest.scala
@@ -313,7 +313,7 @@ class SvcAddrTest extends FunSuite with Matchers with Awaits {
         Map.empty,
         Stats(NullStatsReceiver),
         new PollState,
-        transferMetaData = true
+        transferMetadata = true
       )(timer)
 
       addr.underlying.changes.respond {

--- a/namer/core/src/main/scala/io/buoyant/namer/Metadata.scala
+++ b/namer/core/src/main/scala/io/buoyant/namer/Metadata.scala
@@ -6,4 +6,6 @@ object Metadata {
   val authority = "authority" // HTTP/1.1 Host or HTTP/2.0 :authority
   val nodeName = "nodeName"
   val endpointWeight = WeightedAddress.weightKey
+  val serviceMeta = "service_meta"
+  val nodeMeta = "node_meta"
 }

--- a/namer/core/src/main/scala/io/buoyant/namer/Metadata.scala
+++ b/namer/core/src/main/scala/io/buoyant/namer/Metadata.scala
@@ -6,6 +6,4 @@ object Metadata {
   val authority = "authority" // HTTP/1.1 Host or HTTP/2.0 :authority
   val nodeName = "nodeName"
   val endpointWeight = WeightedAddress.weightKey
-  val serviceMeta = "service_meta"
-  val nodeMeta = "node_meta"
 }

--- a/namerd/iface/mesh/src/test/scala/io/buoyant/namerd/iface/mesh/ResolverServiceTest.scala
+++ b/namerd/iface/mesh/src/test/scala/io/buoyant/namerd/iface/mesh/ResolverServiceTest.scala
@@ -26,7 +26,8 @@ class ResolverServiceTest extends FunSuite {
       inetAf = Some(AddressFamily.INET4),
       address = Some(Buf.ByteArray.Owned(Array[Byte](1, 2, 3, 4))),
       port = Some(7777),
-      meta = Map.empty
+      meta = Some(Endpoint.Meta(nodeName = None)),
+      metadata = Map.empty
     )
     val rsp = await(resolver.getReplicas(req))
     assert(rsp.result.get == Replicas.OneofResult.Bound(Replicas.Bound(Seq(endpoint))))
@@ -47,7 +48,8 @@ class ResolverServiceTest extends FunSuite {
       inetAf = Some(AddressFamily.INET4),
       address = Some(Buf.ByteArray.Owned(Array[Byte](1, 2, 3, 4))),
       port = Some(7777),
-      meta = Map.empty
+      meta = Some(Endpoint.Meta(nodeName = None)),
+      metadata = Map.empty
     )
 
     val stream = resolver.streamReplicas(req)
@@ -61,7 +63,8 @@ class ResolverServiceTest extends FunSuite {
       inetAf = Some(AddressFamily.INET4),
       address = Some(Buf.ByteArray.Owned(Array[Byte](5, 6, 7, 8))),
       port = Some(7777),
-      meta = Map.empty
+      meta = Some(Endpoint.Meta(nodeName = None)),
+      metadata = Map.empty
     )
     val item1 = await(resolver.streamReplicas(req).recv())
     assert(item1.value.result.get == Replicas.OneofResult.Bound(Replicas.Bound(Seq(endpoint1))))
@@ -84,7 +87,8 @@ class ResolverServiceTest extends FunSuite {
       inetAf = Some(AddressFamily.INET4),
       address = Some(Buf.ByteArray.Owned(Array[Byte](1, 2, 3, 4))),
       port = Some(7777),
-      meta = Map.empty
+      meta = Some(Endpoint.Meta(nodeName = None)),
+      metadata = Map.empty
     )
     val rsp = await(resolver.getReplicas(req))
     assert(rsp.result.get == Replicas.OneofResult.Bound(Replicas.Bound(Seq(endpoint))))
@@ -106,7 +110,8 @@ class ResolverServiceTest extends FunSuite {
       inetAf = Some(AddressFamily.INET4),
       address = Some(Buf.ByteArray.Owned(Array[Byte](1, 2, 3, 4))),
       port = Some(7777),
-      meta = Map.empty
+      meta = Some(Endpoint.Meta(nodeName = None)),
+      metadata = Map.empty
     )
 
     val stream = resolver.streamReplicas(req)
@@ -120,7 +125,8 @@ class ResolverServiceTest extends FunSuite {
       inetAf = Some(AddressFamily.INET4),
       address = Some(Buf.ByteArray.Owned(Array[Byte](5, 6, 7, 8))),
       port = Some(7777),
-      meta = Map.empty
+      meta = Some(Endpoint.Meta(nodeName = None)),
+      metadata = Map.empty
     )
     val item1 = await(resolver.streamReplicas(req).recv())
     assert(item1.value.result.get == Replicas.OneofResult.Bound(Replicas.Bound(Seq(endpoint1))))

--- a/namerd/iface/mesh/src/test/scala/io/buoyant/namerd/iface/mesh/ResolverServiceTest.scala
+++ b/namerd/iface/mesh/src/test/scala/io/buoyant/namerd/iface/mesh/ResolverServiceTest.scala
@@ -26,7 +26,7 @@ class ResolverServiceTest extends FunSuite {
       inetAf = Some(AddressFamily.INET4),
       address = Some(Buf.ByteArray.Owned(Array[Byte](1, 2, 3, 4))),
       port = Some(7777),
-      meta = Some(Endpoint.Meta(nodeName = None))
+      meta = Map.empty
     )
     val rsp = await(resolver.getReplicas(req))
     assert(rsp.result.get == Replicas.OneofResult.Bound(Replicas.Bound(Seq(endpoint))))
@@ -47,7 +47,7 @@ class ResolverServiceTest extends FunSuite {
       inetAf = Some(AddressFamily.INET4),
       address = Some(Buf.ByteArray.Owned(Array[Byte](1, 2, 3, 4))),
       port = Some(7777),
-      meta = Some(Endpoint.Meta(nodeName = None))
+      meta = Map.empty
     )
 
     val stream = resolver.streamReplicas(req)
@@ -61,7 +61,7 @@ class ResolverServiceTest extends FunSuite {
       inetAf = Some(AddressFamily.INET4),
       address = Some(Buf.ByteArray.Owned(Array[Byte](5, 6, 7, 8))),
       port = Some(7777),
-      meta = Some(Endpoint.Meta(nodeName = None))
+      meta = Map.empty
     )
     val item1 = await(resolver.streamReplicas(req).recv())
     assert(item1.value.result.get == Replicas.OneofResult.Bound(Replicas.Bound(Seq(endpoint1))))
@@ -84,7 +84,7 @@ class ResolverServiceTest extends FunSuite {
       inetAf = Some(AddressFamily.INET4),
       address = Some(Buf.ByteArray.Owned(Array[Byte](1, 2, 3, 4))),
       port = Some(7777),
-      meta = Some(Endpoint.Meta(nodeName = None))
+      meta = Map.empty
     )
     val rsp = await(resolver.getReplicas(req))
     assert(rsp.result.get == Replicas.OneofResult.Bound(Replicas.Bound(Seq(endpoint))))
@@ -106,7 +106,7 @@ class ResolverServiceTest extends FunSuite {
       inetAf = Some(AddressFamily.INET4),
       address = Some(Buf.ByteArray.Owned(Array[Byte](1, 2, 3, 4))),
       port = Some(7777),
-      meta = Some(Endpoint.Meta(nodeName = None))
+      meta = Map.empty
     )
 
     val stream = resolver.streamReplicas(req)
@@ -120,7 +120,7 @@ class ResolverServiceTest extends FunSuite {
       inetAf = Some(AddressFamily.INET4),
       address = Some(Buf.ByteArray.Owned(Array[Byte](5, 6, 7, 8))),
       port = Some(7777),
-      meta = Some(Endpoint.Meta(nodeName = None))
+      meta = Map.empty
     )
     val item1 = await(resolver.streamReplicas(req).recv())
     assert(item1.value.result.get == Replicas.OneofResult.Bound(Replicas.Bound(Seq(endpoint1))))


### PR DESCRIPTION
This allows namerd to return metadata that is received from Consul for both services and nodes. 

Fixes #2269
Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>