### PR TITLE
Update release versions for JDK8/9 to bring in default container support

### DIFF
--- a/project/Base.scala
+++ b/project/Base.scala
@@ -33,8 +33,8 @@ class Base extends Build {
   import Base._
 
   val headVersion = "1.6.3"
-  val openJdkVersion = "8u151"
-  val openJ9Version = "jdk8u192-b12_openj9-0.11.0"
+  val openJdkVersion = "8u212"
+  val openJ9Version = "jdk8u212-b04_openj9-0.14.2"
 
   object Git {
     def git(arg: String, args: String*) = Process("git" +: arg +: args)


### PR DESCRIPTION
The motivation behind this change is #2179. In essence, having  `+UseContainerSupport` on by default was backported to java8 and 9. In order to benefit from that we need to get the newer docker images and package using them. 

Overall there is a lot that has been said about container support for the JVM. My opinion is that, it is beneficial in some very obvious scenarios (such as limiting the max heap) and needs a bit more individual tweaking in other scenarios (high number of short/long bursts of thred contention, etc). So to provide capability to the jvm to detect certain limits that are set on the container, it is desirable to have the option turned on by default. Opinions are more than welcome

Some useful resources: 
- [Docker blogpost on the topic](https://blog.docker.com/2018/04/improved-docker-container-integration-with-java-10/)
- [Nice simple example relating to memory](https://blog.softwaremill.com/docker-support-in-new-java-8-finally-fd595df0ca54)
- [The original article by Chris](http://www.batey.info/docker-jvm-k8s.html)
- [A useful release note](https://bugs.openjdk.java.net/browse/JDK-8196595)

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>