### PR TITLE
Always send SNI if commonName is set

### DIFF
--- a/finagle/buoyant/src/main/scala/com/twitter/finagle/buoyant/TlsClientConfig.scala
+++ b/finagle/buoyant/src/main/scala/com/twitter/finagle/buoyant/TlsClientConfig.scala
@@ -21,8 +21,9 @@ case class TlsClientConfig(
   def params: Stack.Params = this match {
     case TlsClientConfig(Some(false), _, _, _, _, _, _) =>
       Stack.Params.empty + Transport.ClientSsl(None)
-    case TlsClientConfig(_, Some(true), _, _, _, clientAuth, enabledProtocols) =>
+    case TlsClientConfig(_, Some(true), cn, _, _, clientAuth, enabledProtocols) =>
       val tlsConfig = SslClientConfiguration(
+        hostname = cn,
         trustCredentials = TrustCredentials.Insecure,
         keyCredentials = keyCredentials(clientAuth),
         protocols = enabledProtocols.map(Protocols.Enabled).getOrElse(Protocols.Unspecified)

--- a/linkerd/docs/client_tls.md
+++ b/linkerd/docs/client_tls.md
@@ -62,7 +62,7 @@ to destination services.
 Key               | Default Value                              | Description
 ----------------- | ------------------------------------------ | -----------
 disableValidation | false                                      | Enable this to skip hostname validation (unsafe). Setting `disableValidation: true` is incompatible with `clientAuth`.
-commonName        | _required_ unless disableValidation is set | The common name to use for all TLS requests.
+commonName        | _required_ unless disableValidation is set | The common name to use for all TLS requests. Make sure to set it (even when `disableValidation: true`) if your server requires SNI
 trustCerts        | empty list                                 | A list of file paths of CA certs to use for common name validation (deprecated, please use trustCertsBundle).
 trustCertsBundle  | empty                                      | A file path of CA certs bundle to use for common name validation
 clientAuth        | none                                       | A client auth object used to sign requests.


### PR DESCRIPTION
After a bit of testing, I reached the conclusion that finagle uses `TlsClientConfig.hostname` to set the server_name extension value for the TLS handshake in case the `Address` is an Ipv4/6 and not a hostname. That being said, the introduced change always sets the `TlsClientConfig.hostname` to be the `commonName` specified (if present). This has been verified to work with wireshark using namerd + linkerd and the following configs: 

- Namerd: 

```
admin:
  port: 9991
storage:
  kind: io.l5d.inMemory
  namespaces:
    default: |
      /svc/mnot => /$/inet/www.mnot.net/443
namers: []
interfaces:
- kind: io.l5d.httpController
```
- Linkerd: 
```
routers:
  - protocol: http
    interpreter:
      kind: io.l5d.namerd.http
      experimental: true
      dst: /$/inet/localhost/4180
      namespace: default
    servers:
      - port: 4140
    client:
      tls:
        commonName: "www.mnot.net"
        disableValidation: true
```

- Curl: 
`http_proxy=localhost:4140 curl http://mnot`

If you sniff you traffic via wireshark filtering with 
`ssl.handshake.extensions_server_name and ip.dst == 119.9.43.241`
you will see that the SNI extension is present in the hello message: 

```
Extension: server_name (len=17)
    Type: server_name (0)
    Length: 17
    Server Name Indication extension
        Server Name list length: 15
        Server Name Type: host_name (0)
        Server Name length: 12
        Server Name: www.mnot.net
```



Fixes #1920
Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>