### PR TITLE
Introduce option to enable dtab compression for Consul

### DIFF
--- a/consul/src/main/scala/io/buoyant/consul/v1/BaseApi.scala
+++ b/consul/src/main/scala/io/buoyant/consul/v1/BaseApi.scala
@@ -13,6 +13,7 @@ import com.twitter.finagle._
 import com.twitter.io.{Buf, Reader}
 import com.twitter.util._
 import io.buoyant.consul.log
+import scala.collection.immutable.Map
 import scala.util.control.NonFatal
 
 // a thunked version of the api call such that we can peek at the request before making the call
@@ -117,4 +118,6 @@ object Headers {
   val Index = "X-Consul-Index"
 }
 
-case class Indexed[T](value: T, index: Option[String])
+case class Indexed[T](value: T, index: Option[String]) {
+  def mapValue[R](f: T => R): Indexed[R] = copy(value = f(value))
+}

--- a/interpreter/consul/src/main/scala/io/buoyant/interpreter/consul/ConsulInterpreterInitializer.scala
+++ b/interpreter/consul/src/main/scala/io/buoyant/interpreter/consul/ConsulInterpreterInitializer.scala
@@ -34,7 +34,8 @@ case class ConsulDtabInterpreterConfig(
   writeConsistencyMode: Option[ConsistencyMode] = None,
   failFast: Option[Boolean] = None,
   backoff: Option[BackoffConfig] = None,
-  tls: Option[TlsClientConfig] = None
+  tls: Option[TlsClientConfig] = None,
+  enableValueCompression: Option[Boolean] = None
 ) extends InterpreterConfig {
 
   import ConsulDtabInterpreterConfig._
@@ -54,6 +55,7 @@ case class ConsulDtabInterpreterConfig(
     val servicePort = port.getOrElse(DefaultPort).port
     val backoffs = backoff.map(_.mk).getOrElse(DefaultBackoff)
     val tlsParams = tls.map(_.params).getOrElse(Stack.Params.empty)
+    val enableValCompression = enableValueCompression.getOrElse(false)
     val service = Http.client
       .interceptInterrupts
       .failFast(failFast)
@@ -63,7 +65,7 @@ case class ConsulDtabInterpreterConfig(
       .withParams(tlsParams)
       .newService(s"/$$/inet/$serviceHost/$servicePort")
 
-    KvApi(service, backoffs)
+    KvApi(service, backoffs, enableValCompression)
   }
 
   @JsonIgnore

--- a/interpreter/consul/src/test/scala/io/buoyant/interpreter/consul/ConsulInterpreterTest.scala
+++ b/interpreter/consul/src/test/scala/io/buoyant/interpreter/consul/ConsulInterpreterTest.scala
@@ -46,7 +46,7 @@ class ConsulInterpreterTest extends FunSuite with Inside {
 
     val config = parse(yaml)
     inside(config) {
-      case ConsulDtabInterpreterConfig(host, port, _, namespace, _, _, _, _, _, _, _) =>
+      case ConsulDtabInterpreterConfig(host, port, _, namespace, _, _, _, _, _, _, _, _) =>
         assert(host.get == "consul-node")
         assert(port.get == Port(9999))
         assert(namespace.get == "internal")

--- a/linkerd/docs/interpreter.md
+++ b/linkerd/docs/interpreter.md
@@ -189,3 +189,4 @@ writeConsistencyMode | `default` | Select between [Consul API consistency modes]
 failFast | `false` | If `false`, disable fail fast and failure accrual for Consul client. Keep it `false` when using a local agent but change it to `true` when talking directly to an HA Consul API.
 backoff |  exponential backoff from 1ms to 1min | Object that determines which backoff algorithm should be used. See [retry backoff](https://linkerd.io/config/head/linkerd#retry-backoff-parameters)
 tls | no tls | Use TLS during connection with Consul. see [Consul Encryption](https://www.consul.io/docs/agent/encryption.html) and [Namer TLS](#namer-tls).
+enableValueCompression | `false` | Enables the use of Gzip compression for values stored in Consul. Allows for larger dtabs.

--- a/namerd/docs/storage.md
+++ b/namerd/docs/storage.md
@@ -189,6 +189,7 @@ writeConsistencyMode | `default` | Select between [Consul API consistency modes]
 failFast | `false` | If `false`, disable fail fast and failure accrual for Consul client. Keep it `false` when using a local agent but change it to `true` when talking directly to an HA Consul API.
 backoff |  exponential backoff from 1ms to 1min | Object that determines which backoff algorithm should be used. See [retry backoff](https://linkerd.io/config/head/linkerd#retry-backoff-parameters)
 tls | no tls | Use TLS during connection with Consul. see [Consul Encryption](https://www.consul.io/docs/agent/encryption.html) and [Namer TLS](#namer-tls).
+enableValueCompression | `false` | Enables the use of Gzip compression for values stored in Consul. Allows for larger dtabs.
 
 ### Namer TLS
 

--- a/namerd/storage/consul/src/main/scala/io/buoyant/namerd/storage/consul/ConsulDtabStoreInitializer.scala
+++ b/namerd/storage/consul/src/main/scala/io/buoyant/namerd/storage/consul/ConsulDtabStoreInitializer.scala
@@ -23,7 +23,8 @@ case class ConsulConfig(
   writeConsistencyMode: Option[ConsistencyMode] = None,
   failFast: Option[Boolean] = None,
   backoff: Option[BackoffConfig] = None,
-  tls: Option[TlsClientConfig] = None
+  tls: Option[TlsClientConfig] = None,
+  enableValueCompression: Option[Boolean] = None
 ) extends DtabStoreConfig {
   import ConsulConfig._
 
@@ -36,6 +37,7 @@ case class ConsulConfig(
     val servicePort = port.getOrElse(DefaultPort).port
     val backoffs = backoff.map(_.mk).getOrElse(DefaultBackoff)
     val tlsParams = tls.map(_.params).getOrElse(Stack.Params.empty)
+    val enableValCompression = enableValueCompression.getOrElse(false)
 
     val service = Http.client
       .interceptInterrupts
@@ -46,7 +48,7 @@ case class ConsulConfig(
       .withParams(tlsParams)
       .newService(s"/$$/inet/$serviceHost/$servicePort")
     new ConsulDtabStore(
-      KvApi(service, backoffs),
+      KvApi(service, backoffs, enableValCompression),
       root,
       datacenter = datacenter,
       readConsistency = readConsistencyMode,

--- a/namerd/storage/consul/src/test/scala/io/buoyant/namerd/storage/consul/ConsulConfigTest.scala
+++ b/namerd/storage/consul/src/test/scala/io/buoyant/namerd/storage/consul/ConsulConfigTest.scala
@@ -24,6 +24,7 @@ class ConsulConfigTest extends FunSuite with OptionValues {
          |datacenter: us-east-42
          |readConsistencyMode: stale
          |writeConsistencyMode: consistent
+         |enableValueCompression: true
          |tls:
          |  disableValidation: false
          |  commonName: consul.io
@@ -41,6 +42,7 @@ class ConsulConfigTest extends FunSuite with OptionValues {
     assert(consul.datacenter == Some("us-east-42"))
     assert(consul.readConsistencyMode == Some(ConsistencyMode.Stale))
     assert(consul.writeConsistencyMode == Some(ConsistencyMode.Consistent))
+    assert(consul.enableValueCompression == Some(true))
     val clientAuth = ClientAuth("/certificates/cert.pem", None, "/certificates/key.pem")
     val tlsConfig = TlsClientConfig(None, Some(false), Some("consul.io"), None, Some("/certificates/cacert-bundle.pem"), Some(clientAuth))
     assert(consul.tls == Some(tlsConfig))

--- a/router/base-http/src/main/scala/io/buoyant/router/http/MaxCallDepthFilter.scala
+++ b/router/base-http/src/main/scala/io/buoyant/router/http/MaxCallDepthFilter.scala
@@ -8,8 +8,7 @@ import io.buoyant.router.http.ForwardClientCertFilter.Enabled
 import io.buoyant.router.http.MaxCallDepthFilter.MaxCallDepthExceeded
 import scala.util.control.NoStackTrace
 
-class MaxCallDepthFilter[Req, H: HeadersLike, Rep](maxCalls: Int, headerKey: String)
-  (implicit requestLike: RequestLike[Req, H]) extends SimpleFilter[Req, Rep] {
+class MaxCallDepthFilter[Req, H: HeadersLike, Rep](maxCalls: Int, headerKey: String)(implicit requestLike: RequestLike[Req, H]) extends SimpleFilter[Req, Rep] {
 
   def numCalls(viaValue: String) = viaValue.split(",").length
 
@@ -27,7 +26,7 @@ object MaxCallDepthFilter {
 
   final case class MaxCallDepthExceeded(calls: Int)
     extends Exception(s"Maximum number of calls ($calls) has been exceeded. Please check for proxy loops.")
-      with NoStackTrace
+    with NoStackTrace
 
   final case class Param(value: Int) extends AnyVal {
     def mk(): (Param, Stack.Param[Param]) = (this, Param.param)
@@ -37,8 +36,7 @@ object MaxCallDepthFilter {
     implicit val param = Stack.Param(Param(1000))
   }
 
-  def module[Req, H: HeadersLike, Rep](headerKey: String)
-    (implicit requestLike: RequestLike[Req, H]): Stackable[ServiceFactory[Req, Rep]] =
+  def module[Req, H: HeadersLike, Rep](headerKey: String)(implicit requestLike: RequestLike[Req, H]): Stackable[ServiceFactory[Req, Rep]] =
     new Stack.Module1[Param, ServiceFactory[Req, Rep]] {
       val role = Stack.Role("MaxCallDepthFilter")
       val description = "Limits the number of hops by looking at the Via header of a request"


### PR DESCRIPTION
Allows for making use of Gzip compression when interacting with Consul KV Api. 

Fixes #2202 

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>