### PR TITLE
Avoid leaking H2 frames from BufferedStream

### DIFF
--- a/router/h2/src/main/scala/io/buoyant/router/h2/ClassifiedRetryFilter.scala
+++ b/router/h2/src/main/scala/io/buoyant/router/h2/ClassifiedRetryFilter.scala
@@ -7,6 +7,7 @@ import com.twitter.finagle.service.{ResponseClass, RetryBudget}
 import com.twitter.finagle.stats.StatsReceiver
 import com.twitter.finagle.{Service, SimpleFilter}
 import com.twitter.util._
+import scala.util.control.NonFatal
 import scala.{Stream => SStream}
 
 /**
@@ -137,6 +138,12 @@ class ClassifiedRetryFilter(
         case e if responseClassifier(H2ReqRep(req, Throw(e))).contains(ResponseClass.RetryableFailure) =>
           // Request is retryable, attempt to create a new child request stream.
           retry(orElse = { retriesStat.add(count); Future.exception(e) })
+        case NonFatal(e) =>
+          // request is not retryable, we need to make sure the buffer is discarded
+          // so all buffered frames are released
+          requestBuffer.discardBuffer()
+          retriesStat.add(count)
+          Future.exception(e)
       }
     }
 


### PR DESCRIPTION
This PR adds a change that ensures `BufferedStream` objects are discarded when exceptions occur. This prevents leaking H2 frames and as conseqeuence leaking netty `ByteByf` objects (heap or non heap based ones).  To illustrate things a bit more clearly, we can take a look at the folllowing exameple. 

- **Linkerd config:** 

```yaml
admin:
  port: 9995

routers:
  - protocol: http
    dtab: |
      /svc => /$/inet/127.1/9995;
    servers:
      - port: 4145

  - protocol: h2
    h2AccessLog: logs/access.log
    h2AccessLogRollPolicy: daily
    h2AccessLogAppend: true
    h2AccessLogRotateCount: -1
    dtab: |
      /svc => /$/inet/127.1/9999;
    identifier:
      kind: io.l5d.header.token
      header: ":authority"
    servers:
      - port: 4150
        maxConcurrentStreamsPerConnection: 300
        addForwardedHeader:
          by: {kind: "ip:port"}
          for: {kind: "ip:port"}
        initialStreamWindowBytes: 1048576 # 1MB
    client:
      initialStreamWindowBytes: 1048576 # 1MB
```

- **Steps**

1. Start linkerd with the supplied config and vm options: 
     `-Xmx128M -XX:MaxDirectMemorySize=64M -Dio.netty.noUnsafe=true`
2. Start dealiner server:

        java -Dlogback.configurationFile=logback.xml \
                -Djava.util.logging.config.file=logging.properties \
                -classpath deadliner.jar \
                 com.bigcommerce.deadliner.DeadlinerServer

3. Start dealiner client:

       java -Dlogback.configurationFile=logback.xml \
              -classpath deadliner.jar \
               com.bigcommerce.deadliner.DeadlinerClient \
               127.0.0.1 \
               4150 \
               20 \
               1000000 \
               1


You will fairly quickly see that your heap grows with time and eventually you will get OOM. This is not the correct behavior obviously. If we look at the memory footprint over the lifecycle of 50000 requests it becomes clear that there is a problem. 

<img width="1050" alt="Screenshot 2019-08-13 at 14 18 35" src="https://user-images.githubusercontent.com/4391506/62938578-f5256e00-bdd7-11e9-8362-1d8c7dd04729.png">

Notice how before the fix, the memory is not reclaimed. Looking closely at the heap dump, we can see that we end up accumulating quite a lot of netty `PoolChunk` objects containing the h2 request frames: 

**Number of pool chunks before fix**: 
<img width="406" alt="Screenshot 2019-08-13 at 14 19 06" src="https://user-images.githubusercontent.com/4391506/62938732-4c2b4300-bdd8-11e9-829b-b6b50d1c202c.png">

**Number of pool chunks after fix**: 
<img width="384" alt="Screenshot 2019-08-13 at 14 03 01" src="https://user-images.githubusercontent.com/4391506/62938884-9e6c6400-bdd8-11e9-8c60-39254e42595c.png">


**Sample content of `PoolChunk`**
<img width="1432" alt="Screenshot 2019-08-13 at 14 41 38" src="https://user-images.githubusercontent.com/4391506/62938808-7c72e180-bdd8-11e9-9bff-337619ca51fa.png">

As you might imagine because each `Frame.Data` is wrapped in a `RefCountedFrame` once it finds its way into the `BufferedStream` even though all forked children might be canceled the original `Frame.Data` will never be released until the buffer is discarded and the `RefCountedFrame.latch`  reaches 0.

fixes #2279 
fixes #2247 

PS: That was tons of fun!

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>