### PR TITLE
Fix content-type header in gRPC runtime

### DIFF
--- a/grpc/runtime/src/main/scala/io/buoyant/grpc/runtime/ClientDispatcher.scala
+++ b/grpc/runtime/src/main/scala/io/buoyant/grpc/runtime/ClientDispatcher.scala
@@ -3,6 +3,7 @@ package io.buoyant.grpc.runtime
 import com.twitter.finagle.buoyant.h2
 import com.twitter.finagle.{Failure, FailureFlags, Service => FinagleService}
 import com.twitter.util._
+import io.buoyant.grpc.runtime.H2Headers.requestHeaders
 import io.netty.buffer.Unpooled
 
 object ClientDispatcher {
@@ -12,7 +13,7 @@ object ClientDispatcher {
     val frame = h2.Frame.Data(buf, eos = true)
     val stream = h2.Stream()
     stream.write(frame) // don't wait
-    h2.Request("http", h2.Method.Post, "", path, stream)
+    h2.Request(requestHeaders(path), stream)
   }
 
   private[this] def requestStreaming[T](path: String, msgs: Stream[T], codec: Codec[T]): h2.Request = {
@@ -41,7 +42,7 @@ object ClientDispatcher {
       msgs.reset(rst)
     }
 
-    h2.Request("http", h2.Method.Post, "", path, frames)
+    h2.Request(requestHeaders(path), frames)
   }
 
   private[this] def acceptUnary[T](result: Try[h2.Response], codec: Codec[T]): Future[T] =

--- a/grpc/runtime/src/main/scala/io/buoyant/grpc/runtime/H2Headers.scala
+++ b/grpc/runtime/src/main/scala/io/buoyant/grpc/runtime/H2Headers.scala
@@ -3,19 +3,21 @@ package io.buoyant.grpc.runtime
 import com.twitter.finagle.buoyant.h2
 
 private[runtime] object H2Headers {
-  private[this] val ContentType = "content-type"
-  private[this] val GrpcProtoContentType = "application/grpc+proto"
+  private[this] val AuthorityHeader = h2.Headers.Authority -> ""
+  private[this] val ContentTypeHeader = "content-type" -> "application/grpc+proto"
+  private[this] val MethodHeader = h2.Headers.Method -> h2.Method.Post.toString
+  private[this] val SchemeHeader = h2.Headers.Scheme -> "http"
 
   def responseHeaders(http2Status: h2.Status = h2.Status.Ok): h2.Headers = h2.Headers(
     h2.Headers.Status -> http2Status.toString,
-    ContentType -> GrpcProtoContentType
+    ContentTypeHeader
   )
 
   def requestHeaders(path: String): h2.Headers = h2.Headers(
-    h2.Headers.Scheme -> "http",
-    h2.Headers.Method -> h2.Method.Post.toString,
-    h2.Headers.Authority -> "",
     h2.Headers.Path -> path,
-    ContentType -> GrpcProtoContentType
+    AuthorityHeader,
+    ContentTypeHeader,
+    MethodHeader,
+    SchemeHeader
   )
 }

--- a/grpc/runtime/src/main/scala/io/buoyant/grpc/runtime/H2Headers.scala
+++ b/grpc/runtime/src/main/scala/io/buoyant/grpc/runtime/H2Headers.scala
@@ -1,0 +1,21 @@
+package io.buoyant.grpc.runtime
+
+import com.twitter.finagle.buoyant.h2
+
+private[runtime] object H2Headers {
+  private[this] val ContentType = "content-type"
+  private[this] val GrpcProtoContentType = "application/grpc+proto"
+
+  def responseHeaders(http2Status: h2.Status = h2.Status.Ok): h2.Headers = h2.Headers(
+    h2.Headers.Status -> http2Status.toString,
+    ContentType -> GrpcProtoContentType
+  )
+
+  def requestHeaders(path: String): h2.Headers = h2.Headers(
+    h2.Headers.Scheme -> "http",
+    h2.Headers.Method -> h2.Method.Post.toString,
+    h2.Headers.Authority -> "",
+    h2.Headers.Path -> path,
+    ContentType -> GrpcProtoContentType
+  )
+}

--- a/grpc/runtime/src/main/scala/io/buoyant/grpc/runtime/ServerDispatcher.scala
+++ b/grpc/runtime/src/main/scala/io/buoyant/grpc/runtime/ServerDispatcher.scala
@@ -150,12 +150,11 @@ class ServerDispatcher(services: Seq[ServerDispatcher.Service])
     }.toMap
 
   override def apply(req: h2.Request): Future[h2.Response] = {
-    // According to gRPC spec, server must return 415 if content-type is not set to
-    // application/grpc to allow for graceful error handling when plain H2 client
-    // makes request to a gRPC endpoint.
+    // According to gRPC spec (https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md)
+    // server must return 415 if content-type is not set to application/grpc to allow for graceful
+    // error handling when plain H2 client makes request to a gRPC endpoint.
     // This, however, would be a breaking change on linkerd side.
-    // Postponing content-type validation for now.
-    // https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md
+    // https://github.com/linkerd/linkerd/issues/2326
     req.method match {
       case h2.Method.Post =>
         rpcByPath.get(req.path) match {

--- a/grpc/runtime/src/main/scala/io/buoyant/grpc/runtime/ServerDispatcher.scala
+++ b/grpc/runtime/src/main/scala/io/buoyant/grpc/runtime/ServerDispatcher.scala
@@ -3,6 +3,7 @@ package io.buoyant.grpc.runtime
 import com.twitter.finagle.{Failure, Service => FinagleService}
 import com.twitter.finagle.buoyant.h2
 import com.twitter.util.{Future, Return, Throw, Try}
+import io.buoyant.grpc.runtime.H2Headers.responseHeaders
 
 object ServerDispatcher {
 
@@ -87,7 +88,7 @@ object ServerDispatcher {
         val frames = h2.Stream()
         frames.write(h2.Frame.Data(buf, eos = false))
           .before(frames.write(GrpcStatus.Ok().toTrailers))
-        h2.Response(h2.Status.Ok, frames)
+        h2.Response(responseHeaders(), frames)
 
       case Throw(e) =>
         val status = e match {
@@ -96,7 +97,7 @@ object ServerDispatcher {
         }
         val frames = h2.Stream()
         frames.write(status.toTrailers)
-        h2.Response(h2.Status.Ok, frames)
+        h2.Response(responseHeaders(), frames)
     }
 
     private[this] def respondStreaming[Rsp](codec: Codec[Rsp], msgs: Stream[Rsp]): h2.Response = {
@@ -124,13 +125,13 @@ object ServerDispatcher {
         msgs.reset(rst)
       }
 
-      h2.Response(h2.Status.Ok, frames)
+      h2.Response(responseHeaders(), frames)
     }
   }
 
   private def fail(status: GrpcStatus): Future[h2.Response] = {
     val stream = h2.Stream.const(status.toTrailers)
-    Future.value(h2.Response(h2.Status.BadRequest, stream))
+    Future.value(h2.Response(responseHeaders(h2.Status.BadRequest), stream))
   }
 
   def apply(hd: Service, tl: Service*): ServerDispatcher =
@@ -148,7 +149,13 @@ class ServerDispatcher(services: Seq[ServerDispatcher.Service])
       }
     }.toMap
 
-  override def apply(req: h2.Request): Future[h2.Response] =
+  override def apply(req: h2.Request): Future[h2.Response] = {
+    // According to gRPC spec, server must return 415 if content-type is not set to
+    // application/grpc to allow for graceful error handling when plain H2 client
+    // makes request to a gRPC endpoint.
+    // This, however, would be a breaking change on linkerd side.
+    // Postponing content-type validation for now.
+    // https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md
     req.method match {
       case h2.Method.Post =>
         rpcByPath.get(req.path) match {
@@ -157,4 +164,5 @@ class ServerDispatcher(services: Seq[ServerDispatcher.Service])
         }
       case method => ServerDispatcher.fail(GrpcStatus.Unknown(s"unsupported method: $method"))
     }
+  }
 }


### PR DESCRIPTION
According to the spec https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md gRPC servers and clients must set content-type header to `application/grpc`.
Failing to do so makes valid gRPC applications (particularly ones written in go) to fail during request/response validation.

This PR updates buoyant gRPC runtime to set `content-type` header to `application/grpc+proto`.

This PR does NOT add `content-type` header validation on server though. This would be a breaking change which may cause denial of service for existing linkerd users.
