### PR TITLE
[DNM] Respect maxConcurrentStreams for client and server H2 dispatchers

### DIFF
--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/H2.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/H2.scala
@@ -2,6 +2,7 @@ package com.twitter.finagle.buoyant
 
 import com.twitter.finagle.buoyant.h2._
 import com.twitter.finagle.buoyant.h2.netty4._
+import com.twitter.finagle.buoyant.h2.param.Settings.MaxConcurrentStreams
 import com.twitter.finagle.client.{StackClient, StdStackClient, Transporter}
 import com.twitter.finagle.liveness.FailureDetector
 import com.twitter.finagle.param.{WithDefaultLoadBalancer, WithSessionPool}
@@ -109,7 +110,8 @@ object H2 extends Client[Request, Response] with Server[Request, Response] {
       },
       service: Service[Request, Response]
     ): Closable = {
-      new Netty4ServerDispatcher(trans, None, service, statsReceiver)
+      val maxConcurrentStreams = params[MaxConcurrentStreams].streams
+      new Netty4ServerDispatcher(trans, None, service, statsReceiver, maxConcurrentStreams)
     }
   }
 

--- a/finagle/h2/src/main/scala/io/netty/handler/codec/http2/H2FrameCodec.scala
+++ b/finagle/h2/src/main/scala/io/netty/handler/codec/http2/H2FrameCodec.scala
@@ -307,6 +307,14 @@ object H2FrameCodec {
         val pingAck = new DefaultHttp2PingFrame(data, true)
         ctx.fireChannelRead(pingAck); ()
       }
+
+      override def onSettingsRead(
+        ctx: ChannelHandlerContext,
+        settings: Http2Settings
+      ): Unit = {
+        println(s"Read settings from remote: $settings")
+        ctx.fireChannelRead(new DefaultHttp2SettingsFrame(settings)); ()
+      }
     }
   }
 }

--- a/finagle/h2/src/main/scala/io/netty/handler/codec/http2/H2FrameStream.scala
+++ b/finagle/h2/src/main/scala/io/netty/handler/codec/http2/H2FrameStream.scala
@@ -1,7 +1,13 @@
 package io.netty.handler.codec.http2
 
-case class H2FrameStream(streamId: Int, streamState: Http2Stream.State) extends Http2FrameStream {
+case class H2FrameStream(streamId: Int, streamState: Http2Stream.State)
+  extends Http2FrameStream {
   override def state(): Http2Stream.State = streamState
 
   override def id(): Int = streamId
+}
+
+object H2FrameStream {
+  def apply(stream: Http2FrameStream): H2FrameStream =
+    H2FrameStream(stream.id(), stream.state())
 }

--- a/finagle/h2/src/test/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4ClientDispatcherTest.scala
+++ b/finagle/h2/src/test/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4ClientDispatcherTest.scala
@@ -2,6 +2,7 @@ package com.twitter.finagle.buoyant.h2
 package netty4
 
 import com.twitter.concurrent.AsyncQueue
+import com.twitter.finagle.buoyant.h2.Frame.Data.NoopRelease
 import com.twitter.finagle.{Status => SvcStatus}
 import com.twitter.finagle.stats.InMemoryStatsReceiver
 import com.twitter.finagle.transport.{SimpleTransportContext, Transport, TransportContext}
@@ -9,26 +10,36 @@ import com.twitter.util.{Future, Promise, Time}
 import io.buoyant.test.FunSuite
 import io.netty.buffer.Unpooled
 import io.netty.handler.codec.http2._
-import java.net.SocketAddress
 import java.nio.charset.StandardCharsets
 
 class Netty4ClientDispatcherTest extends FunSuite {
   setLogLevel(com.twitter.logging.Level.OFF)
 
-  test("dispatches multiple concurrent requests on underlying transport") {
+
+  def withDispatcher(initialFrames: Http2Frame*)
+    (f: (AsyncQueue[Http2Frame], AsyncQueue[Http2Frame], Netty4ClientDispatcher) => Any) = {
+
     val recvq, sentq = new AsyncQueue[Http2Frame]
+    initialFrames.foreach(recvq.offer)
     val closeP = new Promise[Throwable]
     val transport = new Transport[Http2Frame, Http2Frame] {
       type Context = TransportContext
+
       def context: Context = new SimpleTransportContext()
+
       def status = ???
+
       def peerCertificate = ???
+
       def read(): Future[Http2Frame] = recvq.poll()
+
       def write(f: Http2Frame): Future[Unit] = {
         sentq.offer(f)
         Future.Unit
       }
+
       def onClose = closeP
+
       def close(d: Time): Future[Unit] = {
         closeP.setValue(new Exception)
         Future.Unit
@@ -39,133 +50,310 @@ class Netty4ClientDispatcherTest extends FunSuite {
     val dispatcher = new Netty4ClientDispatcher(transport, None, stats)
     assert(dispatcher.status == SvcStatus.Open)
 
-    var released = 0
-    def releaser: Int => Future[Unit] = { bytes =>
-      released += bytes
-      Future.Unit
-    }
-
-    // Issue req0
-    val req0q = new AsyncQueue[Frame]
-    val req0EndP = new Promise[Unit]
-    val req0 = {
-      val hs = new DefaultHttp2Headers
-      hs.scheme("http")
-      hs.method("sup")
-      hs.path("/")
-      hs.authority("auf")
-      val stream = new Stream {
-        override val isEmpty = false
-        override def onEnd = req0EndP
-        override def read() = req0q.poll()
-        override def cancel(reset: Reset): Unit = ???
-        override def onCancel: Future[Reset] = Future.never
-      }
-      Netty4Message.Request(hs, stream)
-    }
-    val rsp0f = dispatcher(req0)
-    assert(!rsp0f.isDefined)
-
-    val req1 = {
-      val hs = new DefaultHttp2Headers
-      hs.scheme("http")
-      hs.method("sup")
-      hs.path("/")
-      hs.authority("auf")
-      Netty4Message.Request(hs, Stream.empty())
-    }
-    val rsp1f = dispatcher(req1)
-    assert(!rsp1f.isDefined)
-
-    // Initial headers were sent to the server for req0
-    val req0InitF = sentq.poll()
-    assert(req0InitF.isDefined)
-    await(req0InitF) match {
-      case hf: Http2HeadersFrame =>
-        assert(hf.headers.method == "sup")
-        assert(hf.stream.id == 3)
-      case f =>
-        fail(s"unexpected frame: $f")
-    }
-
-    // Initial headers were sent to the server for req1
-    val req1InitF = sentq.poll()
-    assert(req1InitF.isDefined)
-    await(req1InitF) match {
-      case hf: Http2HeadersFrame =>
-        assert(hf.headers.method == "sup")
-        assert(hf.stream.id == 5)
-      case f =>
-        fail(s"unexpected frame: $f")
-    }
-
-    assert(req0q.offer({
-      val buf = Unpooled.copiedBuffer("how's it goin?", StandardCharsets.UTF_8)
-      val sz = buf.readableBytes()
-      Frame.Data(buf, false, () => releaser(sz))
-    }))
-
-    // We receive a response for req1 first:
-    assert(recvq.offer({
-      val hs = new DefaultHttp2Headers
-      hs.status("222")
-      new DefaultHttp2HeadersFrame(hs, false).stream(H2FrameStream(5, Http2Stream.State.OPEN))
-    }))
-
-    assert(rsp0f.poll == None)
-    assert(rsp1f.isDefined)
-    val rsp1 = await(rsp1f)
-    assert(rsp1.status == Status.Cowabunga)
-
-    // We receive a response for req0 second:
-    assert(recvq.offer({
-      val hs = new DefaultHttp2Headers
-      hs.status("222")
-      new DefaultHttp2HeadersFrame(hs, false).stream(H2FrameStream(3, Http2Stream.State.OPEN))
-    }))
-    assert(rsp0f.isDefined)
-    val rsp0 = await(rsp0f)
-    assert(rsp0.status == Status.Cowabunga)
-    assert(rsp0.stream.nonEmpty)
-
-    assert(recvq.offer({
-      val buf = Unpooled.copiedBuffer("sup", StandardCharsets.UTF_8)
-      val dataFrame = new DefaultHttp2DataFrame(buf, true)
-      dataFrame.stream(H2FrameStream(3, Http2Stream.State.OPEN))
-    }))
-    assert(recvq.offer({
-      val buf = Unpooled.copiedBuffer("yo", StandardCharsets.UTF_8)
-      val headersFrame = new DefaultHttp2DataFrame(buf, true)
-      headersFrame.stream(H2FrameStream(5, Http2Stream.State.OPEN))
-    }))
-
-    val d0f = rsp0.stream.read()
-    assert(d0f.isDefined)
-
-    val d1f = rsp1.stream.read()
-    assert(d1f.isDefined)
-
-    await(d0f) match {
-      case f: Frame.Data =>
-        assert(f.buf.toString(StandardCharsets.UTF_8) == "sup")
-        assert(f.isEnd)
-        await(f.release())
-      case f =>
-        fail(s"unexpected frame: $f")
-    }
-    assert(rsp0.stream.onEnd.isDefined)
-
-    await(d1f) match {
-      case f: Frame.Data =>
-        assert(f.buf.toString(StandardCharsets.UTF_8) == "yo")
-        assert(f.isEnd)
-        await(f.release())
-      case f =>
-        fail(s"unexpected frame: $f")
-    }
-    assert(rsp1.stream.onEnd.isDefined)
+    f(recvq, sentq, dispatcher)
 
     await(transport.close())
     assert(dispatcher.status == SvcStatus.Closed)
+  }
+
+  test("dispatches multiple concurrent requests on underlying transport") {
+    withDispatcher() { (recvq, sentq, dispatcher) =>
+
+      var released = 0
+
+      def releaser: Int => Future[Unit] = { bytes =>
+        released += bytes
+        Future.Unit
+      }
+
+      // Issue req0
+      val req0q = new AsyncQueue[Frame]
+      val req0EndP = new Promise[Unit]
+      val req0 = {
+        val hs = new DefaultHttp2Headers
+        hs.scheme("http")
+        hs.method("sup")
+        hs.path("/")
+        hs.authority("auf")
+        val stream = new Stream {
+          override val isEmpty = false
+
+          override def onEnd = req0EndP
+
+          override def read() = req0q.poll()
+
+          override def cancel(reset: Reset): Unit = ???
+
+          override def onCancel: Future[Reset] = Future.never
+        }
+        Netty4Message.Request(hs, stream)
+      }
+      val rsp0f = dispatcher(req0)
+      assert(!rsp0f.isDefined)
+
+      val req1 = {
+        val hs = new DefaultHttp2Headers
+        hs.scheme("http")
+        hs.method("sup")
+        hs.path("/")
+        hs.authority("auf")
+        Netty4Message.Request(hs, Stream.empty())
+      }
+      val rsp1f = dispatcher(req1)
+      assert(!rsp1f.isDefined)
+
+      // Initial headers were sent to the server for req0
+      val req0InitF = sentq.poll()
+      assert(req0InitF.isDefined)
+      await(req0InitF) match {
+        case hf: Http2HeadersFrame =>
+          assert(hf.headers.method == "sup")
+          assert(hf.stream.id == 3)
+        case f =>
+          fail(s"unexpected frame: $f")
+      }
+
+      // Initial headers were sent to the server for req1
+      val req1InitF = sentq.poll()
+      assert(req1InitF.isDefined)
+      await(req1InitF) match {
+        case hf: Http2HeadersFrame =>
+          assert(hf.headers.method == "sup")
+          assert(hf.stream.id == 5)
+        case f =>
+          fail(s"unexpected frame: $f")
+      }
+
+      assert(
+        req0q.offer(
+        {
+          val buf = Unpooled.copiedBuffer("how's it goin?", StandardCharsets.UTF_8)
+          val sz = buf.readableBytes()
+          Frame.Data(buf, false, () => releaser(sz))
+        }
+        )
+      )
+
+      // We receive a response for req1 first:
+      assert(
+        recvq.offer(
+        {
+          val hs = new DefaultHttp2Headers
+          hs.status("222")
+          new DefaultHttp2HeadersFrame(hs, false).stream(H2FrameStream(5, Http2Stream.State.OPEN))
+        }
+        )
+      )
+
+      assert(rsp0f.poll == None)
+      assert(rsp1f.isDefined)
+      val rsp1 = await(rsp1f)
+      assert(rsp1.status == Status.Cowabunga)
+
+      // We receive a response for req0 second:
+      assert(
+        recvq.offer(
+        {
+          val hs = new DefaultHttp2Headers
+          hs.status("222")
+          new DefaultHttp2HeadersFrame(hs, false).stream(H2FrameStream(3, Http2Stream.State.OPEN))
+        }
+        )
+      )
+      assert(rsp0f.isDefined)
+      val rsp0 = await(rsp0f)
+      assert(rsp0.status == Status.Cowabunga)
+      assert(rsp0.stream.nonEmpty)
+
+      assert(
+        recvq.offer(
+        {
+          val buf = Unpooled.copiedBuffer("sup", StandardCharsets.UTF_8)
+          val dataFrame = new DefaultHttp2DataFrame(buf, true)
+          dataFrame.stream(H2FrameStream(3, Http2Stream.State.OPEN))
+        }
+        )
+      )
+      assert(
+        recvq.offer(
+        {
+          val buf = Unpooled.copiedBuffer("yo", StandardCharsets.UTF_8)
+          val headersFrame = new DefaultHttp2DataFrame(buf, true)
+          headersFrame.stream(H2FrameStream(5, Http2Stream.State.OPEN))
+        }
+        )
+      )
+
+      val d0f = rsp0.stream.read()
+      assert(d0f.isDefined)
+
+      val d1f = rsp1.stream.read()
+      assert(d1f.isDefined)
+
+      await(d0f) match {
+        case f: Frame.Data =>
+          assert(f.buf.toString(StandardCharsets.UTF_8) == "sup")
+          assert(f.isEnd)
+          await(f.release())
+        case f =>
+          fail(s"unexpected frame: $f")
+      }
+      assert(rsp0.stream.onEnd.isDefined)
+
+      await(d1f) match {
+        case f: Frame.Data =>
+          assert(f.buf.toString(StandardCharsets.UTF_8) == "yo")
+          assert(f.isEnd)
+          await(f.release())
+        case f =>
+          fail(s"unexpected frame: $f")
+      }
+      assert(rsp1.stream.onEnd.isDefined)
+
+
+    }
+  }
+
+  test("do not accept requests if they go over the max streams allowed by remote") {
+    val settingsFrame = new DefaultHttp2SettingsFrame(new Http2Settings().maxConcurrentStreams(2l))
+
+    withDispatcher(settingsFrame) { (recvq, sentq, dispatcher) =>
+      eventually {
+        assert(dispatcher.maxAllowedStreams.contains(2l))
+        ()
+      }
+
+      val resp0f = dispatcher(Netty4Message.Request(new DefaultHttp2Headers, Stream.empty()))
+      val resp1f = dispatcher(Netty4Message.Request(new DefaultHttp2Headers, Stream.empty()))
+      assert(!resp0f.isDefined)
+      assert(!resp1f.isDefined)
+
+      val resp2 = await(dispatcher(Netty4Message.Request(new DefaultHttp2Headers, Stream.empty())))
+      assert(resp2.status == Status.TooManyRequests)
+    }
+
+  }
+
+  test("continue accepting requests when open streams count decreases below max allowed") {
+    val settingsFrame = new DefaultHttp2SettingsFrame(new Http2Settings().maxConcurrentStreams(2l))
+
+    withDispatcher(settingsFrame) { (recvq, sentq, dispatcher) =>
+      eventually {
+        assert(dispatcher.maxAllowedStreams.contains(2l))
+        ()
+      }
+
+      // Issue req0
+      val req0q = new AsyncQueue[Frame]
+      val req0 = {
+        val hs = new DefaultHttp2Headers
+        hs.scheme("http")
+        hs.method("sup")
+        hs.path("/")
+        hs.authority("auf")
+        val stream = new Stream {
+          override val isEmpty = false
+
+          override def onEnd = new Promise[Unit]
+
+          override def read() = req0q.poll()
+
+          override def cancel(reset: Reset): Unit = ???
+
+          override def onCancel: Future[Reset] = Future.never
+        }
+        Netty4Message.Request(hs, stream)
+      }
+      val rsp0f = dispatcher(req0)
+      assert(!rsp0f.isDefined)
+
+      val rsp1f = dispatcher(Netty4Message.Request(new DefaultHttp2Headers, Stream.empty()))
+      assert(!rsp1f.isDefined)
+
+      // too many active streams at the moment
+      val rejectedResp = await(
+        dispatcher(
+          Netty4Message
+            .Request(new DefaultHttp2Headers, Stream.empty())
+        )
+      )
+      assert(rejectedResp.status == Status.TooManyRequests)
+      assert(dispatcher.activeStreams == 2) // currently two streams open
+
+      // we transition into SendCLosed here by sending an EOS
+      assert(
+        req0q.offer(
+        {
+          val buf = Unpooled.copiedBuffer("first and last word", StandardCharsets.UTF_8)
+          val sz = buf.readableBytes()
+          Frame.Data(buf, eos = true, NoopRelease)
+        }
+        )
+      )
+
+      assert(dispatcher.activeStreams == 2) // still two streams open as we are in HALF_CLOSED
+
+      // We receive a response for req0 second and end the stream with EOS
+      // This should transition the stream to fully closed and make room for
+      // another request
+      assert(
+        recvq.offer(
+        {
+          val hs = new DefaultHttp2Headers
+          hs.status("222")
+          new DefaultHttp2HeadersFrame(hs, true).stream(H2FrameStream(3, Http2Stream.State.OPEN))
+        }
+        )
+      )
+      assert(rsp0f.isDefined)
+      val rsp0 = await(rsp0f)
+      assert(rsp0.status == Status.Cowabunga)
+      assert(rsp0.stream.onEnd.isDefined)
+
+      assert(dispatcher.activeStreams == 1) // only one stream left open
+
+      // request will not error out immediately
+      val undefinedResp = dispatcher(Netty4Message.Request(new DefaultHttp2Headers, Stream.empty()))
+      assert(!undefinedResp.isDefined)
+
+      assert(dispatcher.activeStreams == 2) // now we have two active streams
+    }
+  }
+
+
+  test("reflect remote update to maximum concurrent streams") {
+    val settingsFrame1 = new DefaultHttp2SettingsFrame(new Http2Settings().maxConcurrentStreams(2l))
+    val settingsFrame2 = new DefaultHttp2SettingsFrame(new Http2Settings().maxConcurrentStreams(3l))
+
+    withDispatcher(settingsFrame1) { (recvq, sentq, dispatcher) =>
+      eventually {
+        assert(dispatcher.maxAllowedStreams.contains(2l))
+        ()
+      }
+
+      val resp0f = dispatcher(Netty4Message.Request(new DefaultHttp2Headers, Stream.empty()))
+      val resp1f = dispatcher(Netty4Message.Request(new DefaultHttp2Headers, Stream.empty()))
+      assert(!resp0f.isDefined)
+      assert(!resp1f.isDefined)
+
+      val resp2 = await(dispatcher(Netty4Message.Request(new DefaultHttp2Headers, Stream.empty())))
+      assert(resp2.status == Status.TooManyRequests)
+      assert(dispatcher.activeStreams == 2)
+
+      // remote sends updated settings with new
+      // values for maximum allowed streams
+      assert(recvq.offer(settingsFrame2))
+      eventually {
+        assert(dispatcher.maxAllowedStreams.contains(3l))
+        ()
+      }
+
+      dispatcher(Netty4Message.Request(new DefaultHttp2Headers, Stream.empty()))
+      eventually {
+        assert(dispatcher.activeStreams == 3)
+        ()
+      }
+
+    }
   }
 }

--- a/finagle/h2/src/test/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4ServerDispatcherTest.scala
+++ b/finagle/h2/src/test/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4ServerDispatcherTest.scala
@@ -8,7 +8,6 @@ import com.twitter.finagle.transport.{SimpleTransportContext, Transport, Transpo
 import com.twitter.util.{Future, Promise, Time}
 import io.buoyant.test.FunSuite
 import io.netty.handler.codec.http2._
-import java.net.SocketAddress
 import java.util.concurrent.atomic.AtomicBoolean
 import scala.collection.immutable.Queue
 
@@ -21,15 +20,22 @@ class Netty4ServerDispatcherTest extends FunSuite {
     val closeP = new Promise[Throwable]
     val transport = new Transport[Http2Frame, Http2Frame] {
       type Context = TransportContext
+
       def context: Context = new SimpleTransportContext()
+
       def status = ???
+
       def peerCertificate = None
+
       def read(): Future[Http2Frame] = recvq.poll()
+
       def write(f: Http2Frame): Future[Unit] = {
         sentq = sentq :+ f
         Future.Unit
       }
+
       def onClose = closeP
+
       def close(d: Time): Future[Unit] = {
         closeP.setValue(new Exception)
         Future.Unit
@@ -56,55 +62,71 @@ class Netty4ServerDispatcherTest extends FunSuite {
     }
 
     val stats = new InMemoryStatsReceiver
-    val dispatcher = new Netty4ServerDispatcher(transport, None, service, stats)
+    val dispatcher = new Netty4ServerDispatcher(transport, None, service, stats, None)
 
     assert(!bartmanCalled.get)
-    assert(recvq.offer({
-      val hs = new DefaultHttp2Headers
-      hs.scheme("http")
-      hs.method("GET")
-      hs.authority("bartman")
-      hs.path("/")
-      val hf = new DefaultHttp2HeadersFrame(hs, true)
-      hf.stream(H2FrameStream(3, Http2Stream.State.OPEN))
-    }))
-    eventually { assert(bartmanCalled.get) }
+    assert(
+      recvq.offer(
+      {
+        val hs = new DefaultHttp2Headers
+        hs.scheme("http")
+        hs.method("GET")
+        hs.authority("bartman")
+        hs.path("/")
+        val hf = new DefaultHttp2HeadersFrame(hs, true)
+        hf.stream(H2FrameStream(3, Http2Stream.State.OPEN))
+      }
+      )
+    )
+    eventually {
+      assert(bartmanCalled.get)
+    }
 
     assert(!elBartoCalled.get)
-    assert(recvq.offer({
-      val hs = new DefaultHttp2Headers
-      hs.scheme("http")
-      hs.method("GET")
-      hs.authority("elbarto")
-      hs.path("/")
-      val hf = new DefaultHttp2HeadersFrame(hs, true)
-      hf.stream(H2FrameStream(5, Http2Stream.State.HALF_CLOSED_REMOTE))
-    }))
-    eventually { assert(elBartoCalled.get) }
+    assert(
+      recvq.offer(
+      {
+        val hs = new DefaultHttp2Headers
+        hs.scheme("http")
+        hs.method("GET")
+        hs.authority("elbarto")
+        hs.path("/")
+        val hf = new DefaultHttp2HeadersFrame(hs, true)
+        hf.stream(H2FrameStream(5, Http2Stream.State.HALF_CLOSED_REMOTE))
+      }
+      )
+    )
+    eventually {
+      assert(elBartoCalled.get)
+    }
 
     assert(sentq.isEmpty)
 
     val bartmanStream = new AsyncQueue[Frame]
     bartmanStreamP.setValue(Stream(bartmanStream))
     eventually {
-      assert(sentq.head == {
-        val hs = new DefaultHttp2Headers
-        hs.status("222")
-        val hf = new DefaultHttp2HeadersFrame(hs, false)
-        hf.stream(H2FrameStream(3, Http2Stream.State.HALF_CLOSED_REMOTE))
-      })
+      assert(
+        sentq.head == {
+          val hs = new DefaultHttp2Headers
+          hs.status("222")
+          val hf = new DefaultHttp2HeadersFrame(hs, false)
+          hf.stream(H2FrameStream(3, Http2Stream.State.HALF_CLOSED_REMOTE))
+        }
+      )
     }
     sentq = sentq.tail
 
     val elBartoStream = new AsyncQueue[Frame]
     elBartoStreamP.setValue(Stream(elBartoStream))
     eventually {
-      assert(sentq.head == {
-        val hs = new DefaultHttp2Headers
-        hs.status("222")
-        val hf = new DefaultHttp2HeadersFrame(hs, false)
-        hf.stream(H2FrameStream(5, Http2Stream.State.HALF_CLOSED_REMOTE))
-      })
+      assert(
+        sentq.head == {
+          val hs = new DefaultHttp2Headers
+          hs.status("222")
+          val hf = new DefaultHttp2HeadersFrame(hs, false)
+          hf.stream(H2FrameStream(5, Http2Stream.State.HALF_CLOSED_REMOTE))
+        }
+      )
     }
     sentq = sentq.tail
 
@@ -144,4 +166,241 @@ class Netty4ServerDispatcherTest extends FunSuite {
     }
     sentq = sentq.tail
   }
+
+  test("respects maxConcurrentStreams") {
+    val recvq = new AsyncQueue[Http2Frame]
+    @volatile var sentq = Queue.empty[Http2Frame]
+    val closeP = new Promise[Throwable]
+    val transport = new Transport[Http2Frame, Http2Frame] {
+      type Context = TransportContext
+
+      def context: Context = new SimpleTransportContext()
+
+      def status = ???
+
+      def peerCertificate = None
+
+      def read(): Future[Http2Frame] = recvq.poll()
+
+      def write(f: Http2Frame): Future[Unit] = {
+        sentq = sentq :+ f
+        Future.Unit
+      }
+
+      def onClose = closeP
+
+      def close(d: Time): Future[Unit] = {
+        closeP.setValue(new Exception)
+        Future.Unit
+      }
+    }
+
+    val stream1Called = new AtomicBoolean(false)
+    val stream1StreamP = new Promise[Stream]
+
+    val service = Service.mk[Request, Response] { req =>
+      req.authority match {
+        case "stream1" if stream1Called.compareAndSet(false, true) =>
+          stream1StreamP.map(Response(Status.Cowabunga, _))
+
+        case _ =>
+          Future.value(Response(Status.EatMyShorts, Stream.empty()))
+      }
+    }
+
+    val stats = new InMemoryStatsReceiver
+    val dispatcher = new Netty4ServerDispatcher(
+      transport,
+      None,
+      service,
+      stats,
+      maxConcurrentStreams = Some(1l)
+    )
+
+    assert(!stream1Called.get)
+    assert(
+      recvq.offer(
+      {
+        val hs = new DefaultHttp2Headers
+        hs.scheme("http")
+        hs.method("GET")
+        hs.authority("stream1")
+        hs.path("/")
+        val hf = new DefaultHttp2HeadersFrame(hs, true)
+        hf.stream(H2FrameStream(3, Http2Stream.State.OPEN))
+      }
+      )
+    )
+
+    eventually {
+      assert(stream1Called.get)
+    }
+    eventually {
+      assert(dispatcher.activeStreams == 1)
+    }
+
+    assert(
+      recvq.offer(
+      {
+        val hs = new DefaultHttp2Headers
+        hs.scheme("http")
+        hs.method("GET")
+        hs.authority("stream2")
+        hs.path("/")
+        val hf = new DefaultHttp2HeadersFrame(hs, true)
+        hf.stream(H2FrameStream(5, Http2Stream.State.OPEN))
+      }
+      )
+    )
+
+    // client attempts to initiate a new stream but gets REFUSED_STREAM
+    // instead as we already have one active stream
+    eventually {
+      assert(
+        sentq.head == new DefaultHttp2ResetFrame(Http2Error.REFUSED_STREAM)
+          .stream(H2FrameStream(5, Http2Stream.State.OPEN))
+      )
+    }
+    assert(dispatcher.activeStreams == 1)
+  }
+
+  test("continue allowing stream creation when active streams count decreases below max allowed") {
+    val recvq = new AsyncQueue[Http2Frame]
+    @volatile var sentq = Queue.empty[Http2Frame]
+    val closeP = new Promise[Throwable]
+    val transport = new Transport[Http2Frame, Http2Frame] {
+      type Context = TransportContext
+
+      def context: Context = new SimpleTransportContext()
+
+      def status = ???
+
+      def peerCertificate = None
+
+      def read(): Future[Http2Frame] = recvq.poll()
+
+      def write(f: Http2Frame): Future[Unit] = {
+        sentq = sentq :+ f
+        Future.Unit
+      }
+
+      def onClose = closeP
+
+      def close(d: Time): Future[Unit] = {
+        closeP.setValue(new Exception)
+        Future.Unit
+      }
+    }
+
+    val stream1Called = new AtomicBoolean(false)
+    val stream1StreamP = new Promise[Stream]
+
+    val stream2Called = new AtomicBoolean(false)
+    val stream2StreamP = new Promise[Stream]
+
+    val service = Service.mk[Request, Response] { req =>
+      req.authority match {
+        case "stream1" if stream1Called.compareAndSet(false, true) =>
+          stream1StreamP.map(Response(Status.Cowabunga, _))
+
+        case "stream2" if stream2Called.compareAndSet(false, true) =>
+          stream2StreamP.map(Response(Status.Cowabunga, _))
+
+        case _ =>
+          Future.value(Response(Status.EatMyShorts, Stream.empty()))
+      }
+    }
+
+    val stats = new InMemoryStatsReceiver
+    val dispatcher = new Netty4ServerDispatcher(
+      transport,
+      None,
+      service,
+      stats,
+      maxConcurrentStreams = Some(1l)
+    )
+
+    assert(!stream1Called.get)
+    assert(
+      recvq.offer(
+      {
+        val hs = new DefaultHttp2Headers
+        hs.scheme("http")
+        hs.method("GET")
+        hs.authority("stream1")
+        hs.path("/")
+        val hf = new DefaultHttp2HeadersFrame(hs, true)
+        hf.stream(H2FrameStream(3, Http2Stream.State.OPEN))
+      }
+      )
+    )
+
+    eventually {
+      assert(stream1Called.get)
+    }
+    eventually {
+      assert(dispatcher.activeStreams == 1)
+    }
+
+    val stream2Headers = {
+      val hs = new DefaultHttp2Headers
+      hs.scheme("http")
+      hs.method("GET")
+      hs.authority("stream2")
+      hs.path("/")
+      val hf = new DefaultHttp2HeadersFrame(hs, false)
+      hf.stream(H2FrameStream(5, Http2Stream.State.OPEN))
+    }
+
+    assert(recvq.offer(stream2Headers))
+    // client attempts to initiate a new stream but gets REFUSED_STREAM
+    // instead as we already have one active stream
+    eventually {
+      assert(
+        sentq.head == new DefaultHttp2ResetFrame(Http2Error.REFUSED_STREAM)
+          .stream(H2FrameStream(5, Http2Stream.State.OPEN))
+      )
+    }
+    sentq = sentq.tail
+
+    assert(dispatcher.activeStreams == 1)
+    eventually {
+      assert(!stream2Called.get)
+    } // ensure stream 2 switch was not touched
+
+    val stream1 = new AsyncQueue[Frame]
+    stream1StreamP.setValue(Stream(stream1))
+    eventually {
+      assert(
+        sentq.head == {
+          val hs = new DefaultHttp2Headers
+          hs.status("222")
+          val hf = new DefaultHttp2HeadersFrame(hs, false)
+          hf.stream(H2FrameStream(3, Http2Stream.State.HALF_CLOSED_REMOTE))
+        }
+      )
+    }
+    sentq = sentq.tail
+
+    assert(stream1.offer(Frame.Data("0", true)))
+    eventually {
+      sentq.headOption match {
+        case Some(f: Http2DataFrame) =>
+          assert(f.stream.id == 3)
+          assert(f.isEndStream)
+        case f =>
+          fail(s"unexpected frame: $f")
+      }
+    }
+    sentq = sentq.tail
+
+    assert(recvq.offer(stream2Headers))
+    eventually {
+      assert(stream2Called.get)
+    } // ensure stream 2 switch was touched
+    eventually {
+      assert(dispatcher.activeStreams == 1)
+    }
+  }
+
 }


### PR DESCRIPTION
This PR addresses two problems 

The first commit makes sure that we respect MAX_CONCURRENT_STREAMS settings for the H2 protocol. This has two sides: 

**Client Side**
From the perspective of an H2 client, its pretty easy. We make sure that we process the Http2Settings frame that is received from the remote peer right after the connection initiation is done. This allows us to establish the maximum allowed concurrent streams that we can initiate with the remote. If we issue a request that goes over this advertised by the remote side threshold,  we fail the request with a 429 status. Note that this value can be dynamic and the remote peer can at any point send us another settings frame that overrides this threshold. That is accounted for as well. 

**Server side:** 
Things here are a bit more under our control. Namely, we take into account the maximumConcurrentStreams setting and track that in our `Netty4ServerDispatcher`. If the remote side tries to  send us a headers frame proposing to open another stream that will go over this threshold we respond with a reset frame with a `STREAM_REFUSED` status. 

The second commit is a bit more radical and attempts to redefine the definition of  a concurrent stream from the perspective of an h2 server. Ultimately `MAX_CONCURRENT_STREAMS` has to do with backpressure and the avoidance of resource exhaustion. For that to take effect, we don't only need to limit the amount of streams being created but also change the definition of what is an active stream from the perspective of our H2 server. Until now, the moment we transition our stream state into fully closed, which might happen in the case of sending an EOS frame and receiving a EOS frame, we consider this stream closed and we stop accounting for it. The problem with that is that the number of frames that are in the  recv queue of the stream might be arbitrary value. We loose the idea of when these are consumed (drained and released) and hope that this will somehow happen in the future either through successful consumption of the queue or through failure (e.g. service exception). 

In my mind this is not a perfect strategy as it exposes us to situations where we have streams being created at a really fast pace and not being consumed  quickly enough (classic fast producer, slow consumer problem), which leads to depletion of resources for linkerd. This is part of the reason  #2320 is happening and why it cannot be resolved by simply setting the `MAX_CONCURRENT_STREAMS` setting. 
All of that being said, this change makes sure that we complete a stream, when we have consumed and released its last frame (if there are frames at all). Until then this stream is counted towards active streams, although its in `CLOSED` state. This allows for exerting e2e backpressure when acting as an H2 server. 

I am still trying to  come up with a few more tests to make sure this is completely correct, but to me the behaviour sounds logical. Comments are more than welcome :) 


Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>