### PR TITLE
Respect maxConcurrentStreams 

### DIFF
--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/H2.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/H2.scala
@@ -2,6 +2,7 @@ package com.twitter.finagle.buoyant
 
 import com.twitter.finagle.buoyant.h2._
 import com.twitter.finagle.buoyant.h2.netty4._
+import com.twitter.finagle.buoyant.h2.param.Settings.MaxConcurrentStreams
 import com.twitter.finagle.client.{StackClient, StdStackClient, Transporter}
 import com.twitter.finagle.liveness.FailureDetector
 import com.twitter.finagle.param.{WithDefaultLoadBalancer, WithSessionPool}
@@ -109,7 +110,8 @@ object H2 extends Client[Request, Response] with Server[Request, Response] {
       },
       service: Service[Request, Response]
     ): Closable = {
-      new Netty4ServerDispatcher(trans, None, service, statsReceiver)
+      val maxConcurrentStreams = params[MaxConcurrentStreams].streams
+      new Netty4ServerDispatcher(trans, None, service, statsReceiver, maxConcurrentStreams)
     }
   }
 

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4DispatcherBase.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4DispatcherBase.scala
@@ -95,6 +95,12 @@ trait Netty4DispatcherBase[SendMsg <: Message, RecvMsg <: Message] {
 
   protected[this] def demuxing: Future[Unit]
 
+
+  // We count all streams towards active. The reason for that
+  // is the fact that under normal circumstances when the
+  // protocol is respected eventually the stream state will
+  // reach a point of being fully closed and will be removed
+  // from the map.
   def activeStreams: Long = streams.size()
 
   protected[this] def registerStream(

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4DispatcherBase.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4DispatcherBase.scala
@@ -95,6 +95,8 @@ trait Netty4DispatcherBase[SendMsg <: Message, RecvMsg <: Message] {
 
   protected[this] def demuxing: Future[Unit]
 
+  def activeStreams: Long = streams.size()
+
   protected[this] def registerStream(
     id: Int,
     stream: Netty4StreamTransport[SendMsg, RecvMsg]

--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4ServerDispatcher.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4ServerDispatcher.scala
@@ -33,7 +33,8 @@ class Netty4ServerDispatcher(
   override protected[this] val transport: Transport[Http2Frame, Http2Frame],
   override protected[this] val failureThreshold: Option[FailureDetector.Config],
   service: Service[Request, Response],
-  protected[this] val stats: StatsReceiver
+  protected[this] val stats: StatsReceiver,
+  protected[this] val maxConcurrentStreams: Option[Long]
 ) extends Netty4DispatcherBase[Response, Request] with Closable {
   import Netty4ServerDispatcher._
 
@@ -128,6 +129,8 @@ class Netty4ServerDispatcher(
 
   override protected[this] val demuxing: Future[Unit] = demux()
 
+  private[this] def streamLimitExhausted: Boolean = maxConcurrentStreams.exists(_ <= activeStreams)
+
   /**
    * The stream didn't exist. We're either receiving HEADERS
    * to initiate a new request, or we're receiving an
@@ -135,6 +138,10 @@ class Netty4ServerDispatcher(
    * connection to be closed with a protocol error.
    */
   override protected[this] def demuxNewStream(f: Http2Frame): Future[Unit] = f match {
+    case frame: Http2HeadersFrame if streamLimitExhausted =>
+      log.error("[%s S:%s] Exhausted  maxConcurrentStreams limit. Sending RESET.REFUSED for stream %s", prefix, frame, frame.stream().id())
+      writer.reset(H2FrameStream(frame.stream()), Reset.Refused)
+
     case frame: Http2HeadersFrame =>
       val st = newStreamTransport(frame.stream.id)
       if (st.recv(frame)) serveStream(st)

--- a/finagle/h2/src/main/scala/io/netty/handler/codec/http2/H2FrameStream.scala
+++ b/finagle/h2/src/main/scala/io/netty/handler/codec/http2/H2FrameStream.scala
@@ -5,3 +5,8 @@ case class H2FrameStream(streamId: Int, streamState: Http2Stream.State) extends 
 
   override def id(): Int = streamId
 }
+
+object H2FrameStream {
+  def apply(stream: Http2FrameStream): H2FrameStream =
+    H2FrameStream(stream.id(), stream.state())
+}

--- a/finagle/h2/src/test/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4ServerDispatcherTest.scala
+++ b/finagle/h2/src/test/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4ServerDispatcherTest.scala
@@ -8,7 +8,6 @@ import com.twitter.finagle.transport.{SimpleTransportContext, Transport, Transpo
 import com.twitter.util.{Future, Promise, Time}
 import io.buoyant.test.FunSuite
 import io.netty.handler.codec.http2._
-import java.net.SocketAddress
 import java.util.concurrent.atomic.AtomicBoolean
 import scala.collection.immutable.Queue
 
@@ -21,15 +20,22 @@ class Netty4ServerDispatcherTest extends FunSuite {
     val closeP = new Promise[Throwable]
     val transport = new Transport[Http2Frame, Http2Frame] {
       type Context = TransportContext
+
       def context: Context = new SimpleTransportContext()
+
       def status = ???
+
       def peerCertificate = None
+
       def read(): Future[Http2Frame] = recvq.poll()
+
       def write(f: Http2Frame): Future[Unit] = {
         sentq = sentq :+ f
         Future.Unit
       }
+
       def onClose = closeP
+
       def close(d: Time): Future[Unit] = {
         closeP.setValue(new Exception)
         Future.Unit
@@ -56,55 +62,71 @@ class Netty4ServerDispatcherTest extends FunSuite {
     }
 
     val stats = new InMemoryStatsReceiver
-    val dispatcher = new Netty4ServerDispatcher(transport, None, service, stats)
+    val dispatcher = new Netty4ServerDispatcher(transport, None, service, stats, None)
 
     assert(!bartmanCalled.get)
-    assert(recvq.offer({
-      val hs = new DefaultHttp2Headers
-      hs.scheme("http")
-      hs.method("GET")
-      hs.authority("bartman")
-      hs.path("/")
-      val hf = new DefaultHttp2HeadersFrame(hs, true)
-      hf.stream(H2FrameStream(3, Http2Stream.State.OPEN))
-    }))
-    eventually { assert(bartmanCalled.get) }
+    assert(
+      recvq.offer(
+      {
+        val hs = new DefaultHttp2Headers
+        hs.scheme("http")
+        hs.method("GET")
+        hs.authority("bartman")
+        hs.path("/")
+        val hf = new DefaultHttp2HeadersFrame(hs, true)
+        hf.stream(H2FrameStream(3, Http2Stream.State.OPEN))
+      }
+      )
+    )
+    eventually {
+      assert(bartmanCalled.get)
+    }
 
     assert(!elBartoCalled.get)
-    assert(recvq.offer({
-      val hs = new DefaultHttp2Headers
-      hs.scheme("http")
-      hs.method("GET")
-      hs.authority("elbarto")
-      hs.path("/")
-      val hf = new DefaultHttp2HeadersFrame(hs, true)
-      hf.stream(H2FrameStream(5, Http2Stream.State.HALF_CLOSED_REMOTE))
-    }))
-    eventually { assert(elBartoCalled.get) }
+    assert(
+      recvq.offer(
+      {
+        val hs = new DefaultHttp2Headers
+        hs.scheme("http")
+        hs.method("GET")
+        hs.authority("elbarto")
+        hs.path("/")
+        val hf = new DefaultHttp2HeadersFrame(hs, true)
+        hf.stream(H2FrameStream(5, Http2Stream.State.HALF_CLOSED_REMOTE))
+      }
+      )
+    )
+    eventually {
+      assert(elBartoCalled.get)
+    }
 
     assert(sentq.isEmpty)
 
     val bartmanStream = new AsyncQueue[Frame]
     bartmanStreamP.setValue(Stream(bartmanStream))
     eventually {
-      assert(sentq.head == {
-        val hs = new DefaultHttp2Headers
-        hs.status("222")
-        val hf = new DefaultHttp2HeadersFrame(hs, false)
-        hf.stream(H2FrameStream(3, Http2Stream.State.HALF_CLOSED_REMOTE))
-      })
+      assert(
+        sentq.head == {
+          val hs = new DefaultHttp2Headers
+          hs.status("222")
+          val hf = new DefaultHttp2HeadersFrame(hs, false)
+          hf.stream(H2FrameStream(3, Http2Stream.State.HALF_CLOSED_REMOTE))
+        }
+      )
     }
     sentq = sentq.tail
 
     val elBartoStream = new AsyncQueue[Frame]
     elBartoStreamP.setValue(Stream(elBartoStream))
     eventually {
-      assert(sentq.head == {
-        val hs = new DefaultHttp2Headers
-        hs.status("222")
-        val hf = new DefaultHttp2HeadersFrame(hs, false)
-        hf.stream(H2FrameStream(5, Http2Stream.State.HALF_CLOSED_REMOTE))
-      })
+      assert(
+        sentq.head == {
+          val hs = new DefaultHttp2Headers
+          hs.status("222")
+          val hf = new DefaultHttp2HeadersFrame(hs, false)
+          hf.stream(H2FrameStream(5, Http2Stream.State.HALF_CLOSED_REMOTE))
+        }
+      )
     }
     sentq = sentq.tail
 
@@ -144,4 +166,241 @@ class Netty4ServerDispatcherTest extends FunSuite {
     }
     sentq = sentq.tail
   }
+
+  test("respects maxConcurrentStreams") {
+    val recvq = new AsyncQueue[Http2Frame]
+    @volatile var sentq = Queue.empty[Http2Frame]
+    val closeP = new Promise[Throwable]
+    val transport = new Transport[Http2Frame, Http2Frame] {
+      type Context = TransportContext
+
+      def context: Context = new SimpleTransportContext()
+
+      def status = ???
+
+      def peerCertificate = None
+
+      def read(): Future[Http2Frame] = recvq.poll()
+
+      def write(f: Http2Frame): Future[Unit] = {
+        sentq = sentq :+ f
+        Future.Unit
+      }
+
+      def onClose = closeP
+
+      def close(d: Time): Future[Unit] = {
+        closeP.setValue(new Exception)
+        Future.Unit
+      }
+    }
+
+    val stream1Called = new AtomicBoolean(false)
+    val stream1StreamP = new Promise[Stream]
+
+    val service = Service.mk[Request, Response] { req =>
+      req.authority match {
+        case "stream1" if stream1Called.compareAndSet(false, true) =>
+          stream1StreamP.map(Response(Status.Cowabunga, _))
+
+        case _ =>
+          Future.value(Response(Status.EatMyShorts, Stream.empty()))
+      }
+    }
+
+    val stats = new InMemoryStatsReceiver
+    val dispatcher = new Netty4ServerDispatcher(
+      transport,
+      None,
+      service,
+      stats,
+      maxConcurrentStreams = Some(1l)
+    )
+
+    assert(!stream1Called.get)
+    assert(
+      recvq.offer(
+      {
+        val hs = new DefaultHttp2Headers
+        hs.scheme("http")
+        hs.method("GET")
+        hs.authority("stream1")
+        hs.path("/")
+        val hf = new DefaultHttp2HeadersFrame(hs, true)
+        hf.stream(H2FrameStream(3, Http2Stream.State.OPEN))
+      }
+      )
+    )
+
+    eventually {
+      assert(stream1Called.get)
+    }
+    eventually {
+      assert(dispatcher.activeStreams == 1)
+    }
+
+    assert(
+      recvq.offer(
+      {
+        val hs = new DefaultHttp2Headers
+        hs.scheme("http")
+        hs.method("GET")
+        hs.authority("stream2")
+        hs.path("/")
+        val hf = new DefaultHttp2HeadersFrame(hs, true)
+        hf.stream(H2FrameStream(5, Http2Stream.State.OPEN))
+      }
+      )
+    )
+
+    // client attempts to initiate a new stream but gets REFUSED_STREAM
+    // instead as we already have one active stream
+    eventually {
+      assert(
+        sentq.head == new DefaultHttp2ResetFrame(Http2Error.REFUSED_STREAM)
+          .stream(H2FrameStream(5, Http2Stream.State.OPEN))
+      )
+    }
+    assert(dispatcher.activeStreams == 1)
+  }
+
+  test("continue allowing stream creation when active streams count decreases below max allowed") {
+    val recvq = new AsyncQueue[Http2Frame]
+    @volatile var sentq = Queue.empty[Http2Frame]
+    val closeP = new Promise[Throwable]
+    val transport = new Transport[Http2Frame, Http2Frame] {
+      type Context = TransportContext
+
+      def context: Context = new SimpleTransportContext()
+
+      def status = ???
+
+      def peerCertificate = None
+
+      def read(): Future[Http2Frame] = recvq.poll()
+
+      def write(f: Http2Frame): Future[Unit] = {
+        sentq = sentq :+ f
+        Future.Unit
+      }
+
+      def onClose = closeP
+
+      def close(d: Time): Future[Unit] = {
+        closeP.setValue(new Exception)
+        Future.Unit
+      }
+    }
+
+    val stream1Called = new AtomicBoolean(false)
+    val stream1StreamP = new Promise[Stream]
+
+    val stream2Called = new AtomicBoolean(false)
+    val stream2StreamP = new Promise[Stream]
+
+    val service = Service.mk[Request, Response] { req =>
+      req.authority match {
+        case "stream1" if stream1Called.compareAndSet(false, true) =>
+          stream1StreamP.map(Response(Status.Cowabunga, _))
+
+        case "stream2" if stream2Called.compareAndSet(false, true) =>
+          stream2StreamP.map(Response(Status.Cowabunga, _))
+
+        case _ =>
+          Future.value(Response(Status.EatMyShorts, Stream.empty()))
+      }
+    }
+
+    val stats = new InMemoryStatsReceiver
+    val dispatcher = new Netty4ServerDispatcher(
+      transport,
+      None,
+      service,
+      stats,
+      maxConcurrentStreams = Some(1l)
+    )
+
+    assert(!stream1Called.get)
+    assert(
+      recvq.offer(
+      {
+        val hs = new DefaultHttp2Headers
+        hs.scheme("http")
+        hs.method("GET")
+        hs.authority("stream1")
+        hs.path("/")
+        val hf = new DefaultHttp2HeadersFrame(hs, true)
+        hf.stream(H2FrameStream(3, Http2Stream.State.OPEN))
+      }
+      )
+    )
+
+    eventually {
+      assert(stream1Called.get)
+    }
+    eventually {
+      assert(dispatcher.activeStreams == 1)
+    }
+
+    val stream2Headers = {
+      val hs = new DefaultHttp2Headers
+      hs.scheme("http")
+      hs.method("GET")
+      hs.authority("stream2")
+      hs.path("/")
+      val hf = new DefaultHttp2HeadersFrame(hs, false)
+      hf.stream(H2FrameStream(5, Http2Stream.State.OPEN))
+    }
+
+    assert(recvq.offer(stream2Headers))
+    // client attempts to initiate a new stream but gets REFUSED_STREAM
+    // instead as we already have one active stream
+    eventually {
+      assert(
+        sentq.head == new DefaultHttp2ResetFrame(Http2Error.REFUSED_STREAM)
+          .stream(H2FrameStream(5, Http2Stream.State.OPEN))
+      )
+    }
+    sentq = sentq.tail
+
+    assert(dispatcher.activeStreams == 1)
+    eventually {
+      assert(!stream2Called.get)
+    } // ensure stream 2 switch was not touched
+
+    val stream1 = new AsyncQueue[Frame]
+    stream1StreamP.setValue(Stream(stream1))
+    eventually {
+      assert(
+        sentq.head == {
+          val hs = new DefaultHttp2Headers
+          hs.status("222")
+          val hf = new DefaultHttp2HeadersFrame(hs, false)
+          hf.stream(H2FrameStream(3, Http2Stream.State.HALF_CLOSED_REMOTE))
+        }
+      )
+    }
+    sentq = sentq.tail
+
+    assert(stream1.offer(Frame.Data("0", true)))
+    eventually {
+      sentq.headOption match {
+        case Some(f: Http2DataFrame) =>
+          assert(f.stream.id == 3)
+          assert(f.isEndStream)
+        case f =>
+          fail(s"unexpected frame: $f")
+      }
+    }
+    sentq = sentq.tail
+
+    assert(recvq.offer(stream2Headers))
+    eventually {
+      assert(stream2Called.get)
+    } // ensure stream 2 switch was touched
+    eventually {
+      assert(dispatcher.activeStreams == 1)
+    }
+  }
+
 }


### PR DESCRIPTION
This commit adds the functionality to respect maxConcurrentStreams for server dispatchers. The reason for this is that H2 settings such as `maxConcurrentStreams` are merely advertisement based. We as a server need to protect against misbehaving clients that do not respect the settings we have advertised. Otherwise we are prone to memory leaks and all sorts of resource depletion problems. 

This  PR is a limited version of #2325 which was a more opinionated version of this work. 

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>