### PR TITLE
Fix for #2114 Support b3 trace header 

### DIFF
--- a/linkerd/protocol/base-http/src/main/scala/io/buoyant/linkerd/http/ZipkinTracePropagator.scala
+++ b/linkerd/protocol/base-http/src/main/scala/io/buoyant/linkerd/http/ZipkinTracePropagator.scala
@@ -1,0 +1,94 @@
+package io.buoyant.linkerd.protocol.http
+
+import com.twitter.finagle.{SimpleFilter, Stack}
+import com.twitter.finagle.buoyant.Sampler
+import com.twitter.finagle.http.util.StringUtil
+import com.twitter.finagle.tracing.{Flags, SpanId, TraceId}
+import com.twitter.util.Try
+import io.buoyant.linkerd.{TracePropagator, TracePropagatorInitializer}
+import io.buoyant.router.http.{HeadersLike, RequestLike}
+
+class ZipkinTracePropagator[Req, H: HeadersLike](implicit requestLike: RequestLike[Req, H]) extends TracePropagator[Req] {
+  /**
+   * Read the trace id from the request, if it has one.
+   */
+  override def traceId(req: Req): Option[TraceId] = {
+    var traceId = ZipkinTrace.get(requestLike.headers(req))
+
+    traceId
+  }
+
+  /**
+   * Return a sampler which decides if the given request should be sampled, based on properties
+   * of the request (zipkin or linkerd if zipkin not present).  If None is returned, the decision of whether to sample the request is deferred
+   * to the tracer.
+   */
+  override def sampler(req: Req): Option[Sampler] = {
+    var sampler = ZipkinTrace.getSampler(requestLike.headers(req)).map(Sampler(_))
+
+    sampler
+  }
+
+  /**
+   * Write the trace id onto a request.
+   */
+  override def setContext(
+    req: Req,
+    traceId: TraceId
+  ): Unit = {
+    ZipkinTrace.set(requestLike.headers(req), traceId)
+  }
+}
+
+object ZipkinTrace {
+
+  val ZipkinSpanHeader = "x-b3-spanid"
+  val ZipkinParentHeader = "x-b3-parentspanid"
+  val ZipkinTraceHeader = "x-b3-traceid"
+  val ZipkinSampleHeader = "x-b3-sampled"
+  val ZipkinFlagsHeader = "x-b3-flags"
+
+  def get[H: HeadersLike](headers: H): Option[TraceId] = {
+    val headersLike = implicitly[HeadersLike[H]]
+
+    val trace = caseInsensitiveGet(headers, ZipkinTraceHeader).flatMap(SpanId.fromString)
+    val parent = caseInsensitiveGet(headers, ZipkinParentHeader).flatMap(SpanId.fromString)
+    val span = caseInsensitiveGet(headers, ZipkinSpanHeader).flatMap(SpanId.fromString)
+    val sample = caseInsensitiveGet(headers, ZipkinSampleHeader).map(StringUtil.toBoolean)
+    val flags = caseInsensitiveGet(headers, ZipkinFlagsHeader).map(StringUtil.toSomeLong) match {
+      case Some(f) => Flags(f)
+      case None => Flags()
+    }
+    span.map { s =>
+      TraceId(trace, parent, s, sample, flags)
+    }
+  }
+
+  def set[H: HeadersLike](headers: H, id: TraceId): Unit = {
+    val headersLike = implicitly[HeadersLike[H]]
+
+    headersLike.set(headers, ZipkinSpanHeader, id.spanId.toString)
+    headersLike.set(headers, ZipkinTraceHeader, id.traceId.toString)
+    headersLike.set(headers, ZipkinParentHeader, id.parentId.toString)
+    headersLike.set(headers, ZipkinSampleHeader, (if ((id.sampled exists { _ == true })) 1 else 0).toString)
+    headersLike.set(headers, ZipkinFlagsHeader, id.flags.toLong.toString)
+    ()
+  }
+
+  def getSampler[H: HeadersLike](headers: H): Option[Float] = {
+    val headersLike = implicitly[HeadersLike[H]]
+
+    headersLike.get(headers, ZipkinSampleHeader).flatMap { s =>
+      Try(s.toFloat).toOption.map {
+        case v if v < 0 => 0.0f
+        case v if v > 1 => 1.0f
+        case v => v
+      }
+    }
+  }
+
+  private def caseInsensitiveGet[H: HeadersLike](headers: H, key: String): Option[String] = {
+    val headersLike = implicitly[HeadersLike[H]]
+    headersLike.iterator(headers).collectFirst { case (k, v) if key.equalsIgnoreCase(k) => v }
+  }
+}

--- a/linkerd/protocol/base-http/src/main/scala/io/buoyant/linkerd/http/ZipkinTracePropagator.scala
+++ b/linkerd/protocol/base-http/src/main/scala/io/buoyant/linkerd/http/ZipkinTracePropagator.scala
@@ -7,7 +7,6 @@ import com.twitter.finagle.tracing.{Flags, SpanId, TraceId, TraceId128}
 import com.twitter.util.Try
 import io.buoyant.linkerd.{TracePropagator, TracePropagatorInitializer}
 import io.buoyant.router.http.{HeadersLike, RequestLike}
-import com.twitter.logging.Logger
 
 class ZipkinTracePropagator[Req, H: HeadersLike](implicit requestLike: RequestLike[Req, H]) extends TracePropagator[Req] {
   /**
@@ -21,7 +20,7 @@ class ZipkinTracePropagator[Req, H: HeadersLike](implicit requestLike: RequestLi
 
   /**
    * Return a sampler which decides if the given request should be sampled, based on properties
-   * of the request (zipkin or linkerd if zipkin not present).  If None is returned, the decision of whether to sample the request is deferred
+   * of the request (zipkin).  If None is returned, the decision of whether to sample the request is deferred
    * to the tracer.
    */
   override def sampler(req: Req): Option[Sampler] = {
@@ -49,9 +48,66 @@ object ZipkinTrace {
   val ZipkinSampleHeader = "x-b3-sampled"
   val ZipkinFlagsHeader = "x-b3-flags"
 
-  def get[H: HeadersLike](headers: H): Option[TraceId] = {
-    val headersLike = implicitly[HeadersLike[H]]
+  /**
+   * The separate "b3" header in b3 single header format :
+   * b3={x-b3-traceid}-{x-b3-spanid}-{if x-b3-flags 'd' else x-b3-sampled}-{x-b3-parentspanid},
+   * where the last two fields are optional.
+   */
+  val ZipkinB3SingleHeader = "b3"
 
+  /**
+   * Extract a traceid from the Zipkin b3 single header. If no traceid try returning the sampled/flags info.
+   * @note A traceid cannot be constructed if no spanid is present.
+   * @param b3SingleHeader
+   * @tparam H
+   * @return A tuple of three values (traceid, sampled, flags)
+   */
+  def getFromB3SingleHeader[H: HeadersLike](b3SingleHeader: String): (Option[TraceId], Option[Boolean], Flags) = {
+    /* extract from the b3 single header the values of sampled and flags which closely
+    * match the behavior from X-B3 multi headers, X-B3-Sampled and X-B3-Flags */
+    def matchSampledAndFlags(value: String): (Option[Boolean], Flags) = {
+      value match {
+        case "0" => (Option(false), Flags())
+        case "d" => (None, Flags(1))
+        case "1" => (Option(true), Flags())
+        case _ => (None, Flags())
+      }
+    }
+
+    b3SingleHeader.split("-").toList match {
+      case sampled :: Nil =>
+        // only debug flag or sampled
+        val (sampled_, flags) = matchSampledAndFlags(sampled)
+        (None, sampled_, flags)
+
+      case traceId :: spanId :: Nil =>
+        // expect to read a 128bit traceid field, b3 single header supports 128bit traceids
+        val trace128Bit = TraceId128(traceId)
+        val (sampled_, flags) = matchSampledAndFlags("")
+        (SpanId.fromString(spanId).map(sid => TraceId(trace128Bit.low, None, sid, None, Flags(), trace128Bit.high)), sampled_, flags)
+
+      case traceId :: spanId :: sampled :: Nil =>
+        // expect to read a 128bit traceid field, b3 single header supports 128bit traceids
+
+        val trace128Bit = TraceId128(traceId)
+        val (sampled_, flags) = matchSampledAndFlags(sampled)
+
+        (SpanId.fromString(spanId).map(sid => TraceId(trace128Bit.low, None, sid, sampled_, flags, trace128Bit.high)), sampled_, flags)
+
+      case traceId :: spanId :: sampled :: parentId :: Nil =>
+        // expect to read a 128bit traceid field, b3 single header supports 128bit traceids
+        val trace128Bit = TraceId128(traceId)
+        val (sampled_, flags) = matchSampledAndFlags(sampled)
+
+        (SpanId.fromString(spanId).map(sid => TraceId(trace128Bit.low, SpanId.fromString(parentId), sid, sampled_, flags, trace128Bit.high)), sampled_, flags)
+
+      case _ =>
+        // bogus, do not handle the case when b3 is empty or has more than 4 components
+        (None, None, Flags())
+    }
+  }
+
+  def getFromXB3MultiHeaders[H: HeadersLike](headers: H): Option[TraceId] = {
     // expect to read a 128bit traceid field, b3 single header supports 128bit traceids
     val trace128Bit = caseInsensitiveGet(headers, ZipkinTraceHeader) match {
       case Some(s) => TraceId128(s)
@@ -71,8 +127,44 @@ object ZipkinTrace {
     }
   }
 
+  /**
+   * Get a trace id from the request, if it has one, in either the historical multiple "x-b3-" headers or the
+   * newer "b3" single header. The "b3" single-header variant takes precedence over the multiple header one
+   * when extracting fields, that also implies ignoring the latter if "b3" single header is read.
+   *
+   * @note This method does not touches the request, b3 header is not remove, x-b3- headers not removed
+   * @note The "b3" encodings specs, single or multi: https://github.com/openzipkin/b3-propagation#http-encodings
+   * @param headers
+   * @return Option[TraceId]
+   */
+  def get[H: HeadersLike](headers: H): Option[TraceId] = {
+    val headersLike = implicitly[HeadersLike[H]]
+
+    caseInsensitiveGet(headers, ZipkinB3SingleHeader) match {
+      case Some(v) => {
+        val (traceId, sampled, flags) = getFromB3SingleHeader(v)
+        traceId
+      }
+      case _ => getFromXB3MultiHeaders(headers)
+    }
+  }
+
+  /**
+   * There's no way to know what the downstream is capable of, and it is more likely it supports "X-B3-*" vs not, so,
+   * the portable choice is to always write down "X-B3-"  even if we read "b3". Finagle does a similar thing in
+   * finagle-http-base: read "b3", write back "X-B3-".
+   *
+   * @note This method does not touches the request, b3 header is not remove, x-b3- headers not removed
+   * @note The "b3" encodings specs, single or multi: https://github.com/openzipkin/b3-propagation#http-encodings
+   * @param headers
+   * @return Option[TraceId]
+   */
+
   def set[H: HeadersLike](headers: H, id: TraceId): Unit = {
     val headersLike = implicitly[HeadersLike[H]]
+
+    // remove any b3 single header, if present, before setting x-b3 multi headers
+    val _ = headersLike.remove(headers, ZipkinB3SingleHeader)
 
     headersLike.set(headers, ZipkinSpanHeader, id.spanId.toString)
 
@@ -97,6 +189,7 @@ object ZipkinTrace {
         case None => // do nothing
       }
     }
+
     ()
   }
 
@@ -106,24 +199,43 @@ object ZipkinTrace {
     val samplerTrue: Option[Float] = Option(1.0f)
     val samplerFalse: Option[Float] = Option(0.0f)
 
-    // first try getting x-b3-flags, flags = 1 means debug
-    val flags = caseInsensitiveGet(headers, ZipkinFlagsHeader)
-    if (flags.isEmpty) {
-      // try getting x-b3-sampled only if x-b3-flags not present
-      caseInsensitiveGet(headers, ZipkinSampleHeader).flatMap { s =>
-        Try(s.toFloat).toOption match {
-          //x-b3-sampled present, the only valid values for x-b3-sampled are 0 and 1, any other values are invalid and should be ignored
-          case Some(v) if v == 0 => samplerFalse
-          case Some(v) if v == 1 => samplerTrue
-          case _ => samplerNone
+    // first try getting flags/sampled info from b3 single header
+    caseInsensitiveGet(headers, ZipkinB3SingleHeader) match {
+      case Some(v) => {
+        val (traceId, sampled, flags) = getFromB3SingleHeader(v)
+        flags match {
+          case Flags(1) => samplerTrue // flags debug
+          case _ => { // flags invalid or not present, look for sampled field
+            sampled match {
+              case Some(true) => samplerTrue
+              case Some(false) => samplerFalse
+              case _ => samplerNone
+            }
+          }
         }
       }
-    } else {
-      flags.flatMap { s =>
-        Try(s.toLong).toOption match {
-          //x-b3-flags present, the only valid value for x-b3-flags is 1, any other values are invalid and should be ignored
-          case Some(v) if v == 1 => samplerTrue
-          case _ => samplerNone
+      case _ => {
+        // fallback to getting flags/sampled info from x-b3 headers in case b3 not present
+        // first try getting x-b3-flags, flags = 1 means debug
+        val flags = caseInsensitiveGet(headers, ZipkinFlagsHeader)
+        if (flags.isEmpty) {
+          // try getting x-b3-sampled only if x-b3-flags not present
+          caseInsensitiveGet(headers, ZipkinSampleHeader).flatMap { s =>
+            Try(s.toFloat).toOption match {
+              //x-b3-sampled present, the only valid values for x-b3-sampled are 0 and 1, any other values are invalid and should be ignored
+              case Some(v) if v == 0 => samplerFalse
+              case Some(v) if v == 1 => samplerTrue
+              case _ => samplerNone
+            }
+          }
+        } else {
+          flags.flatMap { s =>
+            Try(s.toLong).toOption match {
+              //x-b3-flags present, the only valid value for x-b3-flags is 1, any other values are invalid and should be ignored
+              case Some(v) if v == 1 => samplerTrue
+              case _ => samplerNone
+            }
+          }
         }
       }
     }

--- a/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/ZipkinTracePropagator.scala
+++ b/linkerd/protocol/h2/src/main/scala/io/buoyant/linkerd/protocol/h2/ZipkinTracePropagator.scala
@@ -1,14 +1,10 @@
 package io.buoyant.linkerd.protocol.h2
 
-import java.util.Base64
-
 import com.twitter.finagle.Stack
-import com.twitter.finagle.buoyant.Sampler
-import com.twitter.finagle.buoyant.h2.{Headers, LinkerdHeaders, Request}
-import com.twitter.finagle.http.util.StringUtil
-import com.twitter.finagle.tracing.{Flags, SpanId, TraceId}
-import com.twitter.util.Try
+import com.twitter.finagle.buoyant.h2.{Headers, Request}
 import io.buoyant.linkerd.{TracePropagator, TracePropagatorInitializer}
+import io.buoyant.linkerd.protocol.http.ZipkinTracePropagator
+import io.buoyant.router.H2Instances._
 
 class ZipkinTracePropagatorInitializer extends TracePropagatorInitializer {
   override val configClass = classOf[ZipkinTracePropagatorConfig]
@@ -16,80 +12,5 @@ class ZipkinTracePropagatorInitializer extends TracePropagatorInitializer {
 }
 
 case class ZipkinTracePropagatorConfig() extends H2TracePropagatorConfig {
-  override def mk(params: Stack.Params): TracePropagator[Request] = new ZipkinTracePropagator
-}
-
-class ZipkinTracePropagator extends TracePropagator[Request] {
-  /**
-   * Read the trace id from the request, if it has one.
-   */
-  override def traceId(req: Request): Option[TraceId] = {
-    var traceId = ZipkinTrace.get(req.headers)
-    LinkerdHeaders.Ctx.Trace.clear(req.headers)
-    traceId
-  }
-
-  /**
-   * Return a sampler which decides if the given request should be sampled, based on properties
-   * of the request (zipkin or linkerd if zipkin not present).  If None is returned, the decision of whether to sample the request is deferred
-   * to the tracer.
-   */
-  override def sampler(req: Request): Option[Sampler] = {
-    var sampler = ZipkinTrace.getSampler(req.headers).map(Sampler(_))
-    LinkerdHeaders.Sample.clear(req.headers)
-    sampler
-  }
-
-  /**
-   * Write the trace id onto a request.
-   */
-  override def setContext(
-    req: Request,
-    traceId: TraceId
-  ): Unit = {
-    ZipkinTrace.set(req.headers, traceId)
-  }
-}
-
-object ZipkinTrace {
-
-  val ZipkinSpanHeader = "x-b3-spanid"
-  val ZipkinParentHeader = "x-b3-parentspanid"
-  val ZipkinTraceHeader = "x-b3-traceid"
-  val ZipkinSampleHeader = "x-b3-sampled"
-  val ZipkinFlagsHeader = "x-b3-flags"
-
-  def get(headers: Headers): Option[TraceId] = {
-    val trace = caseInsensitiveGet(headers, ZipkinTraceHeader).flatMap(SpanId.fromString)
-    val parent = caseInsensitiveGet(headers, ZipkinParentHeader).flatMap(SpanId.fromString)
-    val span = caseInsensitiveGet(headers, ZipkinSpanHeader).flatMap(SpanId.fromString)
-    val sample = caseInsensitiveGet(headers, ZipkinSampleHeader).map(StringUtil.toBoolean)
-    val flags = caseInsensitiveGet(headers, ZipkinFlagsHeader).map(StringUtil.toSomeLong) match {
-      case Some(f) => Flags(f)
-      case None => Flags()
-    }
-    span.map { s =>
-      TraceId(trace, parent, s, sample, flags)
-    }
-  }
-
-  def set(headers: Headers, id: TraceId): Unit = {
-    val _ = headers.set(ZipkinSpanHeader, id.spanId.toString)
-    val __ = headers.set(ZipkinTraceHeader, id.traceId.toString)
-    val ___ = headers.set(ZipkinParentHeader, id.parentId.toString)
-    val ____ = headers.set(ZipkinSampleHeader, (if ((id.sampled exists { _ == true })) 1 else 0).toString)
-    val _____ = headers.set(ZipkinFlagsHeader, id.flags.toLong.toString)
-  }
-
-  def getSampler(headers: Headers): Option[Float] =
-    headers.get(ZipkinSampleHeader).flatMap { s =>
-      Try(s.toFloat).toOption.map {
-        case v if v < 0 => 0.0f
-        case v if v > 1 => 1.0f
-        case v => v
-      }
-    }
-
-  private def caseInsensitiveGet(headers: Headers, key: String): Option[String] =
-    headers.toSeq.iterator.collectFirst { case (k, v) if key.equalsIgnoreCase(k) => v }
+  override def mk(params: Stack.Params): TracePropagator[Request] = new ZipkinTracePropagator[Request, Headers]
 }

--- a/linkerd/protocol/h2/src/test/scala/io/buoyant/linkerd/protocol/h2/ZipkinTracePropagatorTest.scala
+++ b/linkerd/protocol/h2/src/test/scala/io/buoyant/linkerd/protocol/h2/ZipkinTracePropagatorTest.scala
@@ -1,0 +1,47 @@
+package io.buoyant.linkerd.protocol.h2
+
+import org.scalatest.FunSuite
+import com.twitter.finagle.buoyant.h2.{Headers, Request}
+import com.twitter.finagle.buoyant.h2._
+import io.buoyant.router.RoutingFactory._
+import io.buoyant.linkerd.protocol.http._
+import io.buoyant.router.H2Instances._
+
+class ZipkinTracePropagatorTest extends FunSuite {
+  test("get traceid from multi x-b3 headers, 64bit trace id, sampled, UPPER CASE header doesn't matter") {
+    val ztp = new ZipkinTracePropagator
+
+    //x-b3 multi headers with lower case
+    val req1 = Request("http", Method.Get, "auf", "/", Stream.empty())
+    req1.headers.add("x-b3-traceid", "80f198ee56343ba8")
+    req1.headers.add("x-b3-spanid", "05e3ac9a4f6e3b90")
+    req1.headers.add("x-b3-sampled", "1")
+    req1.headers.add("x-b3-parentspanid", "e457b5a2e4d86bd1")
+
+    //X-B3 multi heders with upper case
+    val req2 = Request("http", Method.Get, "auf", "/", Stream.empty())
+    req2.headers.add("X-B3-TRACEID", "80f198ee56343ba8")
+    req2.headers.add("X-B3-SPANID", "05e3ac9a4f6e3b90")
+    req2.headers.add("X-B3-SAMPLED", "1")
+    req2.headers.add("X-B3-PARENTSPANID", "e457b5a2e4d86bd1")
+
+    val trace1 = ztp.traceId(req1)
+    val trace2 = ztp.traceId(req2)
+
+    // traceid is the same, lower/upper case doesn't matter
+    assert(trace1 == trace2)
+
+    assert(trace1.isDefined) //expect trace exists
+    trace1.foreach { tid => {
+      assert(tid.traceId.toString().equals("80f198ee56343ba8"))
+      assert(tid.spanId.toString().equals("05e3ac9a4f6e3b90"))
+      assert(tid.parentId.toString().equals("e457b5a2e4d86bd1"))
+      assert(tid.sampled.contains(true))
+
+      // expect to get the right sampled value which is 0
+      val sampler = ZipkinTrace.getSampler(req1.headers)
+      assert(sampler.contains(1.0f))
+    }}
+  }
+
+ }

--- a/linkerd/protocol/h2/src/test/scala/io/buoyant/linkerd/protocol/h2/ZipkinTracePropagatorTest.scala
+++ b/linkerd/protocol/h2/src/test/scala/io/buoyant/linkerd/protocol/h2/ZipkinTracePropagatorTest.scala
@@ -42,6 +42,32 @@ class ZipkinTracePropagatorTest extends FunSuite {
       val sampler = ZipkinTrace.getSampler(req1.headers)
       assert(sampler.contains(1.0f))
     }}
+
+    // expect to get the right sampled value which is 1
+    val sampler1 = ZipkinTrace.getSampler(req1.headers)
+    assert(sampler1.contains(1.0f))
+    // expect to get the right sampled value which is 1
+    val sampler2 = ZipkinTrace.getSampler(req2.headers)
+    assert(sampler2.contains(1.0f))
   }
 
+  test("get traceid from multi x-b3 headers - set/get 128bit trace, two fields") {
+    val ztp = new ZipkinTracePropagator()
+    val req = Request("http", Method.Get, "auf", "/", Stream.empty())
+    req.headers.add("x-b3-traceid", "80f198ee56343ba864fe8b2a57d3eff7")
+    req.headers.add("x-b3-spanid", "05e3ac9a4f6e3b90")
+
+    val trace = ztp.traceId(req)
+    assert(trace.isDefined) //expect trace exists
+    trace.foreach { tid => {
+      assert(tid.traceId.toString().equals("64fe8b2a57d3eff7"))
+      assert(tid.spanId.toString().equals("05e3ac9a4f6e3b90"))
+      assert(tid.traceIdHigh.toString().contains("80f198ee56343ba8)"))
+
+      val req2 = Request("http", Method.Get, "auf", "/", Stream.empty())
+      ztp.setContext(req2, tid)
+      assert(req2.headers.get("x-b3-traceid").contains("80f198ee56343ba864fe8b2a57d3eff7"))
+      assert(req2.headers.get("x-b3-spanid").contains("05e3ac9a4f6e3b90"))
+    }}
+  }
  }

--- a/linkerd/protocol/h2/src/test/scala/io/buoyant/linkerd/protocol/h2/ZipkinTracePropagatorTest.scala
+++ b/linkerd/protocol/h2/src/test/scala/io/buoyant/linkerd/protocol/h2/ZipkinTracePropagatorTest.scala
@@ -38,7 +38,7 @@ class ZipkinTracePropagatorTest extends FunSuite {
       assert(tid.parentId.toString().equals("e457b5a2e4d86bd1"))
       assert(tid.sampled.contains(true))
 
-      // expect to get the right sampled value which is 0
+      // expect to get the right sampled value which is 1
       assert(ZipkinTrace.getSampler(req1.headers).contains(1.0f))
     }}
 
@@ -81,7 +81,7 @@ class ZipkinTracePropagatorTest extends FunSuite {
     //flags 0 (invalid value), no sampled => sampler None
     req.headers.remove("x-b3-flags")
     req.headers.add("x-b3-flags", "0")
-    assert(ZipkinTrace.getSampler(req.headers).contains(0.0f))
+    assert(ZipkinTrace.getSampler(req.headers).isEmpty)
 
     //flags asd (invalid value), no sampled = > sampler None
     req.headers.remove("x-b3-flags")
@@ -110,5 +110,304 @@ class ZipkinTracePropagatorTest extends FunSuite {
     req.headers.remove("x-b3-flags")
     req.headers.remove("x-b3-sampled")
     assert(ZipkinTrace.getSampler(req.headers).isEmpty)
+  }
+
+  test("get traceid from a b3 single header - empty header") {
+    // b3:
+    val ztp = new ZipkinTracePropagator()
+    val req = Request("http", Method.Get, "auf", "/", Stream.empty())
+    req.headers.add("b3", "")
+
+    val trace = ztp.traceId(req)
+    // this should not have returned a traceId because there's no span
+    assert(trace.isEmpty)
+    //b3 has not been removed, other x-b3 have not been added
+    assert(req.headers.contains("b3"))
+
+    val sampler = ztp.sampler(req)
+    // no sampler should be returned
+    assert(sampler.isEmpty)
+  }
+
+  test("get traceid from a b3 single header - one field - don't sample - b3: 0") {
+    //b3: 0
+    val ztp = new ZipkinTracePropagator()
+    val req = Request("http", Method.Get, "auf", "/", Stream.empty())
+    req.headers.add("b3", "0")
+
+    val trace = ztp.traceId(req)
+    // this should not have returned a traceId because there's no span
+    assert(trace.isEmpty)
+    //b3 has not been removed, other x-b3 have not been added
+    assert(req.headers.contains("b3"))
+
+    // expect to get the right sampled value which is 0
+    val sampler = ZipkinTrace.getSampler(req.headers)
+    assert(sampler.contains(0.0f))
+  }
+
+  test("get traceid from a b3 single header - one field - sampled - b3: 1") {
+    //b3: 1
+    val ztp = new ZipkinTracePropagator()
+    val req = Request("http", Method.Get, "auf", "/", Stream.empty())
+    req.headers.add("b3", "1")
+
+    val trace = ztp.traceId(req)
+    // this should not have returned a traceId because there's no span
+    assert(trace.isEmpty)
+    //b3 has not been removed, other x-b3 have not been added
+    assert(req.headers.contains("b3"))
+
+    // expect to get the right sampled value which is 1
+    val sampler = ZipkinTrace.getSampler(req.headers)
+    assert(sampler.contains(1.0f))
+  }
+
+  test("get traceid from a b3 single header - one field - debug - b3: d") {
+    //b3: d
+    val ztp = new ZipkinTracePropagator()
+    val req = Request("http", Method.Get, "auf", "/", Stream.empty())
+    req.headers.add("b3", "d")
+
+    val trace = ztp.traceId(req)
+    // this should not have returned a traceId because there's no span
+    assert(trace.isEmpty)
+    //b3 has not been removed, other x-b3 have not been added
+    assert(req.headers.contains("b3"))
+
+    // expect to get the right sampled value which is 1 when debug is set
+    val sampler = ZipkinTrace.getSampler(req.headers)
+    assert(sampler.contains(1.0f))
+  }
+
+  test("get traceid from a b3 single header - one field - invalid - b3: 2") {
+    //b3: d
+    val ztp = new ZipkinTracePropagator()
+    val req = Request("http", Method.Get, "auf", "/", Stream.empty())
+    req.headers.add("b3", "s")
+
+    val trace = ztp.traceId(req)
+    // this should not have returned a traceId because there's no span
+    assert(trace.isEmpty)
+    //b3 has not been removed, other x-b3 have not been added
+    assert(req.headers.contains("b3"))
+
+    // expect to not get a sampler when sampling bit is invalid value (other than 0/1/d)
+    val sampler = ZipkinTrace.getSampler(req.headers)
+    assert(sampler.isEmpty)
+  }
+
+  test("get traceid from a b3 single header - two fields - not yet sampled root span") {
+    //b3: a3ce929d0e0e4736-00f067aa0ba902b7
+    val ztp = new ZipkinTracePropagator()
+    val req = Request("http", Method.Get, "auf", "/", Stream.empty())
+    req.headers.add("b3", "a3ce929d0e0e4736-00f067aa0ba902b7")
+
+    val trace = ztp.traceId(req)
+    //b3 has not been removed, other x-b3 have not been added
+    assert(req.headers.contains("b3"))
+
+    assert(trace.isDefined) //expect trace exists
+    trace.foreach { tid => {
+      assert(tid.traceId.toString().equals("a3ce929d0e0e4736"))
+      assert(tid.spanId.toString().equals("00f067aa0ba902b7"))
+
+      // expect to not get a sampler when sampling bit is not set
+      val sampler = ZipkinTrace.getSampler(req.headers)
+      assert(sampler.isEmpty)
+
+      ztp.setContext(req, tid)
+      // check "b3" has been removed, "x-b3-traceid" and "x-b3-spanid" have been added to request
+      assert(req.headers.get("b3").isEmpty)
+      assert(req.headers.contains("x-b3-traceid"))
+      assert(req.headers.contains("x-b3-spanid"))
+    }}
+
+    // after "x-b3-" have been added check they have expected values
+    val trace2 = ztp.traceId(req)
+    assert(trace == trace2)
+  }
+
+  test("get traceid from a b3 single header - three fields - sampled root span") {
+    //b3: a3ce929d0e0e4736-00f067aa0ba902b7-1
+    val ztp = new ZipkinTracePropagator()
+    val req = Request("http", Method.Get, "auf", "/", Stream.empty())
+    req.headers.add("b3", "a3ce929d0e0e4736-00f067aa0ba902b7-1")
+
+    val trace = ztp.traceId(req)
+    //b3 has not been removed, other x-b3 have not been added
+    assert(req.headers.contains("b3"))
+
+    assert(trace.isDefined) //expect trace exists
+    trace.foreach { tid => {
+      assert(tid.traceId.toString().equals("a3ce929d0e0e4736"))
+      assert(tid.spanId.toString().equals("00f067aa0ba902b7"))
+      assert(tid.sampled.contains(true))
+
+      // expect to get the right sampled value which is 1
+      val sampler = ZipkinTrace.getSampler(req.headers)
+      assert(sampler.contains(1.0f))
+
+      ztp.setContext(req, tid)
+      // check "b3" has been removed, "x-b3-traceid" and "x-b3-spanid" and "x-b3-sampledid" have been added to request
+      assert(req.headers.get("b3").isEmpty)
+      assert(req.headers.contains("x-b3-traceid"))
+      assert(req.headers.contains("x-b3-spanid"))
+      assert(req.headers.contains("x-b3-sampled"))
+    }}
+
+    // after "x-b3-" have been added check they have the same values as above
+    val trace2 = ztp.traceId(req)
+    assert(trace == trace2)
+  }
+
+  test("get traceid from a b3 single header - four fields - child span on debug") {
+    //b3: a3ce929d0e0e4736-00f067aa0ba902b7-d-5b4185666d50f68b
+
+    val ztp = new ZipkinTracePropagator()
+    val req = Request("http", Method.Get, "auf", "/", Stream.empty())
+    req.headers.add("b3", "a3ce929d0e0e4736-00f067aa0ba902b7-d-5b4185666d50f68b")
+
+    val trace = ztp.traceId(req)
+    //b3 has not been removed, other x-b3 have not been added
+    assert(req.headers.contains("b3"))
+
+    assert(trace.isDefined) //expect trace exists
+    trace.foreach { tid => {
+      assert(tid.traceId.toString().equals("a3ce929d0e0e4736"))
+      assert(tid.spanId.toString().equals("00f067aa0ba902b7"))
+      assert(tid.parentId.toString().equals("5b4185666d50f68b"))
+      assert(tid.flags.toLong == 1)
+
+      // expect to get the right sampled value which is 1
+      val sampler = ZipkinTrace.getSampler(req.headers)
+      assert(sampler.contains(1.0f))
+
+      ztp.setContext(req, tid)
+      // check "b3" has been removed, "x-b3-traceid" and "x-b3-spanid" and "x-b3-flags" have been added to request
+      assert(req.headers.get("b3").isEmpty)
+      // check sampled not set when debug flag set
+      assert(req.headers.get("x-b3-sampled").isEmpty)
+      assert(req.headers.contains("x-b3-traceid"))
+      assert(req.headers.contains("x-b3-spanid"))
+      assert(req.headers.contains("x-b3-flags"))
+    }}
+
+    //test x-b3- headers have been added so we can get the same trace from them
+    val trace2 = ztp.traceId(req)
+    assert(trace == trace2)
+  }
+
+  test("get traceid from a b3 single header - four fields - not sampled child span") {
+    //b3: a3ce929d0e0e4736-00f067aa0ba902b7-d-5b4185666d50f68b
+
+    val ztp = new ZipkinTracePropagator()
+    val req = Request("http", Method.Get, "auf", "/", Stream.empty())
+    req.headers.add("b3", "a3ce929d0e0e4736-00f067aa0ba902b7-0-5b4185666d50f68b")
+
+    val trace = ztp.traceId(req)
+    //b3 has not been removed, other x-b3 have not been added
+    assert(req.headers.contains("b3"))
+
+    assert(trace.isDefined) //expect trace exists
+    trace.foreach { tid => {
+      assert(tid.traceId.toString().equals("a3ce929d0e0e4736"))
+      assert(tid.spanId.toString().equals("00f067aa0ba902b7"))
+      assert(tid.parentId.toString().equals("5b4185666d50f68b"))
+      assert(tid.sampled.contains(false))
+
+      // expect to get the right sampled value which is 0
+      val sampler = ZipkinTrace.getSampler(req.headers)
+      assert(sampler.contains(0.0f))
+
+      ztp.setContext(req, tid)
+      // check "b3" has been removed, "x-b3-traceid" and "x-b3-spanid" and "x-b3-parentspanid" have been added to request
+      assert(req.headers.get("b3").isEmpty)
+      // check sampled not set when debug flag set
+      assert(req.headers.contains("x-b3-traceid"))
+      assert(req.headers.contains("x-b3-spanid"))
+      assert(req.headers.contains("x-b3-parentspanid"))
+      assert(req.headers.contains("x-b3-sampled"))
+    }}
+
+    //test x-b3- headers have been added so we can get the same trace from them
+    val trace2 = ztp.traceId(req)
+    assert(trace == trace2)
+  }
+
+  test("get traceid from a b3 single header - 128bit trace, two fields") {
+    //b3: 80f198ee56343ba864fe8b2a57d3eff7-05e3ac9a4f6e3b90
+    val ztp = new ZipkinTracePropagator()
+    val req = Request("http", Method.Get, "auf", "/", Stream.empty())
+    req.headers.add("b3", "80f198ee56343ba864fe8b2a57d3eff7-05e3ac9a4f6e3b90")
+
+    val trace = ztp.traceId(req)
+    //b3 has not been removed
+    assert(!req.headers.get("b3").isEmpty)
+    // check "x-b3-traceid" and "x-b3-spanid" have been added to request
+    //assert(req.headers.toSeq.toSet == Set("x-b3-traceid", "x-b3-spanid"))
+
+    assert(trace.isDefined) //expect trace exists
+    trace.foreach { tid => {
+      assert(tid.traceId.toString().equals("64fe8b2a57d3eff7"))
+      assert(tid.spanId.toString().equals("05e3ac9a4f6e3b90"))
+      assert(tid.traceIdHigh.toString().contains("80f198ee56343ba8)"))
+    }}
+
+    // after "x-b3-" have been added check they have expected values
+    val trace2 = ztp.traceId(req)
+    assert(trace == trace2)
+  }
+
+
+  test("b3 single headers preferred over x-b3- multi headers") {
+    val ztp = new ZipkinTracePropagator()
+    val req = Request("http", Method.Get, "auf", "/", Stream.empty())
+    req.headers.add("b3", "a3ce929d0e0e4736-00f067aa0ba902b7-1")
+    req.headers.add("x-b3-traceid", "0000000000000001")
+    req.headers.add("x-b3-spanid", "0000000000000002")
+    req.headers.add("x-b3-sampled", "0")
+
+    val trace = ztp.traceId(req)
+    assert(trace.isDefined)  //expect trace exists
+    trace.foreach { tid => {
+      assert(tid.traceId.toString().equals("a3ce929d0e0e4736"))  //expect traceid from b3 not from x-b3-traceid)
+      assert(tid.spanId.toString().equals("00f067aa0ba902b7")) // expect spanid from b3 not from x-b3-spanid
+      assert(tid.sampled.contains(true)) // expect samplef from b3 not from x-b3-sampled
+    }}
+  }
+
+  test("same trace from b3 single headers and x-b3- multi headers, 128bit traceid, UPPER CASE header don't matter") {
+    /* Turn on tracing and see if
+      b3=80f198ee56343ba864fe8b2a57d3eff7-05e3ac9a4f6e3b90-1-e457b5a2e4d86bd1 results in the same context as:
+      X-B3-TraceId: 80f198ee56343ba864fe8b2a57d3eff7
+      X-B3-ParentSpanId: 05e3ac9a4f6e3b90
+      X-B3-SpanId: e457b5a2e4d86bd1
+      X-B3-Sampled: 1
+     */
+
+    //NOTE: This will also test case doesn't matter for b3 single or x-b3- multi headers
+    val ztp = new ZipkinTracePropagator()
+    val req1 = Request("http", Method.Get, "auf", "/", Stream.empty())
+    req1.headers.add("B3", "80f198ee56343ba864fe8b2a57d3eff7-05e3ac9a4f6e3b90-1-e457b5a2e4d86bd1")
+
+    val req2 = Request("http", Method.Get, "auf", "/", Stream.empty())
+    req2.headers.add("X-B3-TRACEID", "80f198ee56343ba864fe8b2a57d3eff7")
+    req2.headers.add("X-B3-SPANID", "05e3ac9a4f6e3b90")
+    req2.headers.add("X-B3-SAMPLED", "1")
+    req2.headers.add("X-B3-PARENTSPANID", "e457b5a2e4d86bd1")
+
+    val trace1 = ztp.traceId(req1)
+    val trace2 = ztp.traceId(req2)
+
+    assert(trace1 == trace2)
+  }
+
+  test("cannot get trace from invalid b3 single header, too many fields") {
+    val ztp = new ZipkinTracePropagator()
+    val req1 = Request("http", Method.Get, "auf", "/", Stream.empty())
+    req1.headers.add("B3", "80f198ee56343ba864fe8b2a57d3eff7-05e3ac9a4f6e3b90-1-e457b5a2e4d86bd1-extra1")
+
+    assert(ztp.traceId(req1).isEmpty)
   }
 }

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/ZipkinTracePropagator.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/ZipkinTracePropagator.scala
@@ -1,15 +1,10 @@
 package io.buoyant.linkerd.protocol
 
-import java.util.Base64
-
 import com.twitter.finagle.Stack
-import com.twitter.finagle.buoyant.Sampler
-import com.twitter.finagle.buoyant.linkerd.Headers
-import com.twitter.finagle.http.util.StringUtil
 import com.twitter.finagle.http.{HeaderMap, Request}
-import com.twitter.finagle.tracing.{Flags, SpanId, TraceId}
-import com.twitter.util.Try
 import io.buoyant.linkerd.{TracePropagator, TracePropagatorInitializer}
+import io.buoyant.linkerd.protocol.http.ZipkinTracePropagator
+import io.buoyant.router.HttpInstances._
 
 class ZipkinTracePropagatorInitializer extends TracePropagatorInitializer {
   override val configClass = classOf[ZipkinTracePropagatorConfig]
@@ -17,81 +12,5 @@ class ZipkinTracePropagatorInitializer extends TracePropagatorInitializer {
 }
 
 case class ZipkinTracePropagatorConfig() extends HttpTracePropagatorConfig {
-  override def mk(params: Stack.Params): TracePropagator[Request] = new ZipkinTracePropagator
-}
-
-class ZipkinTracePropagator extends TracePropagator[Request] {
-  /**
-   * Read the trace id from the request, if it has one.
-   */
-  override def traceId(req: Request): Option[TraceId] = {
-    var traceId = ZipkinTrace.get(req.headerMap)
-    Headers.Ctx.Trace.clear(req.headerMap)
-    traceId
-  }
-
-  /**
-   * Return a sampler which decides if the given request should be sampled, based on properties
-   * of the request (zipkin or linkerd if zipkin not present).  If None is returned, the decision of whether to sample the request is deferred
-   * to the tracer.
-   */
-  override def sampler(req: Request): Option[Sampler] = {
-    var sampler = ZipkinTrace.getSampler(req.headerMap).map(Sampler(_))
-    Headers.Sample.clear(req.headerMap)
-    sampler
-  }
-
-  /**
-   * Write the trace id onto a request.
-   */
-  override def setContext(
-    req: Request,
-    traceId: TraceId
-  ): Unit = {
-    ZipkinTrace.set(req.headerMap, traceId)
-  }
-
-}
-
-object ZipkinTrace {
-
-  val ZipkinSpanHeader = "x-b3-spanid"
-  val ZipkinParentHeader = "x-b3-parentspanid"
-  val ZipkinTraceHeader = "x-b3-traceid"
-  val ZipkinSampleHeader = "x-b3-sampled"
-  val ZipkinFlagsHeader = "x-b3-flags"
-
-  def get(headers: HeaderMap): Option[TraceId] = {
-    val trace = caseInsensitiveGet(headers, ZipkinTraceHeader).flatMap(SpanId.fromString)
-    val parent = caseInsensitiveGet(headers, ZipkinParentHeader).flatMap(SpanId.fromString)
-    val span = caseInsensitiveGet(headers, ZipkinSpanHeader).flatMap(SpanId.fromString)
-    val sample = caseInsensitiveGet(headers, ZipkinSampleHeader).map(StringUtil.toBoolean)
-    val flags = caseInsensitiveGet(headers, ZipkinFlagsHeader).map(StringUtil.toSomeLong) match {
-      case Some(f) => Flags(f)
-      case None => Flags()
-    }
-    span.map { s =>
-      TraceId(trace, parent, s, sample, flags)
-    }
-  }
-
-  def set(headers: HeaderMap, id: TraceId): Unit = {
-    val _ = headers.set(ZipkinSpanHeader, id.spanId.toString)
-    val __ = headers.set(ZipkinTraceHeader, id.traceId.toString)
-    val ___ = headers.set(ZipkinParentHeader, id.parentId.toString)
-    val ____ = headers.set(ZipkinSampleHeader, (if ((id.sampled exists { _ == true })) 1 else 0).toString)
-    val _____ = headers.set(ZipkinFlagsHeader, id.flags.toLong.toString)
-  }
-
-  def getSampler(headers: HeaderMap): Option[Float] =
-    headers.get(ZipkinSampleHeader).flatMap { s =>
-      Try(s.toFloat).toOption.map {
-        case v if v < 0 => 0.0f
-        case v if v > 1 => 1.0f
-        case v => v
-      }
-    }
-
-  private def caseInsensitiveGet(headers: HeaderMap, key: String): Option[String] =
-    headers.iterator.collectFirst { case (k, v) if key.equalsIgnoreCase(k) => v }
+  override def mk(params: Stack.Params): TracePropagator[Request] = new ZipkinTracePropagator[Request, HeaderMap]
 }

--- a/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/ZipkinTracePropagatorTest.scala
+++ b/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/ZipkinTracePropagatorTest.scala
@@ -36,6 +36,9 @@ class ZipkinTracePropagatorTest extends FunSuite {
       assert(tid.spanId.toString().equals("05e3ac9a4f6e3b90"))
       assert(tid.parentId.toString().equals("e457b5a2e4d86bd1"))
       assert(tid.sampled.contains(true))
+
+      // expect to get the right sampled value which is 1
+      assert(ZipkinTrace.getSampler(req1.headerMap).contains(1.0f))
     }}
 
     // expect to get the right sampled value which is 1
@@ -77,7 +80,7 @@ class ZipkinTracePropagatorTest extends FunSuite {
     //flags 0 (invalid value), no sampled => sampler None
     req.headerMap.remove("x-b3-flags")
     req.headerMap.add("x-b3-flags", "0")
-    assert(ZipkinTrace.getSampler(req.headerMap).contains(0.0f))
+    assert(ZipkinTrace.getSampler(req.headerMap).isEmpty)
 
     //flags asd (invalid value), no sampled = > sampler None
     req.headerMap.remove("x-b3-flags")
@@ -106,5 +109,296 @@ class ZipkinTracePropagatorTest extends FunSuite {
     req.headerMap.remove("x-b3-flags")
     req.headerMap.remove("x-b3-sampled")
     assert(ZipkinTrace.getSampler(req.headerMap).isEmpty)
+  }
+
+  test("get traceid from a b3 single header - empty header") {
+    // b3:
+    val ztp = new ZipkinTracePropagator
+    val req = Request()
+    req.headerMap.add("b3", "")
+
+    val trace = ztp.traceId(req)
+    // this should not have returned a traceId because there's no span
+    assert(trace.isEmpty)
+    //b3 has not been removed, other x-b3 have not been added
+    assert(req.headerMap.keys == Set("b3"))
+
+    val sampler = ztp.sampler(req)
+    // no sampler should be returned
+    assert(sampler.isEmpty)
+  }
+
+  test("get traceid from a b3 single header - one field - don't sample - b3: 0") {
+    //b3: 0
+    val ztp = new ZipkinTracePropagator()
+    val req = Request()
+    req.headerMap.add("b3", "0")
+
+    val trace = ztp.traceId(req)
+    // this should not have returned a traceId because there's no span
+    assert(trace.isEmpty)
+    //b3 has not been removed, other x-b3 have not been added
+    assert(req.headerMap.keys == Set("b3"))
+
+    // expect to get the right sampled value which is 0
+    val sampler = ZipkinTrace.getSampler(req.headerMap)
+    assert(sampler.contains(0.0f))
+  }
+
+  test("get traceid from a b3 single header - one field - sampled - b3: 1") {
+    //b3: 1
+    val ztp = new ZipkinTracePropagator()
+    val req = Request()
+    req.headerMap.add("b3", "1")
+
+    val trace = ztp.traceId(req)
+    // this should not have returned a traceId because there's no span
+    assert(trace.isEmpty)
+    //b3 has not been removed, other x-b3 have not been added
+    assert(req.headerMap.keys == Set("b3"))
+
+    // expect to get the right sampled value which is 1
+    val sampler = ZipkinTrace.getSampler(req.headerMap)
+    assert(sampler.contains(1.0f))
+  }
+
+  test("get traceid from a b3 single header - one field - debug - b3: d") {
+    //b3: d
+    val ztp = new ZipkinTracePropagator()
+    val req = Request()
+    req.headerMap.add("b3", "d")
+
+    val trace = ztp.traceId(req)
+    // this should not have returned a traceId because there's no span
+    assert(trace.isEmpty)
+    //b3 has not been removed, other x-b3 have not been added
+    assert(req.headerMap.keys == Set("b3"))
+
+    // expect to get the right sampled value which is 1 when debug is set
+    val sampler = ZipkinTrace.getSampler(req.headerMap)
+    assert(sampler.contains(1.0f))
+  }
+
+  test("get traceid from a b3 single header - one field - invalid - b3: 2") {
+    //b3: d
+    val ztp = new ZipkinTracePropagator()
+    val req = Request()
+    req.headerMap.add("b3", "s")
+
+    val trace = ztp.traceId(req)
+    // this should not have returned a traceId because there's no span
+    assert(trace.isEmpty)
+    //b3 has not been removed, other x-b3 have not been added
+    assert(req.headerMap.keys == Set("b3"))
+
+    // expect to not get a sampler when sampling bit is invalid value (other than 0/1/d)
+    val sampler = ZipkinTrace.getSampler(req.headerMap)
+    assert(sampler.isEmpty)
+  }
+
+  test("get traceid from a b3 single header - two fields - not yet sampled root span") {
+    //b3: a3ce929d0e0e4736-00f067aa0ba902b7
+    val ztp = new ZipkinTracePropagator()
+    val req = Request()
+    req.headerMap.add("b3", "a3ce929d0e0e4736-00f067aa0ba902b7")
+
+    val trace = ztp.traceId(req)
+    //b3 has not been removed, other x-b3 have not been added
+    assert(req.headerMap.keys == Set("b3"))
+
+    assert(trace.isDefined) //expect trace exists
+    trace.foreach { tid => {
+      assert(tid.traceId.toString().equals("a3ce929d0e0e4736"))
+      assert(tid.spanId.toString().equals("00f067aa0ba902b7"))
+
+      // expect to not get a sampler when sampling bit is not set
+      val sampler = ZipkinTrace.getSampler(req.headerMap)
+      assert(sampler.isEmpty)
+
+      ztp.setContext(req, tid)
+      // check "b3" has been removed, "x-b3-traceid" and "x-b3-spanid" have been added to request
+      assert(req.headerMap.get("b3").isEmpty)
+      assert(Set("x-b3-traceid", "x-b3-spanid").subsetOf(req.headerMap.keys.toSet))
+    }}
+
+    // after "x-b3-" have been added check they have expected values
+    val trace2 = ztp.traceId(req)
+    assert(trace == trace2)
+  }
+
+  test("get traceid from a b3 single header - three fields - sampled root span") {
+    //b3: a3ce929d0e0e4736-00f067aa0ba902b7-1
+    val ztp = new ZipkinTracePropagator()
+    val req = Request()
+    req.headerMap.add("b3", "a3ce929d0e0e4736-00f067aa0ba902b7-1")
+
+    val trace = ztp.traceId(req)
+    //b3 has not been removed, other x-b3 have not been added
+    assert(req.headerMap.keys == Set("b3"))
+
+    assert(trace.isDefined) //expect trace exists
+    trace.foreach { tid => {
+      assert(tid.traceId.toString().equals("a3ce929d0e0e4736"))
+      assert(tid.spanId.toString().equals("00f067aa0ba902b7"))
+      assert(tid.sampled.contains(true))
+
+      // expect to get the right sampled value which is 1
+      val sampler = ZipkinTrace.getSampler(req.headerMap)
+      assert(sampler.contains(1.0f))
+
+      ztp.setContext(req, tid)
+      // check "b3" has been removed, "x-b3-traceid" and "x-b3-spanid" and "x-b3-sampledid" have been added to request
+      assert(req.headerMap.get("b3").isEmpty)
+      assert(Set("x-b3-traceid", "x-b3-spanid", "x-b3-sampled").subsetOf(req.headerMap.keys.toSet))
+    }}
+
+    // after "x-b3-" have been added check they have the same values as above
+    val trace2 = ztp.traceId(req)
+    assert(trace == trace2)
+  }
+
+  test("get traceid from a b3 single header - four fields - child span on debug") {
+    //b3: a3ce929d0e0e4736-00f067aa0ba902b7-d-5b4185666d50f68b
+
+    val ztp = new ZipkinTracePropagator()
+    val req = Request()
+    req.headerMap.add("b3", "a3ce929d0e0e4736-00f067aa0ba902b7-d-5b4185666d50f68b")
+
+    val trace = ztp.traceId(req)
+    //b3 has not been removed, other x-b3 have not been added
+    assert(req.headerMap.keys == Set("b3"))
+
+    assert(trace.isDefined) //expect trace exists
+    trace.foreach { tid => {
+      assert(tid.traceId.toString().equals("a3ce929d0e0e4736"))
+      assert(tid.spanId.toString().equals("00f067aa0ba902b7"))
+      assert(tid.parentId.toString().equals("5b4185666d50f68b"))
+      assert(tid.flags.toLong == 1)
+
+      // expect to get the right sampled value which is 1
+      val sampler = ZipkinTrace.getSampler(req.headerMap)
+      assert(sampler.contains(1.0f))
+
+      ztp.setContext(req, tid)
+      // check "b3" has been removed, "x-b3-traceid" and "x-b3-spanid" and "x-b3-flags" have been added to request
+      assert(req.headerMap.get("b3").isEmpty)
+      // check sampled not set when debug flag set
+      assert(req.headerMap.get("x-b3-sampled").isEmpty)
+      assert(Set("x-b3-traceid", "x-b3-spanid", "x-b3-flags").subsetOf(req.headerMap.keys.toSet))
+    }}
+
+    //test x-b3- headers have been added so we can get the same trace from them
+    val trace2 = ztp.traceId(req)
+    assert(trace == trace2)
+  }
+
+  test("get traceid from a b3 single header - four fields - not sampled child span") {
+    //b3: a3ce929d0e0e4736-00f067aa0ba902b7-d-5b4185666d50f68b
+
+    val ztp = new ZipkinTracePropagator()
+    val req = Request()
+    req.headerMap.add("b3", "a3ce929d0e0e4736-00f067aa0ba902b7-0-5b4185666d50f68b")
+
+    val trace = ztp.traceId(req)
+    //b3 has not been removed, other x-b3 have not been added
+    assert(req.headerMap.keys == Set("b3"))
+
+    assert(trace.isDefined) //expect trace exists
+    trace.foreach { tid => {
+      assert(tid.traceId.toString().equals("a3ce929d0e0e4736"))
+      assert(tid.spanId.toString().equals("00f067aa0ba902b7"))
+      assert(tid.parentId.toString().equals("5b4185666d50f68b"))
+      assert(tid.sampled.contains(false))
+
+      // expect to get the right sampled value which is 0
+      val sampler = ZipkinTrace.getSampler(req.headerMap)
+      assert(sampler.contains(0.0f))
+
+      ztp.setContext(req, tid)
+      // check "b3" has been removed, "x-b3-traceid" and "x-b3-spanid" and "x-b3-parentspanid" have been added to request
+      assert(req.headerMap.get("b3").isEmpty)
+      // check sampled not set when debug flag set
+      assert(Set("x-b3-traceid", "x-b3-spanid", "x-b3-parentspanid", "x-b3-sampled").subsetOf(req.headerMap.keys.toSet))
+    }}
+
+    //test x-b3- headers have been added so we can get the same trace from them
+    val trace2 = ztp.traceId(req)
+    assert(trace == trace2)
+  }
+
+  test("get traceid from a b3 single header - 128bit trace, two fields") {
+    //b3: 80f198ee56343ba864fe8b2a57d3eff7-05e3ac9a4f6e3b90
+    val ztp = new ZipkinTracePropagator()
+    val req = Request()
+    req.headerMap.add("b3", "80f198ee56343ba864fe8b2a57d3eff7-05e3ac9a4f6e3b90")
+
+    val trace = ztp.traceId(req)
+    //b3 has not been removed
+    assert(!req.headerMap.get("b3").isEmpty)
+    // check "x-b3-traceid" and "x-b3-spanid" have been added to request
+    //assert(req.headerMap.keys == Set("x-b3-traceid", "x-b3-spanid"))
+
+    assert(trace.isDefined) //expect trace exists
+    trace.foreach { tid => {
+      assert(tid.traceId.toString().equals("64fe8b2a57d3eff7"))
+      assert(tid.spanId.toString().equals("05e3ac9a4f6e3b90"))
+      assert(tid.traceIdHigh.toString().contains("80f198ee56343ba8)"))
+    }}
+
+    // after "x-b3-" have been added check they have expected values
+    val trace2 = ztp.traceId(req)
+    assert(trace == trace2)
+  }
+
+
+  test("b3 single headers preferred over x-b3- multi headers") {
+    val ztp = new ZipkinTracePropagator()
+    val req = Request()
+    req.headerMap.add("b3", "a3ce929d0e0e4736-00f067aa0ba902b7-1")
+    req.headerMap.add("x-b3-traceid", "0000000000000001")
+    req.headerMap.add("x-b3-spanid", "0000000000000002")
+    req.headerMap.add("x-b3-sampled", "0")
+
+    val trace = ztp.traceId(req)
+    assert(trace.isDefined)  //expect trace exists
+    trace.foreach { tid => {
+      assert(tid.traceId.toString().equals("a3ce929d0e0e4736"))  //expect traceid from b3 not from x-b3-traceid)
+      assert(tid.spanId.toString().equals("00f067aa0ba902b7")) // expect spanid from b3 not from x-b3-spanid
+      assert(tid.sampled.contains(true)) // expect samplef from b3 not from x-b3-sampled
+    }}
+  }
+
+  test("same trace from b3 single headers and x-b3- multi headers, 128bit traceid, UPPER CASE header don't matter") {
+    /* Turn on tracing and see if
+      b3=80f198ee56343ba864fe8b2a57d3eff7-05e3ac9a4f6e3b90-1-e457b5a2e4d86bd1 results in the same context as:
+      X-B3-TraceId: 80f198ee56343ba864fe8b2a57d3eff7
+      X-B3-ParentSpanId: 05e3ac9a4f6e3b90
+      X-B3-SpanId: e457b5a2e4d86bd1
+      X-B3-Sampled: 1
+     */
+
+    //NOTE: This will also test case doesn't matter for b3 single or x-b3- multi headers
+    val ztp = new ZipkinTracePropagator()
+    val req1 = Request()
+    req1.headerMap.add("B3", "80f198ee56343ba864fe8b2a57d3eff7-05e3ac9a4f6e3b90-1-e457b5a2e4d86bd1")
+
+    val req2 = Request()
+    req2.headerMap.add("X-B3-TRACEID", "80f198ee56343ba864fe8b2a57d3eff7")
+    req2.headerMap.add("X-B3-SPANID", "05e3ac9a4f6e3b90")
+    req2.headerMap.add("X-B3-SAMPLED", "1")
+    req2.headerMap.add("X-B3-PARENTSPANID", "e457b5a2e4d86bd1")
+
+    val trace1 = ztp.traceId(req1)
+    val trace2 = ztp.traceId(req2)
+
+    assert(trace1 == trace2)
+  }
+
+  test("cannot get trace from invalid b3 single header, too many fields") {
+    val ztp = new ZipkinTracePropagator()
+    val req1 = Request()
+    req1.headerMap.add("B3", "80f198ee56343ba864fe8b2a57d3eff7-05e3ac9a4f6e3b90-1-e457b5a2e4d86bd1-extra1")
+
+    assert(ztp.traceId(req1).isEmpty)
   }
 }

--- a/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/ZipkinTracePropagatorTest.scala
+++ b/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/ZipkinTracePropagatorTest.scala
@@ -1,0 +1,46 @@
+package io.buoyant.linkerd.protocol.http
+
+import com.twitter.finagle.http.{Request}
+import org.scalatest.FunSuite
+
+import io.buoyant.linkerd.protocol.http._
+import io.buoyant.router.HttpInstances._
+
+class ZipkinTracePropagatorTest extends FunSuite {
+  test("get traceid from multi x-b3 headers, 64bit trace id, sampled, UPPER CASE header doesn't matter") {
+    val ztp = new ZipkinTracePropagator
+
+    //x-b3 multi headers with lower case
+    val req1 = Request()
+    req1.headerMap.add("x-b3-traceid", "80f198ee56343ba8")
+    req1.headerMap.add("x-b3-spanid", "05e3ac9a4f6e3b90")
+    req1.headerMap.add("x-b3-sampled", "1")
+    req1.headerMap.add("x-b3-parentspanid", "e457b5a2e4d86bd1")
+
+    //X-B3 multi heders with upper case
+    val req2 = Request()
+    req2.headerMap.add("X-B3-TRACEID", "80f198ee56343ba8")
+    req2.headerMap.add("X-B3-SPANID", "05e3ac9a4f6e3b90")
+    req2.headerMap.add("X-B3-SAMPLED", "1")
+    req2.headerMap.add("X-B3-PARENTSPANID", "e457b5a2e4d86bd1")
+
+    val trace1 = ztp.traceId(req1)
+    val trace2 = ztp.traceId(req2)
+
+    // traceid is the same, lower/upper case doesn't matter
+    assert(trace1 == trace2)
+
+    assert(trace1.isDefined) //expect trace exists
+    trace1.foreach { tid => {
+      assert(tid.traceId.toString().equals("80f198ee56343ba8"))
+      assert(tid.spanId.toString().equals("05e3ac9a4f6e3b90"))
+      assert(tid.parentId.toString().equals("e457b5a2e4d86bd1"))
+      assert(tid.sampled.contains(true))
+
+      // expect to get the right sampled value which is 0
+      val sampler = ZipkinTrace.getSampler(req1.headerMap)
+      assert(sampler.contains(1.0f))
+    }}
+  }
+
+ }

--- a/project/LinkerdBuild.scala
+++ b/project/LinkerdBuild.scala
@@ -606,8 +606,12 @@ object LinkerdBuild extends Base {
 
     object Protocol {
 
+      val baseHttp = projectDir("linkerd/protocol/base-http")
+        .dependsOn(Router.baseHttp, core)
+        .withTests()
+
       val h2 = projectDir("linkerd/protocol/h2")
-        .dependsOn(core, Router.h2, istio, Finagle.h2 % "test->test;e2e->test", tls % Test)
+        .dependsOn(core, baseHttp, Router.h2, istio, Finagle.h2 % "test->test;e2e->test", tls % Test)
         .withTests().withE2e().withIntegration()
         .withGrpc
         .withTwitterLibs(Deps.finagle("netty4"))
@@ -617,6 +621,7 @@ object LinkerdBuild extends Base {
         .withTwitterLibs(Deps.finagle("netty4-http"))
         .dependsOn(
           core % "compile->compile;e2e->test;integration->test",
+          baseHttp,
           istio,
           istioProto,
           failureAccrual % "e2e",
@@ -642,7 +647,7 @@ object LinkerdBuild extends Base {
         .settings(publishArtifact := false)
         .withTwitterLib(Deps.twitterUtil("benchmark"))
 
-      val all = aggregateDir("linkerd/protocol", benchmark, h2, http, mux, thrift, thriftMux)
+      val all = aggregateDir("linkerd/protocol", benchmark, baseHttp, h2, http, mux, thrift, thriftMux)
     }
 
     object Announcer {
@@ -854,6 +859,7 @@ object LinkerdBuild extends Base {
   val linkerdMain = Linkerd.main
   val linkerdProtocol = Linkerd.Protocol.all
   val linkerdProtocolH2 = Linkerd.Protocol.h2
+  val LinkerdProtocolBaseHttp = Linkerd.Protocol.baseHttp
   val linkerdProtocolHttp = Linkerd.Protocol.http
   val linkerdProtocolMux = Linkerd.Protocol.mux
   val linkerdProtocolThrift = Linkerd.Protocol.thrift

--- a/router/base-http/src/main/scala/io/buoyant/router/http/HeadersLike.scala
+++ b/router/base-http/src/main/scala/io/buoyant/router/http/HeadersLike.scala
@@ -12,4 +12,5 @@ trait HeadersLike[H] {
   def add(headers: H, k: String, v: String): Unit
   def set(headers: H, k: String, v: String): Unit
   def remove(headers: H, key: String): Seq[String]
+  def iterator(headers: H): Iterator[(String, String)]
 }

--- a/router/base-http/src/test/scala/io/buoyant/router/http/MaxCallDepthFilterTest.scala
+++ b/router/base-http/src/test/scala/io/buoyant/router/http/MaxCallDepthFilterTest.scala
@@ -17,6 +17,7 @@ class MaxCallDepthFilterTest extends FunSuite with Awaits {
     override def add(headers: HeaderMap, k: String, v: String): Unit = ???
     override def set(headers: HeaderMap, k: String, v: String): Unit = ???
     override def remove(headers: HeaderMap, key: String): Seq[String] = ???
+    override def iterator(headers: HeaderMap): Iterator[(String, String)] = ???
   }
 
   implicit object HttpRequestLike extends RequestLike[Request, HeaderMap] {

--- a/router/h2/src/main/scala/io/buoyant/router/H2Instances.scala
+++ b/router/h2/src/main/scala/io/buoyant/router/H2Instances.scala
@@ -19,6 +19,8 @@ object H2Instances {
     override def set(headers: Headers, k: String, v: String): Unit = headers.set(k, v)
 
     override def remove(headers: Headers, key: String): Seq[String] = headers.remove(key)
+
+    override def iterator(headers: Headers): Iterator[(String, String)] = headers.toSeq.iterator
   }
 
   implicit object H2RequestLike extends RequestLike[Request, Headers] {

--- a/router/http/src/main/scala/io/buoyant/router/HttpInstances.scala
+++ b/router/http/src/main/scala/io/buoyant/router/HttpInstances.scala
@@ -29,6 +29,8 @@ object HttpInstances {
       headers -= key
       r
     }
+
+    override def iterator(headers: HeaderMap): Iterator[(String, String)] = headers.iterator
   }
 
   implicit object HttpRequestLike extends RequestLike[Request, HeaderMap] {


### PR DESCRIPTION
Linkerd Zipkin propagator will now read b3 single header the same way it reads x-b3- multi headers. If a request contains the "b3" single header and multiple "X-B3-" headers, the trace context from "b3" is preferred and "x-b3-" headers will be ignored. 

B3 is also preferred and read for the sampling decision, if not present, sampling decision falls back to X-B3. 

On the way out "X-B3-" multi headers are still preferred over "B3". There's no way to know what the downstream is capable of, and it is more likely it supports "X-B3-*" vs not, so, the portable choice is to always write down "X-B3-"  even if we read "b3".

No config changes were needed for this solution.