### PR TITLE
Fix for Expose DaemonSet transformer state #2149. 

### DIFF
--- a/interpreter/k8s/src/main/scala/io/buoyant/transformer/k8s/DaemonSetTransformerInitializer.scala
+++ b/interpreter/k8s/src/main/scala/io/buoyant/transformer/k8s/DaemonSetTransformerInitializer.scala
@@ -16,8 +16,6 @@ class DaemonSetTransformerInitializer extends TransformerInitializer {
   override val configId = "io.l5d.k8s.daemonset"
 }
 
-object DaemonSetTransformerInitializer extends DaemonSetTransformerInitializer
-
 case class DaemonSetTransformerConfig(
   k8sHost: Option[String],
   k8sPort: Option[Port],

--- a/interpreter/k8s/src/test/scala/io/buoyant/transformer/k8s/DaemonSetTransformerTest.scala
+++ b/interpreter/k8s/src/test/scala/io/buoyant/transformer/k8s/DaemonSetTransformerTest.scala
@@ -142,7 +142,7 @@ class DaemonSetTransformerTest extends FunSuite
   }
 
   private[this] def parse(yaml: String): DaemonSetTransformerConfig =
-    Parser.objectMapper(yaml, Iterable(Seq(DaemonSetTransformerInitializer)))
+    Parser.objectMapper(yaml, Iterable(Seq(new DaemonSetTransformerInitializer)))
       .readValue[TransformerConfig](yaml)
       .asInstanceOf[DaemonSetTransformerConfig]
 

--- a/interpreter/k8s/src/test/scala/io/buoyant/transformer/k8s/DaemonSetTransformerTest.scala
+++ b/interpreter/k8s/src/test/scala/io/buoyant/transformer/k8s/DaemonSetTransformerTest.scala
@@ -191,10 +191,7 @@ class DaemonSetTransformerTest extends FunSuite
     val transformer = parse(yaml_hostNetwork_false).mk(Stack.Params.empty)
 
     val interpreter = new NameInterpreter {
-      override def bind(
-                         dtab: Dtab,
-                         path: Path
-                       ): Activity[NameTree[Bound]] = {
+      override def bind(dtab: Dtab, path: Path): Activity[NameTree[Bound]] = {
         val Path.Utf8(ip, nodeName) = path
         Activity.value(
           NameTree.Leaf(Name.Bound(Var(Addr.Bound(

--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/LinkerdAdmin.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/LinkerdAdmin.scala
@@ -84,19 +84,11 @@ object LinkerdAdmin {
   }
 
   def extractTransformersNamerHandlers(namers: Seq[Namer]): Seq[Admin.Handler] = {
-    namers.flatMap(namer =>
-      namer match {
-        case withNameTreeTransformer: WithNameTreeTransformer =>
-          withNameTreeTransformer.transformers.toSeq.flatMap(transformer =>
-            transformer match {
-              case withHandlers: Admin.WithHandlers =>
-                withHandlers.adminHandlers
-              case _ =>
-                Seq()
-            })
-        case _ =>
-          Seq()
-      })
+    for {
+      n <- namers.collect { case n: WithNameTreeTransformer => n }
+      t <- n.transformers.collect { case t: Admin.WithHandlers => t }
+      h <- t.adminHandlers
+    } yield h
   }
 
   def extractInterpreterHandlers(routers: Seq[Router]): Seq[Admin.Handler] = {
@@ -113,18 +105,11 @@ object LinkerdAdmin {
   }
 
   def extractInterpreterTransformerHandlers(routers: Seq[Router]): Seq[Admin.Handler] = {
-    routers.flatMap(router =>
-      router.interpreter match {
-        case withNameTreeTransformer: WithNameTreeTransformer =>
-          withNameTreeTransformer.transformers.toSeq.flatMap(transformer =>
-            transformer match {
-              case withHandlers: Admin.WithHandlers => withHandlers.adminHandlers
-              case _ =>
-                Seq()
-            })
-        case _ =>
-          Seq()
-      })
+    for {
+      r <- routers.collect { case r: WithNameTreeTransformer => r }
+      t <- r.transformers.collect { case t: Admin.WithHandlers => t }
+      h <- t.adminHandlers
+    } yield h
   }
 
   def apply(lc: Linker.LinkerConfig, linker: Linker): Seq[Handler] = {

--- a/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/LinkerdAdmin.scala
+++ b/linkerd/admin/src/main/scala/io/buoyant/linkerd/admin/LinkerdAdmin.scala
@@ -106,8 +106,8 @@ object LinkerdAdmin {
 
   def extractInterpreterTransformerHandlers(routers: Seq[Router]): Seq[Admin.Handler] = {
     for {
-      r <- routers.collect { case r: WithNameTreeTransformer => r }
-      t <- r.transformers.collect { case t: Admin.WithHandlers => t }
+      i <- routers.map(_.interpreter).collect { case i: WithNameTreeTransformer => i }
+      t <- i.transformers.collect { case t: Admin.WithHandlers => t }
       h <- t.adminHandlers
     } yield h
   }

--- a/linkerd/docs/transformer.md
+++ b/linkerd/docs/transformer.md
@@ -67,7 +67,9 @@ This can be used to redirect traffic to a reverse-proxy that runs as a
 daemonset.
 
 This transformer assumes that there is a Kubernetes service for the daemonset
-which can be used to find all pods in the daemonset.
+which can be used to find all pods in the daemonset. The internal state of each daemonset namer can be viewed at the
+admin endpoint: `/namer_state/io.l5d.k8s.daemonset/$namespace/$port/$service.json`, where $namespace/$port/$service are the required key configs for the DaemonSetTransformer.
+
 
 Key | Default Value | Description
 --- | ------------- | -----------


### PR DESCRIPTION
Linkerd's current view of each DaemonSet namer will be exposed to :9990/namer_state//io.l5d.k8s.daemonset/// , where namespace/port/service are the required config for the DaemonSet transformer.

Signed-off-by: dst4096 <dst4096@gmail.com>