### PR TITLE
 Use fully specified paths so that the generated code doesn't cause ambiguity

### DIFF
--- a/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4DispatcherBase.scala
+++ b/finagle/h2/src/main/scala/com/twitter/finagle/buoyant/h2/netty4/Netty4DispatcherBase.scala
@@ -95,7 +95,6 @@ trait Netty4DispatcherBase[SendMsg <: Message, RecvMsg <: Message] {
 
   protected[this] def demuxing: Future[Unit]
 
-
   // We count all streams towards active. The reason for that
   // is the fact that under normal circumstances when the
   // protocol is respected eventually the stream state will

--- a/grpc/eg/src/main/protobuf/eg.proto
+++ b/grpc/eg/src/main/protobuf/eg.proto
@@ -6,6 +6,13 @@ import "base.proto";
 
 option java_outer_classname = "Eg";
 
+message Seq {}
+message Map {}
+message Option {}
+message Some {}
+message None {}
+message Nil {}
+
 enum Enumeration {
   ZERO = 0;
   ONE = 1;


### PR DESCRIPTION
Fixes #2346 