### PR TITLE
Address two documentation updates for Linkerd 1.x:

### DIFF
--- a/linkerd/docs/routers.md
+++ b/linkerd/docs/routers.md
@@ -90,7 +90,7 @@ socketOptions | none | Socket options to set for the router interface. See [Sock
 tls | no tls | The server will serve over TLS if this parameter is provided. see [TLS](#server-tls).
 maxConcurrentRequests | unlimited | The maximum number of concurrent requests the server will accept.
 announce | an empty list | A list of concrete names to announce using the router's [announcers](#announcers).
-clearContext | `false` | If `true`, all headers that set Linkerd contexts are removed from inbound requests. Useful for servers exposed on untrusted networks.
+clearContext | `false` | If `true`, all headers that set Linkerd contexts are removed from inbound requests. Useful for servers exposed on untrusted networks. **NOTE**: Setting this to `true` will interfere with [Diagnostic Tracing](https://linkerd.io/2018/06/19/debugging-production-issues-with-linkerds-diagnostic-tracing/). You will need to set this to `false` to see diagnostic tracing output.
 
 ## Service Configuration
 

--- a/linkerd/docs/transformer.md
+++ b/linkerd/docs/transformer.md
@@ -80,7 +80,7 @@ hostNetwork | `false` | If true, use nodeName instead of /24 subnet to determine
 
 <aside class="notice">
 The Kubernetes namer does not support TLS.  Instead, you should run `kubectl proxy` on each host,
-which will create a local proxy for securely talking to the Kubernetes cluster API. See (the k8s guide)[https://linkerd.io/doc/latest/k8s/] for more information.
+which will create a local proxy for securely talking to the Kubernetes cluster API. See (the k8s guide)[https://linkerd.io/1/getting-started/k8s/] for more information.
 </aside>
 
 ## Localnode (Kubernetes)


### PR DESCRIPTION
Update the url for the linkerd k8s guides to the new url from site redesign.
Add additional detail for clearContext configuration and its interference with Diagnostic Tracing