### PR TITLE
[#2352] Add configuration server.serverSession to allow expiring server conne…

### DIFF
--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/ClientConfig.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/ClientConfig.scala
@@ -93,13 +93,4 @@ case class HostConnectionPool(
 case class ClientSessionConfig(
   @JsonDeserialize(contentAs = classOf[java.lang.Integer]) lifeTimeMs: Option[Int],
   @JsonDeserialize(contentAs = classOf[java.lang.Integer]) idleTimeMs: Option[Int]
-) {
-  @JsonIgnore
-  private[this] val default = ExpiringService.Param.param.default
-
-  @JsonIgnore
-  def param = ExpiringService.Param(
-    lifeTime = lifeTimeMs.map(_.millis).getOrElse(default.lifeTime),
-    idleTime = idleTimeMs.map(_.millis).getOrElse(default.idleTime)
-  )
-}
+) extends SessionConfig

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/SessionConfig.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/SessionConfig.scala
@@ -1,0 +1,21 @@
+package io.buoyant.linkerd
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.twitter.conversions.DurationOps._
+import com.twitter.finagle.service.ExpiringService
+
+trait SessionConfig {
+
+  def lifeTimeMs: Option[Int]
+  def idleTimeMs: Option[Int]
+
+  @JsonIgnore
+  private[this] val default = ExpiringService.Param.param.default
+
+  @JsonIgnore
+  def param = ExpiringService.Param(
+    lifeTime = lifeTimeMs.map(_.millis).getOrElse(default.lifeTime),
+    idleTime = idleTimeMs.map(_.millis).getOrElse(default.idleTime)
+  )
+
+}

--- a/linkerd/docs/routers.md
+++ b/linkerd/docs/routers.md
@@ -91,6 +91,16 @@ tls | no tls | The server will serve over TLS if this parameter is provided. see
 maxConcurrentRequests | unlimited | The maximum number of concurrent requests the server will accept.
 announce | an empty list | A list of concrete names to announce using the router's [announcers](#announcers).
 clearContext | `false` | If `true`, all headers that set Linkerd contexts are removed from inbound requests. Useful for servers exposed on untrusted networks. **NOTE**: Setting this to `true` will interfere with [Diagnostic Tracing](https://linkerd.io/2018/06/19/debugging-production-issues-with-linkerds-diagnostic-tracing/). You will need to set this to `false` to see diagnostic tracing output.
+serverSession | An empty object | see [serverSession](#server-session) 
+
+### Server Session
+
+Configures the behavior of established server sessions.
+
+Key | Default Value | Description
+--- | ------------- | -----------
+idleTimeMs | forever | The max amount of time for which a connection is allowed to be idle. When this time exceeded the connection will close itself.
+lifeTimeMs | forever | Max lifetime of a connection.
 
 ## Service Configuration
 

--- a/linkerd/protocol/http/src/e2e/scala/io/buoyant/linkerd/protocol/HttpEndToEndTest.scala
+++ b/linkerd/protocol/http/src/e2e/scala/io/buoyant/linkerd/protocol/HttpEndToEndTest.scala
@@ -842,6 +842,107 @@ class HttpEndToEndTest
     }
   }
 
+  test("serverSession idleTimeMs should close server connections") {
+    val config =
+      s"""|routers:
+          |- protocol: http
+          |  experimental: true
+          |  dtab: |
+          |    /p/fox => /$$/inet/127.1/{fox.port} ;
+          |    /svc/century => /p/fox ;
+          |  servers:
+          |  - port: 0
+          |    serverSession:
+          |      idleTimeMs: 1500
+          |      lifeTimeMs: 3000
+          |""".stripMargin
+
+    serverIdleTimeMsBaseTest(config){ (router:Router.Initialized, stats:InMemoryStatsReceiver) =>
+      // Assert
+      def connectsCount = () => stats.counters(Seq("rt", "http", "server", "127.0.0.1/0", "connects"))
+      def activeConnectionsCount = stats.gauges(Seq("rt", "http", "server", "127.0.0.1/0", "connections"))
+      def idleConnectionsCount = () => stats.counters(Seq("rt", "http", "server", "127.0.0.1/0", "idle"))
+      def lifetimeConnectionsCount = () => stats.counters(Seq("rt", "http", "server", "127.0.0.1/0", "lifetime"))
+
+      // An incoming request through the Http.Router will establish an active connection; We expect to see it here
+      assert(connectsCount() == 1.0)
+      assert(activeConnectionsCount() == 1.0)
+
+      eventually(timeout(Span(5, Seconds)), interval(Span(250, Millis))) {
+        assert(activeConnectionsCount() == 0.0)
+        assert(idleConnectionsCount() == 1.0)
+      }
+
+      ()
+    }
+  }
+
+  test("serverSession lifeTimeMs should close server connections") {
+    val config =
+      s"""|routers:
+          |- protocol: http
+          |  experimental: true
+          |  dtab: |
+          |    /p/fox => /$$/inet/127.1/{fox.port} ;
+          |    /svc/century => /p/fox ;
+          |  servers:
+          |  - port: 0
+          |    serverSession:
+          |      idleTimeMs: 3000
+          |      lifeTimeMs: 1500
+          |""".stripMargin
+
+    serverIdleTimeMsBaseTest(config){ (router:Router.Initialized, stats:InMemoryStatsReceiver) =>
+      // Assert
+      def connectsCount = () => stats.counters(Seq("rt", "http", "server", "127.0.0.1/0", "connects"))
+      def activeConnectionsCount = stats.gauges(Seq("rt", "http", "server", "127.0.0.1/0", "connections"))
+      def idleConnectionsCount = () => stats.counters(Seq("rt", "http", "server", "127.0.0.1/0", "idle"))
+      def lifetimeConnectionsCount = () => stats.counters(Seq("rt", "http", "server", "127.0.0.1/0", "lifetime"))
+
+      // An incoming request through the Http.Router will establish an active connection; We expect to see it here
+      assert(connectsCount() == 1.0)
+      assert(activeConnectionsCount() == 1.0)
+
+      eventually(timeout(Span(5, Seconds)), interval(Span(250, Millis))) {
+        assert(activeConnectionsCount() == 0.0)
+        assert(lifetimeConnectionsCount() == 1.0)
+      }
+
+      ()
+    }
+  }
+
+  test("serverSession lifeTimeMs should not close server connections if not specified") {
+    val config =
+      s"""|routers:
+          |- protocol: http
+          |  experimental: true
+          |  dtab: |
+          |    /p/fox => /$$/inet/127.1/{fox.port} ;
+          |    /svc/century => /p/fox ;
+          |  servers:
+          |  - port: 0
+          |""".stripMargin
+
+    serverIdleTimeMsBaseTest(config){ (router:Router.Initialized, stats:InMemoryStatsReceiver) =>
+      // Assert
+      def connectsCount = () => stats.counters(Seq("rt", "http", "server", "127.0.0.1/0", "connects"))
+      def activeConnectionsCount = stats.gauges(Seq("rt", "http", "server", "127.0.0.1/0", "connections"))
+      def idleConnectionsCount = () => stats.counters(Seq("rt", "http", "server", "127.0.0.1/0", "idle"))
+      def lifetimeConnectionsCount = () => stats.counters(Seq("rt", "http", "server", "127.0.0.1/0", "lifetime"))
+
+      // An incoming request through the Http.Router will establish an active connection; We expect to see it here
+      assert(connectsCount() == 1.0)
+      assert(activeConnectionsCount() == 1.0)
+
+      assert(router.servers.head.params[ExpiringService.Param].idleTime == Duration.Top)
+      assert(router.servers.head.params[ExpiringService.Param].lifeTime == Duration.Top)
+
+      ()
+    }
+  }
+
+
   test("requests with Max-Forwards header, l5d-add-context and method TRACE are sent downstream") {
     @volatile var headers: HeaderMap = null
     @volatile var method: Method = null
@@ -1000,6 +1101,47 @@ class HttpEndToEndTest
 
       // Assert
       assertionsF(router, stats, fox.port)
+
+    } finally {
+      await(client.close())
+      await(fox.server.close())
+      await(server.close())
+      await(router.close())
+    }
+  }
+
+  def serverIdleTimeMsBaseTest(config:String)(assertionsF: (Router.Initialized, InMemoryStatsReceiver) => Unit): Unit = {
+    // Arrange
+    val stats = new InMemoryStatsReceiver
+    val fox = Downstream.const("fox", "what does the fox say?")
+
+    val configWithPort = config.replace("{fox.port}", fox.port.toString)
+
+    val linker = Linker.Initializers(Seq(HttpInitializer)).load(configWithPort)
+      .configured(param.Stats(stats))
+
+    val router = linker.routers.head.initialize()
+    val server = router.servers.head.serve()
+
+    val client = upstream(server)
+
+    def get(host: String, path: String = "/")(f: Response => Unit): Unit = {
+      val req = Request(path)
+      req.host = host
+      val rsp = await(client(req))
+      f(rsp)
+    }
+
+    // Act
+    try {
+      get("century") { rsp =>
+        assert(rsp.status == Status.Ok)
+        assert(rsp.contentString == "what does the fox say?")
+        ()
+      }
+
+      // Assert
+      assertionsF(router, stats)
 
     } finally {
       await(client.close())

--- a/linkerd/protocol/http/src/e2e/scala/io/buoyant/linkerd/protocol/HttpEndToEndTest.scala
+++ b/linkerd/protocol/http/src/e2e/scala/io/buoyant/linkerd/protocol/HttpEndToEndTest.scala
@@ -859,13 +859,12 @@ class HttpEndToEndTest
 
     serverIdleTimeMsBaseTest(config){ (router:Router.Initialized, stats:InMemoryStatsReceiver) =>
       // Assert
-      def connectsCount = () => stats.counters(Seq("rt", "http", "server", "127.0.0.1/0", "connects"))
+      def connectsCount = stats.counters(Seq("rt", "http", "server", "127.0.0.1/0", "connects"))
       def activeConnectionsCount = stats.gauges(Seq("rt", "http", "server", "127.0.0.1/0", "connections"))
       def idleConnectionsCount = () => stats.counters(Seq("rt", "http", "server", "127.0.0.1/0", "idle"))
-      def lifetimeConnectionsCount = () => stats.counters(Seq("rt", "http", "server", "127.0.0.1/0", "lifetime"))
 
       // An incoming request through the Http.Router will establish an active connection; We expect to see it here
-      assert(connectsCount() == 1.0)
+      assert(connectsCount == 1.0)
       assert(activeConnectionsCount() == 1.0)
 
       eventually(timeout(Span(5, Seconds)), interval(Span(250, Millis))) {
@@ -894,13 +893,12 @@ class HttpEndToEndTest
 
     serverIdleTimeMsBaseTest(config){ (router:Router.Initialized, stats:InMemoryStatsReceiver) =>
       // Assert
-      def connectsCount = () => stats.counters(Seq("rt", "http", "server", "127.0.0.1/0", "connects"))
+      def connectsCount = stats.counters(Seq("rt", "http", "server", "127.0.0.1/0", "connects"))
       def activeConnectionsCount = stats.gauges(Seq("rt", "http", "server", "127.0.0.1/0", "connections"))
-      def idleConnectionsCount = () => stats.counters(Seq("rt", "http", "server", "127.0.0.1/0", "idle"))
       def lifetimeConnectionsCount = () => stats.counters(Seq("rt", "http", "server", "127.0.0.1/0", "lifetime"))
 
       // An incoming request through the Http.Router will establish an active connection; We expect to see it here
-      assert(connectsCount() == 1.0)
+      assert(connectsCount == 1.0)
       assert(activeConnectionsCount() == 1.0)
 
       eventually(timeout(Span(5, Seconds)), interval(Span(250, Millis))) {
@@ -926,13 +924,11 @@ class HttpEndToEndTest
 
     serverIdleTimeMsBaseTest(config){ (router:Router.Initialized, stats:InMemoryStatsReceiver) =>
       // Assert
-      def connectsCount = () => stats.counters(Seq("rt", "http", "server", "127.0.0.1/0", "connects"))
+      def connectsCount = stats.counters(Seq("rt", "http", "server", "127.0.0.1/0", "connects"))
       def activeConnectionsCount = stats.gauges(Seq("rt", "http", "server", "127.0.0.1/0", "connections"))
-      def idleConnectionsCount = () => stats.counters(Seq("rt", "http", "server", "127.0.0.1/0", "idle"))
-      def lifetimeConnectionsCount = () => stats.counters(Seq("rt", "http", "server", "127.0.0.1/0", "lifetime"))
 
       // An incoming request through the Http.Router will establish an active connection; We expect to see it here
-      assert(connectsCount() == 1.0)
+      assert(connectsCount == 1.0)
       assert(activeConnectionsCount() == 1.0)
 
       assert(router.servers.head.params[ExpiringService.Param].idleTime == Duration.Top)


### PR DESCRIPTION
…ctions

This PR fixes #2352.

There might be clients opening connections to Linkerd not closing them properly.
Also sometimes network components might silently drop connections to Linkerd.
This results in connections that are never closed and after a longer time this might accumulate to so many open connections until the Linkerd process runs out of file handles.
Right now I could not find a configuration parameter to control expiring of inbound connections like it is supported for client connections.

Therefore this PR proposes to add a configuration parameter `serverSession` to a server that behaves similar to the `clientSession`.
With the following configuration server connections will be closed after 2 seconds of idling or after a full life time of 30 seconds:
```yaml
servers:
- port: 4140
  serverSession:
    idleTimeMs: 2000
    lifeTimeMs: 30000
```