### PR TITLE
Adding Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+## Linkerd Community Code of Conduct
+
+Linkerd follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).


### PR DESCRIPTION
Linkerd follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).

Signed-off-by: Nguyen Hai Truong <truongnh@fujitsu.com>