### PR TITLE
Fix openssl in phantomjs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ jobs:
       - image: openjdk:8
         environment:
           CI_TERRIBLENESS: 30.seconds
+          OPENSSL_CONF: admin/src/main/resources/io/buoyant/admin/openssl.cnf
     # Run two containers, $CIRCLE_NODE_TOTAL = 2, $CIRCLE_NODE_INDEX = [0|1]
     parallelism: 2
     resource_class: large

--- a/admin/src/main/resources/io/buoyant/admin/openssl.cnf
+++ b/admin/src/main/resources/io/buoyant/admin/openssl.cnf
@@ -1,0 +1,1 @@
+# Empty openssl.cnf to satisfy phantomjs


### PR DESCRIPTION
At some point, phantomjs tests on CI started failing with

```
12 03 2020 12:35:18.784:ERROR [phantomjs.launcher]: Auto configuration failed
139650115362432:error:25066067:DSO support routines:DLFCN_LOAD:could not load the shared library:dso_dlfcn.c:185:filename(libssl_conf.so): libssl_conf.so: cannot open shared object file: No such file or directory
139650115362432:error:25070067:DSO support routines:DSO_load:could not load the shared library:dso_lib.c:244:
139650115362432:error:0E07506E:configuration file routines:MODULE_LOAD_DSO:error loading dso:conf_mod.c:285:module=ssl_conf, path=ssl_conf
139650115362432:error:0E076071:configuration file routines:MODULE_RUN:unknown module name:conf_mod.c:222:module=ssl_conf

12 03 2020 12:35:18.787:ERROR [launcher]: Cannot start PhantomJS
```

It seems that the openssl config in the underlying docker image got upgraded from under us to a version that phantomjs cannot parse.  To remedy this, we manually specify an empty openssl config.