### PR TITLE
Add zaharidichev as a super-maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-* @adleong @olix0r
+* @adleong @olix0r @zaharidichev
 
 # William and Oliver should approve all changelog entries.
 CHANGES.md @wmorgan @olix0r @admc

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -2,6 +2,7 @@ The Linkerd maintainers are:
 
 * Oliver Gould <ver@buoyant.io> @olix0r (super-maintainer)
 * Alex Leong <alex@buoyant.io> @adleong (super-maintainer)
+* Zarahi Dichev <zahari@buoyant.io> @zaharidichev (super-maintainer)
 * Risha Mars <mars@buoyant.io> @rmars: Admin UI
 * William Morgan <william@buoyant.io> @wmorgan: docs and governance
 * Adam Christian <adam@buoyant.io> @admc: docs and governance


### PR DESCRIPTION
As per the project governance, super-maintainers are responsible for the project as a whole, and are expected to guide general project direction as well as being the final reviewer on PRs.  I would like to propose @zaharidichev as a super-maintainer.

Zahari has a long list of contributions to the across the project (https://github.com/linkerd/linkerd/commits?author=zaharidichev) including several critical performance fixes.  He has a deep understanding of the code and the project as a whole.  He is an active member of the community on the Linkerd slack and regularly provides support to users.

Adding a super-maintainer requires a 2/3 majority organization vote.  Please give this due consideration.  Thank you.

Signed-off-by: Alex Leong <alex@buoyant.io>