### PR TITLE
Update ServersetNamer to support dtabs with shard fragment

### DIFF
--- a/namer/serversets/src/main/scala/com/twitter/finagle/serversets2/BouyantZkResolver.scala
+++ b/namer/serversets/src/main/scala/com/twitter/finagle/serversets2/BouyantZkResolver.scala
@@ -1,0 +1,33 @@
+package com.twitter.finagle.serverset2
+
+import com.twitter.finagle.{Addr, Path, Resolver}
+import com.twitter.finagle.serverset2.naming.ServersetPath
+import com.twitter.util.Var
+
+trait BouyantZkResolver {
+  protected[this] def addrOf(
+    zkHosts: String,
+    zkPath: String,
+    endpoint: Option[String],
+    shardId: Option[Int]
+  ): Var[Addr]
+
+  def resolve(path: Path): Var[Addr] = ServersetPath.of(path) match {
+    case Some(ServersetPath(zkHosts, zkPath, endpoint, shardId)) =>
+      addrOf(zkHosts, zkPath.show, endpoint, shardId)
+    case _ =>
+      Var.value(Addr.Neg)
+  }
+}
+
+class BouyantZkResolverImpl(zk2: Zk2Resolver) extends BouyantZkResolver {
+  def this() = this(Resolver.get(classOf[Zk2Resolver]).get)
+
+  protected[this] def addrOf(
+    zkHosts: String,
+    zkPath: String,
+    endpoint: Option[String],
+    shardId: Option[Int]
+  ): Var[Addr] =
+    zk2.addrOf(zkHosts, zkPath, endpoint, shardId)
+}

--- a/namer/serversets/src/main/scala/io/buoyant/namer/serversets/ServersetNamer.scala
+++ b/namer/serversets/src/main/scala/io/buoyant/namer/serversets/ServersetNamer.scala
@@ -3,6 +3,7 @@ package io.buoyant.namer.serversets
 
 import com.twitter.finagle._
 import com.twitter.util.{Activity, Var}
+import com.twitter.finagle.serverset2.{BouyantZkResolver, BouyantZkResolverImpl}
 
 /**
  * The serverset namer takes Paths of the form
@@ -25,51 +26,27 @@ import com.twitter.util.{Activity, Var}
  *
  * Cribbed from https://github.com/twitter/finagle/blob/develop/finagle-serversets/src/main/scala/com/twitter/serverset.scala
  */
-class ServersetNamer(zkHost: String, idPrefix: Path) extends Namer {
-
-  /** Resolve a resolver string to a Var[Addr]. */
-  protected[this] def resolve(spec: String): Var[Addr] = Resolver.eval(spec) match {
-    case Name.Bound(addr) => addr
-    case _ => Var.value(Addr.Neg)
-  }
-
-  protected[this] def resolveServerset(hosts: String, path: String) =
-    resolve(s"zk2!$hosts!$path")
-
-  protected[this] def resolveServerset(hosts: String, path: String, endpoint: String) =
-    resolve(s"zk2!$hosts!$path!$endpoint")
+class ServersetNamer(zkHost: Path, idPrefix: Path, zk2: BouyantZkResolver) extends Namer {
+  def this(zkHost: String, idPrefix: Path) = this(Path.Utf8(zkHost), idPrefix, new BouyantZkResolverImpl)
 
   /** Bind a name. */
   protected[this] def bind(path: Path, residual: Path = Path.empty): Activity[NameTree[Name]] = {
-    // Clients may depend on Name.Bound ids being Paths which resolve
-    // back to the same Name.Bound
-    val id = idPrefix ++ path
-    path match {
-      case Path.Utf8(segments@_*) =>
-        val addr = if (segments.nonEmpty && (segments.last contains ":")) {
-          val Array(name, endpoint) = segments.last.split(":", 2)
-          val zkPath = (segments.init :+ name).mkString("/", "/", "")
-          resolveServerset(zkHost, zkPath, endpoint)
-        } else {
-          val zkPath = segments.mkString("/", "/", "")
-          resolveServerset(zkHost, zkPath)
-        }
-
-        val act = Activity(addr.map(Activity.Ok(_)))
-
-        act.flatMap {
-          case Addr.Neg if !path.isEmpty =>
-            val n = path.size
-            bind(path.take(n - 1), path.drop(n - 1) ++ residual)
-          case Addr.Neg =>
-            Activity.value(NameTree.Neg)
-          case Addr.Bound(_, _) =>
-            Activity.value(NameTree.Leaf(Name.Bound(addr, id, residual)))
-          case Addr.Pending =>
-            Activity.pending
-          case Addr.Failed(exc) =>
-            Activity.exception(exc)
-        }
+    val addr = zk2.resolve(zkHost ++ path)
+    Activity(addr.map(Activity.Ok(_))).flatMap {
+      case Addr.Neg if !path.isEmpty =>
+        val n = path.size
+        bind(path.take(n - 1), path.drop(n - 1) ++ residual)
+      case Addr.Neg =>
+        Activity.value(NameTree.Neg)
+      case Addr.Bound(_, _) =>
+        // Clients may depend on Name.Bound ids being Paths which resolve
+        // back to the same Name.Bound
+        val id = idPrefix ++ path
+        Activity.value(NameTree.Leaf(Name.Bound(addr, id, residual)))
+      case Addr.Pending =>
+        Activity.pending
+      case Addr.Failed(exc) =>
+        Activity.exception(exc)
     }
   }
 

--- a/namer/serversets/src/main/scala/io/buoyant/namer/serversets/ServersetNamer.scala
+++ b/namer/serversets/src/main/scala/io/buoyant/namer/serversets/ServersetNamer.scala
@@ -2,7 +2,7 @@
 package io.buoyant.namer.serversets
 
 import com.twitter.finagle._
-import com.twitter.util.{Activity, Var}
+import com.twitter.util.{Activity, Var, Try, Return, Throw}
 import com.twitter.finagle.serverset2.{BouyantZkResolver, BouyantZkResolverImpl}
 
 /**
@@ -30,25 +30,29 @@ class ServersetNamer(zkHost: Path, idPrefix: Path, zk2: BouyantZkResolver) exten
   def this(zkHost: String, idPrefix: Path) = this(Path.Utf8(zkHost), idPrefix, new BouyantZkResolverImpl)
 
   /** Bind a name. */
-  protected[this] def bind(path: Path, residual: Path = Path.empty): Activity[NameTree[Name]] = {
-    val addr = zk2.resolve(zkHost ++ path)
-    Activity(addr.map(Activity.Ok(_))).flatMap {
-      case Addr.Neg if !path.isEmpty =>
-        val n = path.size
-        bind(path.take(n - 1), path.drop(n - 1) ++ residual)
-      case Addr.Neg =>
-        Activity.value(NameTree.Neg)
-      case Addr.Bound(_, _) =>
-        // Clients may depend on Name.Bound ids being Paths which resolve
-        // back to the same Name.Bound
-        val id = idPrefix ++ path
-        Activity.value(NameTree.Leaf(Name.Bound(addr, id, residual)))
-      case Addr.Pending =>
-        Activity.pending
-      case Addr.Failed(exc) =>
+  protected[this] def bind(path: Path, residual: Path = Path.empty): Activity[NameTree[Name]] =
+    Try(zk2.resolve(zkHost ++ path)) match {
+      case Return(addr) =>
+        val act = Activity(addr.map(Activity.Ok(_)))
+        act.flatMap {
+          case Addr.Neg if !path.isEmpty =>
+            val n = path.size
+            bind(path.take(n - 1), path.drop(n - 1) ++ residual)
+          case Addr.Neg =>
+            Activity.value(NameTree.Neg)
+          case Addr.Bound(_, _) =>
+            // Clients may depend on Name.Bound ids being Paths which resolve
+            // back to the same Name.Bound
+            val id = idPrefix ++ path
+            Activity.value(NameTree.Leaf(Name.Bound(addr, id, residual)))
+          case Addr.Pending =>
+            Activity.pending
+          case Addr.Failed(exc) =>
+            Activity.exception(exc)
+        }
+      case Throw(exc) =>
         Activity.exception(exc)
     }
-  }
 
   // We have to involve a serverset roundtrip here to return a tree. We run the
   // risk of invalidating an otherwise valid tree when there is a bad serverset


### PR DESCRIPTION
Implements the feature from https://github.com/linkerd/linkerd/issues/2390 that I requested to allow shards to be considered in DTABs.  This is exposing the same functionality that Finagle already supports.

This allows the following DTAB snipped to be considered valid.

```
/srv/foo => /zk/prod/read:http#0 | /zk/prod/read:http#1 | !
```