### PR TITLE
Set MaxInitialLineSize from maxInitialSizeKB config

### DIFF
--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpConfig.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/HttpConfig.scala
@@ -267,6 +267,7 @@ case class HttpConfig(
     .maybeWith(httpAccessLogAppend.map(AccessLogger.param.Append.apply))
     .maybeWith(httpAccessLogRotateCount.map(AccessLogger.param.RotateCount.apply))
     .maybeWith(maxHeadersKB.map(kb => hparam.MaxHeaderSize(kb.kilobytes)))
+    .maybeWith(maxInitialLineKB.map(kb => hparam.MaxInitialLineSize(kb.kilobytes)))
     .maybeWith(streamAfterContentLengthKB.map(kb => hparam.FixedLengthStreamedAfter(kb.kilobytes)))
     .maybeWith(Some(streaming))
     .maybeWith(Some(hparam.MaxRequestSize(MaxReqRespSize)))


### PR DESCRIPTION
MaxInitialLineSize parameter is not set from the config. This appears to
be a regression in 1.7.x

This commit adds test case to demonstrate the issue and a fix

Fixes #2393

Signed-off-by: Dmytro Kostiuchenko <edio@archlinux.us>