### PR TITLE
Pin protobuf version to v0.1.1

### DIFF
--- a/namerd/iface/destination/src/main/resources/pull-destination-proto.sh
+++ b/namerd/iface/destination/src/main/resources/pull-destination-proto.sh
@@ -7,6 +7,6 @@ PROTOFILES="destination.proto net.proto"
 
 for proto_file in $PROTOFILES; do
   echo "Copying $proto_file from linkerd2 repo"
-  printf "//This file is added using pull-destination-proto.sh. DO NOT EDIT!\\n%s" "$(curl $BASE_PROTO_URL/$proto_file)" > $proto_file
+  printf "//This file is added using pull-destination-proto.sh. DO NOT EDIT!\\n%s" "$(curl $BASE_PROTO_URL/"$proto_file")" > "$proto_file"
 done
 

--- a/namerd/iface/destination/src/main/resources/pull-destination-proto.sh
+++ b/namerd/iface/destination/src/main/resources/pull-destination-proto.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 cd ../protobuf || exit
-DESTINATION_PROTO=$(curl https://raw.githubusercontent.com/linkerd/linkerd2-proxy-api/master/proto/destination.proto)
-NET_PROTO=$(curl https://raw.githubusercontent.com/linkerd/linkerd2-proxy-api/master/proto/net.proto)
-
-echo "Copying destination.proto from linkerd2 repo"
-printf "//This file is added using pull-destination-proto.sh. DO NOT EDIT!\\n%s" "$DESTINATION_PROTO" > destination.proto
+LATEST_API_RELEASE=v0.1.1
+BASE_PROTO_URL=https://raw.githubusercontent.com/linkerd/linkerd2-proxy-api/$LATEST_API_RELEASE/proto
+PROTOFILES="destination.proto net.proto"
 
 
-echo "Copying net.proto from linkerd2 repo"
-printf "//This file is added using pull-destination-proto.sh. DO NOT EDIT!\\n%s" "$NET_PROTO" > net.proto
+for proto_file in $PROTOFILES; do
+  echo "Copying $proto_file from linkerd2 repo"
+  printf "//This file is added using pull-destination-proto.sh. DO NOT EDIT!\\n%s" "$(curl $BASE_PROTO_URL/$proto_file)" > $proto_file
+done
 


### PR DESCRIPTION
## What
Namerd uses protobuf files in the `linkerd2-proxy-api` repository which are retrieved with curl from the HEAD of the repository. This PR pins the version to [v0.1.1](https://github.com/linkerd/linkerd2-proxy-api/tree/v0.1.1/proto) of those files.

## Why
Ensures stability and a reliable version

## How
Added the LATEST_API_RELEASE variable to the pull-destination-proto.sh script which specifies the version of the linkerd2-proxy-api to use. This follows the design pattern of the `.proxy-version` configuration in the `linkerd2` repository

Also did a bit of refactoring to loop over files to download, rather than explicitly naming the files and their URLs.

Signed-off-by: Charles Pretzer <charles@buoyant.io>