### PR TITLE
Update Finagle to 21.4.0

### DIFF
--- a/admin/src/main/scala/io/buoyant/admin/App.scala
+++ b/admin/src/main/scala/io/buoyant/admin/App.scala
@@ -9,5 +9,4 @@ trait App extends TApp
   with Logging
   with TimeZoneLogFormat
   with Hooks
-  with Lifecycle
   with Stats

--- a/consul/src/main/scala/io/buoyant/consul/v1/AgentApi.scala
+++ b/consul/src/main/scala/io/buoyant/consul/v1/AgentApi.scala
@@ -1,10 +1,9 @@
 package io.buoyant.consul.v1
 
 import com.twitter.conversions.DurationOps._
-import com.twitter.finagle.http
-import com.twitter.finagle.service.Backoff
+import com.twitter.finagle.{Backoff, http}
 import com.twitter.finagle.stats.{DefaultStatsReceiver, StatsReceiver}
-import com.twitter.util.{Closable, Duration, Future}
+import com.twitter.util.{Closable, Future}
 
 object AgentApi {
   def apply(c: Client): AgentApi = new AgentApi(c, s"/$versionString")
@@ -13,7 +12,7 @@ object AgentApi {
 class AgentApi(
   val client: Client,
   val uriPrefix: String,
-  val backoffs: Stream[Duration] = Backoff.exponentialJittered(1.milliseconds, 5.seconds),
+  val backoffs: Backoff = Backoff.exponentialJittered(1.milliseconds, 5.seconds),
   val stats: StatsReceiver = DefaultStatsReceiver
 ) extends BaseApi with Closable {
 

--- a/consul/src/main/scala/io/buoyant/consul/v1/BaseApi.scala
+++ b/consul/src/main/scala/io/buoyant/consul/v1/BaseApi.scala
@@ -26,7 +26,7 @@ trait BaseApi extends Closable {
 
   def uriPrefix: String
 
-  def backoffs: Stream[Duration]
+  def backoffs: Backoff
 
   def stats: StatsReceiver
 

--- a/consul/src/main/scala/io/buoyant/consul/v1/ConsulApi.scala
+++ b/consul/src/main/scala/io/buoyant/consul/v1/ConsulApi.scala
@@ -1,10 +1,9 @@
 package io.buoyant.consul.v1
 
 import com.twitter.conversions.DurationOps._
-import com.twitter.finagle.http
-import com.twitter.finagle.service.Backoff
+import com.twitter.finagle.{Backoff, http}
 import com.twitter.finagle.stats.{DefaultStatsReceiver, StatsReceiver}
-import com.twitter.util.{Closable, Duration, Future}
+import com.twitter.util.{Closable, Duration}
 
 trait ConsulApi extends BaseApi {
 
@@ -33,7 +32,7 @@ object CatalogApi {
 class CatalogApi(
   val client: Client,
   val uriPrefix: String,
-  val backoffs: Stream[Duration] = Backoff.exponentialJittered(1.milliseconds, 5.seconds),
+  val backoffs: Backoff = Backoff.exponentialJittered(1.milliseconds, 5.seconds),
   val stats: StatsReceiver = DefaultStatsReceiver
 ) extends ConsulApi with Closable {
 
@@ -91,7 +90,7 @@ class HealthApi(
   override val client: Client,
   val statuses: Set[HealthStatus.Value],
   override val uriPrefix: String,
-  override val backoffs: Stream[Duration] = Backoff.exponentialJittered(1.milliseconds, 5.seconds),
+  override val backoffs: Backoff = Backoff.exponentialJittered(1.milliseconds, 5.seconds),
   override val stats: StatsReceiver = DefaultStatsReceiver
 ) extends CatalogApi(
   client,

--- a/consul/src/main/scala/io/buoyant/consul/v1/KvApi.scala
+++ b/consul/src/main/scala/io/buoyant/consul/v1/KvApi.scala
@@ -2,20 +2,18 @@ package io.buoyant.consul.v1
 
 import java.util.Base64
 
-import com.twitter.conversions.DurationOps._
-import com.twitter.finagle.http
-import com.twitter.finagle.service.Backoff
+import com.twitter.finagle.{Backoff, http}
 import com.twitter.finagle.stats.{DefaultStatsReceiver, StatsReceiver}
 import com.twitter.util._
 
 object KvApi {
-  def apply(c: Client, backoff: Stream[Duration]): KvApi = new KvApi(c, s"/$versionString", backoff)
+  def apply(c: Client, backoff: Backoff): KvApi = new KvApi(c, s"/$versionString", backoff)
 }
 
 class KvApi(
   val client: Client,
   val uriPrefix: String,
-  val backoffs: Stream[Duration],
+  val backoffs: Backoff,
   val stats: StatsReceiver = DefaultStatsReceiver
 ) extends BaseApi with Closable {
   val kvPrefix = s"$uriPrefix/kv"

--- a/consul/src/test/scala/io/buoyant/consul/v1/BaseApiTest.scala
+++ b/consul/src/test/scala/io/buoyant/consul/v1/BaseApiTest.scala
@@ -5,10 +5,10 @@ import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
 import com.twitter.finagle.{Service, http}
 import com.twitter.finagle.http.{Request, Response, Status, Version}
-import com.twitter.finagle.service.Backoff
+import com.twitter.finagle.Backoff
 import com.twitter.finagle.stats.{DefaultStatsReceiver, StatsReceiver}
 import com.twitter.io.{Buf, Reader}
-import com.twitter.util.{Duration, Future}
+import com.twitter.util.Future
 import io.buoyant.test.Awaits
 import org.scalatest.FunSuite
 import com.twitter.conversions.DurationOps._
@@ -56,7 +56,7 @@ object BaseApiTest {
 
   final case class StubApi(client: Client) extends BaseApi {
     override val uriPrefix: String = s"/$versionString"
-    override val backoffs: Stream[Duration] = Backoff.exponentialJittered(1.milliseconds, 5.seconds)
+    override val backoffs: Backoff = Backoff.exponentialJittered(1.milliseconds, 5.seconds)
 
     override def stats: StatsReceiver = DefaultStatsReceiver
 

--- a/consul/src/test/scala/io/buoyant/consul/v1/KvApiTest.scala
+++ b/consul/src/test/scala/io/buoyant/consul/v1/KvApiTest.scala
@@ -1,7 +1,7 @@
 package io.buoyant.consul.v1
 
 import com.twitter.finagle.http.{Request, Response}
-import com.twitter.finagle.service.Backoff
+import com.twitter.finagle.Backoff
 import com.twitter.finagle.{Failure, FailureFlags, Service}
 import com.twitter.io.Buf
 import com.twitter.util.{Duration, Future}

--- a/finagle/h2/src/test/scala/com/twitter/finagle/buoyant/h2/BufferedStreamTest.scala
+++ b/finagle/h2/src/test/scala/com/twitter/finagle/buoyant/h2/BufferedStreamTest.scala
@@ -48,11 +48,11 @@ class BufferedStreamTest extends FunSuite {
     assert(buffer.fork().isThrow)
     // all streams should now be complete
     for (child <- children) {
-      assert(child.onEnd.isDone)
+      assert(child.onEnd.isDefined)
     }
     assert(data.onRelease.isDefined)
     assert(trailer.onRelease.isDefined)
-    assert(source.onEnd.isDone)
+    assert(source.onEnd.isDefined)
   }
 
   test("sending frames after dicarding buffer") {
@@ -96,7 +96,7 @@ class BufferedStreamTest extends FunSuite {
     }
 
     assert(trailer.onRelease.isDefined)
-    assert(source.onEnd.isDone)
+    assert(source.onEnd.isDefined)
   }
 
   test("forking with frames in the buffer") {
@@ -150,12 +150,12 @@ class BufferedStreamTest extends FunSuite {
     val frame1 = await(child.read()).asInstanceOf[Frame.Data]
     val frame2 = await(child.read()).asInstanceOf[Frame.Data]
 
-    assert(!buffer.onBufferDiscarded.isDone)
+    assert(!buffer.onBufferDiscarded.isDefined)
 
     // not enough room for this in the buffer; discard the buffer
     val frame3 = await(child.read()).asInstanceOf[Frame.Data]
 
-    assert(buffer.onBufferDiscarded.isDone)
+    assert(buffer.onBufferDiscarded.isDefined)
     assert(buffer.fork().isThrow)
 
     // even after buffer is discarded, frames should be fanned out to existing children

--- a/interpreter/consul/src/main/scala/io/buoyant/interpreter/consul/ConsulInterpreterInitializer.scala
+++ b/interpreter/consul/src/main/scala/io/buoyant/interpreter/consul/ConsulInterpreterInitializer.scala
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import com.twitter.finagle._
 import com.twitter.finagle.buoyant.TlsClientConfig
 import com.twitter.finagle.naming.NameInterpreter
-import com.twitter.finagle.service.Backoff
 import com.twitter.finagle.tracing.NullTracer
 import com.twitter.conversions.DurationOps._
 import io.buoyant.config.types.Port

--- a/interpreter/mesh/src/main/scala/io/buoyant/interpreter/MeshInterpreterInitializer.scala
+++ b/interpreter/mesh/src/main/scala/io/buoyant/interpreter/MeshInterpreterInitializer.scala
@@ -9,7 +9,7 @@ import com.twitter.finagle.buoyant.{H2, TlsClientConfig}
 import com.twitter.finagle.liveness.FailureDetector
 import com.twitter.finagle.liveness.FailureDetector.ThresholdConfig
 import com.twitter.finagle.naming.NameInterpreter
-import com.twitter.finagle.service.Backoff
+import com.twitter.finagle.Backoff
 import com.twitter.finagle.util.DefaultTimer
 import com.twitter.logging.Logger
 import io.buoyant.interpreter.mesh.Client

--- a/interpreter/mesh/src/test/scala/io/buoyant/interpreter/mesh/ClientTest.scala
+++ b/interpreter/mesh/src/test/scala/io/buoyant/interpreter/mesh/ClientTest.scala
@@ -1,6 +1,6 @@
 package io.buoyant.interpreter.mesh
 
-import com.twitter.finagle.{Addr, Address, Dtab, Name, NameTree, Path}
+import com.twitter.finagle.{Addr, Address, Backoff, Dtab, Name, NameTree, Path}
 import com.twitter.finagle.util.DefaultTimer
 import com.twitter.io.Buf
 import com.twitter.util.{Activity, Future, Promise}
@@ -38,7 +38,7 @@ class ClientTest extends FunSuite {
           addrRsps
         }
       }
-      Client(Path.Utf8("foons"), interp, resolv, unusedDelegator, scala.Stream.empty, DefaultTimer)
+      Client(Path.Utf8("foons"), interp, resolv, unusedDelegator, Backoff.empty, DefaultTimer)
     }
 
     val act = client.bind(Dtab.read("/stuff => /mas"), Path.read("/some/name"))

--- a/k8s/src/main/scala/io/buoyant/k8s/EndpointsNamer.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/EndpointsNamer.scala
@@ -5,7 +5,7 @@ import java.net.{InetAddress, InetSocketAddress}
 import com.twitter.conversions.DurationOps._
 import com.twitter.finagle.buoyant.ExistentialStability._
 import com.twitter.finagle.http.{MediaType, Request, Response}
-import com.twitter.finagle.service.Backoff
+import com.twitter.finagle.Backoff
 import com.twitter.finagle.util.DefaultTimer
 import com.twitter.finagle._
 import com.twitter.logging.Logger
@@ -13,7 +13,6 @@ import com.twitter.util._
 import io.buoyant.admin.Admin
 import io.buoyant.config.Parser
 import io.buoyant.namer.{InstrumentedActivity, Metadata}
-import scala.Function.untupled
 import scala.collection.{breakOut, mutable}
 import scala.language.implicitConversions
 
@@ -21,7 +20,7 @@ class MultiNsNamer(
   idPrefix: Path,
   labelName: Option[String],
   mkApi: String => v1.NsApi,
-  backoff: Stream[Duration] = EndpointsNamer.DefaultBackoff
+  backoff: Backoff = EndpointsNamer.DefaultBackoff
 )(implicit timer: Timer = DefaultTimer)
   extends EndpointsNamer(idPrefix, mkApi, labelName, backoff)(timer) {
 
@@ -72,7 +71,7 @@ class SingleNsNamer(
   labelName: Option[String],
   nsName: String,
   mkApi: String => v1.NsApi,
-  backoff: Stream[Duration] = EndpointsNamer.DefaultBackoff
+  backoff: Backoff = EndpointsNamer.DefaultBackoff
 )(implicit timer: Timer = DefaultTimer)
   extends EndpointsNamer(idPrefix, mkApi, labelName, backoff)(timer) {
 
@@ -123,7 +122,7 @@ abstract class EndpointsNamer(
   idPrefix: Path,
   mkApi: String => v1.NsApi,
   labelName: Option[String] = None,
-  backoff: Stream[Duration] = EndpointsNamer.DefaultBackoff
+  backoff: Backoff = EndpointsNamer.DefaultBackoff
 )(implicit timer: Timer = DefaultTimer)
   extends Namer with Admin.WithHandlers {
   import EndpointsNamer._
@@ -261,7 +260,7 @@ abstract class EndpointsNamer(
 }
 
 object EndpointsNamer {
-  val DefaultBackoff: Stream[Duration] =
+  val DefaultBackoff: Backoff =
     Backoff.exponentialJittered(10.milliseconds, 10.seconds)
 
   private[EndpointsNamer] case class ServiceKey(

--- a/k8s/src/main/scala/io/buoyant/k8s/ServiceNamer.scala
+++ b/k8s/src/main/scala/io/buoyant/k8s/ServiceNamer.scala
@@ -3,7 +3,7 @@ package io.buoyant.k8s
 import java.net.InetSocketAddress
 import com.twitter.conversions.DurationOps._
 import com.twitter.finagle.buoyant.ExistentialStability._
-import com.twitter.finagle.service.Backoff
+import com.twitter.finagle.Backoff
 import com.twitter.finagle.util.DefaultTimer
 import com.twitter.finagle.{Service => _, _}
 import com.twitter.util._
@@ -22,7 +22,7 @@ class ServiceNamer(
   idPrefix: Path,
   labelName: Option[String],
   mkApi: String => NsApi,
-  backoff: Stream[Duration] = Backoff.exponentialJittered(10.milliseconds, 10.seconds)
+  backoff: Backoff = Backoff.exponentialJittered(10.milliseconds, 10.seconds)
 )(implicit timer: Timer = DefaultTimer) extends Namer {
   import ServiceNamer._
 

--- a/k8s/src/test/scala/io/buoyant/k8s/EndpointsNamerTest.scala
+++ b/k8s/src/test/scala/io/buoyant/k8s/EndpointsNamerTest.scala
@@ -726,7 +726,7 @@ class EndpointsNamerTest extends FunSuite with Awaits {
     }
     val api = v1.Api(service)
     val timer = new MockTimer
-    val namer = new MultiNsNamer(Path.read("/test"), None, api.withNamespace, Stream.continually(1.millis))(timer)
+    val namer = new MultiNsNamer(Path.read("/test"), None, api.withNamespace, Backoff.const(1.millis))(timer)
 
     def name = "/srv/http/sessions"
 
@@ -784,7 +784,7 @@ class EndpointsNamerTest extends FunSuite with Awaits {
     }
 
     val api = v1.Api(service)
-    val namer = new SingleNsNamer(Path.read("/test"), None, "srv", api.withNamespace, Stream.continually(1.millis))
+    val namer = new SingleNsNamer(Path.read("/test"), None, "srv", api.withNamespace, Backoff.const(1.millis))
     namer.lookup(Path.read("/http/sessions/d3adb33f")).states.respond { s =>
       state = s
     }
@@ -1063,7 +1063,7 @@ class EndpointsNamerTest extends FunSuite with Awaits {
     }
     val api = v1.Api(service)
     val timer = new MockTimer
-    val namer = new MultiNsNamer(Path.read("/test"), None, api.withNamespace, Stream.continually(1.millis))(timer)
+    val namer = new MultiNsNamer(Path.read("/test"), None, api.withNamespace, Backoff.const(1.millis))(timer)
 
     @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
 
@@ -1126,7 +1126,7 @@ class EndpointsNamerTest extends FunSuite with Awaits {
 
     val api = v1.Api(service)
     val timer = new MockTimer
-    val namer = new MultiNsNamer(Path.read("/test"), None, api.withNamespace, Stream.continually(1.millis))(timer)
+    val namer = new MultiNsNamer(Path.read("/test"), None, api.withNamespace, Backoff.const(1.millis))(timer)
 
     @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
 
@@ -1163,7 +1163,7 @@ class EndpointsNamerTest extends FunSuite with Awaits {
 
     val api = v1.Api(service)
     val timer = new MockTimer
-    val namer = new MultiNsNamer(Path.read("/test"), None, api.withNamespace, Stream.continually(1.millis))(timer)
+    val namer = new MultiNsNamer(Path.read("/test"), None, api.withNamespace, Backoff.const(1.millis))(timer)
 
     @volatile var state: Set[Address] = Set.empty
 
@@ -1211,7 +1211,7 @@ class EndpointsNamerTest extends FunSuite with Awaits {
     }
     val api = v1.Api(service)
     val timer = new MockTimer
-    val namer = new MultiNsNamer(Path.read("/test"), None, api.withNamespace, Stream.continually(1.millis))(timer)
+    val namer = new MultiNsNamer(Path.read("/test"), None, api.withNamespace, Backoff.const(1.millis))(timer)
 
     @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
 
@@ -1272,7 +1272,7 @@ class EndpointsNamerTest extends FunSuite with Awaits {
     }
     val api = v1.Api(service)
     val timer = new MockTimer
-    val namer = new MultiNsNamer(Path.read("/test"), None, api.withNamespace, Stream.continually(1.millis))(timer)
+    val namer = new MultiNsNamer(Path.read("/test"), None, api.withNamespace, Backoff.const(1.millis))(timer)
 
     @volatile var state: Activity.State[NameTree[Name]] = Activity.Pending
 

--- a/k8s/src/test/scala/io/buoyant/k8s/ServiceNamerTest.scala
+++ b/k8s/src/test/scala/io/buoyant/k8s/ServiceNamerTest.scala
@@ -150,7 +150,7 @@ class ServiceNamerTest extends FunSuite with Awaits {
     }
     val api = v1.Api(service)
     val timer = new MockTimer
-    val namer = new ServiceNamer(Path.read("/test"), None, api.withNamespace, Stream.continually(1.millis))(timer)
+    val namer = new ServiceNamer(Path.read("/test"), None, api.withNamespace, Backoff.const(1.millis))(timer)
 
     def lookup: Path
 

--- a/linkerd/core/src/main/scala/io/buoyant/linkerd/FailureAccrualInitializer.scala
+++ b/linkerd/core/src/main/scala/io/buoyant/linkerd/FailureAccrualInitializer.scala
@@ -3,8 +3,7 @@ package io.buoyant.linkerd
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.twitter.conversions.DurationOps._
 import com.twitter.finagle.liveness.{FailureAccrualFactory, FailureAccrualPolicy}
-import com.twitter.finagle.service.Backoff
-import com.twitter.util.Duration
+import com.twitter.finagle.Backoff
 import io.buoyant.config.{ConfigInitializer, PolymorphicConfig}
 import io.buoyant.namer.BackoffConfig
 
@@ -17,7 +16,7 @@ abstract class FailureAccrualConfig extends PolymorphicConfig {
   var backoff: Option[BackoffConfig] = None
 
   @JsonIgnore
-  def backoffOrDefault: Stream[Duration] =
+  def backoffOrDefault: Backoff =
     backoff.map(_.mk).getOrElse(FailureAccrualConfig.defaultBackoff)
 }
 
@@ -26,7 +25,7 @@ object FailureAccrualConfig {
   // in linkerd to make it easier to reason about the default failure accrual settings
   private val defaultConsecutiveFailures = 5
 
-  private val defaultBackoff: Stream[Duration] =
+  private val defaultBackoff: Backoff =
     Backoff.equalJittered(5.seconds, 300.seconds)
 
   private val defaultPolicy =

--- a/linkerd/core/src/test/scala/io/buoyant/linkerd/RetriesConfigTest.scala
+++ b/linkerd/core/src/test/scala/io/buoyant/linkerd/RetriesConfigTest.scala
@@ -1,6 +1,6 @@
 package io.buoyant.linkerd
 
-import com.twitter.finagle.service.Retries
+import com.twitter.finagle.Backoff
 import com.twitter.util.Duration
 import io.buoyant.config.Parser
 import io.buoyant.namer.{ConstantBackoffConfig, JitteredBackoffConfig}
@@ -26,7 +26,7 @@ class RetriesConfigTest extends FunSuite {
           |""".stripMargin
     val config = ConstantBackoffConfig(30)
     assert(parse(yaml) == RetriesConfig(Some(config), None))
-    assert(config.mk.isInstanceOf[Stream[Duration]])
+    assert(config.mk.isInstanceOf[Backoff])
   }
 
   test("jittered backoff") {
@@ -38,7 +38,7 @@ class RetriesConfigTest extends FunSuite {
           |""".stripMargin
     val config = JitteredBackoffConfig(Some(30), Some(6000))
     assert(parse(yaml) == RetriesConfig(Some(config), None))
-    assert(config.mk.isInstanceOf[Stream[Duration]])
+    assert(config.mk.isInstanceOf[Backoff])
   }
 
   test("jittered backoff: no min") {
@@ -50,7 +50,7 @@ class RetriesConfigTest extends FunSuite {
     val config = JitteredBackoffConfig(None, Some(6000))
     assert(parse(yaml) == RetriesConfig(Some(config), None))
     val e = intercept[IllegalArgumentException] {
-      assert(config.mk.isInstanceOf[Stream[Duration]])
+      assert(config.mk.isInstanceOf[Backoff])
     }
     assert(e.getMessage == "'minMs' must be specified")
   }

--- a/linkerd/failure-accrual/src/test/scala/io/buoyant/linkerd/failureAccrual/ConfigTest.scala
+++ b/linkerd/failure-accrual/src/test/scala/io/buoyant/linkerd/failureAccrual/ConfigTest.scala
@@ -72,8 +72,8 @@ class ConfigTest extends FunSuite
   private[this] val positiveInts = Gen.choose(1, Integer.MAX_VALUE)
 
   test("constant backoff configs produce streams of constant durations") {
-    forAll { (n: Int) =>
-      ConstantBackoffConfig(n).mk.take(100).foreach(d => assert(d == n.millis))
+    forAll(positiveInts) { (n: Int) =>
+      ConstantBackoffConfig(n).mk.take(100).toStream.foreach(d => assert(d == n.millis))
     }
   }
 
@@ -82,6 +82,7 @@ class ConfigTest extends FunSuite
       whenever(min < max) {
         JitteredBackoffConfig(Some(min), Some(max)).mk
           .take(100)
+          .toStream
           .foreach(d => assert(d >= min.millis && d <= max.millis))
       }
     }
@@ -91,7 +92,7 @@ class ConfigTest extends FunSuite
     forAll((positiveInts, "min"), (positiveInts, "max")) { (min: Int, max: Int) =>
       whenever(min < max) {
         val n_unique = JitteredBackoffConfig(Some(min), Some(max)).mk
-          .take(300).toSet.size
+          .take(300).toStream.toSet.size
         assert(n_unique >= 2)
       }
     }

--- a/linkerd/protocol/http/src/e2e/scala/io/buoyant/linkerd/protocol/HttpEndToEndTest.scala
+++ b/linkerd/protocol/http/src/e2e/scala/io/buoyant/linkerd/protocol/HttpEndToEndTest.scala
@@ -199,10 +199,10 @@ class HttpEndToEndTest
       assert(okrsp.status == Status.Ok)
       assert(stats.counters.get(Seq("rt", "http", "server", "127.0.0.1/0", "requests")) == Some(1))
       assert(stats.counters.get(Seq("rt", "http", "server", "127.0.0.1/0", "success")) == Some(1))
-      assert(stats.counters.get(Seq("rt", "http", "server", "127.0.0.1/0", "failures")) == None)
+      assert(stats.counters.get(Seq("rt", "http", "server", "127.0.0.1/0", "failures")) == Some(0))
       assert(stats.counters.get(Seq("rt", "http", "client", label, "requests")) == Some(1))
       assert(stats.counters.get(Seq("rt", "http", "client", label, "success")) == Some(1))
-      assert(stats.counters.get(Seq("rt", "http", "client", label, "failures")) == None)
+      assert(stats.counters.get(Seq("rt", "http", "client", label, "failures")) == Some(0))
 
       val errreq = Request()
       errreq.host = "dog"
@@ -320,7 +320,7 @@ class HttpEndToEndTest
         val name = "svc/dog"
         assert(stats.counters.get(Seq("rt", "http", "service", name, "requests")) == Some(1))
         assert(stats.counters.get(Seq("rt", "http", "service", name, "success")) == Some(1))
-        assert(stats.counters.get(Seq("rt", "http", "service", name, "failures")) == None)
+        assert(stats.counters.get(Seq("rt", "http", "service", name, "failures")).getOrElse(0) == 0)
         assert(stats.stats.get(Seq("rt", "http", "service", name, "retries", "per_request")) == Some(Seq(1.0)))
         assert(stats.counters.get(Seq("rt", "http", "service", name, "retries", "total")) == Some(1))
         withAnnotations { anns =>

--- a/linkerd/protocol/http/src/e2e/scala/io/buoyant/linkerd/protocol/HttpStreamingTest.scala
+++ b/linkerd/protocol/http/src/e2e/scala/io/buoyant/linkerd/protocol/HttpStreamingTest.scala
@@ -5,7 +5,7 @@ import com.twitter.finagle.buoyant._
 import com.twitter.finagle.http.param.{MaxRequestSize, Streaming}
 import com.twitter.finagle.http.{Method, Request, Response, Version}
 import com.twitter.finagle.{Http, Service, Stack}
-import com.twitter.io.{Buf, BufReader, BufReaders, Reader}
+import com.twitter.io.{Buf, BufReader, Reader}
 import com.twitter.util.{Future, Promise, StorageUnit}
 import io.buoyant.test.{Awaits, BudgetedRetries}
 import java.net.InetSocketAddress

--- a/linkerd/protocol/http/src/e2e/scala/io/buoyant/linkerd/protocol/ResponseClassificationEndToEndTest.scala
+++ b/linkerd/protocol/http/src/e2e/scala/io/buoyant/linkerd/protocol/ResponseClassificationEndToEndTest.scala
@@ -55,9 +55,12 @@ class ResponseClassificationEndToEndTest extends FunSuite {
     req.host = "foo"
     await(client(req))
 
-    assert(stats.counters(Seq("rt", "http", "client", s"$$/inet/127.1/${downstream.port}", "service", "svc/foo", "success")) == 1)
-    assert(stats.counters(Seq("rt", "http", "service", "svc/foo", "success")) == 1)
     assert(stats.counters(Seq("rt", "http", "server", "127.0.0.1/0", "success")) == 1)
+    assert(stats.counters(Seq("rt", "http", "server", "127.0.0.1/0", "failures")) == 0)
+    assert(stats.counters(Seq("rt", "http", "service", "svc/foo", "success")) == 1)
+    assert(stats.counters(Seq("rt", "http", "service", "svc/foo", "failures")) == 0)
+    assert(stats.counters(Seq("rt", "http", "client", s"$$/inet/127.1/${downstream.port}", "service", "svc/foo", "success")) == 1)
+    assert(stats.counters(Seq("rt", "http", "client", s"$$/inet/127.1/${downstream.port}", "service", "svc/foo", "failures")) == 0)
   }
 
   test("non-retryable failure") {
@@ -89,9 +92,12 @@ class ResponseClassificationEndToEndTest extends FunSuite {
     req.host = "foo"
     await(client(req))
 
-    assert(stats.counters(Seq("rt", "http", "client", s"$$/inet/127.1/${downstream.port}", "service", "svc/foo", "failures")) == 1)
-    assert(stats.counters(Seq("rt", "http", "service", "svc/foo", "failures")) == 1)
+    assert(stats.counters(Seq("rt", "http", "server", "127.0.0.1/0", "success")) == 0)
     assert(stats.counters(Seq("rt", "http", "server", "127.0.0.1/0", "failures")) == 1)
+    assert(stats.counters(Seq("rt", "http", "service", "svc/foo", "success")) == 0)
+    assert(stats.counters(Seq("rt", "http", "service", "svc/foo", "failures")) == 1)
+    assert(stats.counters(Seq("rt", "http", "client", s"$$/inet/127.1/${downstream.port}", "service", "svc/foo", "success")) == 0)
+    assert(stats.counters(Seq("rt", "http", "client", s"$$/inet/127.1/${downstream.port}", "service", "svc/foo", "failures")) == 1)
   }
 
   test("retryable failure") {
@@ -129,9 +135,9 @@ class ResponseClassificationEndToEndTest extends FunSuite {
     await(client(req))
 
     assert(stats.counters(Seq("rt", "http", "server", "127.0.0.1/0", "success")) == 1)
-    assert(stats.counters.get(Seq("rt", "http", "server", "127.0.0.1/0", "failures")) == None)
+    assert(stats.counters(Seq("rt", "http", "server", "127.0.0.1/0", "failures")) == 0)
     assert(stats.counters(Seq("rt", "http", "service", "svc/foo", "success")) == 1)
-    assert(stats.counters.get(Seq("rt", "http", "service", "svc/foo", "failures")) == None)
+    assert(stats.counters(Seq("rt", "http", "service", "svc/foo", "failures")) == 0)
     assert(stats.counters(Seq("rt", "http", "client", s"$$/inet/127.1/${downstream.port}", "service", "svc/foo", "success")) == 1)
     assert(stats.counters(Seq("rt", "http", "client", s"$$/inet/127.1/${downstream.port}", "service", "svc/foo", "failures")) == 1)
   }
@@ -172,9 +178,9 @@ class ResponseClassificationEndToEndTest extends FunSuite {
     await(client(req))
 
     assert(stats.counters(Seq("rt", "http", "server", "127.0.0.1/0", "success")) == 1)
-    assert(stats.counters.get(Seq("rt", "http", "server", "127.0.0.1/0", "failures")).isEmpty)
+    assert(stats.counters(Seq("rt", "http", "server", "127.0.0.1/0", "failures")) == 0)
     assert(stats.counters(Seq("rt", "http", "service", "svc/foo", "success")) == 1)
-    assert(stats.counters.get(Seq("rt", "http", "service", "svc/foo", "failures")).isEmpty)
+    assert(stats.counters(Seq("rt", "http", "service", "svc/foo", "failures")) == 0)
     assert(stats.counters(Seq("rt", "http", "client", s"$$/inet/127.1/${downstream.port}", "service", "svc/foo", "success")) == 1)
     assert(stats.counters(Seq("rt", "http", "client", s"$$/inet/127.1/${downstream.port}", "service", "svc/foo", "failures")) == 1)
   }
@@ -222,9 +228,9 @@ class ResponseClassificationEndToEndTest extends FunSuite {
     await(client(req))
 
     assert(stats.counters(Seq("rt", "http", "server", "127.0.0.1/0", "success")) == 1)
-    assert(stats.counters.get(Seq("rt", "http", "server", "127.0.0.1/0", "failures")) == None)
+    assert(stats.counters(Seq("rt", "http", "server", "127.0.0.1/0", "failures")) == 0)
     assert(stats.counters(Seq("rt", "http", "service", "svc/a", "success")) == 1)
-    assert(stats.counters.get(Seq("rt", "http", "service", "svc/a", "failures")) == None)
+    assert(stats.counters(Seq("rt", "http", "service", "svc/a", "failures")) == 0)
     assert(stats.counters(Seq("rt", "http", "client", s"$$/inet/127.1/${downstream.port}", "service", "svc/a", "success")) == 1)
     assert(stats.counters(Seq("rt", "http", "client", s"$$/inet/127.1/${downstream.port}", "service", "svc/a", "failures")) == 1)
 
@@ -269,9 +275,9 @@ class ResponseClassificationEndToEndTest extends FunSuite {
     req.host = "foo"
     await(client(req))
 
-    assert(stats.counters.get(Seq("rt", "http", "service", "svc/foo", "success")) == Some(1))
-    assert(stats.counters.get(Seq("rt", "http", "service", "svc/foo", "failures")) == None)
-    assert(stats.counters.get(Seq("rt", "http", "client", s"$$/inet/127.1/${downstream.port}", "service", "svc/foo", "success")) == Some(1))
-    assert(stats.counters.get(Seq("rt", "http", "client", s"$$/inet/127.1/${downstream.port}", "service", "svc/foo", "failures")) == None)
+    assert(stats.counters(Seq("rt", "http", "service", "svc/foo", "success")) == 1)
+    assert(stats.counters(Seq("rt", "http", "service", "svc/foo", "failures")) == 0)
+    assert(stats.counters(Seq("rt", "http", "client", s"$$/inet/127.1/${downstream.port}", "service", "svc/foo", "success")) == 1)
+    assert(stats.counters(Seq("rt", "http", "client", s"$$/inet/127.1/${downstream.port}", "service", "svc/foo", "failures")) == 0)
   }
 }

--- a/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/HttpConfigTest.scala
+++ b/linkerd/protocol/http/src/test/scala/io/buoyant/linkerd/protocol/http/HttpConfigTest.scala
@@ -1,6 +1,6 @@
 package io.buoyant.linkerd.protocol.http
 
-import com.fasterxml.jackson.databind.exc.InvalidDefinitionException
+import com.fasterxml.jackson.databind.exc.ValueInstantiationException
 import com.twitter.finagle.buoyant.Dst
 import com.twitter.finagle.http.param.{MaxInitialLineSize, Streaming}
 import com.twitter.finagle.http.{Method, Request}
@@ -129,7 +129,7 @@ class HttpConfigTest extends FunSuite with Awaits {
                   |- port: 5000
       """.stripMargin
 
-    intercept[InvalidDefinitionException] {
+    intercept[ValueInstantiationException] {
       parse(yaml)
     }
   }

--- a/namer/consul/src/main/scala/io/buoyant/namer/consul/LookupCache.scala
+++ b/namer/consul/src/main/scala/io/buoyant/namer/consul/LookupCache.scala
@@ -2,7 +2,6 @@ package io.buoyant.namer.consul
 
 import com.twitter.conversions.DurationOps._
 import com.twitter.finagle._
-import com.twitter.finagle.service.Backoff
 import com.twitter.finagle.stats.{NullStatsReceiver, StatsReceiver}
 import com.twitter.util._
 import io.buoyant.consul.v1
@@ -13,7 +12,7 @@ import scala.Function.untupled
 
 private[consul] object LookupCache {
 
-  val DefaultBackoffs: Stream[Duration] = Backoff.exponentialJittered(10.milliseconds, 5.seconds)
+  val DefaultBackoffs: Backoff = Backoff.exponentialJittered(10.milliseconds, 5.seconds)
 
 }
 

--- a/namer/consul/src/test/scala/io/buoyant/namer/consul/ConsulNamerTest.scala
+++ b/namer/consul/src/test/scala/io/buoyant/namer/consul/ConsulNamerTest.scala
@@ -5,7 +5,7 @@ import com.twitter.finagle.http.{Response, Status}
 import com.twitter.finagle.stats.InMemoryStatsReceiver
 import com.twitter.io.Buf
 import com.twitter.logging.Level
-import com.twitter.util.{Config => _, _}
+import com.twitter.util._
 import io.buoyant.consul.v1._
 import io.buoyant.namer.{ConfiguredDtabNamer, Metadata}
 import io.buoyant.test.{Awaits, FunSuite}

--- a/namer/core/src/main/scala/io/buoyant/namer/BackoffConfig.scala
+++ b/namer/core/src/main/scala/io/buoyant/namer/BackoffConfig.scala
@@ -1,8 +1,7 @@
 package io.buoyant.namer
 
 import com.fasterxml.jackson.annotation.{JsonIgnore, JsonSubTypes}
-import com.twitter.finagle.service.Backoff
-import com.twitter.util.Duration
+import com.twitter.finagle.Backoff
 import com.twitter.conversions.DurationOps._
 import io.buoyant.config.PolymorphicConfig
 
@@ -12,7 +11,7 @@ import io.buoyant.config.PolymorphicConfig
 ))
 abstract class BackoffConfig extends PolymorphicConfig {
   @JsonIgnore
-  def mk: Stream[Duration]
+  def mk: Backoff
 }
 
 case class ConstantBackoffConfig(ms: Int) extends BackoffConfig {

--- a/namerd/iface/interpreter-thrift/src/test/scala/io/buoyant/namerd/iface/ThriftNamerClientTest.scala
+++ b/namerd/iface/interpreter-thrift/src/test/scala/io/buoyant/namerd/iface/ThriftNamerClientTest.scala
@@ -78,7 +78,7 @@ class ThriftNamerClientTest extends FunSuite with Awaits {
     val namespace = "yeezy"
     val clientId = Path.read("/rando/x8u4i5j")
     val service = new TestNamerService(clientId)
-    val client = new ThriftNamerClient(service, namespace, Stream.continually(Duration.Zero), clientId = clientId)
+    val client = new ThriftNamerClient(service, namespace, Backoff.const(Duration.Zero), clientId = clientId)
 
     val delegation = client.delegate(Dtab.empty, Path.read("/yeezy/tlop/wolves"))
     assert(!delegation.isDefined)
@@ -107,7 +107,7 @@ class ThriftNamerClientTest extends FunSuite with Awaits {
     """)
 
     val service = new TestNamerService(clientId)
-    val client = new ThriftNamerClient(service, namespace, Stream.continually(Duration.Zero), clientId = clientId)
+    val client = new ThriftNamerClient(service, namespace, Backoff.const(Duration.Zero), clientId = clientId)
     @volatile var state: Activity.State[NameTree[Name.Bound]] = Activity.Pending
     val closer = client.bind(dtab, wolvesPath).states.respond(state = _)
     try {

--- a/namerd/iface/interpreter-thrift/src/test/scala/io/buoyant/namerd/iface/ThriftNamerEndToEndTest.scala
+++ b/namerd/iface/interpreter-thrift/src/test/scala/io/buoyant/namerd/iface/ThriftNamerEndToEndTest.scala
@@ -1,6 +1,5 @@
 package io.buoyant.namerd.iface
 
-import com.twitter.conversions.DurationOps._
 import com.twitter.finagle._
 import com.twitter.finagle.naming.NameInterpreter
 import com.twitter.finagle.stats.NullStatsReceiver
@@ -48,7 +47,7 @@ class ThriftNamerEndToEndTest extends FunSuite with Eventually with IntegrationP
     }
     val namers = Map(Path.read("/io.l5d.w00t") -> namer)
     val service = new ThriftNamerInterface(interpreter, namers, newStamper, Capacity.default, NullStatsReceiver)
-    val client = new ThriftNamerClient(service, ns, Stream.continually(Duration.Zero), clientId = clientId)
+    val client = new ThriftNamerClient(service, ns, Backoff.const(Duration.Zero), clientId = clientId)
 
     val act = client.bind(reqDtab, reqPath)
     val obs = act.states.respond { s =>
@@ -128,7 +127,7 @@ class ThriftNamerEndToEndTest extends FunSuite with Eventually with IntegrationP
       namers
     )
     val service = new ThriftNamerInterface(interpreter, namers.toMap, newStamper, Capacity.default, NullStatsReceiver)
-    val client = new ThriftNamerClient(service, ns, Stream.continually(Duration.Zero), clientId = clientId)
+    val client = new ThriftNamerClient(service, ns, Backoff.const(Duration.Zero), clientId = clientId)
 
     val tree = await(client.delegate(
       Dtab.read("/host/poop => /srv/woop"),
@@ -177,7 +176,7 @@ class ThriftNamerEndToEndTest extends FunSuite with Eventually with IntegrationP
       namers
     )
     val service = new ThriftNamerInterface(interpreter, namers.toMap, newStamper, Capacity.default, NullStatsReceiver)
-    val client = new ThriftNamerClient(service, ns, Stream.continually(Duration.Top), clientId = clientId)
+    val client = new ThriftNamerClient(service, ns, Backoff.const(Duration.Top), clientId = clientId)
     witness.notify(Return(NameTree.Leaf(Name.Bound(
       Var(Addr.Bound(Address("localhost", 9000))),
       Path.read("/io.l5d.w00t/foo"),

--- a/namerd/storage/consul/src/main/scala/io/buoyant/namerd/storage/consul/ConsulDtabStoreInitializer.scala
+++ b/namerd/storage/consul/src/main/scala/io/buoyant/namerd/storage/consul/ConsulDtabStoreInitializer.scala
@@ -1,15 +1,13 @@
 package io.buoyant.namerd.storage.consul
 
 import com.fasterxml.jackson.annotation.JsonIgnore
-import com.twitter.finagle.service.Backoff
 import com.twitter.finagle.tracing.NullTracer
-import com.twitter.finagle.{Http, Path}
+import com.twitter.finagle.{Backoff, Http, Path, Stack}
 import io.buoyant.config.types.Port
 import io.buoyant.consul.utils.RichConsulClient
 import io.buoyant.consul.v1.{ConsistencyMode, KvApi}
 import io.buoyant.namer.BackoffConfig
 import com.twitter.conversions.DurationOps._
-import com.twitter.finagle.Stack
 import com.twitter.finagle.buoyant.TlsClientConfig
 import io.buoyant.namerd.{DtabStore, DtabStoreConfig, DtabStoreInitializer}
 

--- a/namerd/storage/consul/src/test/scala/io/buoyant/namerd/storage/consul/ConsulDtabStoreTest.scala
+++ b/namerd/storage/consul/src/test/scala/io/buoyant/namerd/storage/consul/ConsulDtabStoreTest.scala
@@ -1,8 +1,7 @@
 package io.buoyant.namerd.storage.consul
 
 import com.twitter.finagle.http.{Request, Response, Status}
-import com.twitter.finagle.service.Backoff
-import com.twitter.finagle.{Dtab, Path, Service}
+import com.twitter.finagle.{Backoff, Dtab, Path, Service}
 import com.twitter.io.Buf
 import com.twitter.util._
 import io.buoyant.consul.v1.KvApi

--- a/project/Base.scala
+++ b/project/Base.scala
@@ -163,6 +163,7 @@ class Base extends Build {
       case "BUILD" => MergeStrategy.discard
       case "com/twitter/common/args/apt/cmdline.arg.info.txt.1" => MergeStrategy.discard
       case "META-INF/io.netty.versions.properties" => MergeStrategy.last
+      case "module-info.class" => MergeStrategy.discard
       case path => (assemblyMergeStrategy in assembly).value(path)
     }
   )

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -8,30 +8,29 @@ object Deps {
 
   // process lifecycle
   val twitterServer =
-    ("com.twitter" %% "twitter-server" % "20.4.1")
+    ("com.twitter" %% "twitter-server" % "21.4.0")
       .exclude("com.twitter", "finagle-zipkin_2.12")
 
   def twitterUtil(mod: String) =
-    "com.twitter" %% s"util-$mod" % "20.4.1"
+    "com.twitter" %% s"util-$mod" % "21.4.0"
 
   // networking
   def finagle(mod: String) =
-    "com.twitter" %% s"finagle-$mod" % "20.4.1"
+    "com.twitter" %% s"finagle-$mod" % "21.4.0"
 
   def netty4(mod: String) =
-    "io.netty" % s"netty-$mod" % "4.1.47.Final"
+    "io.netty" % s"netty-$mod" % "4.1.59.Final"
 
-  val boringssl = "io.netty" % "netty-tcnative-boringssl-static" % "2.0.30.Final"
+  val boringssl = "io.netty" % "netty-tcnative-boringssl-static" % "2.0.35.Final"
 
   // Jackson (parsing)
-  val jacksonVersion = "2.9.10"
-  val jacksonDatabindVersion = "2.9.10.1"
+  val jacksonVersion = "2.11.2"
   val jacksonCore =
     "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion
   val jacksonAnnotations =
     "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion
   val jacksonDatabind =
-    "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion
+    "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion
   val jacksonScala =
     "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion
   val jackson =

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -18,7 +18,7 @@ addSbtPlugin("com.eed3si9n"      % "sbt-assembly"  % "0.14.1")
 addSbtPlugin("se.marcuslonnberg" % "sbt-docker"    % "1.4.1")
 
 // scrooge
-addSbtPlugin("com.twitter" %% "scrooge-sbt-plugin" % "20.4.1")
+addSbtPlugin("com.twitter" %% "scrooge-sbt-plugin" % "21.4.0")
 
 // microbenchmarking for tests.
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.27")

--- a/router/core/src/main/scala/com/twitter/finagle/buoyant/FailureAccrualFactory.scala
+++ b/router/core/src/main/scala/com/twitter/finagle/buoyant/FailureAccrualFactory.scala
@@ -80,13 +80,9 @@ class FailureAccrualFactory[Req, Rep](
 ) extends FFailureAccrualFactory[Req, Rep](
   underlying, policy, FailureAccrualFactory.NullResponseClassifier, timer, statsReceiver
 ) {
-  override protected def isSuccess(reqRep: ReqRep): Boolean = {
+  override protected def classify(reqRep: ReqRep): ResponseClass = {
     val param.ResponseClassifier(classifier) =
       ResponseClassifierCtx.current.getOrElse(param.ResponseClassifier.param.default)
-    classifier.applyOrElse(reqRep, ResponseClassifier.Default) match {
-      case ResponseClass.Ignorable => true
-      case ResponseClass.Successful(_) => true
-      case ResponseClass.Failed(_) => false
-    }
+    classifier.applyOrElse(reqRep, ResponseClassifier.Default)
   }
 }

--- a/router/core/src/main/scala/io/buoyant/router/RetryBudgetModule.scala
+++ b/router/core/src/main/scala/io/buoyant/router/RetryBudgetModule.scala
@@ -3,7 +3,8 @@ package io.buoyant.router
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.twitter.conversions.DurationOps._
 import com.twitter.finagle.{ServiceFactory, Stack}
-import com.twitter.finagle.service.{Backoff, Retries, RetryBudget}
+import com.twitter.finagle.service.{Retries, RetryBudget}
+import com.twitter.finagle.Backoff
 import com.twitter.util.Duration
 
 object RetryBudgetModule {

--- a/router/core/src/test/scala/io/buoyant/router/ClassifiedRetriesTest.scala
+++ b/router/core/src/test/scala/io/buoyant/router/ClassifiedRetriesTest.scala
@@ -16,7 +16,7 @@ class ClassifiedRetriesTest extends FunSuite {
     val stats = new InMemoryStatsReceiver
     val timer = new MockTimer
     val tracer = new BufferingTracer
-    var backoffs = 1.second #:: 2.seconds #:: Stream.Empty
+    var backoffs = Backoff.const(1.second).take(1) ++ Backoff.const(2.seconds).take(1)
     var budget = RetryBudget()
     private val classifier = ResponseClassifier.named("test") {
       case ReqRep("retry", Throw(_: Badness)) => ResponseClass.RetryableFailure

--- a/router/core/src/test/scala/io/buoyant/router/PerDstPathStatsFilterTest.scala
+++ b/router/core/src/test/scala/io/buoyant/router/PerDstPathStatsFilterTest.scala
@@ -54,6 +54,7 @@ class PerDstPathStatsFilterTest extends FunSuite {
       (catPfx :+ "failures" :+ "io.buoyant.router.DangCat" :+ "io.buoyant.router.NotDog") -> 1,
       (dogPfx :+ "requests") -> 2,
       (dogPfx :+ "success") -> 2,
+      (dogPfx :+ "failures") -> 0,
       (catPfx :+ "success") -> 0
     ))
     assert(stats.gauges.keys == Set(

--- a/router/h2/src/test/scala/com/twitter/finagle/buoyant/h2/H2FailureAccrualFactoryTest.scala
+++ b/router/h2/src/test/scala/com/twitter/finagle/buoyant/h2/H2FailureAccrualFactoryTest.scala
@@ -6,14 +6,13 @@ import com.twitter.finagle.context.Contexts
 import com.twitter.finagle.liveness.FailureAccrualPolicy
 import com.twitter.finagle.service.ResponseClass
 import com.twitter.finagle.stats.InMemoryStatsReceiver
-import com.twitter.finagle.{FactoryToService, Service, ServiceFactory, Status => FStatus}
+import com.twitter.finagle.{Backoff, FactoryToService, Service, ServiceFactory, Status => FStatus}
 import com.twitter.util.{Duration, Future, MockTimer, Return}
 import io.buoyant.router.DiscardingFactoryToService
 import io.buoyant.router.DiscardingFactoryToService.RequestDiscarder
 import io.buoyant.router.context.h2.H2ClassifierCtx
 import io.buoyant.test.FunSuite
 import java.util
-import scala.{Stream => SStream}
 
 class H2FailureAccrualFactoryTest extends FunSuite {
 
@@ -39,7 +38,7 @@ class H2FailureAccrualFactoryTest extends FunSuite {
 
     val fa = new H2FailureAccrualFactory(
       underlying,
-      FailureAccrualPolicy.consecutiveFailures(5, SStream.continually(Duration.Top)),
+      FailureAccrualPolicy.consecutiveFailures(5, Backoff.const(Duration.Top)),
       timer,
       stats
     )
@@ -82,7 +81,7 @@ class H2FailureAccrualFactoryTest extends FunSuite {
 
     val fa = new H2FailureAccrualFactory(
       underlying,
-      FailureAccrualPolicy.consecutiveFailures(5, SStream.continually(Duration.Top)),
+      FailureAccrualPolicy.consecutiveFailures(5, Backoff.const(Duration.Top)),
       timer,
       stats
     )

--- a/router/h2/src/test/scala/io/buoyant/router/h2/ClassifiedRetryFilterTest.scala
+++ b/router/h2/src/test/scala/io/buoyant/router/h2/ClassifiedRetryFilterTest.scala
@@ -2,7 +2,7 @@ package io.buoyant.router.h2
 
 import com.twitter.concurrent.AsyncQueue
 import com.twitter.conversions.DurationOps._
-import com.twitter.finagle.Service
+import com.twitter.finagle.{Backoff, Service}
 import com.twitter.finagle.buoyant.h2.service.{H2Classifier, H2ReqRep, H2ReqRepFrame}
 import com.twitter.finagle.buoyant.h2.{Frame, Headers, Request, Reset, Response, Status, Stream}
 import com.twitter.finagle.service.{ResponseClass, RetryBudget}
@@ -11,7 +11,6 @@ import com.twitter.util._
 import io.buoyant.test.FunSuite
 import io.netty.buffer.{ByteBuf, Unpooled}
 import java.nio.charset.StandardCharsets
-import scala.{Stream => SStream}
 
 class ClassifiedRetryFilterTest extends FunSuite {
 
@@ -36,7 +35,7 @@ class ClassifiedRetryFilterTest extends FunSuite {
   def filter(stats: StatsReceiver = NullStatsReceiver) = new ClassifiedRetryFilter(
     stats,
     classifier,
-    SStream.continually(0.millis),
+    Backoff.const(0.millis),
     RetryBudget.Infinite
   )
 
@@ -184,7 +183,7 @@ class ClassifiedRetryFilterTest extends FunSuite {
     val svc = new ClassifiedRetryFilter(
       stats,
       classifier,
-      SStream.continually(0.millis),
+      Backoff.const(0.millis),
       RetryBudget.Infinite,
       requestBufferSize = 3
     ).andThen(new TestService())
@@ -215,7 +214,7 @@ class ClassifiedRetryFilterTest extends FunSuite {
     val svc = new ClassifiedRetryFilter(
       stats,
       classifier,
-      SStream.continually(0.millis),
+      Backoff.const(0.millis),
       RetryBudget.Infinite,
       responseBufferSize = 4
     ).andThen(new TestService())
@@ -270,7 +269,7 @@ class ClassifiedRetryFilterTest extends FunSuite {
     val svc = new ClassifiedRetryFilter(
       stats,
       classifier,
-      SStream.continually(0.millis),
+      Backoff.const(0.millis),
       RetryBudget.Infinite,
       classificationTimeout = 1.second
     ).andThen(Service.mk { req: Request =>

--- a/telemetry/core/src/main/scala/com/twitter/finagle/stats/buoyant/Metric.scala
+++ b/telemetry/core/src/main/scala/com/twitter/finagle/stats/buoyant/Metric.scala
@@ -1,6 +1,6 @@
 package com.twitter.finagle.stats.buoyant
 
-import com.twitter.finagle.stats.{BucketAndCount, BucketedHistogram, Counter => FCounter, Stat => FStat}
+import com.twitter.finagle.stats.{BucketAndCount, BucketedHistogram, Metadata, NoMetadata, Counter => FCounter, Stat => FStat}
 import com.twitter.util.{Duration, Time}
 import java.util.concurrent.atomic.AtomicLong
 
@@ -16,6 +16,8 @@ object Metric {
       val _ = value.getAndAdd(delta)
     }
     def get: Long = value.get
+
+    def metadata: Metadata = NoMetadata
   }
 
   class Stat extends FStat with Metric {
@@ -66,6 +68,8 @@ object Metric {
     }
 
     def snapshottedSummary: HistogramSummary = summarySnapshot
+
+    def metadata: Metadata = NoMetadata
   }
 
   class Gauge(f: => Float) extends Metric {

--- a/telemetry/core/src/main/scala/io/buoyant/telemetry/MetricsTreeStatsReceiver.scala
+++ b/telemetry/core/src/main/scala/io/buoyant/telemetry/MetricsTreeStatsReceiver.scala
@@ -9,8 +9,8 @@ class MetricsTreeStatsReceiver(
 
   val repr: AnyRef = this
 
-  protected[this] def registerGauge(verbosity: Verbosity, name: Seq[String], f: => Float): Unit =
-    tree.resolve(name).registerGauge(verbosity, f)
+  protected[this] def registerGauge(schema: GaugeSchema, f: => Float): Unit =
+    tree.resolve(schema.metricBuilder.name).registerGauge(schema.metricBuilder.verbosity, f)
 
   protected[this] def deregisterGauge(name: Seq[String]): Unit =
     tree.resolve(name).deregisterGauge()

--- a/telemetry/statsd/src/main/scala/io/buoyant/telemetry/statsd/Metric.scala
+++ b/telemetry/statsd/src/main/scala/io/buoyant/telemetry/statsd/Metric.scala
@@ -1,13 +1,15 @@
 package io.buoyant.telemetry.statsd
 
 import com.timgroup.statsd.StatsDClient
-import com.twitter.finagle.stats.{Counter => FCounter, Stat => FStat}
+import com.twitter.finagle.stats.{Metadata, NoMetadata, Counter => FCounter, Stat => FStat}
 
 private[statsd] object Metric {
 
   // stats (timing/histograms) only send when Math.random() <= sampleRate
   class Counter(statsDClient: StatsDClient, name: String, sampleRate: Double) extends FCounter {
     def incr(delta: Long): Unit = statsDClient.count(name, delta, sampleRate)
+
+    def metadata: Metadata = NoMetadata
   }
 
   // gauges simply evaluate on send
@@ -20,5 +22,7 @@ private[statsd] object Metric {
     def add(value: Float): Unit =
       // would prefer `recordHistogramValue`, but that's an extension, supported by Datadog and InfluxDB
       statsDClient.recordExecutionTime(name, value.toLong, sampleRate)
+
+    def metadata: Metadata = NoMetadata
   }
 }

--- a/telemetry/statsd/src/main/scala/io/buoyant/telemetry/statsd/StatsDStatsReceiver.scala
+++ b/telemetry/statsd/src/main/scala/io/buoyant/telemetry/statsd/StatsDStatsReceiver.scala
@@ -6,12 +6,12 @@ import com.timgroup.statsd.StatsDClient
 import com.twitter.finagle.stats.{
   Counter,
   CounterSchema,
+  GaugeSchema,
   HistogramSchema,
   Stat,
   StatsReceiverWithCumulativeGauges,
   Verbosity
 }
-
 import scala.jdk.CollectionConverters._
 
 private[telemetry] object StatsDStatsReceiver {
@@ -41,10 +41,10 @@ private[telemetry] class StatsDStatsReceiver(
   private[this] val gauges = new ConcurrentHashMap[String, Metric.Gauge]
   private[this] val stats = new ConcurrentHashMap[String, Metric.Stat]
 
-  protected[this] def registerGauge(verbosity: Verbosity, name: Seq[String], f: => Float): Unit = {
-    deregisterGauge(name)
+  protected[this] def registerGauge(schema: GaugeSchema, f: => Float): Unit = {
+    deregisterGauge(schema.metricBuilder.name)
 
-    val statsDName = mkName(name)
+    val statsDName = mkName(schema.metricBuilder.name)
     val _ = gauges.put(statsDName, new Metric.Gauge(statsDClient, statsDName, f))
   }
 

--- a/telemetry/zipkin/src/main/scala/com/twitter/finagle/buoyant/zipkin/ZipkinTracer.scala
+++ b/telemetry/zipkin/src/main/scala/com/twitter/finagle/buoyant/zipkin/ZipkinTracer.scala
@@ -1,0 +1,54 @@
+package com.twitter.finagle.buoyant.zipkin
+
+import com.twitter.conversions.DurationOps._
+import com.twitter.finagle.client.DefaultPool
+import com.twitter.finagle.stats.{ClientStatsReceiver, NullStatsReceiver}
+import com.twitter.finagle.thrift.Protocols
+import com.twitter.finagle.{Address, Name, Thrift}
+import com.twitter.finagle.thrift.scribe.thriftscala.Scribe
+import com.twitter.finagle.tracing.{NullTracer, Record, TraceId, Tracer, TracelessFilter}
+import com.twitter.finagle.util.DefaultTimer
+import com.twitter.finagle.zipkin.thrift.{ScribeRawZipkinTracer, ZipkinTracer => TZipkinTracer}
+
+class ZipkinTracer(
+  host: String,
+  port: Int,
+  sampleRate: Float
+) extends Tracer {
+
+  val underlying: Tracer = {
+    // Cribbed heavily from com.twitter.finagle.zipkin.thrift.RawZipkinTracer
+    val transport = Thrift.client
+      .withStatsReceiver(ClientStatsReceiver)
+      .withSessionPool.maxSize(5)
+      .configured(DefaultPool.Param.param.default.copy(maxWaiters = 250))
+      // reduce timeouts because trace requests should be fast
+      .withRequestTimeout(100.millis)
+      // disable failure accrual so that we don't evict nodes when connections
+      // are saturated
+      .withSessionQualifier.noFailureAccrual
+      // disable fail fast since we often be sending to a load balancer
+      .withSessionQualifier.noFailFast
+      .withTracer(NullTracer)
+      .newService(Name.bound(Address(host, port)), "zipkin-tracer")
+
+    val client: Scribe.MethodPerEndpoint = new Scribe.FinagledClient(
+      new TracelessFilter andThen transport,
+      Protocols.binaryFactory()
+    )
+
+    val rawTracer = ScribeRawZipkinTracer(
+      client,
+      "zipkin",
+      NullStatsReceiver,
+      DefaultTimer
+    )
+    new TZipkinTracer(
+      rawTracer,
+      sampleRate
+    )
+  }
+
+  def sampleTrace(t: TraceId) = underlying.sampleTrace(t)
+  def record(r: Record) = underlying.record(r)
+}

--- a/telemetry/zipkin/src/main/scala/io/buoyant/telemetry/ZipkinInitializer.scala
+++ b/telemetry/zipkin/src/main/scala/io/buoyant/telemetry/ZipkinInitializer.scala
@@ -1,16 +1,11 @@
 package io.buoyant.telemetry
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
-import com.twitter.conversions.DurationOps._
 import com.twitter.finagle._
-import com.twitter.finagle.client.DefaultPool
-import com.twitter.finagle.stats.{ClientStatsReceiver, NullStatsReceiver}
-import com.twitter.finagle.thrift.Protocols
+import com.twitter.finagle.buoyant.zipkin.ZipkinTracer
+import com.twitter.finagle.stats.NullStatsReceiver
 import com.twitter.finagle.tracing._
-import com.twitter.finagle.util.DefaultTimer
 import com.twitter.finagle.zipkin.core.Sampler
-import com.twitter.finagle.zipkin.thrift.{ScribeRawZipkinTracer, ZipkinTracer}
-import com.twitter.finagle.zipkin.thriftscala.Scribe
 
 class ZipkinInitializer extends TelemeterInitializer {
   type Config = ZipkinConfig
@@ -24,43 +19,11 @@ case class ZipkinConfig(
   @JsonDeserialize(contentAs = classOf[java.lang.Double]) sampleRate: Option[Double]
 ) extends TelemeterConfig {
 
-  private[this] val tracer: Tracer = new Tracer {
-    val underlying: Tracer = {
-      // Cribbed heavily from com.twitter.finagle.zipkin.thrift.RawZipkinTracer
-      val transport = Thrift.client
-        .withStatsReceiver(ClientStatsReceiver)
-        .withSessionPool.maxSize(5)
-        .configured(DefaultPool.Param.param.default.copy(maxWaiters = 250))
-        // reduce timeouts because trace requests should be fast
-        .withRequestTimeout(100.millis)
-        // disable failure accrual so that we don't evict nodes when connections
-        // are saturated
-        .withSessionQualifier.noFailureAccrual
-        // disable fail fast since we often be sending to a load balancer
-        .withSessionQualifier.noFailFast
-        .withTracer(NullTracer)
-        .newService(Name.bound(Address(host.getOrElse("localhost"), port.getOrElse(9410))), "zipkin-tracer")
-
-      val client = new Scribe.FinagledClient(
-        new TracelessFilter andThen transport,
-        Protocols.binaryFactory()
-      )
-
-      val rawTracer = ScribeRawZipkinTracer(
-        client,
-        "zipkin",
-        NullStatsReceiver,
-        DefaultTimer
-      )
-      new ZipkinTracer(
-        rawTracer,
-        sampleRate.map(_.toFloat).getOrElse(Sampler.DefaultSampleRate)
-      )
-    }
-
-    def sampleTrace(t: TraceId) = underlying.sampleTrace(t)
-    def record(r: Record) = underlying.record(r)
-  }
+  private[this] val tracer: Tracer = new ZipkinTracer(
+    host.getOrElse("localhost"),
+    port.getOrElse(9410),
+    sampleRate.map(_.toFloat).getOrElse(Sampler.DefaultSampleRate)
+  )
 
   def mk(params: Stack.Params): ZipkinTelemeter = new ZipkinTelemeter(tracer)
 }
@@ -68,18 +31,6 @@ case class ZipkinConfig(
 class ZipkinTelemeter(underlying: Tracer) extends Telemeter {
   val stats = NullStatsReceiver
   lazy val tracer = underlying
-  def run() = Telemeter.nopRun
-}
 
-/**
- * _Copied from Finagle's RawZipkinTracer.scala_
- *
- * Makes sure we don't trace the Scribe logging.
- */
-private class TracelessFilter[Req, Rep] extends SimpleFilter[Req, Rep] {
-  def apply(request: Req, service: Service[Req, Rep]) = {
-    Trace.letClear {
-      service(request)
-    }
-  }
+  def run() = Telemeter.nopRun
 }


### PR DESCRIPTION
Update Finagle from 20.4.1 to 21.4.0. Also update following dependencies
to match versions used by Finagle:

* netty 4.1.47 -> 41.1.59
* netty-tcnative-boringssl-static 2.0.30 -> 2.0.35
* jackson 2.9.10 -> 2.11.2

Signed-off-by: Henri Hagberg <henri.hagberg@relexsolutions.com>