### PR TITLE
Release notes for Linkerd 1.7.5

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,5 @@
 ## 1.7.5 2022-05-24
-Linkerd 1.7.5 i a maintenance release which adds an option to build the Linkerd
+Linkerd 1.7.5 is a maintenance release which adds an option to build the Linkerd
 and Namerd executable jar files without including the Zookeeper libraries which
 depend on an old version of log4j
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## 1.7.5 2022-05-24
+Linkerd 1.7.5 i a maintenance release which adds an option to build the Linkerd
+and Namerd executable jar files without including the Zookeeper libraries which
+depend on an old version of log4j
+
 ## 1.7.5-rc1 2021-05-28
 Linkerd 1.7.5-rc1 is a release candidate for Linkerd 1.7.5
 

--- a/project/Base.scala
+++ b/project/Base.scala
@@ -32,7 +32,7 @@ object Base {
 class Base extends Build {
   import Base._
 
-  val headVersion = "1.7.5-rc1"
+  val headVersion = "1.7.5"
   val openJdkVersion = "8u212"
   val openJ9Version = "jdk8u212-b04_openj9-0.14.2"
 


### PR DESCRIPTION
* Updated release notes

Linkerd 1.7.5 i a maintenance release which adds an option to build the Linkerd
and Namerd executable jar files without including the Zookeeper libraries which
depend on an old version of log4j

Signed-off-by: Charles Pretzer <charles@buoyant.io>